### PR TITLE
Pin quickshell 0.3.1: 0.3.0's lock screen aborts on DPMS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -128,6 +128,35 @@
           version = omarchyVersion;
           # The compositor the Lua config is written against, not nixpkgs'.
           inherit (hyprland.packages.${final.stdenv.hostPlatform.system}) hyprland;
+
+          # nixpkgs is on 0.3.0, whose session lock aborts on DPMS.
+          #
+          # WlSessionLock::updateSurfaces reached qFatal -- "Tried to show
+          # lockscreen surfaces without active lock" -- when screens slept and
+          # woke while locked. quickshell dies, and because the Wayland
+          # session-lock protocol deliberately keeps the compositor locked when
+          # its lock client disappears, the machine is left blank with nothing to
+          # type a password into. Reboot is the only way out. Seen three times in
+          # one night, ~65-70 MB of coredump each.
+          #
+          # v0.3.1 fixes it, and says so in as many words: "Fixed session lock
+          # crashes on sleep, wake, DPMS, and unlocking." Three commits touch
+          # wayland/lock; 897fcdaa is this one -- it null-checks the wayland
+          # output and skips placeholder screens instead of asserting.
+          #
+          # overrideAttrs rather than a fork: nixpkgs keeps the build, the Qt
+          # wrapper and the dependency set, and only the tag moves. Passed here
+          # rather than set on the overlay, so a machine using quickshell for
+          # something of its own keeps nixpkgs'.
+          #
+          # DELETE THIS once nixpkgs ships >= 0.3.1.
+          quickshell = final.quickshell.overrideAttrs (_: rec {
+            version = "0.3.1";
+            src = final.fetchzip {
+              url = "https://git.outfoxxed.me/quickshell/quickshell/archive/refs/tags/v${version}.tar.gz";
+              hash = "sha256-CLX2Zp5i5BuLbOxNOkwRd9YY84IOrACNxBV79o9/F9Y=";
+            };
+          });
         };
       };
 


### PR DESCRIPTION
Closes the lockout described in #35.

nixpkgs ships quickshell **0.3.0**, whose session lock reaches `qFatal` when screens sleep and wake while locked:

```
FATAL: Tried to show lockscreen surfaces without active lock
```

in `WlSessionLock::updateSurfaces`. The process aborts — and because the Wayland session-lock protocol **deliberately keeps the compositor locked when its lock client disappears**, what's left is a blank screen with nothing to type a password into. Reboot is the only way out. The protocol working as designed, on top of a crash.

Observed three times in one night on a real machine (~65–70 MB of coredump each), with `lock-stranded: recovering` looping beforehand as outputs went away and came back.

## The fix is upstream already

v0.3.1's changelog, verbatim: *"Fixed session lock crashes on sleep, wake, DPMS, and unlocking."*

```diff
  @@ WlSessionLock::updateSurfaces(bool show, WlSessionLock* old) {
- if (dynamic_cast<QWaylandScreen*>(screen->handle()) == nullptr) {
+ auto* waylandScreen = dynamic_cast<QWaylandScreen*>(screen->handle());
+ if (waylandScreen == nullptr || waylandScreen->isPlaceholder()
+     || waylandScreen->output() == nullptr)
```

## Where the bug actually is

Worth stating, because the first diagnosis put it in the wrong place — it blamed "Omarchy's shell lock, vendored in nixarchy":

| | |
|---|---|
| Omarchy's lock plugin | **QML only** — `LockView.qml`, `Service.qml` |
| The fatal string + all 154 `WlSessionLock` symbols | **quickshell's own binary** |
| Does nixarchy vendor quickshell? | **No** — `pkgs/omarchy/default.nix:29,139` takes it from nixpkgs |

So it was never ours to fix in QML, and it didn't need an upstream report — it needed a version bump.

## Why `overrideAttrs`, not a fork

nixpkgs keeps the build, the Qt wrapper and the dependency set; only the tag moves. Ten lines instead of a vendored tree.

Passed to the **omarchy package**, not set on the overlay — so a machine using quickshell for something of its own still gets nixpkgs'.

**Cost:** ~85s source build cold. CI pushes it to `nixarchy.cachix.org`, which the module already configures as a substituter, so users download rather than build.

## Verification

- Shipped binary contains `"not backed by a valid wayland output"`, no longer contains `"not backed by a wayland screen"`
- `omarchy-runtime` resolves `quickshell-0.3.1`
- **`checks.session` passes in 175s** — it drives the real QuickShell bar, so it's a genuine regression check on the bump
- `coexist`, `plugin`, `options`, `integration` — all pass
- fmt, statix, deadnix — clean

Removal tracked in #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5