### PR TITLE
Stop racing systemd-logind, and test the skill links

### DIFF
--- a/tests/coexist.nix
+++ b/tests/coexist.nix
@@ -85,7 +85,13 @@ pkgs.testers.runNixOSTest {
 
     # The bus the launch below needs belongs to the user manager, which
     # autologin starts -- so wait for it rather than assume it is up.
-    machine.wait_for_unit("user@1000.service")
+    # systemd-logind starts user@1000.service asynchronously once the session
+    # opens, so there is a window where the unit is inactive with no job queued
+    # yet. wait_for_unit treats exactly that as a hard failure -- it raises
+    # "is inactive and there are no pending jobs" immediately rather than
+    # waiting -- so on a loaded runner it fails a session that was about to come
+    # up fine. Poll for "active" instead, which tolerates the window.
+    machine.wait_until_succeeds("systemctl is-active user@1000.service")
     machine.wait_until_succeeds("test -S /run/user/1000/bus")
 
     # Launch the session the way a greeter would: whatever Exec= says.

--- a/tests/demo.nix
+++ b/tests/demo.nix
@@ -186,11 +186,14 @@ let
           " | grep -q 'Authentication for user .*omarchy.* successful'")
 
       # ---- the desktop ---------------------------------------------------
-      # A generous timeout rather than the default: authentication succeeding
-      # and the user manager being up are separated by however long it takes
-      # this machine to start one, and the default expired on a workstation
-      # busy building something else.
-      machine.wait_for_unit("user@1000.service", timeout=180)
+      # Poll rather than wait_for_unit, and not for the reason this comment
+      # used to give. The failure here was never a timeout -- wait_for_unit
+      # defaults to fifteen minutes and no workstation takes that long to start
+      # a user manager. systemd-logind starts user@1000.service asynchronously
+      # once the session opens, and wait_for_unit raises "is inactive and there
+      # are no pending jobs" the moment it looks during that window. The
+      # timeout=180 that used to be here addressed the wrong mechanism.
+      machine.wait_until_succeeds("systemctl is-active user@1000.service")
       # -f, matching the whole command line, not -x, matching the process name
       # exactly: on NixOS the running binary is a wrapper, so its name is not
       # literally "quickshell" and -x waits forever on a shell that is up and

--- a/tests/plugin.nix
+++ b/tests/plugin.nix
@@ -131,7 +131,13 @@ pkgs.testers.runNixOSTest {
     PLUGINS = json.loads(r"""${pluginJSON}""")
 
     machine.wait_for_unit("multi-user.target")
-    machine.wait_for_unit("user@1000.service")
+    # systemd-logind starts user@1000.service asynchronously once the session
+    # opens, so there is a window where the unit is inactive with no job queued
+    # yet. wait_for_unit treats exactly that as a hard failure -- it raises
+    # "is inactive and there are no pending jobs" immediately rather than
+    # waiting -- so on a loaded runner it fails a session that was about to come
+    # up fine. Poll for "active" instead, which tolerates the window.
+    machine.wait_until_succeeds("systemctl is-active user@1000.service")
     machine.wait_until_succeeds("test -S /run/user/1000/bus")
 
     # Bring the session up the way the greeter would, exactly as coexist does.

--- a/tests/session.nix
+++ b/tests/session.nix
@@ -213,7 +213,13 @@ pkgs.testers.runNixOSTest {
         " | grep -q 'Authentication for user .*omarchy.* successful'")
 
     # ---- session -------------------------------------------------------
-    machine.wait_for_unit("user@1000.service")
+    # systemd-logind starts user@1000.service asynchronously once the session
+    # opens, so there is a window where the unit is inactive with no job queued
+    # yet. wait_for_unit treats exactly that as a hard failure -- it raises
+    # "is inactive and there are no pending jobs" immediately rather than
+    # waiting -- so on a loaded runner it fails a session that was about to come
+    # up fine. Poll for "active" instead, which tolerates the window.
+    machine.wait_until_succeeds("systemctl is-active user@1000.service")
 
     # Long enough for omarchy-launch-shell to exhaust its supervision budget:
     # it gives up after 5 relaunches inside one minute.
@@ -318,6 +324,36 @@ pkgs.testers.runNixOSTest {
     machine.succeed("test -s /home/omarchy/.config/starship.toml")
     machine.succeed("test -s /home/omarchy/.config/tmux/tmux.conf")
     machine.succeed("test -s /home/omarchy/.config/foot/foot.ini")
+
+    # Agent skills, linked into all four agent homes by the activation script
+    # in modules/home.nix rather than by omarchy-provision-user.
+    #
+    # provision-user does this too, and is guarded by a finalize-user marker, so
+    # it runs once in a machine's life. That is fine on Arch, where the skill
+    # directory is a fixed path overwritten in place, and wrong here: every bump
+    # moves the package to a new store path, so a once-only link keeps pointing
+    # at the previous one. A machine that took the omarchy -> nixarchy rename
+    # went on serving the old Arch skill from a path nothing would update again,
+    # which is what this asserts against.
+    #
+    # The names matter as much as the links: an agent keys on the directory
+    # name, so `omarchy` still being here would mean the rename never reached
+    # the only place it is read.
+    for home in [".agents/skills", ".claude/skills", ".codex/skills",
+                 ".pi/agent/skills"]:
+        for skill in ["nixarchy", "nixos", "diagnose-crash"]:
+            machine.succeed(f"test -L /home/omarchy/{home}/{skill}")
+            # -e follows the link: a link into a store path that is not in this
+            # closure would pass -L and fail here, which is the stale case.
+            machine.succeed(f"test -e /home/omarchy/{home}/{skill}/SKILL.md")
+        machine.fail(f"test -e /home/omarchy/{home}/omarchy")
+    print("agent skills linked into all four agent homes, under the new names")
+
+    # bin/omarchy-agent-crash reads this path literally, so the rename must
+    # never reach it.
+    machine.succeed(
+        "grep -q 'agents/skills/diagnose-crash/SKILL.md' "
+        "$(readlink -f /run/current-system/sw/bin/omarchy-agent-crash)")
 
     # btop.conf asks for a theme literally named "current"; without the link
     # btop starts with no theme at all.


### PR DESCRIPTION
## The race

`checks.plugin` failed CI on #23 with:

```
RequestedAssertionFailed: unit "user@1000.service" is inactive and there are no pending jobs
```

**That is not a timeout.** From the test driver:

```python
if state == "inactive":
    status, jobs = self.systemctl("list-jobs --full 2>&1", user)
    if "No jobs" in jobs:
        ...
        raise RequestedAssertionFailed(
            f'unit "{unit}" is inactive and there are no pending jobs'
        )
```

`wait_for_unit` polls, but hard-fails the instant it finds `ActiveState=inactive` with no queued job. `systemd-logind` starts `user@1000.service` asynchronously after the session opens, so that window is reachable — and on a loaded runner `wait_for_unit` lands in it and fails a session that was about to come up fine.

## It was already here, and already misread

`tests/demo.nix` carried:

> *A generous timeout rather than the default: … the default expired on a workstation busy building something else.*
> `machine.wait_for_unit("user@1000.service", timeout=180)`

`wait_for_unit` defaults to **fifteen minutes**. No workstation takes that long to start a user manager. The timeout addressed the wrong mechanism, which is why it kept recurring.

## The fix

All four sites poll for `active` instead:

```python
machine.wait_until_succeeds("systemctl is-active user@1000.service")
```

Fixing only `plugin.nix` would have left the same race in `coexist`, `session` and `demo`. It fired in `plugin` because that node also starts `dockerd` and is slowest to boot.

## Plus the test #23 shipped without

Nothing verified the skill links land in a booted session — exactly what broke. `session.nix` now asserts:

- all three skills linked in all four agent homes
- each resolves to a `SKILL.md` **inside this closure** — a stale link passes `-L` and fails `-e`, which is the case that matters
- `omarchy` is gone
- `omarchy-agent-crash` still points at `diagnose-crash`

## Verification

| | |
|---|---|
| `checks.coexist` | PASS locally |
| `checks.plugin` | PASS locally |
| `checks.session` | PASS locally, with the new assertions — confirmed by the assertion's print appearing in the build log |
| CI re-run of the failed job, no code change | passed — which is what identified this as a race, not a regression |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5