### PR TITLE
Disk Usage opened nothing, and LocalSend could not be reached

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,6 +297,39 @@ jobs:
           fi
           echo "all checked runtime commands resolve ($(ls result/bin | wc -l) binaries)"
 
+      - name: Verify every desktop entry's command resolves
+        run: |
+          # The step above checks a hand-written list of command names. That
+          # list was built by grepping bin/, so a command referenced only by a
+          # .desktop file is invisible to it -- which is how "Disk Usage"
+          # shipped launching `dua`, opening a terminal that closed instantly.
+          #
+          # This derives the commands from the entries themselves, so a new
+          # launcher row in a future Omarchy release cannot introduce the same
+          # failure silently.
+          nix build .#omarchy --out-link result-omarchy
+          nix build .#omarchy-runtime --out-link result-runtime
+
+          missing=""
+          for f in result-omarchy/share/omarchy/applications/*.desktop; do
+            exec_line=$(sed -n 's/^Exec=//p' "$f" | head -1)
+            # Either `bash -c "cmd ..."` or a plain command as the first word.
+            cmd=$(printf '%s' "$exec_line" | sed -n 's/.*bash -c "\([a-zA-Z0-9_.-]*\).*/\1/p')
+            [ -z "$cmd" ] && cmd=$(printf '%s' "$exec_line" | awk '{print $1}')
+            [ -z "$cmd" ] && continue
+            # Omarchy's own bins live in the package; everything else must come
+            # from runtimeDeps.
+            if [ ! -x "result-omarchy/bin/$cmd" ] && [ ! -x "result-runtime/bin/$cmd" ]; then
+              missing="$missing $cmd($(basename "$f" .desktop))"
+            fi
+          done
+
+          if [ -n "$missing" ]; then
+            echo "::error::desktop entries launch commands nothing provides:$missing"
+            exit 1
+          fi
+          echo "every desktop entry's command resolves"
+
       - name: Verify the generated menu extension and app template
         run: |
           nix build .#nixosConfigurations.vm.config.system.build.toplevel \

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -644,7 +644,32 @@ in
 
     networking = {
       # install/config/firewall.sh (upstream uses ufw)
-      firewall.enable = lib.mkDefault true;
+      firewall = {
+        enable = lib.mkDefault true;
+
+        # The other half of that script, which this module left behind.
+        # Upstream's is not merely "turn the firewall on":
+        #
+        #     ufw default deny incoming
+        #     ufw allow 53317/udp
+        #     ufw allow 53317/tcp   # "Allow ports for LocalSend."
+        #
+        # Porting only the deny half enables a firewall that blocks the one
+        # service Omarchy's manual promises works out of the box: "Omarchy's
+        # firewall is closed by default except for LocalSend's port, so this
+        # works out of the box on a fresh install." On a machine taking this
+        # module's firewall default it did not -- Share > Receive listened on
+        # 53317 and nothing on the network could reach it.
+        #
+        # Discovery was never the missing part: services.avahi above already
+        # opens 5353. Only LocalSend's own transfer port was closed.
+        #
+        # Not mkDefault: these are list options, so they merge with whatever
+        # the user opens rather than replacing it. A mkDefault list would be
+        # dropped whole the moment they opened a port of their own.
+        allowedTCPPorts = [ 53317 ];
+        allowedUDPPorts = [ 53317 ];
+      };
       networkmanager.enable = lib.mkDefault true;
     };
 

--- a/pkgs/omarchy/default.nix
+++ b/pkgs/omarchy/default.nix
@@ -58,6 +58,7 @@
   btop,
   ripgrep,
   fd,
+  dua,
   bat,
   fzf,
   tmux,
@@ -166,6 +167,12 @@ let
     btop
     ripgrep
     fd
+    # applications/Disk Usage.desktop runs `dua i /`. It is the only command any
+    # shipped .desktop entry needs that no script in bin/ also calls, which is
+    # exactly why it was missed: this list was built by grepping bin/, and the
+    # launcher entries were never part of that sweep. The entry opened a
+    # terminal that closed instantly.
+    dua
     bat
     fzf
     tmux

--- a/tests/integration.nix
+++ b/tests/integration.nix
@@ -116,6 +116,13 @@ pkgs.runCommand "nixarchy-integration"
     toplevel = built.system.build.toplevel;
     inherit profile;
     wanted = ours.name;
+
+    # Omarchy's manual promises LocalSend "works out of the box on a
+    # fresh install" because the firewall is closed "except for
+    # LocalSend's port". This module enables that firewall, so it owes
+    # the exception -- and shipped the deny half without the allow half.
+    localsendTcp = builtins.toString (builtins.elem 53317 built.networking.firewall.allowedTCPPorts);
+    localsendUdp = builtins.toString (builtins.elem 53317 built.networking.firewall.allowedUDPPorts);
   }
   ''
     echo "configuration asked for: $wanted"
@@ -138,5 +145,12 @@ pkgs.runCommand "nixarchy-integration"
     esac
 
     echo "the configuration's own Hyprland survived, sessions included"
+
+    # 53317 on both protocols: LocalSend discovers over UDP and
+    # transfers over TCP, so opening one leaves Share > Receive
+    # visible and unusable.
+    [ "$localsendTcp" = "1" ] || { echo "firewall does not open TCP 53317 for LocalSend" >&2; exit 1; }
+    [ "$localsendUdp" = "1" ] || { echo "firewall does not open UDP 53317 for LocalSend" >&2; exit 1; }
+    echo "LocalSend's port is open on both protocols"
     touch $out
   ''


### PR DESCRIPTION
Two features the Omarchy manual documents as working, that did not.

## Disk Usage

`applications/Disk Usage.desktop` runs:

```
Exec=xdg-terminal-exec --app-id=TUI.float -e bash -c "dua i /"
```

`dua` was not installed. The launcher opened a terminal that closed instantly.

`dua` is the **only** command any shipped `.desktop` entry needs that no script in `bin/` also calls — which is exactly why it was missed. `runtimeDeps` was built by grepping `bin/`, and the launcher entries were never part of that sweep.

**Fixing the one command would leave the hole open**, so CI now derives the check from the entries themselves rather than a hand-written list of 34 names. All 16 entries, 8 distinct commands, resolved against the package's own `bin/` and the runtime env.

## LocalSend

`install/config/firewall.sh` is not merely "turn the firewall on":

```bash
ufw default deny incoming
ufw allow 53317/udp
ufw allow 53317/tcp   # "Allow ports for LocalSend."
```

This module ported the **deny** half and skipped the **allow** half — enabling a firewall that blocks the one service the manual promises works out of the box:

> Omarchy's firewall is closed by default except for LocalSend's port, so this works out of the box on a fresh install.

Share → Receive listened on 53317 and nothing could reach it.

Discovery was never the missing piece — `services.avahi` already opens 5353. Only the transfer port was closed, and only on machines taking this module's firewall default.

**Not `mkDefault` on the port lists.** They merge with whatever the user opens rather than replacing it; a `mkDefault` list would be dropped whole the moment they opened a port of their own. Verified — a config adding `22` gets `[22 53317]`:

```
tcp = [53317]   udp = [5353 53317]   mergesWithUser = [22 53317]
```

## Verification

- `dua` present in the runtime env; every desktop entry's command resolves (new CI step, run locally)
- `checks.integration` asserts 53317 on **both** protocols — LocalSend discovers over UDP and transfers over TCP, so opening one leaves Share → Receive visible and unusable
- **Negative-tested:** removed the port, watched the check fail with `firewall does not open TCP 53317 for LocalSend`, restored it, watched it pass. Not trusting a green run this time.
- `checks.options`, `checks.integration`, fmt, statix, deadnix — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5