### PR TITLE
Package omawrite and omacalc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the parts that assume Arch, rather than reimplementing it in Nix.
 Tracking an upstream release is a source bump, not a re-port.
 
 What that buys you: the Install menu writes to a Nix config instead of running
-pacman, **53 applications** are selectable that way, plugins and themes still
+pacman, **55 applications** are selectable that way, plugins and themes still
 install from a git URL at runtime the way upstream intends, and every command
 that assumed `/usr` either points at what NixOS uses or says why it cannot.
 
@@ -41,7 +41,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | **Install menu** | picks write to a Nix config, not pacman |
 | **Remove menu** | deselects apps, never touches your own config |
 | **Update menu** | `nix flake update` + `nixos-rebuild switch --flake` |
-| 53 apps in the selection | 41 from nixpkgs, 5 as NixOS modules, 5 built here, 2 with no equivalent |
+| 55 apps in the selection | 41 from nixpkgs, 5 as NixOS modules, 7 built here, 2 with no equivalent |
 | Learn menu | NixOS wiki, `search.nixos.org` packages and options |
 | Shell functions | bash and zsh source the chain; fish derives it from the same files |
 | RetroArch | 13 libretro cores, resolved from the store rather than `/usr/lib` |
@@ -673,7 +673,7 @@ done
 
 Almost nothing here waits on a maintainer.
 
-**46 of the 53 apps never touch this repo.** Brave, VSCode, Signal and the rest
+**46 of the 55 apps never touch this repo.** Brave, VSCode, Signal and the rest
 are installed as `pkgs.<name>` from **your** nixpkgs, and the five
 module-backed ones (Steam, 1Password, Tailscale, Firefox, Xbox controllers)
 come from there too — the module is NixOS', not this repo's. Your own
@@ -713,7 +713,7 @@ Most of it is not our job, and should not be:
 
 | where the app comes from | who updates it |
 |---|---|
-| nixpkgs (46 of 53 apps) | **nobody** — your own `nix flake update` |
+| nixpkgs (46 of 55 apps) | **nobody** — your own `nix flake update` |
 | pinned in this repo (2) | a weekly bot, opening a PR |
 | `zen` | upstream's own flake |
 | `retroarch` | nixpkgs, via this flake's own pin — it is a rebuild with cores |

--- a/data/apps.nix
+++ b/data/apps.nix
@@ -364,6 +364,24 @@
     attr = "t3code";
     arch = "t3code-bin";
   };
+  omawrite = {
+    # No menuId: Omarchy has no install row for its own applications -- upstream
+    # installs omawrite, omacalc, omacut and aether as preinstalls instead. Here
+    # they cannot be preinstalls, because nixpkgs carries none of them, so this
+    # is the opt-in form: programs.nixarchy.apps.omawrite.
+    label = "Omawrite";
+    category = "Utility";
+    attr = "omawrite";
+    ours = true;
+  };
+  omacalc = {
+    # As omawrite. Ships no .desktop of its own, so the package writes one --
+    # see pkgs/apps/omacalc.nix.
+    label = "Omacalc";
+    category = "Utility";
+    attr = "omacalc";
+    ours = true;
+  };
   hey-cli = {
     # No menuId: Omarchy v4.0.1 ships no HEY row at all -- hey.com/agents asks
     # for "Omarchy 4.1 or later", which is unreleased, and v4.0.1's AI group is

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,12 @@
           # simply follow nixpkgs the way most apps here do.
           hey-cli = final.callPackage ./pkgs/apps/hey-cli.nix { };
 
+          # Two of the four applications Omarchy writes itself. nixpkgs has
+          # none of them, which is why modules/nixos.nix cannot reproduce
+          # upstream's preinstall set; these two close half that gap.
+          omawrite = final.callPackage ./pkgs/apps/omawrite.nix { };
+          omacalc = final.callPackage ./pkgs/apps/omacalc.nix { };
+
           # nixpkgs' `retroarch` is `retroarch-with-cores` built with an
           # EMPTY core list, so installing it gives an emulator that can run
           # nothing. `retroarch-full` is the obvious fix and the wrong one:
@@ -207,6 +213,8 @@
           grok-bot
           retroarch
           hey-cli
+          omawrite
+          omacalc
           ;
 
         # Re-exported so programs.nixarchy.apps.zen resolves like any other

--- a/pkgs/apps/omacalc.nix
+++ b/pkgs/apps/omacalc.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  qt6,
+  makeDesktopItem,
+  copyDesktopItems,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "omacalc";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "omacom";
+    repo = "omacalc";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-I+WxkMz/2hCf4OpJKu99+30c0CxyxFD0M6eSLFDLs1I=";
+  };
+
+  # Sibling of pkgs/apps/omawrite.nix, and the same reasoning: one of the four
+  # applications Omarchy writes itself, none of which are in nixpkgs. Available
+  # through programs.nixarchy.apps.omacalc rather than added to the preinstalls,
+  # because upstream installing it by default is not a reason to put a
+  # calculator on a machine that did not ask for one.
+  nativeBuildInputs = [
+    qt6.qmake
+    qt6.wrapQtAppsHook
+    copyDesktopItems
+  ];
+
+  # QT += core gui qml quick quickcontrols2 dbus -- qtbase and qtdeclarative
+  # between them. One module short of omawrite, which also pulls widgets,
+  # printsupport and quickdialogs2.
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative
+  ];
+
+  # Unlike omawrite, this repo ships no pkgbuild/ -- no .desktop, no icon, only
+  # a screenshot. So the entry is written here. Without one the app installs as
+  # a bare binary: nothing in the launcher, nothing in Omarchy's app menu, and
+  # a GUI calculator you can start only from a terminal is not much of one.
+  #
+  # No Icon= because there is no icon to point at. An entry naming a missing
+  # icon renders as a broken tile; one naming none falls back to the generic,
+  # which looks deliberate.
+  desktopItems = [
+    (makeDesktopItem {
+      name = "omacalc";
+      desktopName = "Omacalc";
+      comment = "Calculator";
+      exec = "omacalc";
+      categories = [
+        "Utility"
+        "Calculator"
+      ];
+      keywords = [
+        "calculator"
+        "math"
+      ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 omacalc $out/bin/omacalc
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Calculator built with Qt Quick, from the Omarchy family";
+    homepage = "https://github.com/omacom/omacalc";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "omacalc";
+  };
+})

--- a/pkgs/apps/omawrite.nix
+++ b/pkgs/apps/omawrite.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  qt6,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "omawrite";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "omacom";
+    repo = "omawrite";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yS3GOL/kc03qx4naWzUdSZwAYxMuCjvrgmhexpwjsfA=";
+  };
+
+  # One of the four applications Omarchy writes itself and installs as a
+  # preinstall. nixpkgs carries none of them, which is why modules/nixos.nix
+  # lists omawrite among the preinstalls it cannot reproduce. Built here so it
+  # is at least available to anyone who wants it.
+  #
+  # Not added to the preinstall set: upstream installs it by default, but a
+  # NixOS user who never asked for a Markdown editor should not get one from a
+  # desktop port. Enable programs.nixarchy.apps.omawrite for it.
+  nativeBuildInputs = [
+    qt6.qmake
+    qt6.wrapQtAppsHook
+  ];
+
+  # QT += ... in omawrite.pro: core gui widgets printsupport dbus come from
+  # qtbase; qml quick quickcontrols2 quickdialogs2 from qtdeclarative.
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative
+  ];
+
+  # Upstream's bin/build is qmake + make with no arguments, which is what the
+  # qmake hook already does. Running their script instead would need a writable
+  # $ROOT/build and buy nothing.
+  #
+  # Fonts are compiled in through src/resources.qrc, so nothing has to be
+  # installed beside the binary for them -- the PKGBUILD copies fonts/OFL.txt
+  # only as a licence.
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 omawrite $out/bin/omawrite
+    install -Dm644 $src/pkgbuild/omawrite.desktop \
+      $out/share/applications/omawrite.desktop
+    install -Dm644 $src/pkgbuild/omawrite.svg \
+      $out/share/icons/hicolor/scalable/apps/omawrite.svg
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Dead-simple Markdown writing app built with Qt Quick";
+    homepage = "https://github.com/omacom/omawrite";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "omawrite";
+
+    # The PKGBUILD also depends on xdg-desktop-portal, for the file dialogs
+    # quickdialogs2 opens. That is a system service on NixOS (xdg.portal), not
+    # something to put in buildInputs, and Omarchy's own module already enables
+    # one -- so it is named here rather than depended on.
+    longDescription = ''
+      File dialogs go through xdg-desktop-portal. Nixarchy's session enables a
+      portal already; on a machine without one, the app runs but Open and Save
+      do nothing.
+    '';
+  };
+})


### PR DESCRIPTION
`modules/nixos.nix` says six of upstream's thirteen preinstalls can't be carried here, naming **aether, omacut, omacalc and omawrite** as *"Omarchy's own applications, not packaged in nixpkgs"*. Two of those four are now packaged — half that gap closes.

## Shape

Both are qmake Qt6 apps. `qtbase` + `qtdeclarative` cover every module their `.pro` files ask for (`core gui qml quick quickcontrols2 dbus`, plus `widgets printsupport quickdialogs2` for omawrite). Fonts are compiled in via `src/resources.qrc`, so nothing installs beside the binary — upstream's PKGBUILD copies `fonts/OFL.txt` only as a licence.

Built from tags with the qmake hook rather than by running upstream's `bin/build`, which is `qmake && make` with no arguments and would want a writable `$ROOT/build` for no gain.

## Opt-in, not preinstalls

Upstream installs both by default. Here they're `programs.nixarchy.apps.omawrite` / `.omacalc` — a NixOS user who never asked for a Markdown editor or a calculator shouldn't get them from a desktop port.

No `menuId` for either: Omarchy ships no install row for its own applications, because upstream has no reason to — they're preinstalls there. Declaring a menuId upstream doesn't ship fails the generator.

## omacalc needed a desktop entry written for it

It ships no `pkgbuild/` — no `.desktop`, no icon, only a screenshot. So the package writes one with `makeDesktopItem`. Without it you get a bare binary: nothing in the launcher, nothing in Omarchy's app menu, and a GUI calculator you can only start from a terminal isn't much of one.

No `Icon=` line, because there's no icon to name and an entry pointing at a missing one renders as a broken tile.

## One runtime note

omawrite's file dialogs go through `xdg-desktop-portal`, which its PKGBUILD depends on. That's a system service on NixOS, not a `buildInput`, and Omarchy's module already enables a portal — so `meta.longDescription` names it rather than depending on it.

## Verification

- `nix build .#omawrite` and `.#omacalc` — both OK, Qt wrapping applied
- Enabling both puts them in `systemPackages`: `{ omacalc = true; omawrite = true; }`
- `checks.options`, `checks.integration` — pass
- README counts 53 → 55 (CI asserts these against `data/apps.nix`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5