### PR TITLE
The doctor was looking for commands that do not exist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,6 +223,51 @@ jobs:
           fi
           echo "agent skills are NixOS-aware"
 
+      - name: Verify every app's attr resolves to a real package
+        run: |
+          # nixarchy-doctor and the Install menu both ask pkgs for an app's
+          # meta.mainProgram to learn which command it puts on PATH, and fall
+          # back to the attribute name when the lookup fails. That fallback is
+          # right by luck when the attribute matches the binary and wrong when
+          # it does not -- it answered `zen` for a package installing zen-beta
+          # and `hey-cli` for one installing hey, so both were reported absent
+          # on machines that had them.
+          #
+          # A silent fallback is the whole problem, so make an unresolvable
+          # attr loud. Entries carrying `option` are NixOS modules rather than
+          # packages and have no attr to resolve; `unavailable` ones have no
+          # nixpkgs equivalent at all.
+          nix eval --impure --raw --expr '
+            let
+              f = builtins.getFlake (toString ./.);
+              lib = f.inputs.nixpkgs.lib;
+              pkgs = import f.inputs.nixpkgs {
+                localSystem = "x86_64-linux";
+                overlays = [ f.overlays.default ];
+              };
+              apps = import ./data/apps.nix;
+              usable = lib.filterAttrs (_: a: !(a ? unavailable) && !(a ? option)) apps;
+              resolves =
+                name: app:
+                let
+                  path = lib.splitString "." (app.attr or name);
+                  probe = builtins.tryEval (
+                    lib.attrByPath path (lib.attrByPath path null pkgs) pkgs.nixarchy-apps
+                  );
+                in
+                probe.success && probe.value != null;
+              broken = lib.attrNames (lib.filterAttrs (n: a: !(resolves n a)) usable);
+            in
+            lib.concatStringsSep " " broken
+          ' > /tmp/broken-attrs
+
+          broken=$(cat /tmp/broken-attrs)
+          if [ -n "$broken" ]; then
+            echo "::error::these data/apps.nix entries name an attr nothing provides:$broken"
+            exit 1
+          fi
+          echo "every app attr resolves to a package"
+
       - name: Verify every Install row is mapped
         run: |
           # data/apps.nix claims CI keeps it from rotting. This is that check.

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,21 @@
           # simply follow nixpkgs the way most apps here do.
           hey-cli = final.callPackage ./pkgs/apps/hey-cli.nix { };
 
+          # Not built here -- upstream's own flake, re-exported into the overlay
+          # so nixarchy-doctor and the Install menu can find it.
+          #
+          # Both ask pkgs for an app's meta.mainProgram to learn which command it
+          # puts on PATH, and fall back to the attribute name when the lookup
+          # fails. zen-browser lived only in packages.<system>, so the lookup
+          # returned null and the fallback answered "zen" -- a command that does
+          # not exist, because this package installs bin/zen-beta. The doctor
+          # could never report Zen as present and the menu never dimmed its row.
+          #
+          # Exactly the vscode/code trap the doctor was written to avoid, reached
+          # by a different road: not a wrong mainProgram, but a package the probe
+          # could not see.
+          zen-browser = zen-browser.packages.${final.stdenv.hostPlatform.system}.default;
+
           # Two of the four applications Omarchy writes itself. nixpkgs has
           # none of them, which is why modules/nixos.nix cannot reproduce
           # upstream's preinstall set; these two close half that gap.
@@ -189,7 +204,18 @@
                       let
                         probe = builtins.tryEval (
                           let
-                            p = nixpkgs.lib.attrByPath (nixpkgs.lib.splitString "." (app.attr or name)) null pkgs;
+                            # nixarchy-apps first, then the top level. Apps
+                            # this repo packages live under nixarchy-apps, so
+                            # probing only the top level returned null for every
+                            # one of them and the fallback answered with the
+                            # attribute name. That is right by luck when the
+                            # attribute matches the binary -- once, omacut,
+                            # ttfx -- and wrong when it does not: `zen` for a
+                            # package installing bin/zen-beta, `hey-cli` for one
+                            # installing bin/hey. Both were reported as absent
+                            # on machines that had them.
+                            path = nixpkgs.lib.splitString "." (app.attr or name);
+                            p = nixpkgs.lib.attrByPath path (nixpkgs.lib.attrByPath path null pkgs) pkgs.nixarchy-apps;
                           in
                           if p == null then null else (p.meta.mainProgram or null)
                         );


### PR DESCRIPTION
`nixarchy-doctor` and the Install menu both ask `pkgs` for an app's `meta.mainProgram` — to learn which command it puts on `PATH` — and fall back to the attribute name when the lookup fails.

**The lookup failed for every app this repo packages.** They live under `pkgs.nixarchy-apps`; the probe searched only the top level, got `null` every time, and the fallback answered with the attribute name.

Right by luck when the attribute matches the binary. Wrong when it doesn't:

```
zen      → package installs bin/zen-beta    ✗
hey-cli  → package installs bin/hey         ✗
once, omacut, ttfx, grok-bot                ✓ (coincidence)
```

Both were reported **absent on machines that had them**, and the Install menu never dimmed their rows.

`hey-cli` is the sharper embarrassment — added earlier tonight with a comment explaining that `mainProgram` is what the menu keys on, in a package where the probe was never reading it.

## Two changes

1. **The probe searches `nixarchy-apps` before the top level.**
2. **`zen-browser` is re-exported into the overlay** — it lived only in `packages.<system>`, so no probe could have found it wherever it looked.

```
zen-beta  Zen           ← was: zen
hey       HEY CLI       ← was: hey-cli
once      ONCE          unchanged
omacut    Omacut        unchanged
```

## And a guard

The failure mode here is a **silent fallback**, not an error — so CI now fails when any `data/apps.nix` entry names an attr nothing provides. Entries carrying `option` are NixOS modules rather than packages and are skipped, as are `unavailable` ones.

**Negative-tested:** pointed `zen` at a non-existent package and watched the guard report `CAUGHT: [zen]`.

## On zen-browser more broadly

Worth recording: the upstream flake (`0xc000022070/zen-browser-flake`) is **healthy** — not archived, pushed today, 973 stars, and it builds. There was never a case for packaging Zen ourselves. The bug was entirely on our side of the boundary.

## Verification

- `checks.options`, `checks.integration`, `checks.session` — all pass
- fmt, statix, deadnix — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5