### PR TITLE
Tell the agent it is on NixOS, not Arch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,6 +147,56 @@ jobs:
           done
           echo "pacman bins replaced, metadata intact"
 
+      - name: Verify the agent skills are NixOS-aware
+        run: |
+          # omarchy-provision-user symlinks every directory here into
+          # ~/.claude/skills, ~/.agents/skills, ~/.codex/skills and
+          # ~/.pi/agent/skills, so this is what an AI agent on the machine is
+          # told to do. Upstream ships Arch instructions; an Omarchy bump that
+          # reworded a line we patch would put them back with nothing failing.
+          skills=result/share/omarchy/default/agents/skills
+
+          have=$(ls "$skills" | sort | tr '\n' ' ')
+          [ "$have" = "diagnose-crash nixarchy nixos " ] || {
+            echo "::error::unexpected skill set: $have"
+            exit 1
+          }
+
+          # bin/omarchy-agent-crash reads this exact path, so the rename must
+          # never reach it.
+          test -f "$skills/diagnose-crash/SKILL.md" || {
+            echo "::error::omarchy-agent-crash reads diagnose-crash/SKILL.md; it is gone"
+            exit 1
+          }
+
+          for d in "$skills"/*/; do
+            name=$(basename "$d")
+            fm=$(sed -n 's/^name: //p' "$d/SKILL.md" | head -1)
+            [ "$fm" = "$name" ] || {
+              echo "::error::$name/SKILL.md declares name: $fm; agents key on the directory"
+              exit 1
+            }
+          done
+
+          # Prose may contrast with Arch on purpose ("upstream runs pacman -S,
+          # here the menu edits apps.nix") -- that comparison is the point. What
+          # must never appear is an Arch command inside a fenced block, because
+          # that is what an agent copies and runs.
+          bad=$(find "$skills" -name '*.md' -print0 | xargs -0 awk '
+            /^```/ { fence = !fence; next }
+            # pre-refresh-pacman.d is a hook DIRECTORY name, not a command, and
+            # the line already says it never runs here. Named, not counted.
+            fence && /pre-refresh-pacman\.d/ { next }
+            fence && /pacman|[^n]yay |\/usr\/share\/omarchy|debuginfod\.archlinux\.org/ {
+              printf "%s:%d: %s\n", FILENAME, FNR, $0
+            }')
+          if [ -n "$bad" ]; then
+            echo "::error::Arch commands inside skill code blocks:"
+            echo "$bad"
+            exit 1
+          fi
+          echo "agent skills are NixOS-aware"
+
       - name: Verify every Install row is mapped
         run: |
           # data/apps.nix claims CI keeps it from rotting. This is that check.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | **Themes** | `omarchy theme install <url>` clones and applies a published theme at runtime |
 | 13 language toolchains | Go, Rust, Node, Bun, Deno, Java, Elixir, Zig, Clojure, Scala, .NET, OCaml, Python — from nixpkgs, not from `mise` |
 | Branded boot splash | Omarchy's Plymouth theme, selected by `boot.plymouth.theme` |
+| **Agent skills** | `nixarchy`, `nixos` and `diagnose-crash` — rewritten for NixOS, not Omarchy's Arch originals |
 
 ## Why vendoring
 
@@ -72,6 +73,46 @@ way, so a `pacman` shim only changes *how*: instead of `command not found`, you
 get told what replaced the command. It keeps pacman's contract (stderr,
 non-zero), so `omarchy version` and `omarchy debug`, which already wrap it in
 `2>/dev/null || fallback`, are unaffected.
+
+## AI agent skills
+
+Omarchy ships skills for coding agents, and `omarchy-provision-user` symlinks every
+one of them into `~/.claude/skills`, `~/.agents/skills`, `~/.codex/skills` and
+`~/.pi/agent/skills`. Whatever is in that directory is what an agent on this machine
+is told to do.
+
+Upstream's are written for Arch. They point at `/usr/share/omarchy`, and their
+decision framework answers "install a package" with `omarchy pkg add` — a script
+this repo replaced with one that deliberately refuses. Shipping them unchanged means
+an agent confidently doing imperative things the next rebuild wipes, which is the
+one failure mode that looks like success.
+
+So three skills ship here instead:
+
+| skill | owns |
+|---|---|
+| **`nixarchy`** | The desktop: Hyprland, the bar, themes, capture. Upstream's `omarchy` skill, renamed and corrected |
+| **`nixos`** | Packages and system changes: `apps.nix`, the Install menu, `nixos-rebuild`, generations, rollback, option search. New — upstream has no equivalent because it does not need one |
+| **`diagnose-crash`** | Upstream's, patched. Keeps its name because `omarchy-agent-crash` reads that path literally |
+
+The split is the point. `nixarchy`'s decision framework used to answer "is it a
+package install?" with a pacman command; now it hands off to `nixos`, which opens
+with the only rule that matters — **a package installed imperatively does not
+survive the next rebuild** — and routes to `nixarchy-app-enable`, a flake edit, or
+`nix shell` depending on which is actually being asked for.
+
+`diagnose-crash` gets three corrections that are not cosmetic: there is no public
+debuginfod serving nixpkgs builds, so it explains `nixseparatedebuginfod` instead
+of pointing at Arch's server; "recent package updates" becomes
+`nix profile diff-closures`, which names exactly what changed between generations;
+and a bug report now has two possible destinations rather than one.
+
+Only `SKILL.md` and `contributing.md` are replaced outright — their guidance is
+wrong here, not merely misspelt. Everything else is patched with `--replace-fail`,
+so an Omarchy bump that rewords a line this depends on fails the build rather than
+quietly restoring Arch instructions. CI additionally asserts that no skill code
+block contains a pacman, yay, `/usr/share/omarchy` or Arch-debuginfod line, because
+prose may contrast with Arch on purpose but a fenced block is what an agent copies.
 
 ## Installing apps
 

--- a/pkgs/omarchy/default.nix
+++ b/pkgs/omarchy/default.nix
@@ -63,7 +63,6 @@
   tmux,
   inotify-tools,
   python3,
-
   # Application tier. These are commands the bins invoke directly, not
   # libraries: omarchy-launch-terminal execs `uwsm-app -- xdg-terminal-exec`,
   # theme-set retints whichever terminals are present, and the menus launch
@@ -106,10 +105,8 @@
   xdg-user-dirs,
   satty,
   wl-screenrec,
-
   # Branding: this is a NixOS port, so the menu button wears the snowflake.
   nixos-icons,
-
 }:
 let
   # Everything the 438 scripts in bin/ invoke. Kept explicit rather than
@@ -714,6 +711,73 @@ stdenvNoCC.mkDerivation {
                   # yet unreachable to the scripts that call it.
                   [ -e "$out/bin/$name" ] || ln -s "$target" "$out/bin/$name"
                 done
+
+                # Agent skills. omarchy-provision-user symlinks every directory under
+                # default/agents/skills/ into ~/.claude/skills, ~/.agents/skills,
+                # ~/.codex/skills and ~/.pi/agent/skills, so whatever is here is what an
+                # AI agent on this machine is told to do. Upstream's are written for
+                # Arch: they point at /usr/share/omarchy, and their decision framework
+                # answers "install a package" with `omarchy pkg add`, which is a script
+                # this repo replaced with one that deliberately refuses. Shipping them
+                # unchanged means an agent confidently doing imperative things a rebuild
+                # then wipes -- the one failure mode that looks like success.
+                #
+                # The `omarchy` skill is renamed to `nixarchy`, so the skill an agent
+                # loads is named for the system it is actually on, and a new `nixos`
+                # skill owns packages and system changes. `diagnose-crash` keeps its
+                # name: bin/omarchy-agent-crash reads that path literally.
+                #
+                # SKILL.md and contributing.md are replaced outright -- their guidance
+                # is wrong here, not merely misspelt -- while the rest are patched, so
+                # an upstream edit to a line we depend on fails the build instead of
+                # quietly shipping Arch instructions again.
+                #
+                # Every --replace-fail pattern AND replacement below is a single line
+                # on purpose. `nix fmt` re-indents multi-line strings inside this
+                # expression, which silently breaks a literal match against file
+                # content that was never indented.
+                mv $out/share/omarchy/default/agents/skills/omarchy \
+                   $out/share/omarchy/default/agents/skills/nixarchy
+                cp -r --no-preserve=mode ${./skills}/. \
+                   $out/share/omarchy/default/agents/skills/
+
+                skills=$out/share/omarchy/default/agents/skills
+
+                # Paths. $OMARCHY_PATH is exported for every one of these readers, and
+                # hardcoding a store hash into documentation would be wrong at the next
+                # bump anyway.
+                substituteInPlace $skills/nixarchy/theming.md \
+                  --replace-fail '2. See how an existing theme is done via `/usr/share/omarchy/themes/catppuccin`.' '2. See how an existing theme is done via `$OMARCHY_PATH/themes/catppuccin`.' \
+                  --replace-fail 'Never edit stock themes under `/usr/share/omarchy/themes/` — changes are lost' 'Stock themes live under `$OMARCHY_PATH/themes/` — a read-only store path, so' \
+                  --replace-fail 'on update. Two safe options:' 'editing one is not possible. Two safe options:' \
+                  --replace-fail 'cp /usr/share/omarchy/themes/catppuccin/colors.toml ~/.config/omarchy/themes/catppuccin/' 'cp --no-preserve=mode "$OMARCHY_PATH"/themes/catppuccin/colors.toml ~/.config/omarchy/themes/catppuccin/' \
+                  --replace-fail 'cp -r /usr/share/omarchy/themes/catppuccin ~/.config/omarchy/themes/catppuccin-custom' 'cp -r --no-preserve=mode "$OMARCHY_PATH"/themes/catppuccin ~/.config/omarchy/themes/catppuccin-custom'
+
+                # `omarchy refresh pacman` does not exist here, so neither does the hook
+                # that runs before it. Marked inert rather than deleted: an agent that
+                # sees the name mentioned upstream should find out here that it is dead.
+                substituteInPlace $skills/nixarchy/hooks.md \
+                  --replace-fail '├── pre-refresh-pacman.d/   # Before `omarchy refresh pacman` re-syncs packages' '├── pre-refresh-pacman.d/   # Arch only — never runs on NixOS' \
+                  --replace-fail '├── post-update.d/          # During `omarchy update`, after system packages and migrations' '├── post-update.d/          # During `omarchy update`, i.e. after nixos-rebuild switch'
+
+                # The crash skill is upstream's and mostly distro-neutral; three claims
+                # are not. Arch'"'"'s debuginfod does not serve nixpkgs builds, "recent
+                # package updates" has a far better answer here than mtimes, and a bug
+                # report has two possible destinations rather than one.
+                substituteInPlace $skills/diagnose-crash/SKILL.md \
+                  --replace-fail 'This is Arch, which runs a public debuginfod server:' 'No public debuginfod serves nixpkgs builds. Symbols resolve only if this machine runs `nixseparatedebuginfod` (which serves the whole store on 127.0.0.1:1949 and exports `DEBUGINFOD_URLS` itself) or the package was built with `separateDebugInfo`. Run it anyway — gdb degrades to an unsymbolized stack rather than failing:' \
+                  --replace-fail 'DEBUGINFOD_URLS="https://debuginfod.archlinux.org" \' 'DEBUGINFOD_URLS="''${DEBUGINFOD_URLS:-}" \' \
+                  --replace-fail '- **Recent package updates.** A crash that starts right after an update points at' '- **Recent system generations.** A crash that starts right after a rebuild points at' \
+                  --replace-fail '  the update.' '  the rebuild. `nix profile diff-closures --profile /nix/var/nix/profiles/system` names exactly what changed between generations — stronger evidence than any package log — and `sudo nixos-rebuild --rollback switch` tests the theory in one command.' \
+                  --replace-fail '## If it is an Omarchy bug' '## If it is a Nixarchy or Omarchy bug' \
+                  --replace-fail 'Most application crashes are upstream bugs in those applications, not Omarchy'"'"'s' 'Most application crashes are upstream bugs in those applications, not the distribution'"'"'s' \
+                  --replace-fail 'doing. In the minority of cases where the cause really does sit within Omarchy'"'"'s' 'doing. In the minority of cases where the cause really does sit within Nixarchy'"'"'s or Omarchy'"'"'s'
+
+                substituteInPlace $skills/diagnose-crash/reporting.md \
+                  --replace-fail '# Reporting a Crash Upstream to Omarchy' '# Reporting a Crash to Nixarchy or Omarchy' \
+                  --replace-fail 'Read this only after concluding that a crash is genuinely Omarchy'"'"'s to fix.' 'Read this only after concluding that a crash is genuinely the distribution'"'"'s to fix. Two projects can own it: Nixarchy (<https://github.com/olafkfreund/nixarchy>) for anything specific to NixOS — the store, a rebuild, `nixarchy-apply`, a hardcoded `/usr` path, a replaced `omarchy-*` command — and Omarchy (<https://github.com/basecamp/omarchy>) for anything that would happen identically on Arch. When unsure, file against Nixarchy; the `nixarchy` skill'"'"'s `contributing.md` has the full rule.' \
+                  --replace-fail 'Omarchy is a configuration layer over Arch Linux, so a crash' 'Omarchy is a configuration layer and Nixarchy packages it for NixOS, so a crash' \
+                  --replace-fail 'Include what happened, what was expected, steps to reproduce, system details from' 'Include what happened, what was expected, steps to reproduce, `nixos-version` and the locked inputs from `nix flake metadata`, system details from'
 
                 # The Arch-name lookup omarchy-pkg-add answers with. Generated rather than
                 # hand-written into the script: data/apps.nix already maps every Install

--- a/pkgs/omarchy/skills/nixarchy/SKILL.md
+++ b/pkgs/omarchy/skills/nixarchy/SKILL.md
@@ -1,0 +1,359 @@
+---
+name: nixarchy
+description: >
+  REQUIRED for end-user customization of the Nixarchy desktop, window manager, or
+  desktop config on NixOS. Use when editing ~/.config/hypr/, ~/.config/omarchy/,
+  ~/.config/alacritty/, ~/.config/foot/, ~/.config/kitty/, or ~/.config/ghostty/.
+  Triggers: Hyprland, window rules, animations, keybindings, monitors, gaps, borders,
+  blur, opacity, omarchy-shell, bar, terminal config, themes, background,
+  night light, idle, lock screen, screenshots, reminders, layer rules, workspace
+  settings, display config, and user-facing omarchy commands. For installing
+  packages or changing anything outside ~/.config, use the `nixos` skill instead.
+---
+
+# Nixarchy Skill
+
+Manage [Nixarchy](https://github.com/olafkfreund/nixarchy) systems — the
+[Omarchy](https://omarchy.org/) desktop vendored for NixOS, with its menus rewired
+to Nix instead of pacman.
+
+This skill is for end-user customization of the **desktop** on an installed system.
+For installing packages or editing the system configuration, use the `nixos` skill.
+This skill is not for contributing to Nixarchy or Omarchy source code.
+
+## Read This First: How Nixarchy Differs From Omarchy
+
+Nixarchy runs Omarchy's real tree, unmodified where it can be. The commands, menus,
+themes, keybindings and shell are upstream's. What changes is everything that
+assumed Arch:
+
+| Upstream Omarchy | Here |
+|---|---|
+| Files live in `/usr/share/omarchy/` | Files live in `$OMARCHY_PATH`, a `/nix/store` path |
+| `omarchy pkg add <pkg>` installs via pacman | Prints the declarative route and **exits non-zero**; nothing is installed imperatively |
+| Install menu runs `pacman -S` | Install menu edits `~/.config/nixarchy/apps.nix`; nothing is built until you apply |
+| `omarchy update` runs a pacman upgrade | Runs `nix flake update` then `nixos-rebuild switch` |
+| Rollback via snapper snapshots | Rollback via NixOS generations (`nixos-rebuild --rollback`, or the boot menu) |
+| AUR | No equivalent. `omarchy pkg aur add` explains rather than installs |
+
+**The most important consequence:** nothing you install imperatively survives a
+rebuild. If a task involves adding a package, it is a `nixos` skill task, not this
+one. Do not reach for `omarchy pkg add` to "just install" something — it is a
+replacement script that deliberately refuses, so that a caller which would go on to
+configure what it thinks it installed stops there instead of half-completing.
+
+## When This Skill MUST Be Used
+
+**ALWAYS invoke this skill for end-user requests involving ANY of these:**
+
+- Editing ANY file in `~/.config/hypr/` (window rules, animations, keybindings, monitors, etc.)
+- Editing `~/.config/omarchy/shell.json` (status bar layout, widgets)
+- Editing terminal configs (alacritty, foot, kitty, ghostty)
+- Editing ANY file in `~/.config/omarchy/`
+- Window behavior, animations, opacity, blur, gaps, borders
+- Layer rules, workspace settings, display/monitor configuration
+- Themes, backgrounds, fonts, appearance changes
+- User-facing `omarchy` commands (`omarchy theme ...`, `omarchy refresh ...`, `omarchy restart ...`, etc.)
+- Screenshots, screen recording, reminders, night light, idle behavior, lock screen
+
+**If you're about to edit a config file in ~/.config/ on this system, STOP and use this skill first.**
+
+**Do NOT use this skill for:**
+- Installing packages or changing system configuration — use the `nixos` skill
+- Nixarchy or Omarchy source development
+
+## Topic Guides
+
+Deeper instructions for common areas live next to this file. Read the
+matching guide before starting:
+
+- [`hyprland.md`](hyprland.md) - keybindings, monitors, window rules, and other Hyprland config
+- [`plugins.md`](plugins.md) - the Omarchy shell: bar layout, widgets, plugins, idle behavior
+- [`theming.md`](theming.md) - themes, backgrounds, and fonts
+- [`hooks.md`](hooks.md) - automation hooks that run on system events
+- [`capture.md`](capture.md) - screenshots, screen recordings, OCR text capture, and file sharing
+- [`contributing.md`](contributing.md) - reporting Nixarchy and Omarchy bugs
+
+## Critical Safety Rules
+
+For privileged commands, follow the Privilege Escalation rules below: `sudo` when a
+terminal is available for the password prompt, `pkexec` when it is not. Do not wrap
+commands that already manage privilege elevation themselves.
+
+**`$OMARCHY_PATH` is a read-only `/nix/store` path. Reading it is safe and
+encouraged; writing to it is impossible.**
+
+This is stronger than upstream's rule. On Arch the package directory is merely
+overwritten on update; here the store is mounted read-only and a write fails
+outright. If a command or an edit is trying to write there, the approach is wrong —
+find the `~/.config/` equivalent.
+
+```
+$OMARCHY_PATH/            # READ-ONLY /nix/store path (reading is OK)
+├── bin/                    # Command source (packaged binaries are on PATH)
+├── config/                 # Default config templates
+├── themes/                 # Stock themes
+├── default/                # System defaults
+├── shell/                  # Omarchy shell source and defaults
+├── migrations/             # Update migrations
+└── install/                # Installation scripts
+```
+
+**Reading `$OMARCHY_PATH` is SAFE and useful** - do it freely to:
+- Understand how omarchy commands work: `omarchy theme set --help` or `cat $(which omarchy-theme-set)`
+- See default configs before customizing: `cat "$OMARCHY_PATH/config/omarchy/shell.json"`
+- Check stock theme files to copy for customization
+- Reference default hyprland settings: `cat "$OMARCHY_PATH"/default/hypr/*`
+
+Always resolve it through the variable. Never hardcode a store hash: it changes on
+every Omarchy or nixpkgs bump, and a path written down today is wrong after the next
+rebuild.
+
+**Always use these safe locations instead:**
+- `~/.config/` - User configuration (safe to edit)
+- `~/.config/omarchy/themes/<custom-name>/` - Custom themes
+- `~/.config/omarchy/hooks/` - Custom automation hooks
+
+If the request is to develop Nixarchy itself, this skill is out of scope.
+
+## Privilege Escalation
+
+For an interactive script or command run in a visible terminal, use `sudo` for
+privileged work. The terminal is the appropriate place to request a password when
+one is needed.
+
+Use `pkexec` only when the caller cannot interact with a terminal or cannot
+enter a password there, such as a command launched by an agent or a graphical
+background process. Do not replace `sudo` with `pkexec` merely because a
+command changes system state.
+
+## System Architecture
+
+Nixarchy is built on:
+
+| Component | Purpose | Config Location |
+|-----------|---------|-----------------|
+| **NixOS** | Base OS | The flake (see the `nixos` skill), `~/.config/` |
+| **Hyprland** | Wayland compositor/WM | `~/.config/hypr/` |
+| **Omarchy shell** | Status bar + notifications (Quickshell) | `~/.config/omarchy/shell.json` |
+| **Launcher/menus** | Quickshell menu | `~/.config/omarchy/extensions/omarchy-menu.jsonc` |
+| **Alacritty/Foot/Kitty/Ghostty** | Terminals | `~/.config/<terminal>/` |
+| **Omarchy OSD** | On-screen display | Quickshell plugin |
+
+Two config systems coexist and the boundary matters: **anything under `~/.config/` is
+yours, imperative, and edited in place. Anything else is declared in the flake and
+only changes at a rebuild.** Getting this backwards is the most common way to do
+something on this system that silently does not last.
+
+## Command Discovery
+
+Nixarchy ships Omarchy's single `omarchy` CLI, which dispatches to all `omarchy-*`
+binaries via `omarchy <group> <action>`. Always prefer this form — it is
+self-documenting and stable. The underlying `omarchy-*` binaries still exist on
+`PATH` and remain safe to read for source.
+
+```bash
+# List every documented command and its summary (--all includes hidden commands)
+omarchy commands
+
+# Show the commands inside a group
+omarchy theme --help
+omarchy refresh --help
+omarchy restart --help
+
+# Show help for a specific command (does not execute it)
+omarchy theme set --help
+
+# Machine-readable listing (binary, route, summary, args, aliases)
+omarchy commands --json
+
+# Read a command's source to understand it
+cat $(which omarchy-theme-set)
+```
+
+Some `omarchy-*` commands are Nixarchy replacements rather than upstream's. They
+keep upstream's name and contract; reading the source is the quickest way to see
+which is which — a replacement says so in its header comment.
+
+### Command Groups
+
+Run `omarchy --help` for the full list. The most common groups:
+
+| Group | Purpose | Example |
+|-------|---------|---------|
+| `omarchy refresh` | Reset config to defaults (backs up first) | `omarchy refresh shell` |
+| `omarchy restart` | Restart a service/app | `omarchy restart shell` |
+| `omarchy toggle` | Toggle feature on/off | `omarchy toggle nightlight` |
+| `omarchy theme` | Theme management | `omarchy theme set <name>` |
+| `omarchy bar` | Bar layout and widgets | `omarchy bar move omarchy.clock --section right` |
+| `omarchy plugin` | Manage/clone shell plugins | `omarchy plugin clone omarchy.clock` |
+| `omarchy hook` | Install automation hooks | `omarchy hook install theme-set <script>` |
+| `omarchy install` | Queue an app into the Nix selection (see the `nixos` skill) | `omarchy install docker dbs` |
+| `omarchy launch` | Launch apps | `omarchy launch browser` |
+| `omarchy capture` | Screenshots and recordings | `omarchy capture screenshot` |
+| `omarchy reminder` | Desktop notification reminders | `omarchy reminder 15 "Pickup Jack"` |
+| `omarchy pkg` | **Explains the declarative route; installs nothing** | `omarchy pkg add <pkg>` |
+| `omarchy setup` | Interactive setup wizards | `omarchy setup security fingerprint` |
+| `omarchy update` | `nix flake update` + `nixos-rebuild switch` | `omarchy update` |
+
+## Configuration Locations
+
+Hyprland config lives in `~/.config/hypr/` — see [`hyprland.md`](hyprland.md).
+The Omarchy shell (bar, notifications, plugins, idle) is configured in
+`~/.config/omarchy/shell.json` — see [`plugins.md`](plugins.md).
+
+### Terminals
+
+```
+~/.config/alacritty/alacritty.toml
+~/.config/foot/foot.ini
+~/.config/kitty/kitty.conf
+~/.config/ghostty/config
+```
+
+**Command:** `omarchy restart terminal`
+
+### Other Configs
+
+| App | Location |
+|-----|----------|
+| btop | `~/.config/btop/btop.conf` |
+| fastfetch | `/etc/fastfetch/config.jsonc` default; `~/.config/fastfetch/config.jsonc` user override |
+| lazygit | `~/.config/lazygit/config.yml` |
+| starship | `~/.config/starship.toml` |
+| git | `~/.config/git/config` |
+
+Note that `/etc` on NixOS is generated from the system configuration. A file there
+may be a symlink into the store, in which case it is not editable and its content
+belongs in the flake — see the `nixos` skill.
+
+## Safe Customization Patterns
+
+### Edit User Config Directly
+
+For simple changes, edit files in `~/.config/`:
+
+```bash
+# 1. Read current config
+cat ~/.config/hypr/bindings.lua
+
+# 2. Backup before changes
+cp ~/.config/hypr/bindings.lua ~/.config/hypr/bindings.lua.bak.$(date +%s)
+
+# 3. Make changes with Edit tool
+
+# 4. Apply changes
+# - Hyprland: auto-reloads on save, but MUST validate with `hyprctl reload` and `hyprctl configerrors`
+# - Omarchy shell: shell.json and user plugin code under ~/.config/omarchy/plugins/ hot-reload on save
+# - Menus/launcher: ~/.config/omarchy/extensions/omarchy-menu.jsonc hot-reloads on save
+# - Terminals: apply with `omarchy restart terminal` (reloads running terminals; foot picks changes up in new windows)
+```
+
+None of this needs a rebuild. That is the point of the boundary: desktop
+customization is immediate, and only the flake half requires `nixos-rebuild`.
+
+If a file under `~/.config/` turns out to be a symlink into `/nix/store`, it is
+managed by Home Manager and editing it is not possible. Change it in your Home
+Manager configuration instead — that is a `nixos` skill task.
+
+### Reset to Defaults -- ALWAYS SEEK USER CONFIRMATION BEFORE RUNNING
+
+When customizations go wrong:
+
+```bash
+# Reset specific config (creates backup automatically)
+omarchy refresh shell
+omarchy refresh hyprland
+
+# The refresh command:
+# 1. Backs up current config with timestamp
+# 2. Copies default from $OMARCHY_PATH/config/
+# 3. Restarts the component where the refresh needs it (e.g. `refresh shell`)
+```
+
+## System Commands
+
+```bash
+omarchy update                  # nix flake update + nixos-rebuild switch
+omarchy version                 # Show Omarchy version
+omarchy debug --no-sudo --print # Debug info (ALWAYS use these flags)
+omarchy system lock             # Lock screen
+omarchy system shutdown         # Shutdown
+omarchy system reboot           # Reboot
+```
+
+**IMPORTANT:** Always run `omarchy debug` with `--no-sudo --print` flags to avoid
+interactive sudo prompts that will hang the terminal.
+
+## Troubleshooting
+
+```bash
+# Get debug information (ALWAYS use these flags to avoid interactive prompts)
+omarchy debug --no-sudo --print
+
+# Reset specific config to defaults
+omarchy refresh <app>
+
+# Refresh specific config file
+# config-file path is relative to ~/.config/
+# eg. `omarchy refresh config hypr/hyprland.lua` will refresh ~/.config/hypr/hyprland.lua
+omarchy refresh config <config-file>
+```
+
+**There is no `omarchy reinstall` here.** Upstream's nuclear option re-runs the Arch
+installer. The equivalent on NixOS is better: the previous working system is still on
+disk as a generation.
+
+```bash
+sudo nixos-rebuild --rollback switch    # back to the previous generation
+```
+
+Or pick an older generation from the boot menu. See the `nixos` skill.
+
+## Decision Framework
+
+When user requests system changes:
+
+1. **Is it a stock omarchy command?** Use it directly
+2. **Is it a config edit under `~/.config/`?** Edit it there, never `$OMARCHY_PATH`
+3. **Is it a theme customization?** Follow [`theming.md`](theming.md); create a NEW custom theme directory
+4. **Is it automation?** Follow [`hooks.md`](hooks.md); use `omarchy hook install` and the hook `.d` directories
+5. **Is it a package install, or any change outside `~/.config/`?** **Use the `nixos` skill.** Do not run `omarchy pkg add` expecting an install, and never install imperatively — it will not survive the next rebuild
+6. **Is it built-in shell/plugin code?** Follow [`plugins.md`](plugins.md); clone it with `omarchy plugin clone`, never edit the packaged copy
+7. **Unsure if command exists?** Run `omarchy commands` (or `omarchy <group> --help` for one group)
+
+### Reminder Requests
+
+When the user asks to set a reminder, use `omarchy reminder <minutes> [message]` directly. Convert natural language durations to minutes and title-case short reminder labels when appropriate.
+
+```bash
+omarchy reminder 15 "Pickup Jack"
+omarchy reminder 60 "Check laundry"
+omarchy reminder show
+omarchy reminder clear
+```
+
+## Out of Scope
+
+This skill intentionally does not cover:
+- Package installation or system configuration — use the `nixos` skill
+- Nixarchy or Omarchy source development
+- Editing anything under `$OMARCHY_PATH` (`bin/`, `config/`, `default/`, `shell/`, `themes/`, `migrations/`) — which is read-only anyway
+- Creating or editing migrations
+
+## Example Requests
+
+- "Change my theme to catppuccin" -> `omarchy theme set catppuccin`
+- "Add a keybinding for Super+E to open file manager" -> Check existing bindings first, call `hl.unbind` if needed, then `o.bind` in `~/.config/hypr/bindings.lua`
+- "Configure my external monitor" -> Edit `~/.config/hypr/monitors.lua`
+- "Make the window gaps smaller" -> Edit `~/.config/hypr/looknfeel.lua`
+- "Turn on night light" -> `omarchy toggle nightlight` (for time-based schedules, edit `~/.config/hypr/hyprsunset.conf` profiles, then `omarchy restart hyprsunset`)
+- "Set a reminder to pickup jack in 15 minutes" -> `omarchy reminder 15 "Pickup Jack"`
+- "Customize the catppuccin theme colors" -> Overlay: put an edited `colors.toml` in `~/.config/omarchy/themes/catppuccin/`, then re-apply the theme (see `theming.md`)
+- "Run a script every time I change themes" -> Install it with `omarchy hook install theme-set <script>`
+- "Lock after ten minutes" -> Set `idle.lock` to `600` in `~/.config/omarchy/shell.json`
+- "Reset shell/bar to defaults" -> `omarchy refresh shell`
+- "Record my screen" -> `omarchy screenrecord --fullscreen`, then `omarchy screenrecord --stop-recording` (see `capture.md`)
+- **"Install Ghostty" -> NOT this skill. Use the `nixos` skill: it is a declarative change, not a command**
+- **"My change disappeared after a reboot" -> it was installed imperatively. Use the `nixos` skill to declare it**
+- "Report this bug" -> Work out whether it is Nixarchy's or Omarchy's first (see `contributing.md`)

--- a/pkgs/omarchy/skills/nixarchy/contributing.md
+++ b/pkgs/omarchy/skills/nixarchy/contributing.md
@@ -1,0 +1,125 @@
+# Reporting Issues and Submitting PRs
+
+Read this when the user wants to report a bug, suggest a feature, or contribute a
+fix.
+
+**There are two projects here, and routing a report to the wrong one wastes
+everybody's time.**
+
+- **Nixarchy** — <https://github.com/olafkfreund/nixarchy> — packages Omarchy for
+  NixOS. Its sphere is the NixOS module, the app catalogue, the replacement
+  `omarchy-*` commands, the declarative Install/Remove/Update menus, and anything
+  that behaves differently here than on Arch.
+- **Omarchy** — <https://github.com/basecamp/omarchy> — the desktop itself. Its
+  sphere is the shell, themes, Hyprland configuration, menus, and the `omarchy-*`
+  commands Nixarchy does not replace.
+
+## Which one is it?
+
+Ask: **would this happen on Arch?**
+
+- **Yes, it would happen on Arch too** -> it is Omarchy's. Reproduce it on stock
+  Omarchy if you can, and report it upstream.
+- **No, it is specific to NixOS** -> it is Nixarchy's. Anything involving the Nix
+  store, a rebuild, `nixarchy-apply`, `apps.nix`, a missing binary at a hardcoded
+  `/usr` path, or a command that works on Arch and not here.
+
+A quick check that settles most cases — whether the failing command is one Nixarchy
+replaced:
+
+```bash
+head -20 "$(which omarchy-<command>)"
+```
+
+Replacements carry a header comment explaining what they replace and why. If the
+command is a replacement and it misbehaves, it is Nixarchy's. If it is upstream's
+and it misbehaves in a way that has nothing to do with Nix, it is Omarchy's.
+
+**When genuinely unsure, file it against Nixarchy.** The port is the newer and
+thinner layer, and its maintainer can route it upstream with the NixOS detail
+already attached. Filing a Nix-specific bug on `basecamp/omarchy` is asking people
+to debug a distribution they do not run.
+
+## Before Filing
+
+Issues are for verified bugs, not support questions.
+
+- **Omarchy feature ideas** -> <https://github.com/basecamp/omarchy/discussions/categories/suggestions>
+- **Omarchy support / "is this a bug?"** -> the Discord at <https://omarchy.org/discord>
+- **Nixarchy questions** -> a GitHub issue is fine; the project is small enough
+
+Search first — a duplicate costs a maintainer more time than no report at all.
+
+```bash
+gh search issues --repo olafkfreund/nixarchy "<terms>"
+gh search issues --repo basecamp/omarchy "<terms>"
+```
+
+Include closed issues. A matching issue closed as fixed, where the bug still
+reproduces, is a regression — worth far more than another duplicate.
+
+## Gathering Diagnostics
+
+```bash
+omarchy version
+omarchy debug --no-sudo --print
+```
+
+For a Nixarchy report, this system detail matters more than CPU and GPU:
+
+```bash
+nixos-version                                    # channel and revision
+nix flake metadata "${NIXARCHY_FLAKE:-/etc/nixos}"   # the pinned inputs
+```
+
+The locked `nixarchy` and `nixpkgs` revisions are usually the first thing anyone
+will ask for, because they identify exactly what was built.
+
+**Capture the problem on screen.** A screenshot or short recording is often worth
+more than the description — see [`capture.md`](capture.md). Keep recordings short and
+focused on the misbehavior. `gh` cannot upload media: save the capture and hand the
+user the file path to drag into the web form.
+
+For screen-recording failures specifically, rerun with
+`OMARCHY_SCREENRECORD_DEBUG=true` and attach `/tmp/omarchy-screenrecord.log`.
+
+## Filing
+
+Never file unprompted. Show the user the exact title and body, and wait for a yes.
+`gh auth status` must succeed; if `gh` is missing or unauthenticated, do not install
+or authenticate it — hand the user the finished text instead.
+
+```bash
+gh issue create --repo olafkfreund/nixarchy --title "..." --body "..."
+```
+
+Include: what happened, what was expected, steps to reproduce, the versions above,
+and the capture.
+
+## Submitting a PR to Nixarchy
+
+Nixarchy is a flake. There is no `/usr/share/omarchy` to develop against and no
+`omarchy dev link` — the packaged tree is a read-only store path.
+
+```bash
+gh repo fork olafkfreund/nixarchy --clone
+cd nixarchy
+nix develop            # the dev shell: nixd, statix, deadnix, qemu, gh
+```
+
+Before pushing:
+
+```bash
+nix fmt                                          # nixfmt-tree; CI runs `nix fmt -- --ci`
+nix run nixpkgs#statix -- check .
+nix run nixpkgs#deadnix -- --fail .
+nix build .#omarchy                              # the package
+nix build .#checks.x86_64-linux.session          # the graphical session test
+```
+
+Checks are built one at a time by name, not with `nix flake check`. `nix run .#vm`
+boots a smoke-test VM if a change needs to be seen.
+
+A change to how Omarchy itself behaves belongs upstream, not here — Nixarchy tracks
+Omarchy releases as a source bump, so a fix landed upstream arrives here for free,
+whereas a patch carried here has to be re-applied at every bump.

--- a/pkgs/omarchy/skills/nixos/SKILL.md
+++ b/pkgs/omarchy/skills/nixos/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: nixos
+description: >
+  REQUIRED for installing, removing or updating software on this NixOS machine, and
+  for any change outside ~/.config/ — system services, users, hardware, boot,
+  networking, fonts, or Home Manager. Use when asked to install an app or package,
+  enable a service or daemon, change a system setting, edit configuration.nix or a
+  flake, run nixos-rebuild, roll back a broken system, search for a package or
+  option, or explain why a change did not survive a reboot. Triggers: install,
+  uninstall, add package, nixpkgs, nixos-rebuild, flake, generation, rollback,
+  systemPackages, home-manager, apps.nix, nixarchy-apply, "make it permanent".
+  For desktop appearance and Hyprland config, use the `nixarchy` skill instead.
+---
+
+# NixOS Skill
+
+Make changes to this machine that **last**.
+
+The single rule that governs everything below: **NixOS is declarative. A package
+installed imperatively does not survive the next rebuild.** There is no
+`apt install`, no `pacman -S`, no `pip install --user` that belongs in a system
+change here. If a request would normally end in an install command, it ends in a
+file edit and a rebuild instead.
+
+## Decide Which Route to Take
+
+Three routes exist on a Nixarchy machine. Pick the highest one that fits.
+
+| The request | Route |
+|---|---|
+| An app Nixarchy already knows about | **`nixarchy-app-enable <id>`**, then `nixarchy-apply` |
+| Any other package, service, or system setting | **Edit the flake**, then `nixos-rebuild switch` |
+| A one-off, throwaway try — not a change to the machine | **`nix shell nixpkgs#<pkg>`** |
+
+Never reach past route 1 for an app it covers: it writes the same file the Install
+menu writes, so the menu and the flake stay in agreement.
+
+**`nix-env -i` and `nix profile install` are not routes.** They create imperative
+user state that no file records, that a rebuild does not reproduce, and that is
+invisible to anyone reading the configuration. If you find yourself typing either,
+the answer is route 2.
+
+## Route 1: Apps Nixarchy Knows
+
+Nixarchy maps the apps Omarchy's Install menu offers onto Nix. The selection lives
+in one file, fully populated and entirely commented out:
+
+```
+~/.config/nixarchy/apps.nix
+```
+
+Enabling an app uncomments one line. Nothing is built until you apply.
+
+```bash
+nixarchy-app-enable brave        # uncomment the line
+nixarchy-app-disable brave       # re-comment it
+nixarchy-apply                   # copy the selection into the flake, then rebuild
+```
+
+`nixarchy-apply` does three things: prints what is enabled, copies
+`~/.config/nixarchy/apps.nix` to `<flake>/nixarchy-apps.nix`, and offers to run
+`sudo nixos-rebuild switch --flake <flake>`.
+
+**The copy is necessary and the import is the user's job.** A flake cannot read a
+file outside its own tree, so the selection has to be copied in. Something in the
+flake then has to import it:
+
+```nix
+imports = [ ./nixarchy-apps.nix ];   # path relative to the file you add it to
+```
+
+Without that line every app looks enabled, the rebuild runs to completion, and
+nothing is installed. `nixarchy-apply` warns loudly when nothing imports the file —
+**if you see that warning, fix it before doing anything else.** It is the single
+most common reason a Nixarchy install "does nothing".
+
+To find out which apps are mapped, and which of them you already have:
+
+```bash
+nix run github:olafkfreund/nixarchy#doctor
+```
+
+Some apps are not plain packages and are wired as NixOS modules instead — Steam
+needs an FHS wrapper, 1Password a setuid helper, Tailscale a daemon, Firefox its
+policy module. `nixarchy-app-enable` already knows which is which; that is why it
+exists rather than a `systemPackages` line.
+
+## Route 2: Edit the Flake
+
+For everything else. First, find where the configuration lives:
+
+```bash
+echo "${NIXARCHY_FLAKE:-/etc/nixos}"       # what Nixarchy's own commands use
+```
+
+`programs.nixarchy.flake` sets that. It is often not `/etc/nixos` — many people keep
+their configuration in a git repo under `~`. Confirm before editing anything.
+
+### Adding a package
+
+```nix
+environment.systemPackages = with pkgs; [
+  ripgrep
+  jq
+];
+```
+
+For one user rather than the whole machine, and if Home Manager is in use:
+
+```nix
+home.packages = with pkgs; [ ripgrep ];
+```
+
+### Enabling a service
+
+Prefer the module over the package almost every time. A package puts a binary on
+`PATH`; the module also creates the unit, the user, the firewall hole and the state
+directory.
+
+```nix
+services.tailscale.enable = true;
+programs.steam.enable = true;
+```
+
+### Finding the right name
+
+Guessing attribute names wastes rebuilds. Search first:
+
+```bash
+nix search nixpkgs ripgrep                 # packages
+man configuration.nix                      # options, offline
+```
+
+Or use <https://search.nixos.org/packages> and <https://search.nixos.org/options>.
+The package attribute and the command it installs often differ — `vscode` puts
+`code` on `PATH`, `obs-studio` puts `obs`. Check `meta.mainProgram` when unsure:
+
+```bash
+nix eval --raw nixpkgs#vscode.meta.mainProgram
+```
+
+### Applying it
+
+```bash
+sudo nixos-rebuild switch --flake "${NIXARCHY_FLAKE:-/etc/nixos}"
+```
+
+Useful variants:
+
+```bash
+# Build and check it works, but do not make it the default at boot
+sudo nixos-rebuild test --flake <flake>
+
+# Build only — no activation. Safest way to check an edit evaluates
+nixos-rebuild build --flake <flake>
+
+# Make it the boot default without switching now
+sudo nixos-rebuild boot --flake <flake>
+```
+
+**Prefer `build` or `test` while iterating**, and `switch` once it is right.
+
+If the flake is a git repository, **Nix ignores untracked files**. A newly created
+`.nix` file that has not been `git add`ed produces `path does not exist` or is
+silently absent from the build. `git add` it before rebuilding.
+
+## Route 3: Try Without Installing
+
+For a one-off — checking whether a tool does what the user wants, running something
+once:
+
+```bash
+nix shell nixpkgs#ripgrep       # a shell with it on PATH; leaves nothing behind
+nix run nixpkgs#ripgrep -- --version
+```
+
+Say clearly that this is temporary. If the user wants to keep it, that is route 1 or 2.
+
+## Updating
+
+```bash
+omarchy update      # nix flake update + nixos-rebuild switch, with a confirmation
+```
+
+Or by hand:
+
+```bash
+nix flake update --flake <flake>          # move every input forward
+nix flake update nixpkgs --flake <flake>  # move just one
+sudo nixos-rebuild switch --flake <flake>
+```
+
+`nix flake update` rewrites `flake.lock`, so the flake directory has to be writable
+by the user running it. A root-owned `/etc/nixos` fails with a permission error on
+the lock file.
+
+## When Something Breaks
+
+This is NixOS's best feature and the most under-used. **The previous working system
+is still on disk.**
+
+```bash
+sudo nixos-rebuild --rollback switch      # back one generation, now
+sudo nix-env --list-generations --profile /nix/var/nix/profiles/system
+```
+
+Or reboot and pick an older generation from the boot menu. Nothing is lost by trying
+a change.
+
+To see what actually changed between two generations:
+
+```bash
+nix profile diff-closures --profile /nix/var/nix/profiles/system
+```
+
+That is the honest answer to "what did that update change?" and it is far better
+evidence than a package log.
+
+### Reading a failure
+
+- **`error: attribute 'foo' missing`** — wrong package name. Search for the real one.
+- **`error: The option 'services.foo' does not exist`** — wrong option path, or the module is not imported. Check <https://search.nixos.org/options>.
+- **`error: path '/nix/store/...' does not exist` on a file you just created** — untracked in git. `git add` it.
+- **`infinite recursion encountered`** — usually a `config` value used to compute something it also defines. Look for a self-reference.
+- **unfree licence errors** — a single unfree package aborts the whole rebuild. Set `nixpkgs.config.allowUnfree = true;` deliberately, or drop the package.
+
+## Rules
+
+- **Read the file before editing it.** Configurations are personal; match the style and structure already there.
+- **Never install imperatively** to "get it working now, declare it later". It will be forgotten, and it will vanish at the next rebuild while looking like it worked.
+- **Show the user the diff before rebuilding.** A rebuild is fast to undo but slow to run; a wrong attribute name found by reading is cheaper than one found by building.
+- **Do not run `nix flake update` as a fix.** It moves every input and changes far more than the problem at hand. Update one input, or none.
+- **Do not garbage-collect to free space unless asked.** `nix-collect-garbage -d` deletes every old generation, which is exactly the rollback safety net above.
+- **A rebuild needs `sudo`; evaluation does not.** Use `nixos-rebuild build` freely to check work without a password prompt.
+
+## Example Requests
+
+- "Install Brave" -> `nixarchy-app-enable brave && nixarchy-apply` (route 1)
+- "Install ripgrep" -> add to `environment.systemPackages`, rebuild (route 2)
+- "Enable Tailscale" -> `services.tailscale.enable = true;` — the module, not the package
+- "Try out helix quickly" -> `nix shell nixpkgs#helix`, and say it is temporary
+- "My package disappeared after reboot" -> it was installed imperatively; declare it properly
+- "Update my system" -> `omarchy update`
+- "That update broke my desktop" -> `sudo nixos-rebuild --rollback switch`, then diff the closures
+- "Add a font" -> `fonts.packages = [ pkgs.<name> ];` — fonts are registered, not just installed
+- "What changed in the last update?" -> `nix profile diff-closures --profile /nix/var/nix/profiles/system`
+- "Change my wallpaper / theme / keybinding" -> NOT this skill. Use the `nixarchy` skill


### PR DESCRIPTION
Omarchy ships agent skills, and `omarchy-provision-user` symlinks every directory under `default/agents/skills/` into `~/.claude/skills`, `~/.agents/skills`, `~/.codex/skills` and `~/.pi/agent/skills`. Whatever is there is what an AI agent on the machine is told to do — and this repo was shipping upstream's Arch-written skills verbatim.

## What was wrong

- **11 broken paths.** Every `/usr/share/omarchy/` reference; here that is a read-only store path.
- **The package-install instruction was backwards.** `SKILL.md` told the agent to use `omarchy pkg add`, which this repo replaced with a script that deliberately refuses.
- **`hooks.md`** documented `pre-refresh-pacman.d/`, which never fires here.
- **The declarative model was invisible.** Nothing mentioned `apps.nix`, the Install menu, `nixarchy-apply` or `nixos-rebuild`, so an agent asked to install something had no correct move available.

The path errors fail loudly. The missing model does not — it makes a capable agent do something imperative that the next rebuild silently erases.

## What changed

| skill | |
|---|---|
| `omarchy` → **`nixarchy`** | renamed and corrected; decision framework now hands package installs off instead of answering them wrongly |
| **`nixos`** | new — `apps.nix`, Install menu, `nixos-rebuild`, generations, rollback, option search |
| `diagnose-crash` | patched; keeps its name because `bin/omarchy-agent-crash` reads that path literally |

`diagnose-crash` gets three non-cosmetic corrections: no public debuginfod serves nixpkgs builds (explains `nixseparatedebuginfod` instead of Arch's server), "recent package updates" becomes `nix profile diff-closures`, and a report now has two possible destinations.

## Drift protection

`SKILL.md` and `contributing.md` are replaced outright; everything else is patched with `--replace-fail`, so an Omarchy bump that rewords a line we depend on fails the build rather than quietly restoring Arch instructions.

Every pattern and replacement is single-line on purpose — `nix fmt` re-indents multi-line strings in this expression and silently breaks a literal match. That happened once while writing this.

CI asserts the skill set, that each `SKILL.md` frontmatter name matches its directory, that `diagnose-crash/SKILL.md` still exists where `omarchy-agent-crash` looks for it, and that **no fenced code block** contains a pacman, yay, `/usr/share/omarchy` or Arch-debuginfod line. Prose may contrast with Arch on purpose; a code block is what an agent copies. Verified by planting a violation and watching it fire.

## Verification

- `nix build .#omarchy` — clean
- `nix fmt -- --ci`, `statix check`, `deadnix --fail` — all clean
- Shipped tree is `diagnose-crash/ nixarchy/ nixos/`, frontmatter names match, no actionable Arch-isms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5