### PR TITLE
Let another desktop's input method win

### DIFF
--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -996,9 +996,20 @@ in
     # dropping fcitx5 into systemPackages: it is what builds fcitx5 with its
     # addons, writes the Qt plugin path, and sets XMODIFIERS and the GTK/Qt IM
     # modules. The unit that starts it is above.
+    # Priority 1250, which is neither of the two names lib gives you, because
+    # this option is squeezed between them. GNOME's desktop-manager module sets
+    # type to "ibus" at mkDefault (1000) and two mkDefaults tie rather than
+    # yield, so a host running GNOME beside this session failed to evaluate at
+    # all -- not the wrong input method, no evaluation. One step lower is not
+    # available either: nixpkgs' own module defines type as null at
+    # mkOptionDefault (1500) to carry the deprecated `enabled` across, and
+    # nullOr refuses to merge null with a value, so matching that ties in the
+    # other direction. Sitting between the two loses to anyone with a real
+    # opinion and still beats nixpkgs' placeholder, which is exactly the rule
+    # this module follows everywhere else: arrive beside what is installed.
     i18n.inputMethod = {
-      enable = lib.mkDefault true;
-      type = lib.mkDefault "fcitx5";
+      enable = lib.mkOverride 1250 true;
+      type = lib.mkOverride 1250 "fcitx5";
     };
 
     # The two of upstream's four that the nixpkgs module does not set. It has

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -36,6 +36,27 @@ let
       ];
     }).config;
 
+  # A host where some other module already has an opinion, so what is being
+  # measured is whose definition survives -- not what nixarchy asks for alone.
+  configBeside =
+    extra:
+    (inputs.nixpkgs.lib.nixosSystem {
+      inherit system;
+      modules = [
+        inputs.self.nixosModules.nixarchy
+        { programs.nixarchy.enable = true; }
+        extra
+        {
+          boot.loader.grub.device = "/dev/sda";
+          fileSystems."/" = {
+            device = "/dev/sda1";
+            fsType = "ext4";
+          };
+          system.stateVersion = "25.05";
+        }
+      ];
+    }).config;
+
   sessionNames =
     cfg: map (p: p.passthru.providedSessions or [ ]) cfg.services.displayManager.sessionPackages;
 
@@ -100,6 +121,20 @@ let
     bootSplash = {
       on = (configWith { bootSplash = "force"; }).boot.plymouth.theme == "omarchy";
       off = (configWith { bootSplash = "off"; }).boot.plymouth.theme == "omarchy";
+    };
+
+    # The input method, which is not an option of ours but a default we set on
+    # someone else's. GNOME's desktop-manager module sets the same option to
+    # "ibus" at mkDefault; when this module matched that priority the two tied
+    # and a host running both failed to evaluate at all -- not a wrong value, no
+    # value. So the assertion is that another module's mkDefault wins outright,
+    # and that fcitx5 still lands on a host with no other opinion.
+    inputMethod = {
+      on = (configWith { }).i18n.inputMethod.type == "fcitx5";
+      off =
+        (configBeside {
+          i18n.inputMethod.type = pkgs.lib.mkDefault "ibus";
+        }).i18n.inputMethod.type == "fcitx5";
     };
 
     browserThemeUser = {


### PR DESCRIPTION
`i18n.inputMethod.type` at `mkDefault` was enough to stop a host **evaluating**. GNOME's desktop-manager module sets the same option to `"ibus"` at the same priority, and two `mkDefault`s tie rather than yield — so a machine running GNOME beside this session got no configuration at all, not merely the wrong input method. Both p620 and razer hit this; it surfaced on a dry-build before deploying, not after.

One step lower isn't available: nixpkgs' own module defines `type` as `null` at `mkOptionDefault` to carry the deprecated `enabled` option across, and `nullOr` refuses to merge `null` with a value — so that priority ties in the other direction. The definition therefore sits between the two named priorities: it loses to anyone with a real opinion, and still beats nixpkgs' placeholder.

`tests/options.nix` now evaluates a host where another module has already claimed the option and asserts that module wins. Negative-controlled: restoring `mkDefault` fails the check.

All eight checks pass; statix and deadnix clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5