### PR TITLE
Relink agent skills on every rebuild, not once ever

### DIFF
--- a/modules/home.nix
+++ b/modules/home.nix
@@ -349,6 +349,49 @@ in
             "${config.xdg.configHome}/omarchy/extensions/omarchy-menu.jsonc"
         fi
 
+        # Agent skills, relinked on every activation.
+        #
+        # Upstream does this in omarchy-provision-user, which is guarded by a
+        # `finalize-user` marker and therefore runs exactly once, ever. That is
+        # fine on Arch, where the skill directory is a fixed path that gets
+        # overwritten in place. Here every bump moves the package to a new store
+        # path, so a once-only link points at the previous one -- still resolving
+        # until it is garbage-collected, then dangling. Renaming the `omarchy`
+        # skill to `nixarchy` made it worse than stale: the machine kept serving
+        # the old Arch skill from a path nothing would update again.
+        #
+        # provision-user's own --force would fix the links and also replay
+        # /etc/skel over $HOME, which is not a thing to do for four symlinks.
+        # So: the same loop, declaratively, on every rebuild.
+        #
+        # Only symlinks whose target is itself a skills directory in the store
+        # are removed. That is what distinguishes a link this module or
+        # provision-user planted from a skill the user wrote by hand, which is a
+        # real directory and is never touched.
+        ${
+          let
+            skillsDir = "${omarchyPath}/default/agents/skills";
+          in
+          ''
+            for agentdir in .agents/skills .claude/skills .codex/skills .pi/agent/skills; do
+              dest="${config.home.homeDirectory}/$agentdir"
+              run mkdir -p "$dest"
+
+              for link in "$dest"/*; do
+                [ -L "$link" ] || continue
+                case "$(readlink "$link")" in
+                  /nix/store/*/agents/skills/*) run rm -f "$link" ;;
+                esac
+              done
+
+              ${pkgs.findutils}/bin/find ${skillsDir} -mindepth 1 -maxdepth 1 -type d |
+                while read -r skill; do
+                  run ln -sfn "$skill" "$dest/$(basename "$skill")"
+                done
+            done
+          ''
+        }
+
         # Declared plugins, linked in by the id their manifest claims.
         #
         # A symlink rather than a copy, and that is a supported shape rather
@@ -382,7 +425,7 @@ in
             fi
             run rm -f "${manifest}"
             ${lib.concatMapStringsSep "
-" (drv: ''
+        " (drv: ''
               id=$(cat ${drv}/id)
               if [ -e "${dir}/$id" ] && [ ! -L "${dir}/$id" ]; then
                 echo "nixarchy: ${dir}/$id is your own directory, not replacing it"

--- a/pkgs/omarchy/default.nix
+++ b/pkgs/omarchy/default.nix
@@ -769,6 +769,7 @@ stdenvNoCC.mkDerivation {
                   --replace-fail 'DEBUGINFOD_URLS="https://debuginfod.archlinux.org" \' 'DEBUGINFOD_URLS="''${DEBUGINFOD_URLS:-}" \' \
                   --replace-fail '- **Recent package updates.** A crash that starts right after an update points at' '- **Recent system generations.** A crash that starts right after a rebuild points at' \
                   --replace-fail '  the update.' '  the rebuild. `nix profile diff-closures --profile /nix/var/nix/profiles/system` names exactly what changed between generations — stronger evidence than any package log — and `sudo nixos-rebuild --rollback switch` tests the theory in one command.' \
+                  --replace-fail '  Covers reporting a confirmed Omarchy bug upstream — see reporting.md.' '  Covers reporting a confirmed Nixarchy or Omarchy bug — see reporting.md.' \
                   --replace-fail '## If it is an Omarchy bug' '## If it is a Nixarchy or Omarchy bug' \
                   --replace-fail 'Most application crashes are upstream bugs in those applications, not Omarchy'"'"'s' 'Most application crashes are upstream bugs in those applications, not the distribution'"'"'s' \
                   --replace-fail 'doing. In the minority of cases where the cause really does sit within Omarchy'"'"'s' 'doing. In the minority of cases where the cause really does sit within Nixarchy'"'"'s or Omarchy'"'"'s'


### PR DESCRIPTION
## The bug, observed on a real host

`omarchy-provision-user` symlinks every skill into `~/.claude/skills`, `~/.agents/skills`, `~/.codex/skills` and `~/.pi/agent/skills` — and is guarded by a `finalize-user` marker, so it runs **exactly once in a machine's life**.

That works on Arch, where the skill directory is a fixed path overwritten in place. Here every bump moves the package to a new store path, so a once-only link points at the previous one: resolving until it is garbage-collected, dangling after.

Renaming `omarchy` → `nixarchy` turned stale into wrong. After rebuilding onto that change:

```
new closure:        diagnose-crash  nixarchy  nixos
~/.claude/skills:   omarchy -> /nix/store/<previous>/…/agents/skills/omarchy  [still resolving]
                    nixarchy -> ABSENT
                    nixos    -> ABSENT
```

The machine went on serving the old Arch skill from a store path nothing would ever update again — the exact failure the rename was meant to end.

## The fix

The same loop, declaratively, in `modules/home.nix`, on every activation.

`provision-user --force` would have fixed the links and also replayed `/etc/skel` over `$HOME` — not a proportionate thing to do for four symlinks.

**Only symlinks whose target is itself a store `agents/skills/` directory are removed.** That is what separates a link this module or `provision-user` planted from a skill the user wrote by hand, which is a real directory and is never touched. Same principle as the plugins block above it, without needing its `.nixarchy-managed` manifest, because here the target is self-identifying.

## Also: the last Arch leftover

`diagnose-crash`'s frontmatter still read *"Covers reporting a confirmed Omarchy bug upstream"*. The body already routes to both projects; the description is what an agent reads to decide relevance. CI could not catch it — it greps fenced code blocks, and frontmatter is neither.

## Verification

- `nix build .#omarchy` — frontmatter now reads "Nixarchy or Omarchy"
- `nix build .#checks.x86_64-linux.vm-toplevel` — home.nix evaluates and builds
- `nix fmt -- --ci`, `statix check`, `deadnix --fail` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5