### PR TITLE
omarchy reinstall does exist here, it just cannot finish

### DIFF
--- a/pkgs/omarchy/skills/nixarchy/SKILL.md
+++ b/pkgs/omarchy/skills/nixarchy/SKILL.md
@@ -300,9 +300,14 @@ omarchy refresh <app>
 omarchy refresh config <config-file>
 ```
 
-**There is no `omarchy reinstall` here.** Upstream's nuclear option re-runs the Arch
-installer. The equivalent on NixOS is better: the previous working system is still on
-disk as a generation.
+**`omarchy reinstall` exists but cannot finish here.** Its first act is
+`omarchy-reinstall-pkgs`, which runs `pacman -Suu`. The shim refuses, `set -e` aborts
+the script, and `omarchy-reinstall-configs` never runs. The ordering is safe — it
+fails before touching anything — but it does mean the command is not a recovery
+route, despite prompting as though it were.
+
+To reset configs, use `omarchy refresh <app>` above. For anything else, the previous
+working system is still on disk as a generation:
 
 ```bash
 sudo nixos-rebuild --rollback switch    # back to the previous generation


### PR DESCRIPTION
Live-testing the new `nixarchy` skill against a running nixarchy machine caught a false claim in it.

The skill said **"There is no `omarchy reinstall` here."** It is a real route — `omarchy commands --json` lists it, and `bin/omarchy-reinstall` is upstream's, unreplaced.

What is actually true is subtler:

```
omarchy-reinstall
  └─ omarchy-reinstall-pkgs      →  pacman -Suu  →  shim exits 1  →  set -e aborts
     omarchy-reinstall-configs   →  never runs
```

So it prompts as though it were a recovery route and is not one — though it fails in the safe order, before touching any config.

An agent told "there is no such command" would have contradicted a user looking at it in the menu.

## Verified on a live machine

- `omarchy commands --json` lists `omarchy reinstall` → `omarchy-reinstall`
- `pacman -Suu` exits `1` via the shim
- `omarchy pkg add ripgrep` exits `1` (the skill's existing claim — correct)
- `omarchy screenshot` / `omarchy screenrecord` are declared aliases and dispatch
- All three skills' frontmatter parses; all relative links resolve
- Route 1 round-trip: `nixarchy-app-enable helix` → line uncommented, "2 queued" → `nixarchy-app-disable helix` → byte-identical revert
- Desktop flow: appended `gaps_out = 20` → `hyprctl reload` ok, no configerrors, live gaps 10→20 → reverted → 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5