### PR TITLE
Point the SDDM greeter at the Hyprland config we already ship

### DIFF
--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -577,9 +577,19 @@ in
         # in nixpkgs tests a Hyprland greeter. mkDefault, so a machine that
         # would rather keep weston -- or has its own answer -- only has to say
         # so.
-        wayland.compositorCommand = lib.mkDefault (
-          "${config.programs.hyprland.package}/bin/Hyprland --config "
-          + "${cfg.package}/share/omarchy/default/sddm/hyprland.lua"
+        #
+        # Guarded by cfg.displayManager, like `enable` above and unlike
+        # `theme`: someone who turned this module's display-manager handling
+        # off has their own greeter arrangement, and replacing its compositor
+        # underneath them is not a default to help itself to. The VM tests are
+        # exactly that case -- they set displayManager = false and bring their
+        # own SDDM -- and an unguarded definition put a Hyprland greeter into
+        # every one of them.
+        wayland.compositorCommand = lib.mkIf cfg.displayManager (
+          lib.mkDefault (
+            "${config.programs.hyprland.package}/bin/Hyprland --config "
+            + "${cfg.package}/share/omarchy/default/sddm/hyprland.lua"
+          )
         );
       };
 

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -549,6 +549,38 @@ in
         # Without this SDDM uses its own stock theme -- a blue gradient with a
         # placeholder avatar -- as the first screen of an Omarchy machine.
         theme = lib.mkDefault "omarchy";
+
+        # etc/sddm.conf.d/10-wayland.conf, which was the one part of upstream's
+        # SDDM configuration this module never carried:
+        #
+        #     CompositorCommand=start-hyprland -- --config /usr/share/sddm/hyprland.lua
+        #
+        # The package vendors that greeter config at default/sddm/hyprland.lua
+        # -- animations off, no logo, no splash -- and until now nothing pointed
+        # at it. NixOS defaults the greeter compositor to `weston --shell=kiosk`,
+        # so weston won by omission and the vendored file was dead weight.
+        #
+        # That is not merely cosmetic. On a hybrid NVIDIA laptop weston's
+        # greeter does not come up at all: sddm-helper exits 1 with
+        # SDDM::Auth::HELPER_TTY_ERROR, systemd hits the restart limit, and the
+        # machine is left with no login manager. Hyprland is already the
+        # compositor the session itself runs on that hardware.
+        #
+        # `Hyprland` rather than upstream's `start-hyprland -- ...`: that
+        # wrapper wants a systemd user session the greeter user does not have
+        # when programs.hyprland.withUWSM is on, and SDDM execs this string
+        # itself rather than parsing it out of an INI file, so the `--`
+        # separator upstream needs has no meaning here.
+        #
+        # Off-label, and worth saying so: nixpkgs types this option `internal`
+        # and offers only weston and kwin through wayland.compositor, so nothing
+        # in nixpkgs tests a Hyprland greeter. mkDefault, so a machine that
+        # would rather keep weston -- or has its own answer -- only has to say
+        # so.
+        wayland.compositorCommand = lib.mkDefault (
+          "${config.programs.hyprland.package}/bin/Hyprland --config "
+          + "${cfg.package}/share/omarchy/default/sddm/hyprland.lua"
+        );
       };
 
       # Left at mkDefault true rather than derived from services.pulseaudio:

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -78,6 +78,32 @@ let
       off = (configWith { displayManager = false; }).services.displayManager.sddm.enable;
     };
 
+    # The greeter compositor. NixOS defaults this to weston, which on hybrid
+    # NVIDIA never comes up -- and the vendored default/sddm/hyprland.lua that
+    # replaces it was shipped for a long time with nothing pointing at it. The
+    # "off" half is a user who set their own: mkDefault has to yield, or this
+    # takes weston away from someone who asked for it.
+    #
+    # Asserting on the whole string rather than merely that it is non-empty:
+    # the option has a default, so "set" is true either way, and what matters
+    # is that it names Hyprland and the vendored config.
+    greeterCompositor =
+      let
+        cmd =
+          (configWith { displayManager = true; }).services.displayManager.sddm.wayland.compositorCommand;
+      in
+      {
+        on = (builtins.match ".*/bin/Hyprland --config .*/default/sddm/hyprland[.]lua" cmd) != null;
+        # Same predicate as `on`, against a config that set its own: false is
+        # the pass here, because mkDefault must have yielded.
+        off =
+          (builtins.match ".*/bin/Hyprland --config .*/default/sddm/hyprland[.]lua" (
+            (configBeside {
+              services.displayManager.sddm.wayland.compositorCommand = "weston --shell=kiosk";
+            }).services.displayManager.sddm.wayland.compositorCommand
+          )) != null;
+      };
+
     binaryCaches = {
       on =
         builtins.elem "https://nixarchy.cachix.org"

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -89,19 +89,23 @@ let
     # is that it names Hyprland and the vendored config.
     greeterCompositor =
       let
-        cmd =
-          (configWith { displayManager = true; }).services.displayManager.sddm.wayland.compositorCommand;
+        greeterCmd = cfg: cfg.services.displayManager.sddm.wayland.compositorCommand;
+        isOurs = cmd: builtins.match ".*/bin/Hyprland --config .*/default/sddm/hyprland[.]lua" cmd != null;
       in
       {
-        on = (builtins.match ".*/bin/Hyprland --config .*/default/sddm/hyprland[.]lua" cmd) != null;
-        # Same predicate as `on`, against a config that set its own: false is
-        # the pass here, because mkDefault must have yielded.
-        off =
-          (builtins.match ".*/bin/Hyprland --config .*/default/sddm/hyprland[.]lua" (
-            (configBeside {
-              services.displayManager.sddm.wayland.compositorCommand = "weston --shell=kiosk";
-            }).services.displayManager.sddm.wayland.compositorCommand
-          )) != null;
+        on = isOurs (
+          greeterCmd (configWith {
+            displayManager = true;
+          })
+        );
+
+        # Same predicate, against a config that set its own: false is the pass
+        # here, because mkDefault has to yield to it.
+        off = isOurs (
+          greeterCmd (configBeside {
+            services.displayManager.sddm.wayland.compositorCommand = "weston --shell=kiosk";
+          })
+        );
       };
 
     binaryCaches = {

--- a/tests/session.nix
+++ b/tests/session.nix
@@ -76,6 +76,23 @@ pkgs.testers.runNixOSTest {
     # shell this test controls.
     environment.sessionVariables.WLR_RENDERER_ALLOW_SOFTWARE = "1";
 
+    # And the greeter, which is a different process in a different environment.
+    # environment.sessionVariables reaches user sessions through PAM; the SDDM
+    # greeter runs as the sddm system user out of display-manager.service and
+    # never sees it.
+    #
+    # This did not matter while the greeter compositor was weston, which starts
+    # without a GPU. It matters now that the module names Hyprland: wlroots
+    # refuses to start without one unless told this is acceptable, so the
+    # greeter died, SDDM never authenticated, and this test sat on the
+    # "Authentication for user omarchy successful" wait until its timeout -- a
+    # hang rather than a failure, which is the slowest way to learn anything.
+    systemd.services.display-manager.environment = {
+      WLR_RENDERER_ALLOW_SOFTWARE = "1";
+      WLR_NO_HARDWARE_CURSORS = "1";
+      LIBGL_ALWAYS_SOFTWARE = "1";
+    };
+
     # No extra GPU device. qemu-vm already gives the machine a display, and
     # machine.screenshot() dumps *that* one -- adding a second sent Hyprland
     # to the new device while the screenshot kept reading the original, which


### PR DESCRIPTION
Upstream's `etc/sddm.conf.d/10-wayland.conf` is one line this module never carried:

```
CompositorCommand=start-hyprland -- --config /usr/share/sddm/hyprland.lua
```

The package has vendored that greeter config since the beginning — `default/sddm/hyprland.lua`, animations off, no logo, no splash — and **nothing has ever pointed at it**. NixOS defaults the greeter compositor to `weston --shell=kiosk`, so weston won by omission and the vendored file was dead weight.

## Not cosmetic

On a hybrid NVIDIA laptop weston's greeter doesn't come up at all:

```
sddm-helper exits 1
SDDM::Auth::HELPER_TTY_ERROR
systemd reaches the restart limit
```

— leaving the machine with **no login manager**, which is worse than a plain-looking greeter, and is how this was found. Hyprland is already the compositor the session runs on that hardware.

## Why `Hyprland`, not upstream's `start-hyprland`

The wrapper wants a systemd user session the greeter user doesn't have when `programs.hyprland.withUWSM` is on, and SDDM execs this string itself rather than parsing it from an INI file — so upstream's `--` separator has no meaning here. Copying the string verbatim carries assumptions true on Arch and not here.

It runs the **same Hyprland as the session**: the package comes from `config.programs.hyprland.package`, which this module already sets to the pinned flake input.

## Off-label, and the comment says so

nixpkgs types `compositorCommand` as `internal = true` and offers only `weston` and `kwin` through `wayland.compositor`:

```nix
compositor = mkOption {
  type = types.enum (builtins.attrNames compositorCmds);   # weston, kwin
  default = "weston";
};
compositorCommand = mkOption {
  type = types.str;
  internal = true;
```

So nothing in nixpkgs exercises a Hyprland greeter. There is no supported path; setting this directly is the only route. `mkDefault`, so anyone who'd rather keep weston only has to say so.

## Verification

`checks.options` gains `greeterCompositor`, asserting both halves per this repo's convention:

- **on** — the command matches `…/bin/Hyprland --config …/default/sddm/hyprland.lua`
- **off** — a config setting its own `compositorCommand` takes it back (mkDefault yields)

Both pass. Resolves to:

```
/nix/store/…-hyprland-0.56.0…/bin/Hyprland --config /nix/store/…-omarchy-4.0.1/share/omarchy/default/sddm/hyprland.lua
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5