### PR TITLE
ttfx is what the screensaver is made of, not an optional extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the parts that assume Arch, rather than reimplementing it in Nix.
 Tracking an upstream release is a source bump, not a re-port.
 
 What that buys you: the Install menu writes to a Nix config instead of running
-pacman, **57 applications** are selectable that way, plugins and themes still
+pacman, **56 applications** are selectable that way, plugins and themes still
 install from a git URL at runtime the way upstream intends, and every command
 that assumed `/usr` either points at what NixOS uses or says why it cannot.
 
@@ -41,7 +41,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | **Install menu** | picks write to a Nix config, not pacman |
 | **Remove menu** | deselects apps, never touches your own config |
 | **Update menu** | `nix flake update` + `nixos-rebuild switch --flake` |
-| 57 apps in the selection | 41 from nixpkgs, 5 as NixOS modules, 9 built here, 2 with no equivalent |
+| 56 apps in the selection | 41 from nixpkgs, 5 as NixOS modules, 8 built here, 2 with no equivalent |
 | Learn menu | NixOS wiki, `search.nixos.org` packages and options |
 | Shell functions | bash and zsh source the chain; fish derives it from the same files |
 | RetroArch | 13 libretro cores, resolved from the store rather than `/usr/lib` |
@@ -673,7 +673,7 @@ done
 
 Almost nothing here waits on a maintainer.
 
-**46 of the 57 apps never touch this repo.** Brave, VSCode, Signal and the rest
+**46 of the 56 apps never touch this repo.** Brave, VSCode, Signal and the rest
 are installed as `pkgs.<name>` from **your** nixpkgs, and the five
 module-backed ones (Steam, 1Password, Tailscale, Firefox, Xbox controllers)
 come from there too — the module is NixOS', not this repo's. Your own
@@ -713,7 +713,7 @@ Most of it is not our job, and should not be:
 
 | where the app comes from | who updates it |
 |---|---|
-| nixpkgs (46 of 57 apps) | **nobody** — your own `nix flake update` |
+| nixpkgs (46 of 56 apps) | **nobody** — your own `nix flake update` |
 | pinned in this repo (2) | a weekly bot, opening a PR |
 | `zen` | upstream's own flake |
 | `retroarch` | nixpkgs, via this flake's own pin — it is a rebuild with cores |

--- a/data/apps.nix
+++ b/data/apps.nix
@@ -390,15 +390,6 @@
     attr = "omacut";
     ours = true;
   };
-  ttfx = {
-    # Not an Omarchy preinstall and not in any Omarchy menu -- a terminal
-    # text-effects binary from the same authors, offered here because it was
-    # asked for. Available as programs.nixarchy.apps.ttfx.
-    label = "ttfx";
-    category = "Utility";
-    attr = "ttfx";
-    ours = true;
-  };
   hey-cli = {
     # No menuId: Omarchy v4.0.1 ships no HEY row at all -- hey.com/agents asks
     # for "Omarchy 4.1 or later", which is unreleased, and v4.0.1's AI group is

--- a/flake.nix
+++ b/flake.nix
@@ -128,6 +128,11 @@
           version = omarchyVersion;
           # The compositor the Lua config is written against, not nixpkgs'.
           inherit (hyprland.packages.${final.stdenv.hostPlatform.system}) hyprland;
+
+          # The screensaver's text-effects engine, packaged in this repo rather
+          # than nixpkgs. Passed explicitly for the same reason hyprland is: it
+          # lives under nixarchy-apps, which callPackage does not search.
+          inherit (final.nixarchy-apps) ttfx;
         };
       };
 

--- a/pkgs/omarchy/default.nix
+++ b/pkgs/omarchy/default.nix
@@ -105,6 +105,7 @@
   xdg-user-dirs,
   satty,
   wl-screenrec,
+  ttfx,
   # Branding: this is a NixOS port, so the menu button wears the snowflake.
   nixos-icons,
 }:
@@ -235,6 +236,18 @@ let
     xdg-user-dirs # xdg-user-dirs-update
     satty # screenshot annotation
     wl-screenrec # screen recording
+
+    # The screensaver is ASCII art driven through text effects, and ttfx is
+    # what drives it. Five scripts call it -- omarchy-screensaver,
+    # omarchy-launch-screensaver, omarchy-system-lock, omarchy-provision-owner
+    # and omarchy-debug-idle -- so it is not optional, it is what Super + Esc
+    # and the idle screensaver are made of.
+    #
+    # It was packaged here first as an opt-in app, on the mistaken reading that
+    # it was a standalone toy. It is a runtime dependency; the catalogue entry
+    # went away with this change, because offering to install something that is
+    # always present is exactly what the menu's dimming exists to prevent.
+    ttfx
   ];
   # arch-name<TAB>kind<TAB>attr<TAB>note, one per line. Apps come from
   # data/apps.nix so the two cannot drift; everything the menu does not select


### PR DESCRIPTION
`Super + Esc` and the idle screensaver did nothing.

`omarchy-screensaver` is ASCII art driven through text effects, and **`ttfx` is what drives it**:

```bash
ttfx -i ~/.config/omarchy/branding/screensaver.txt …
```

**Five** scripts call it — `omarchy-screensaver`, `omarchy-launch-screensaver`, `omarchy-system-lock`, `omarchy-provision-owner`, `omarchy-debug-idle`. It isn't a standalone toy; it's what those features are built from. Note the lock screen is on that list.

## This corrects #30

That PR packaged `ttfx` earlier tonight and filed it as an **opt-in app**, describing it as *"not an Omarchy preinstall and not in any Omarchy menu."* True as far as it went — and the wrong conclusion. It's in no menu **because nothing offers to install it**, because it's a runtime dependency.

So it moves into `runtimeDeps`, and the `data/apps.nix` entry goes. Offering to install something always present is exactly what the Install menu's dimming exists to prevent; that row would have been permanently greyed out.

Passed explicitly through `callPackage`, like `hyprland` and `quickshell` — the package lives under `nixarchy-apps`, which `callPackage` doesn't search, and the build says so outright rather than falling back:

```
error: Function called without required argument "ttfx" …
       did you mean "ttfb", "atf" or "attyx"?
```

## Checked the rest of the manual page while here

From [toggles-idle-screensaver](https://omarchy.org/manual/toggles-idle-screensaver/):

| claim | status |
|---|---|
| `omarchy toggle idle` | dispatches |
| `omarchy toggle screensaver` | dispatches |
| `omarchy toggle idle status` | real — the arg is `status`; my first probe used `--help` and was wrong |
| `omarchy-toggle-enabled` | present |
| `idle.screensaver: 150`, `idle.lock: 300` | shipped defaults correct |
| screensaver renders | **was broken — this PR** |

## Counts

56 apps, 8 built here. The `ttfx` package itself stays; `runtimeDeps` needs it.

## Verification

- `ttfx 0.3.2` resolves in the runtime env
- `checks.options`, `checks.integration`, `checks.session` — pass
- fmt, statix, deadnix — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5