### PR TITLE
Package the HEY CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the parts that assume Arch, rather than reimplementing it in Nix.
 Tracking an upstream release is a source bump, not a re-port.
 
 What that buys you: the Install menu writes to a Nix config instead of running
-pacman, **52 applications** are selectable that way, plugins and themes still
+pacman, **53 applications** are selectable that way, plugins and themes still
 install from a git URL at runtime the way upstream intends, and every command
 that assumed `/usr` either points at what NixOS uses or says why it cannot.
 
@@ -41,7 +41,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | **Install menu** | picks write to a Nix config, not pacman |
 | **Remove menu** | deselects apps, never touches your own config |
 | **Update menu** | `nix flake update` + `nixos-rebuild switch --flake` |
-| 52 apps in the selection | 41 from nixpkgs, 5 as NixOS modules, 4 built here, 2 with no equivalent |
+| 53 apps in the selection | 41 from nixpkgs, 5 as NixOS modules, 5 built here, 2 with no equivalent |
 | Learn menu | NixOS wiki, `search.nixos.org` packages and options |
 | Shell functions | bash and zsh source the chain; fish derives it from the same files |
 | RetroArch | 13 libretro cores, resolved from the store rather than `/usr/lib` |
@@ -673,7 +673,7 @@ done
 
 Almost nothing here waits on a maintainer.
 
-**46 of the 52 apps never touch this repo.** Brave, VSCode, Signal and the rest
+**46 of the 53 apps never touch this repo.** Brave, VSCode, Signal and the rest
 are installed as `pkgs.<name>` from **your** nixpkgs, and the five
 module-backed ones (Steam, 1Password, Tailscale, Firefox, Xbox controllers)
 come from there too — the module is NixOS', not this repo's. Your own
@@ -713,7 +713,7 @@ Most of it is not our job, and should not be:
 
 | where the app comes from | who updates it |
 |---|---|
-| nixpkgs (46 of 52 apps) | **nobody** — your own `nix flake update` |
+| nixpkgs (46 of 53 apps) | **nobody** — your own `nix flake update` |
 | pinned in this repo (2) | a weekly bot, opening a PR |
 | `zen` | upstream's own flake |
 | `retroarch` | nixpkgs, via this flake's own pin — it is a rebuild with cores |

--- a/data/apps.nix
+++ b/data/apps.nix
@@ -364,6 +364,23 @@
     attr = "t3code";
     arch = "t3code-bin";
   };
+  hey-cli = {
+    # No menuId: Omarchy v4.0.1 ships no HEY row at all -- hey.com/agents asks
+    # for "Omarchy 4.1 or later", which is unreleased, and v4.0.1's AI group is
+    # chatgpt/dictation/grok-bot/lm-studio/ollama. The package is available now
+    # as programs.nixarchy.apps.hey-cli; the menu row arrives with the omarchy
+    # bump. The generator fails on a menuId upstream does not ship, which is
+    # what keeps this honest.
+    #
+    # `hey-cli` rather than `hey`, because nixpkgs already has a `hey` and it is
+    # an unrelated HTTP load generator. The binary still installs as `hey`; see
+    # meta.mainProgram in pkgs/apps/hey-cli.nix, which is what the Install menu
+    # and nixarchy-doctor use to notice you already have it.
+    label = "HEY CLI";
+    category = "AI";
+    attr = "hey-cli";
+    ours = true;
+  };
   once = {
     menuId = "install.service.once";
     label = "ONCE";

--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,10 @@
           once = final.callPackage ./pkgs/apps/once.nix { };
           grok-bot = final.callPackage ./pkgs/apps/grok-bot.nix { };
 
+          # nixpkgs' `hey` is an unrelated HTTP load generator, so this cannot
+          # simply follow nixpkgs the way most apps here do.
+          hey-cli = final.callPackage ./pkgs/apps/hey-cli.nix { };
+
           # nixpkgs' `retroarch` is `retroarch-with-cores` built with an
           # EMPTY core list, so installing it gives an emulator that can run
           # nothing. `retroarch-full` is the obvious fix and the wrong one:
@@ -198,7 +202,12 @@
           pkgs = pkgsFor.${system};
         };
 
-        inherit (pkgsFor.${system}.nixarchy-apps) once grok-bot retroarch;
+        inherit (pkgsFor.${system}.nixarchy-apps)
+          once
+          grok-bot
+          retroarch
+          hey-cli
+          ;
 
         # Re-exported so programs.nixarchy.apps.zen resolves like any other
         # `ours` app, without every consumer needing the extra flake input.

--- a/pkgs/apps/hey-cli.nix
+++ b/pkgs/apps/hey-cli.nix
@@ -1,0 +1,141 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  writeShellApplication,
+  curl,
+  jq,
+  gnused,
+  nix,
+  coreutils,
+  gnugrep,
+}:
+let
+  version = "1.3.0";
+
+  # Straight from the release's own checksums.txt, which upstream signs with a
+  # keyless Sigstore bundle -- not from a local download. Same reasoning as
+  # pkgs/apps/once.nix: these should be the artefacts basecamp published, not
+  # whatever a machine here happened to fetch.
+  hashes = {
+    "x86_64-linux" = "2ac446d3b974f53bdefde0ef233c994b135db97e5d714b6dda94b635d0b29454";
+    "aarch64-linux" = "e4b4023723186c6c6192c26174f4691237e6a23fedf11cf2832c040dda779775";
+  };
+  arches = {
+    "x86_64-linux" = "amd64";
+    "aarch64-linux" = "arm64";
+  };
+
+  sources = lib.mapAttrs (
+    system: sha256:
+    fetchurl {
+      url = "https://github.com/basecamp/hey-cli/releases/download/v${version}/hey_${version}_linux_${arches.${system}}.tar.gz";
+      inherit sha256;
+    }
+  ) hashes;
+in
+stdenvNoCC.mkDerivation {
+  pname = "hey-cli";
+  inherit version;
+
+  src =
+    sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "hey-cli: no binary published for ${stdenvNoCC.hostPlatform.system}");
+
+  # The tarball is just the binary and its docs, with no directory above them.
+  sourceRoot = ".";
+  strictDeps = true;
+
+  # No autoPatchelfHook, unlike once: upstream ships a statically linked Go
+  # binary, so there is no interpreter to rewrite and nothing to link against.
+  # Verified rather than assumed --
+  #   hey: ELF 64-bit LSB executable, x86-64, statically linked, Go, stripped
+  # and the unpatched binary runs on NixOS. Adding the hook anyway would be
+  # harmless but would say something untrue about why this works.
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 hey $out/bin/hey
+    runHook postInstall
+  '';
+
+  # Same shape as once's, and here for the same reason: the updater has to move
+  # both architectures together or it produces a tree that builds on x86 and
+  # not on ARM. CI proves every rewrite with a build before it can be committed
+  # (.github/workflows/update.yml), and those PRs are merged by a human because
+  # a build is not proof the CLI still talks to HEY.
+  passthru.updateScript = writeShellApplication {
+    name = "update-hey-cli";
+    runtimeInputs = [
+      curl
+      jq
+      gnused
+      nix
+      coreutils
+      gnugrep
+    ];
+    text = ''
+      file="''${1:-pkgs/apps/hey-cli.nix}"
+      [ -f "$file" ] || { echo "no $file (run from the repo root)" >&2; exit 1; }
+
+      current=$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' "$file" | head -1)
+      latest=$(curl -fsSL https://api.github.com/repos/basecamp/hey-cli/releases/latest \
+        | jq -r '.tag_name' | sed 's/^v//')
+
+      if [ -z "$latest" ] || [ "$latest" = "null" ]; then
+        echo "hey-cli: could not read a release tag from GitHub" >&2
+        exit 1
+      fi
+      if [ "$current" = "$latest" ]; then
+        echo "hey-cli: already at $latest"
+        exit 0
+      fi
+      echo "hey-cli: $current -> $latest"
+
+      # Upstream publishes a checksums.txt per release, so take the hashes from
+      # it rather than re-downloading two 37 MB tarballs to compute what they
+      # already state.
+      sums=$(curl -fsSL "https://github.com/basecamp/hey-cli/releases/download/v$latest/checksums.txt")
+
+      for pair in "x86_64-linux:amd64" "aarch64-linux:arm64"; do
+        key=''${pair%%:*}
+        arch=''${pair##*:}
+        hex=$(echo "$sums" | grep "hey_''${latest}_linux_''${arch}.tar.gz" | cut -d' ' -f1 || true)
+        if [ -z "$hex" ]; then
+          echo "hey-cli: checksums.txt names no hey_''${latest}_linux_''${arch}.tar.gz" >&2
+          exit 1
+        fi
+        before=$(grep -c "$hex" "$file" || true)
+        sed -i -E "s|(\"$key\"[[:space:]]*=[[:space:]]*)\"[0-9a-f]{64}\"|\1\"$hex\"|" "$file"
+        after=$(grep -c "$hex" "$file" || true)
+        if [ "$before" = "$after" ]; then
+          # A bumped version beside a stale hash builds nowhere and reports
+          # success here, so refuse rather than hand that to a reviewer.
+          echo "hey-cli: could not rewrite the hash for '$key' in $file" >&2
+          exit 1
+        fi
+      done
+
+      sed -i -E "0,/version = \"[^\"]*\"/s//version = \"$latest\"/" "$file"
+      echo "hey-cli: rewrote $file to $latest"
+    '';
+  };
+
+  meta = {
+    description = "CLI and TUI for HEY email, and the interface HEY Agents drives";
+    homepage = "https://www.hey.com/agents/";
+    downloadPage = "https://github.com/basecamp/hey-cli/releases";
+    license = lib.licenses.mit;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
+    # nixpkgs already has a `hey` and it is an unrelated HTTP load generator,
+    # so the attribute is hey-cli while the binary keeps upstream's name. The
+    # Install menu and nixarchy-doctor both key on mainProgram to decide
+    # whether an app is already present, and would look for `hey-cli` without
+    # this -- which is the vscode/code trap the doctor exists to avoid.
+    mainProgram = "hey";
+  };
+}


### PR DESCRIPTION
[hey.com/agents](https://www.hey.com/agents/) points coding agents at a `hey` CLI installed with `curl -fsSL https://hey.com/install-cli | bash`, which drops a 37 MB binary into `~/.local/bin`. That works on NixOS — it survives rebuilds because `$HOME` isn't managed by Nix — but nothing records it, no flake update moves it, and a machine rebuilt from the same configuration doesn't have it.

## Why it's simpler than `once`

Upstream ships a **statically linked** Go binary — verified, not assumed:

```
hey: ELF 64-bit LSB executable, x86-64, statically linked, Go, stripped
$ ./hey --version
hey version 1.3.0        # unpatched, on NixOS
```

So no `autoPatchelfHook`, unlike `once`, which this otherwise copies.

## Provenance

Hashes come from the release's own `checksums.txt` — which upstream signs with a keyless Sigstore bundle — rather than from a local download. The `updateScript` reads that same file instead of re-fetching two 37 MB tarballs to recompute what it already states.

## Two naming traps handled

- **Attribute is `hey-cli`**, because nixpkgs already has a `hey` and it's an unrelated HTTP load generator.
- **`meta.mainProgram = "hey"`**, because the Install menu and `nixarchy-doctor` key on it to decide whether you already have an app. Without it they'd look for a command called `hey-cli`. Same trap as `vscode` shipping `code`.

## No menuId, following `t3-code`

Omarchy v4.0.1 ships **no HEY row at all** — its AI group is `chatgpt`/`dictation`/`grok-bot`/`lm-studio`/`ollama` — and hey.com/agents asks for "Omarchy 4.1 or later", which is unreleased. Usable now as `programs.nixarchy.apps.hey-cli`; the menu row arrives with the omarchy bump. Declaring a menuId upstream doesn't ship fails the generator.

## Verification

- `nix build .#hey-cli` → `./result/bin/hey --version` → `hey version 1.3.0`
- `checks.options` and `checks.integration` pass
- Module wiring: a config with `apps.hey-cli.enable = true` puts `hey-cli` in `systemPackages`
- README counts updated 52 → 53 (CI asserts these against `data/apps.nix`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5