### PR TITLE
The menu jsonc is the one file under ~/.config/omarchy you cannot edit

### DIFF
--- a/pkgs/omarchy/skills/nixarchy/SKILL.md
+++ b/pkgs/omarchy/skills/nixarchy/SKILL.md
@@ -136,7 +136,7 @@ Nixarchy is built on:
 | **NixOS** | Base OS | The flake (see the `nixos` skill), `~/.config/` |
 | **Hyprland** | Wayland compositor/WM | `~/.config/hypr/` |
 | **Omarchy shell** | Status bar + notifications (Quickshell) | `~/.config/omarchy/shell.json` |
-| **Launcher/menus** | Quickshell menu | `~/.config/omarchy/extensions/omarchy-menu.jsonc` |
+| **Launcher/menus** | Quickshell menu | `programs.nixarchy.menu.extraEntries` — the jsonc is generated, see below |
 | **Alacritty/Foot/Kitty/Ghostty** | Terminals | `~/.config/<terminal>/` |
 | **Omarchy OSD** | On-screen display | Quickshell plugin |
 
@@ -245,12 +245,47 @@ cp ~/.config/hypr/bindings.lua ~/.config/hypr/bindings.lua.bak.$(date +%s)
 # 4. Apply changes
 # - Hyprland: auto-reloads on save, but MUST validate with `hyprctl reload` and `hyprctl configerrors`
 # - Omarchy shell: shell.json and user plugin code under ~/.config/omarchy/plugins/ hot-reload on save
-# - Menus/launcher: ~/.config/omarchy/extensions/omarchy-menu.jsonc hot-reloads on save
+# - Menus/launcher: NOT editable here -- see "The menu is generated" below
 # - Terminals: apply with `omarchy restart terminal` (reloads running terminals; foot picks changes up in new windows)
 ```
 
 None of this needs a rebuild. That is the point of the boundary: desktop
 customization is immediate, and only the flake half requires `nixos-rebuild`.
+
+### The menu is generated, not yours to edit
+
+`~/.config/omarchy/extensions/omarchy-menu.jsonc` is the one file under
+`~/.config/omarchy/` that is **not** editable. It is a symlink to a read-only
+`/nix/store` path:
+
+```
+~/.config/omarchy/extensions/omarchy-menu.jsonc -> /etc/nixarchy/omarchy-menu.jsonc -> /nix/store/...
+```
+
+That is deliberate. This file carries the rewrite that points every `install.*`
+row at the Nix app selection instead of pacman, so it has to track the package.
+A copy would go stale the moment the package moved and leave the Install menu
+driving commands that no longer match.
+
+Upstream's documentation says this file hot-reloads on save. It does — but you
+cannot save it, and trying is worse than failing: replacing the symlink with a
+real file silently stops the menu tracking the package, and the next rebuild
+overwrites it anyway.
+
+Add rows declaratively instead:
+
+```nix
+programs.nixarchy.menu.extraEntries = {
+  "personal.notes" = {
+    icon = "󰎞";
+    label = "Notes";
+    action = "omarchy-launch-editor ~/notes";
+  };
+};
+```
+
+Nothing else in `~/.config/omarchy/` works this way — `shell.json`, the themes
+and the plugins directory are all real, writable, and yours.
 
 If a file under `~/.config/` turns out to be a symlink into `/nix/store`, it is
 managed by Home Manager and editing it is not possible. Change it in your Home


### PR DESCRIPTION
The `nixarchy` skill carried upstream's line verbatim:

> `# - Menus/launcher: ~/.config/omarchy/extensions/omarchy-menu.jsonc hot-reloads on save`

It does hot-reload. **It cannot be saved.**

```
~/.config/omarchy/extensions/omarchy-menu.jsonc
  -> /etc/nixarchy/omarchy-menu.jsonc
  -> /nix/store/…-nixarchy-omarchy-menu.jsonc     (not writable)
```

That's deliberate — `modules/home.nix` generates it because it carries the rewrite pointing every `install.*` row at the Nix app selection instead of pacman, so it has to track the package. A seeded copy would go stale the moment the package moved and leave the Install menu driving commands that no longer match.

The architecture table had the same problem, naming the jsonc as the config location with nothing to say it's read-only.

## Why this one mattered

This is the exact failure the skills rewrite existed to prevent, and it survived it.

An agent told to add a menu row would try to write a store path, fail, and plausibly "fix" that by replacing the symlink with a real file — which silently stops tracking the package and is overwritten at the next rebuild anyway. Wrong instructions that fail loudly are cheap. This one invites a repair that looks like it worked.

## The fix

Both lines now point at `programs.nixarchy.menu.extraEntries`, and a new section explains *why* the file is generated, so the next agent meets the reason rather than only the prohibition.

It also says plainly that **nothing else** under `~/.config/omarchy/` behaves this way — `shell.json`, the themes and the plugins directory are all real, writable files — because a rule that sounds broader than it is would send someone hunting for a declarative option that doesn't exist.

## No CI assertion

"Does the skill claim an editable path is editable" isn't mechanically checkable. The fenced-code-block guard added in #21 already covers the class of error that is.

## Provenance

Found by the user asking whether the read-only symlink stopped anything. It stops nothing at runtime — I grepped every shipped script for writers to `extensions/` and the only two hits are the guarded v3→v4 migration and a Chromium extensions path — but it stopped the documentation from being true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5