### PR TITLE
Package omacut and ttfx

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the parts that assume Arch, rather than reimplementing it in Nix.
 Tracking an upstream release is a source bump, not a re-port.
 
 What that buys you: the Install menu writes to a Nix config instead of running
-pacman, **55 applications** are selectable that way, plugins and themes still
+pacman, **57 applications** are selectable that way, plugins and themes still
 install from a git URL at runtime the way upstream intends, and every command
 that assumed `/usr` either points at what NixOS uses or says why it cannot.
 
@@ -41,7 +41,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | **Install menu** | picks write to a Nix config, not pacman |
 | **Remove menu** | deselects apps, never touches your own config |
 | **Update menu** | `nix flake update` + `nixos-rebuild switch --flake` |
-| 55 apps in the selection | 41 from nixpkgs, 5 as NixOS modules, 7 built here, 2 with no equivalent |
+| 57 apps in the selection | 41 from nixpkgs, 5 as NixOS modules, 9 built here, 2 with no equivalent |
 | Learn menu | NixOS wiki, `search.nixos.org` packages and options |
 | Shell functions | bash and zsh source the chain; fish derives it from the same files |
 | RetroArch | 13 libretro cores, resolved from the store rather than `/usr/lib` |
@@ -673,7 +673,7 @@ done
 
 Almost nothing here waits on a maintainer.
 
-**46 of the 55 apps never touch this repo.** Brave, VSCode, Signal and the rest
+**46 of the 57 apps never touch this repo.** Brave, VSCode, Signal and the rest
 are installed as `pkgs.<name>` from **your** nixpkgs, and the five
 module-backed ones (Steam, 1Password, Tailscale, Firefox, Xbox controllers)
 come from there too — the module is NixOS', not this repo's. Your own
@@ -713,7 +713,7 @@ Most of it is not our job, and should not be:
 
 | where the app comes from | who updates it |
 |---|---|
-| nixpkgs (46 of 55 apps) | **nobody** — your own `nix flake update` |
+| nixpkgs (46 of 57 apps) | **nobody** — your own `nix flake update` |
 | pinned in this repo (2) | a weekly bot, opening a PR |
 | `zen` | upstream's own flake |
 | `retroarch` | nixpkgs, via this flake's own pin — it is a rebuild with cores |

--- a/data/apps.nix
+++ b/data/apps.nix
@@ -382,6 +382,23 @@
     attr = "omacalc";
     ours = true;
   };
+  omacut = {
+    # As omawrite and omacalc. Needs ffmpeg at runtime, which the package wraps
+    # in rather than adding to systemPackages -- see pkgs/apps/omacut.nix.
+    label = "Omacut";
+    category = "Utility";
+    attr = "omacut";
+    ours = true;
+  };
+  ttfx = {
+    # Not an Omarchy preinstall and not in any Omarchy menu -- a terminal
+    # text-effects binary from the same authors, offered here because it was
+    # asked for. Available as programs.nixarchy.apps.ttfx.
+    label = "ttfx";
+    category = "Utility";
+    attr = "ttfx";
+    ours = true;
+  };
   hey-cli = {
     # No menuId: Omarchy v4.0.1 ships no HEY row at all -- hey.com/agents asks
     # for "Omarchy 4.1 or later", which is unreleased, and v4.0.1's AI group is

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,11 @@
           # upstream's preinstall set; these two close half that gap.
           omawrite = final.callPackage ./pkgs/apps/omawrite.nix { };
           omacalc = final.callPackage ./pkgs/apps/omacalc.nix { };
+          omacut = final.callPackage ./pkgs/apps/omacut.nix { };
+
+          # Not one of Omarchy's preinstalls -- a terminal-effects toy from the
+          # same authors, packaged because it was asked for.
+          ttfx = final.callPackage ./pkgs/apps/ttfx.nix { };
 
           # nixpkgs' `retroarch` is `retroarch-with-cores` built with an
           # EMPTY core list, so installing it gives an emulator that can run
@@ -215,6 +220,8 @@
           hey-cli
           omawrite
           omacalc
+          omacut
+          ttfx
           ;
 
         # Re-exported so programs.nixarchy.apps.zen resolves like any other

--- a/pkgs/apps/omacut.nix
+++ b/pkgs/apps/omacut.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  qt6,
+  ffmpeg,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "omacut";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "omacom";
+    repo = "omacut";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-g6xtaj6XSkP4B49H6McLQXV2pK9y0i2MwSF8R341mxw=";
+  };
+
+  # Third of the four applications Omarchy writes itself; see
+  # pkgs/apps/omawrite.nix for why they are packaged here and why none of them
+  # joins programs.nixarchy.preinstalls.
+  nativeBuildInputs = [
+    qt6.qmake
+    qt6.wrapQtAppsHook
+  ];
+
+  # One module more than its siblings: omacut.pro asks for multimedia, for the
+  # video preview it trims against.
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtmultimedia
+  ];
+
+  # ffmpeg is a runtime dependency, not a build one -- upstream's PKGBUILD puts
+  # it in depends= rather than makedepends=, because the app shells out to it to
+  # do the actual cut. Left off PATH it builds, installs, launches, previews the
+  # video, and then fails at the one thing it exists for. Wrapped rather than
+  # added to the module's systemPackages: nothing a user types needs ffmpeg
+  # here, only this binary does.
+  qtWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ ffmpeg ]}" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 omacut $out/bin/omacut
+    install -Dm644 $src/pkgbuild/omacut.desktop \
+      $out/share/applications/omacut.desktop
+    install -Dm644 $src/pkgbuild/omacut.svg \
+      $out/share/icons/hicolor/scalable/apps/omacut.svg
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Cut a video to the right trim, built with Qt Quick";
+    homepage = "https://github.com/omacom/omacut";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "omacut";
+  };
+})

--- a/pkgs/apps/ttfx.nix
+++ b/pkgs/apps/ttfx.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  rustPlatform,
+  installShellFiles,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ttfx";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "omacom";
+    repo = "ttfx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bwFjC6ZkZibkgXjoYVH2VuqqeXklGR9kmRl2fTitWBU=";
+  };
+
+  cargoHash = "sha256-DNrg12MNqBcQi6yvoJObM1gtE90iGBCxeQ3RwueYCE4=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  # `--print-completion <SHELL>`, not a `completions` subcommand -- and bash and
+  # zsh only, which is what clap_complete is wired for here. Generated from the
+  # binary rather than written out, so they cannot drift from its arguments.
+  postInstall = ''
+    installShellCompletion --cmd ttfx \
+      --bash <($out/bin/ttfx --print-completion bash) \
+      --zsh  <($out/bin/ttfx --print-completion zsh)
+  '';
+
+  meta = {
+    description = "Terminal text effects as a single static binary, a Rust port of terminaltexteffects";
+    homepage = "https://github.com/omacom/ttfx";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "ttfx";
+  };
+})


### PR DESCRIPTION
`omacut` is the third of the four applications Omarchy writes itself — and the last straightforward one. `ttfx` isn't an Omarchy app at all: a terminal text-effects binary from the same authors, packaged because it was asked for.

## omacut

Follows `omawrite` exactly, plus two things its siblings don't need:

- **`qtmultimedia`** — its `.pro` asks for `multimedia`, for the video preview it trims against.
- **`ffmpeg` at runtime, not build time.** Upstream's PKGBUILD puts it in `depends=` rather than `makedepends=`, because the app shells out to it to do the actual cut. Left off `PATH` it builds, installs, launches, previews the video — and then fails at the one thing it exists for. Wrapped into the binary via `qtWrapperArgs` rather than added to `systemPackages`: nothing a user types needs ffmpeg here, only this program does.

## ttfx

Small Rust binary, three dependencies. Completions come from `--print-completion <SHELL>` — **not** a `completions` subcommand — and bash/zsh only. My first attempt asked for a subcommand that doesn't exist and for fish, which it doesn't emit; the build failed on zero-size completion files rather than shipping them. Now generated from the binary so they can't drift from its arguments.

## Not attempted: aether

Worth stating rather than quietly skipping. Two reasons it's a different-sized job:

1. **Licence.** Its README says MIT, but the repository carries **no LICENSE file** and GitHub detects none.
2. **Build.** Go + Wails with an npm frontend (`wails.json`, `package-lock.json`), which needs a fixed-output npm dependency hash on top of the Go one.

That deserves its own change, not a footnote to four qmake apps.

## Verification

- `nix build` for `omacut`, `ttfx`, `omawrite`, `omacalc` — all OK
- `checks.options`, `checks.integration` — pass
- README counts 55 → 57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5