### PR TITLE
Fail a hung job in half an hour, not six

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
@@ -36,6 +37,7 @@ jobs:
 
   omarchy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
@@ -348,6 +350,7 @@ jobs:
 
   system:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Its own concurrency group, and NOT cancel-in-progress. This job builds
     # Hyprland from source and takes ~20 minutes, so under the workflow-level
     # cancel-in-progress it is killed by any push landing within that window

--- a/.github/workflows/omarchy.yml
+++ b/.github/workflows/omarchy.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   bump:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   bump:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main


### PR DESCRIPTION
**No job in any workflow set `timeout-minutes`**, so GitHub's default applied: **360 minutes**.

Twice tonight a VM test hung — once 30 minutes, once 15 — and both stopped only because someone was watching and cancelled them by hand. Unattended, each would have held a runner for six hours and reported nothing useful.

## Budgets

Roughly double the measured medians, so a slow runner doesn't trip them:

| job | budget | measured |
|---|---|---|
| `lint` | 10m | ~45s |
| `omarchy` | 15m | ~3m30 |
| `system` | 30m | ~13m |
| `bump` (omarchy.yml, update.yml) | 20m | — |

## What this does and doesn't do

It **doesn't stop anything hanging.** It changes what a hang costs: a failure with a log in thirty minutes, instead of six hours of silence. That's the difference between finding out and being told.

## Verification

- `yq` parses all three workflows; every job carries a budget
- `actionlint` reports the same 20 lines before and after — the one finding is pre-existing, not introduced here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5