### PR TITLE
A rebuild does not update a running session, and now we say so

### DIFF
--- a/pkgs/doctor.sh
+++ b/pkgs/doctor.sh
@@ -161,6 +161,37 @@ else
 fi
 say ""
 
+# ---- is the running session actually on the installed build? -------------
+# A rebuild cannot change the environment of a graphical session that is
+# already running. OMARCHY_PATH and PATH are set at login and keep pointing at
+# whichever store path was current then, so every omarchy-* command the session
+# runs -- every keybinding, every menu row -- comes from the old package until
+# the user logs out and back in.
+#
+# On Arch this cannot happen: the files live at a fixed /usr/share/omarchy that
+# is overwritten in place, so a running session picks up a new version
+# immediately. Here the path itself changes, which is why this needs saying.
+#
+# It cost an evening to find. A web-app keybinding kept failing after the bug
+# behind it had been fixed and the system rebuilt, because the session was
+# still executing the previous build's copy of the script.
+if [ -n "${OMARCHY_PATH:-}" ] && [ -e "$sw/bin/omarchy" ]; then
+  say "${bold}Session${off}"
+  installed=$(readlink -f "$sw/bin/omarchy" | sed 's|/bin/omarchy$||')
+  if [ "$OMARCHY_PATH" != "$installed" ]; then
+    finding "This session is running an older build" "$warn" ""
+    say "     ${dim}session:   $OMARCHY_PATH${off}"
+    say "     ${dim}installed: $installed${off}"
+    say "     Log out and back in. A rebuild cannot change a running session's"
+    say "     environment, so until you do, every keybinding and menu row still"
+    say "     runs the old package -- including anything you just fixed."
+    notes+=("Your session's OMARCHY_PATH points at an older store path than the installed package. Log out and back in; until then every omarchy-* command the desktop runs comes from the previous build, which is the usual reason a fix 'did not work'.")
+  else
+    finding "Session is on the installed build" "$ok" ""
+  fi
+  say ""
+fi
+
 # ---- the default browser, and whether the menu can change it -------------
 # Setup > Default browser runs omarchy-default-browser, which ends in
 #

--- a/pkgs/omarchy/skills/nixarchy/SKILL.md
+++ b/pkgs/omarchy/skills/nixarchy/SKILL.md
@@ -252,6 +252,31 @@ cp ~/.config/hypr/bindings.lua ~/.config/hypr/bindings.lua.bak.$(date +%s)
 None of this needs a rebuild. That is the point of the boundary: desktop
 customization is immediate, and only the flake half requires `nixos-rebuild`.
 
+### A rebuild does not update a running session
+
+`OMARCHY_PATH` and `PATH` are set at login and keep pointing at whichever store
+path was current then. A `nixos-rebuild switch` installs a new package at a new
+path and **cannot change the environment of a session that is already running**,
+so every `omarchy-*` command the desktop executes — every keybinding, every menu
+row — comes from the old build until the user logs out and back in.
+
+```bash
+# what the session is running vs what is installed
+echo "$OMARCHY_PATH"
+readlink -f /run/current-system/sw/bin/omarchy | sed 's|/bin/omarchy$||'
+```
+
+If they differ, say so and stop. **Do not conclude a fix failed**, and do not
+test one by running the script at its absolute installed path — that path works
+while the keybinding still does not, which looks like the fix working and is the
+most misleading result available here.
+
+This is NixOS-specific. On Arch the tree lives at a fixed `/usr/share/omarchy`
+that is overwritten in place, so a running session picks up a new version at
+once. Here the path itself changes.
+
+`nixarchy-doctor` reports this under **Session**.
+
 ### The menu is generated, not yours to edit
 
 `~/.config/omarchy/extensions/omarchy-menu.jsonc` is the one file under


### PR DESCRIPTION
`OMARCHY_PATH` and `PATH` are set at login and keep pointing at whichever store path was current then. `nixos-rebuild switch` installs a new package at a **new path** and cannot change the environment of a session that is already running — so every `omarchy-*` command the desktop executes comes from the old build until the user logs out and back in.

## This cost an evening

A web-app keybinding kept failing *after* the bug behind it was fixed and the system rebuilt. It took comparing `omarchy-shell`'s `/proc/PID/environ` against the installed closure to see why:

```
session (pid 1620291): /nix/store/x6gff51rwh7v6i8rkmn1l5nfr2f14pdv-…/share/omarchy
live package         : /nix/store/n1wp8pyzfnf0v9gysqdfq3nfmn8ql8sp-…/share/omarchy
```

Worse: the obvious way to test a fix — run the script at its absolute installed path — **works**, while the keybinding still doesn't. So the fix looks correct and the bug report looks wrong. That's the most misleading result available here, and it's the default one.

It's NixOS-specific. On Arch the tree lives at a fixed `/usr/share/omarchy` overwritten in place, so a running session picks up a new version at once. Here the path itself changes — exactly the kind of difference the skills exist to state.

## Two changes

**`pkgs/doctor.sh`** grows a `Session` section:

```
Session
  This session is running an older build
     session:   /nix/store/x6gff51…/share/omarchy
     installed: /nix/store/n1wp8pyz…/share/omarchy
     Log out and back in. A rebuild cannot change a running session's
     environment, so until you do, every keybinding and menu row still
     runs the old package -- including anything you just fixed.
```

Matching path reports one green line instead.

**The `nixarchy` skill** grows a section telling an agent to check this before concluding a fix failed — and specifically **not** to verify by absolute path.

## Verification

- Both branches tested: match → one green line; mismatch → both paths plus the collected note
- `shellcheck` clean (`writeShellApplication` fails on warnings)
- Skills code-block assertion still clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5