### PR TITLE
A manual for the port, not a fork of Omarchy's

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,19 @@
+title: nixarchy
+description: Omarchy, vendored for NixOS
+theme: jekyll-theme-primer
+show_downloads: false
+
+# Only the manual is a site. The screenshots and the demo gif live in docs/
+# too and are linked from the README, so they must not become pages.
+include:
+  - manual
+exclude:
+  - screenshots
+  - capture-screenshots.sh
+  - nixarchy-demo.gif
+
+defaults:
+  - scope:
+      path: "manual"
+    values:
+      layout: default

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,32 @@
+---
+title: nixarchy
+---
+
+# nixarchy
+
+[Omarchy](https://omarchy.org) — the Hyprland desktop — vendored for NixOS, with
+its menus rewired to Nix instead of pacman.
+
+Omarchy 4.x is not a dotfiles repo, it is an application: 429 shell commands, a
+QuickShell desktop shell, 22 themes, and Hyprland configured through the Lua API
+introduced in 0.55. nixarchy packages that tree as a derivation and replaces the
+parts that assume Arch, rather than reimplementing it in Nix.
+
+Tracking an upstream release is a source bump, not a re-port.
+
+## → [The nixarchy manual](manual/)
+
+What is different here, and only that. Omarchy's manual covers the desktop; this
+one covers the port — packages, updates, rollback, the firewall, the agent
+skills, and the NixOS philosophy underneath all of it.
+
+New to NixOS? Start with
+**[the philosophy](manual/philosophy)** and **[updating NixOS](manual/updating-nixos)**.
+
+## Elsewhere
+
+| | |
+|---|---|
+| [Source and README](https://github.com/olafkfreund/nixarchy) | installation, module options, design notes, what is left |
+| [Omarchy's own manual](https://omarchy.org/manual/) | the desktop itself — 38 of its 51 pages are true here unchanged |
+| [Issues](https://github.com/olafkfreund/nixarchy/issues) | including the epic for a bare-metal installer, which does not exist yet |

--- a/docs/manual/ai.md
+++ b/docs/manual/ai.md
@@ -1,0 +1,117 @@
+---
+title: AI
+---
+
+# AI
+
+Omarchy's agent tooling — the lazy-loaded launchers, the default agent, the
+agents panel in the top bar, crash diagnosis, the local-LLM recommendations —
+is upstream's tree running unchanged. `omarchy default agent <name>`,
+`Super + Shift + Ctrl + A`, `omarchy agent prompt "..."`, `omarchy agent crash
+<pid>`, `omarchy toggle crash-capture` and the `omarchy-agent-*` commands all
+work as [the upstream page](https://omarchy.org/manual/ai/) describes them, and
+that page is the reference for how to use them.
+
+Two things differ, and the second matters more than it looks.
+
+## The desktop apps are declared, not installed
+
+The `Install > AI` rows (ChatGPT, Grok Bot, LM Studio, Ollama) do what every
+Install row does here: they queue the app in `~/.config/nixarchy/apps.nix`, and
+`nixarchy-apply` rebuilds. See
+[the philosophy page](philosophy#what-this-does-to-the-install-menu).
+
+The HEY CLI is packaged as `hey-cli` and installs its binary as `hey`. It has
+no Install row yet because the Omarchy release nixarchy vendors ships none, so
+enable it from your flake:
+
+```nix
+programs.nixarchy.apps.hey-cli.enable = true;
+```
+
+## The skills are rewritten, because upstream's would lie
+
+Omarchy ships one agent skill, `omarchy`, and symlinks it into the skill
+directories of Claude Code, Codex, Pi and the generic `~/.agents/skills`
+location, so most harnesses load it automatically. nixarchy keeps the
+mechanism — `omarchy-provision-user` symlinks every directory under
+`$OMARCHY_PATH/default/agents/skills/` into `~/.claude/skills`,
+`~/.agents/skills`, `~/.codex/skills` and `~/.pi/agent/skills` — but ships
+three skills instead of one:
+
+| skill | owns |
+|---|---|
+| `nixarchy` | the desktop: `~/.config/hypr/`, `~/.config/omarchy/`, terminal configs, themes, keybindings, the bar, idle and lock, the `omarchy` commands |
+| `nixos` | packages and everything outside `~/.config/`: services, users, hardware, boot, networking, fonts, Home Manager, the flake, rebuilds and rollback |
+| `diagnose-crash` | working out why a process dumped core, and where to report it if it is a distribution bug |
+
+The split follows the boundary the rest of this manual keeps drawing: what is
+under `~/.config/` is yours and takes effect on save; what is declared in the
+flake only changes at a rebuild. An agent that does not know which side of that
+line a request falls on will do the wrong kind of change, and the wrong kind is
+the one that silently does not last.
+
+### Why `omarchy` could not ship as-is
+
+Upstream's skill is written for Arch. It points the agent at
+`/usr/share/omarchy`, which does not exist here, and its decision framework
+answers "install a package" with `omarchy pkg add`. On nixarchy that command
+prints the declarative route and exits 1; it installs nothing. An agent
+following the upstream skill would run it, see a non-zero exit, and either
+retry with `pacman` — absent — or fall back to `nix-env -i` or `nix profile
+install`, which "work" and then vanish at the next rebuild. That is the one
+failure mode that looks like success, so the skill is renamed `nixarchy` and its
+front page rewritten rather than patched.
+
+`nixos` is new and owns the install question outright. Its first rule is that
+a request that would normally end in an install command ends in a file edit and
+a rebuild instead, and it ranks the routes: `nixarchy-app-enable <id>` then
+`nixarchy-apply` for an app the Install menu knows; a flake edit and
+`nixos-rebuild switch` for anything else; `nix shell nixpkgs#<pkg>` for a
+throwaway try that is not meant to be a change to the machine.
+
+`diagnose-crash` keeps its name because `omarchy-agent-crash` reads that path
+literally. Its body is upstream's with three corrections: there is no public
+debuginfod serving nixpkgs builds, so symbols only resolve if the machine runs
+`nixseparatedebuginfod`; "what changed recently" is answered by
+`nix profile diff-closures --profile /nix/var/nix/profiles/system` rather than
+package mtimes, and `sudo nixos-rebuild --rollback switch` tests the theory; and
+a confirmed bug has two possible homes, nixarchy for anything NixOS-specific and
+Omarchy for anything that would happen identically on Arch.
+
+### The one thing an agent must be told
+
+A rebuild does not update the session the agent is running in.
+
+`OMARCHY_PATH` and `PATH` are set at login and point at whichever store path was
+current then. `nixos-rebuild switch` installs a new package at a *new* store
+path and cannot reach into a session that already exists. Every `omarchy-*`
+command the desktop runs — every keybinding, every menu row — comes from the old
+build until you log out and back in. Home Manager deploying `~/.config/hypr` is
+a symlink swap into the store, which Hyprland's auto-reload does not notice, so
+that needs `hyprctl reload` too.
+
+Humans lose an evening to this. An agent loses it faster, because its natural
+verification — run the script at its full installed path and see that it works
+— *passes*, while the keybinding still runs the old one. The `nixarchy` skill
+spells out the check:
+
+```sh
+echo "$OMARCHY_PATH"
+readlink -f /run/current-system/sw/bin/omarchy | sed 's|/bin/omarchy$||'
+```
+
+If those differ, the fix is applied and the session is stale. `nixarchy-doctor`
+reports the same thing under **Session**. Without this in the skill, an agent
+that has just made a correct change will conclude it did not work and start
+undoing it.
+
+### Treat the skills as upstream does
+
+Upstream's advice stands: run in plan mode first, and different models use a
+skill to different effect. The rollback advice changes, though. Upstream says be
+ready to run `omarchy reinstall configs` if the agent makes a mess; here
+`omarchy reinstall` cannot finish, because it runs `pacman -Suu` first and the
+shim refuses. For desktop config, `omarchy refresh <app>` restores a stock
+file. For anything the agent changed in the flake,
+`sudo nixos-rebuild --rollback switch` puts back the previous generation.

--- a/docs/manual/development-tools.md
+++ b/docs/manual/development-tools.md
@@ -1,0 +1,131 @@
+---
+title: Development tools
+---
+
+# Development tools
+
+## Alternative editors
+
+Neovim ships by default. _Install > Editor_ offers VSCode, Cursor, Zed, Helix,
+Vim and Emacs, each a row in the app selection like any other: pick it, then
+_Install > Apply changes_. VSCode and Cursor are unfree and need
+`nixpkgs.config.allowUnfree = true` in your configuration.
+
+Sublime Text is listed but disabled. nixpkgs marks `sublimetext4` broken over
+an insecure OpenSSL dependency, and enabling a broken package aborts the whole
+rebuild rather than failing on its own, so the row says why instead of letting
+you find out at build time.
+
+Theme matching for VSCode, Cursor, VSCodium and Helix, and _Setup > Defaults >
+Editor_ for the system-wide default, work as upstream describes.
+
+## Environments: nixpkgs, not mise
+
+Upstream installs its language runtimes with `mise use --global <lang>@latest`,
+which downloads a prebuilt toolchain into `~/.local/share/mise`. That does
+not fit NixOS twice over. Nothing about it survives into your configuration,
+so a second machine built from the same flake does not have it. And mise's
+prebuilt binaries are linked against loader paths NixOS does not have, so
+several of them — Node is the usual example — do not execute at all.
+
+So the thirteen toolchains in _Install > Development_ are rows in the app
+selection, and the compiler comes from the same nixpkgs as the rest of the
+system:
+
+| Row | nixpkgs attribute | Note |
+|---|---|---|
+| Go | `go` | |
+| Rust | `rustup` | Manages toolchains under `~/.rustup`, as upstream. Use `cargo` and `rustc` instead if you want Nix to pin the compiler |
+| Node.js | `nodejs` | |
+| Bun | `bun` | |
+| Deno | `deno` | |
+| Java | `jdk` | |
+| Elixir | `elixir` | |
+| Zig | `zig` | |
+| Clojure | `clojure` | |
+| Scala | `scala` | |
+| .NET | `dotnet-sdk` | |
+| OCaml | `ocaml` | |
+| Python | `python3` | Already present as a dependency of Omarchy's own scripts; select it anyway so your configuration says so |
+
+PHP and Symfony are rows too. Ruby on Rails, Laravel and Phoenix have no row
+of their own because upstream's `omarchy install dev-env` scripts still drive
+mise and `omarchy-pkg-add` for them.
+
+mise itself is still installed, and `programs.nix-ld` is enabled so that its
+downloads can run. It is fine for a tool that is not in the table; it is the
+wrong place for a compiler your project depends on.
+
+### Per-project environments: `nix develop`
+
+`mise use` in a project directory has a NixOS equivalent that is strictly
+more capable: a devShell. It pins not just the language version but every
+tool the project needs, and it is checked in, so a colleague gets the same
+shell from `git clone`.
+
+A minimal `flake.nix` in the project root:
+
+```nix
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { nixpkgs, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      devShells.${system}.default = pkgs.mkShell {
+        packages = with pkgs; [ nodejs_22 pnpm sqlite ];
+        shellHook = ''
+          export DATABASE_URL=sqlite://./dev.db
+        '';
+      };
+    };
+}
+```
+
+Then:
+
+```sh
+nix develop          # drop into a shell with exactly those tools on PATH
+nix develop -c npm test   # run one command inside it
+```
+
+Nothing is installed globally. Leave the directory and `nodejs_22` is gone
+from your PATH; the global Node from the app selection, if you have one, is
+untouched. Commit `flake.lock` and every checkout gets the same versions.
+
+The global rows in the menu are for the tools you want everywhere — a
+language server for your editor, `go` for one-off scripts. Anything a
+project depends on belongs in that project's devShell.
+
+## Docker
+
+Docker and Docker Compose are enabled by `virtualisation.docker.enable`,
+which nixarchy sets by default, and Lazydocker is on `Super + Shift + D`.
+
+As upstream, your user is not in the `docker` group, for the reason upstream
+gives: the group is effectively passwordless root. Use `sudo docker`, and the
+Docker TUI asks for authorisation through polkit when it needs the socket.
+_Setup > Security > Sudoless Docker_ (`omarchy-setup-security-sudoless-docker`)
+adds you to the group after its warning. To make that choice part of your
+configuration rather than a one-off, the declarative form is:
+
+```nix
+users.users.<you>.extraGroups = [ "docker" ];
+```
+
+Upstream's [Docker section](https://omarchy.org/manual/development-tools/)
+covers the rest — including _Install > Development > Docker DB_ for local
+databases — and none of it is Arch-specific.
+
+## GitHub CLI
+
+Upstream wires `gh` and `ghui` as lazy-loading mise stubs, and those stubs
+are what you get here too: the first `gh` downloads it through mise into
+`~/.local/share/mise`. That works, thanks to nix-ld, but it is the same
+imperative state as any other mise install. If you want `gh` on every machine
+you build from this flake, add `pkgs.gh` to `environment.systemPackages` and
+it takes precedence over the stub.
+
+`gh auth login`, `gh repo clone org/repo` and lazygit are as upstream.

--- a/docs/manual/dotfiles.md
+++ b/docs/manual/dotfiles.md
@@ -1,0 +1,125 @@
+---
+title: Dotfiles
+---
+
+# Dotfiles
+
+Upstream draws one line: `~/.config` is yours, `/usr/share/omarchy` is
+Omarchy's. The same line exists here, and it is enforced harder than upstream
+can enforce it.
+
+| | Who owns it | How it changes |
+|---|---|---|
+| `~/.config/hypr/*.lua`, `~/.config/omarchy/shell.json`, `~/.config/foot/foot.ini`, `~/.XCompose`, `~/.bashrc` | You | Edit in place, effective on save. No rebuild. |
+| `$OMARCHY_PATH` (Omarchy's own tree, a `/nix/store` path) | The package | Read-only filesystem. The write fails; it is not merely discouraged. |
+| Packages, services, fonts, the firewall | Your flake | Only at a rebuild. |
+
+Getting the row wrong is the usual way to make a change that silently does
+not last: a keybinding is a text edit, but the program it launches is a
+rebuild.
+
+Upstream's table of key files and what each controls is unchanged and is not
+repeated here; see [the upstream page](https://omarchy.org/manual/dotfiles/).
+The menu editing routes (*Setup > Monitors*, *Setup > Keybindings*, *Setup >
+Input*, *Setup > Config > [file]*) work the same, including the automatic
+restart of whatever needs restarting when you quit the editor.
+
+## Two files under `~/.config` that are not yours
+
+**A symlink into `/nix/store`.** If you declared a config through Home
+Manager, `~/.config/<that file>` is a link to a read-only store path, and
+editing it fails. It is not a nixarchy file and not an upstream file; it is
+yours, declared in the other place. Change it where you declared it and
+rebuild. `ls -l ~/.config/hypr/` tells you at a glance which files are links.
+The doctor reports this for the Hyprland configs and for `mimeapps.list`,
+where a store-managed file makes *Setup > Default browser* a silent no-op.
+
+Note that a rebuild swaps the symlink rather than rewriting the file, and
+Hyprland's auto-reload does not notice a swap. Run `hyprctl reload`.
+
+**`~/.config/omarchy/extensions/omarchy-menu.jsonc`.** Upstream says to edit
+this to add menu rows. Here it is generated on every rebuild and your edit is
+overwritten by the next one. It has to be generated: it carries the rewrite
+that points every `install.*` and `remove.*` row at the Nix app selection, and
+upstream's merge copies every key of an override rather than filling in the
+ones you omit, so a hand-written row that leaves out `label` renders its raw
+id and one that leaves out `action` does nothing. Add rows in your flake
+instead:
+
+```nix
+programs.nixarchy.menu.extraEntries = {
+  "personal"       = { icon = ""; label = "Personal"; };
+  "personal.notes" = { icon = "󰎞"; label = "Notes"; action = "omarchy-launch-editor ~/notes"; };
+};
+```
+
+Same dotted ids as upstream, so `personal` lands on the root menu and
+`personal.notes` inside it; reuse an existing id to override that row. Give
+every row a `label`, and every leaf an `action`.
+
+## Starting your own apps with the session
+
+Unchanged: `o.launch_on_start("my-service")` in `~/.config/hypr/autostart.lua`.
+The command has to be on `PATH`, which on NixOS means it is in your flake or
+your app selection; a binary dropped in `~/.local/bin` works too, but nothing
+records that it is there.
+
+## Running scripts on system events
+
+The hook directories under `~/.config/omarchy/hooks/<event>.d/` are as
+upstream ships them, and `omarchy hook install <event> <script>` copies a
+script in. One row of upstream's table changes:
+
+| Event | Here |
+|---|---|
+| `post-boot`, `theme-set`, `font-set`, `battery-low` | Unchanged |
+| `post-update` | Runs during `omarchy update`, after the rebuild |
+| `pre-refresh-pacman` | Never runs. There is no pacman; the shipped README in that directory says so. |
+
+## Shell exports, functions, and aliases
+
+`~/.bashrc` is yours and is not touched by a rebuild. Omarchy's aliases and
+functions load from `/etc/bashrc`, *before* `~/.bashrc`, so anything you
+define wins. If you bring your own shell setup entirely, turn the chain off
+in your flake with `programs.nixarchy.bashIntegration = false;`.
+
+## Changing internal Omarchy files
+
+Upstream's advice is "don't, an update overwrites them". Here you cannot:
+`$OMARCHY_PATH` is in `/nix/store` and mounted read-only. Read it freely,
+because it is the best documentation of what each command does:
+
+```sh
+cat "$OMARCHY_PATH"/default/hypr/windows.lua
+cat "$(which omarchy-theme-set)"
+```
+
+Never write the path itself into a config. It changes with every Omarchy or
+nixpkgs bump; always go through `$OMARCHY_PATH`.
+
+Overriding still works the way upstream shows, in your files. Replacing a
+keybinding in `~/.config/hypr/bindings.lua`:
+
+```lua
+hl.unbind("SUPER + SHIFT + O")
+o.bind("SUPER + SHIFT + O", "Joplin", "joplin-desktop")
+```
+
+except that `omarchy-pkg-add joplin-bin` is not how Joplin gets installed;
+pick it from the Install menu or add it to your flake, and rebuild. Stock
+themes are read-only in the same way; put a custom theme in
+`~/.config/omarchy/themes/<slug>/` rather than editing one under
+`$OMARCHY_PATH/themes/`.
+
+Upstream's dev channel (*Update > Channel > Dev*, a git checkout in
+`~/omarchy`) is a pacman concept. The equivalent is pointing the `nixarchy`
+flake input at your own fork or a local path and rebuilding.
+
+## Resetting your changes
+
+`omarchy refresh config <path>` copies one shipped file back over yours and
+keeps a timestamped `.bak` of your version, for example
+`omarchy refresh config hypr/bindings.lua`. `omarchy reinstall configs` replays
+`/etc/skel` over your home, which resets every shipped default at once and is
+as destructive as it sounds. Plain `omarchy reinstall` cannot finish here at
+all; see [troubleshooting](troubleshooting.md).

--- a/docs/manual/dual-boot-install.md
+++ b/docs/manual/dual-boot-install.md
@@ -1,0 +1,37 @@
+---
+title: Dual boot install
+---
+
+# Dual boot install
+
+There is no nixarchy installer, so there is no dual-boot installer either.
+
+Omarchy ships an ISO whose installer offers a **Free space install** next to
+Windows, encrypts the partition with LUKS, and then runs `limine-scan` to add
+the other operating systems to its bootloader. None of that exists here.
+nixarchy is a flake you add to a machine that already runs NixOS; it does not
+partition disks, and it does not ship boot media. A bare-metal installer is
+tracked as [issue #6](https://github.com/olafkfreund/nixarchy/issues/6), an
+epic with 14 sub-issues, and until it lands this page cannot honestly say more
+than the following.
+
+## What to do instead
+
+1. **Make room on the Windows side** exactly as upstream describes — Disk
+   Management, *Shrink Volume*, and turn BitLocker off first, since it encrypts
+   the whole drive rather than a partition. That half of
+   [the upstream page](https://omarchy.org/manual/dual-boot-install/) is about
+   Windows, not Omarchy, and applies unchanged.
+
+2. **Install NixOS into the free space** by whichever method you prefer. The
+   NixOS installer supports installing alongside an existing operating system;
+   partitioning and bootloader setup for that are covered by the NixOS manual,
+   and this manual does not repeat them.
+
+3. **Add nixarchy as a flake input** to the resulting configuration and
+   rebuild. That is the whole of the nixarchy-specific work, and it is
+   described on [the getting-started page](getting-started).
+
+Dual boot is therefore a NixOS question, and the NixOS manual and wiki are the
+right references for it. Once the machine boots into NixOS, nothing about
+adding nixarchy is different for having Windows on the next partition.

--- a/docs/manual/gaming.md
+++ b/docs/manual/gaming.md
@@ -1,0 +1,152 @@
+---
+title: Gaming
+---
+
+# Gaming
+
+Omarchy ships Steam and RetroArch, Battle.net, Lutris and Heroic, Moonlight
+for streaming from a PC, Xbox Cloud Gaming and GeForce NOW for the cloud, and
+Minecraft. All of it is under _Install > Gaming_ in the Omarchy menu
+(`Super + Space`) here too, and _Remove > Gaming_ undoes it. Proton and the
+Steam Deck are the same story on any Linux; see
+[upstream's page](https://omarchy.org/manual/gaming/) for that part.
+
+What changes is how each row installs. Some are plain packages, some are
+NixOS modules, and two go through scripts that need a line in your
+configuration first. The table is the whole page in short:
+
+| Row | What it does here | Unfree? |
+|---|---|---|
+| Steam | enables `programs.steam` | yes |
+| RetroArch | nixarchy's `retroarch`, 13 free cores | no |
+| Xbox Controllers | enables `hardware.xpadneo` | no |
+| Lutris | `pkgs.lutris` | no |
+| Heroic (Epic Games) | `pkgs.heroic` | no |
+| Minecraft | `pkgs.prismlauncher` | no |
+| Xbox Cloud Gaming | a web app, no package at all | — |
+| Battle.net | needs `pkgs.umu-launcher` in your config | — |
+| NVIDIA GeForce NOW | needs `services.flatpak.enable` in your config | — |
+
+The rows marked as packages or modules go into `~/.config/nixarchy/apps.nix`
+like every other app, and _Install > Apply changes_ rebuilds with them. Unfree
+rows need `nixpkgs.config.allowUnfree = true`.
+
+## Steam
+
+Steam is a NixOS module, not a package, and this is the one to understand
+because it is the pattern. Steam's own binaries and every game it downloads
+are built for a normal Linux filesystem layout: `/lib`, `/usr/lib`, libraries
+where the FHS says they are. NixOS has none of those paths, so a bare `steam`
+package starts and immediately fails to find its libraries.
+`programs.steam.enable` builds an FHS environment — a private root with the
+expected layout — and runs Steam inside it. That is why the row enables an
+option rather than adding a package, and why installing `pkgs.steam` by hand
+would not run.
+
+The row also needs `allowUnfree`. The 32-bit half of the graphics stack,
+which upstream adds with `omarchy-install-gaming-gpu-lib32`, is one option on
+NixOS instead of a per-driver package:
+
+```nix
+hardware.graphics.enable32Bit = true;
+```
+
+Steam still takes 10–20 seconds to start with no feedback, as upstream warns.
+
+## RetroArch
+
+nixpkgs' `retroarch` is `retroarch-with-cores` built with an empty core
+list: it installs cleanly and emulates nothing. The obvious fix,
+`retroarch-full`, pulls in unfree cores, and an unfree package in the app
+selection aborts the entire rebuild for everyone who has not set
+`allowUnfree` — rather than failing on its own.
+
+So nixarchy builds its own `retroarch`: every core Omarchy's picker offers
+that nixpkgs ships under a free licence, minus the two largest. Thirteen
+cores — bsnes for SNES, mesen for NES, gambatte and mgba for Game Boy,
+blastem for Mega Drive, beetle-pce-fast, beetle-psx-hw, parallel-n64,
+desmume, flycast, ppsspp, puae for Amiga and vice-x64 for the C64. snes9x and genesis-plus-gx are
+unfree in nixpkgs, which is why bsnes and blastem cover those systems.
+
+If you want the unfree ones — snes9x, genesis-plus-gx, mame, dolphin — set
+`allowUnfree` and override the package in your `nixarchy-apps.nix`:
+
+```nix
+programs.nixarchy.apps.retroarch.package =
+  pkgs.retroarch.withCores (c: [ c.snes9x c.mame c.dolphin ]);
+```
+
+That replaces the core list rather than adding to it, so name everything you
+want.
+
+Two things differ from upstream's walkthrough. RetroArch loads cores from
+`/usr/lib/libretro` on Arch; here they live inside the package, and
+`omarchy-retroarch-cores` prints the current directory if you need it. And
+`~/Games/roms` and `~/Games/bios`, along with the CRT Royale shader preset,
+are written by upstream's `omarchy-install-gaming-retroarch` script, whose
+first step is a package install that stops here — so set your ROM and BIOS
+directories in RetroArch's own settings after the first launch. The _RetroArch
+Game Launcher_ row, which gives one game its own launcher entry, works.
+
+## Xbox controllers
+
+Bluetooth Xbox controllers need the `xpadneo` kernel driver. On Arch that is a
+DKMS package; on NixOS an out-of-tree module has to be built against the
+running kernel and loaded, which is what `hardware.xpadneo.enable` does, so
+the row enables that option. Pair with `Super + Ctrl + B` afterwards. A
+controller on a USB-C cable does not need it.
+
+## Battle.net and GeForce NOW
+
+These two run upstream's install scripts unchanged, and each begins by asking
+`omarchy-pkg-add` for a package, which prints the declarative route and stops.
+The route in each case is one line:
+
+```nix
+environment.systemPackages = [ pkgs.umu-launcher ];   # Battle.net
+services.flatpak.enable = true;                       # GeForce NOW
+```
+
+Battle.net is a Windows installer run under umu-launcher; the wine prefix it
+builds lives under `$HOME` and the rest of the script works once the launcher
+exists. GeForce NOW ships only as a Flatpak, and Flatpak on NixOS is a service
+rather than a package — without it there is nowhere for the app to be
+installed. After the rebuild: `flatpak install flathub com.nvidia.geforcenow`.
+
+## Xbox Cloud Gaming
+
+A web app. It touches no package manager, so the row works exactly as
+upstream describes.
+
+## Minecraft
+
+nixpkgs removed its `minecraft` launcher as broken, and its own removal
+message points at Prism Launcher, so that is what the row installs — nixpkgs'
+recommendation rather than a substitution invented here. Sign in with your
+Microsoft account inside it.
+
+## Moonlight and Sunshine
+
+Moonlight is preinstalled and streams from a Windows PC running Sunshine
+exactly as upstream says.
+
+Hosting from this machine is different. Upstream's `omarchy install service
+sunshine` installs Sunshine with pacman and opens its ports with ufw; here
+the package step stops and there is no ufw. Add the package yourself and open
+the ports where the rest of the firewall lives:
+
+```nix
+environment.systemPackages = [ pkgs.sunshine ];
+networking.firewall.allowedTCPPorts = [ 47984 47989 48010 ];
+networking.firewall.allowedUDPPorts = [ 47998 47999 48000 48002 48010 ];
+```
+
+Those are the ports upstream's script opens, minus 5353, which
+`services.avahi` already has open. Upstream restricts them to private LAN
+ranges and the Tailscale interface; `networking.firewall.interfaces.<name>`
+does the same job if you want it.
+
+## Lutris and Heroic
+
+Plain packages, and upstream's advice applies: both look like nothing is
+happening while a game installs. Give them time.

--- a/docs/manual/getting-started.md
+++ b/docs/manual/getting-started.md
@@ -1,0 +1,135 @@
+---
+title: Getting Started
+---
+
+# Getting Started
+
+Omarchy ships as an ISO: boot it, answer a few questions, and a machine comes
+out the other end. **nixarchy does not.** There is no ISO, no bare-metal
+installer, no dual-boot or unattended install. nixarchy is a flake that you add
+to a machine that already runs NixOS. Installing NixOS is your job; turning it
+into an Omarchy desktop is the flake's.
+
+A bare-metal installer is tracked as an epic (issue #6, 14 sub-issues). Until
+it lands, the path below is the only one, and the pages upstream devotes to
+[dual-boot](https://omarchy.org/manual/dual-boot-install/) and
+[unattended installs](https://omarchy.org/manual/unattended-installs/) do not
+apply here.
+
+## 1. Install NixOS
+
+Use the official NixOS installer and get to a booting system with a user
+account. Two things worth deciding at that stage, because nixarchy inherits
+them rather than setting them:
+
+| Upstream default | Here |
+|---|---|
+| Full-disk encryption, mandatory | Yours to choose during the NixOS install (LUKS is a checkbox in the graphical installer). nixarchy does not add it afterwards. |
+| Limine boot loader with snapshots | Whatever boot loader you picked; systemd-boot is the common one. Rollback comes from NixOS generations, see [system snapshots](system-snapshots.md). |
+
+Upstream's note about Bluetooth keyboards still holds if you encrypt: the
+passphrase prompt runs before Bluetooth, so use a wired or 2.4 GHz keyboard.
+
+## 2. Run the doctor first
+
+```sh
+nix run github:olafkfreund/nixarchy#doctor
+```
+
+It reads the running system and prints the configuration this particular
+machine needs, before nixarchy is an input anywhere. It changes nothing. On a
+machine that already has Hyprland behind greetd, for example, it tells you to
+keep your greeter and your Hyprland package rather than letting the rebuild
+fail on the conflict. Paste what it prints into the module block in the next
+step.
+
+## 3. Add the flake input
+
+From the README, the whole of it:
+
+```nix
+{
+  inputs.nixarchy.url = "github:olafkfreund/nixarchy/v4.0.1-1";
+
+  outputs = { nixpkgs, nixarchy, ... }: {
+    nixosConfigurations.mymachine = nixpkgs.lib.nixosSystem {
+      modules = [
+        nixarchy.nixosModules.nixarchy
+        {
+          programs.nixarchy.enable = true;
+          # Where nixarchy-apply copies your app selection before rebuilding.
+          programs.nixarchy.flake = "/home/you/nixos-config";
+        }
+        ./nixarchy-apps.nix # the generated selection
+      ];
+    };
+  };
+}
+```
+
+And for the user who will sit at the desktop, in Home Manager:
+
+```nix
+{
+  imports = [ nixarchy.homeManagerModules.nixarchy ];
+  programs.nixarchy.enable = true;
+}
+```
+
+Without the Home Manager half there is no app selection, no theme state and no
+seeded config. Pin a release tag rather than `main` unless you want the desktop
+moving under you.
+
+Two lines deserve a second look:
+
+- **`programs.nixarchy.flake`** is the directory `nixarchy-apply` copies your
+  app selection into. It defaults to `/etc/nixos`; most people keep their flake
+  in a git repo under `~`, so set it.
+- **`./nixarchy-apps.nix`** must be imported by you. `nixarchy-apply` writes
+  that file into the flake root, but a flake cannot read outside its own tree
+  and nothing imports the copy on your behalf. Leave the line out and the
+  Install menu marks apps enabled, the rebuild succeeds, and nothing is ever
+  installed. `nixarchy-apply` warns loudly when nothing imports the file, so
+  read what it prints.
+
+## 4. Rebuild, log out, pick Omarchy
+
+```sh
+sudo nixos-rebuild switch --flake /home/you/nixos-config
+```
+
+Every remaining conflict shows up here as an evaluation error, not as a broken
+machine. Then log out and choose the **Omarchy** session at the login screen.
+On SDDM the login screen is Omarchy's own branded greeter; on greetd, GDM or
+LightDM you keep your greeter and it offers the Omarchy entry like any other
+session.
+
+If you already have a `~/.config/hypr/hyprland.lua`, it is not touched. The
+Omarchy session runs Hyprland against Omarchy's config in the store, so both
+desktops keep working and you choose between them at the greeter.
+
+## 5. Check it from inside
+
+```sh
+nix run github:olafkfreund/nixarchy#verify
+```
+
+Run from the Omarchy session. It asks the questions CI cannot: hardware
+rendering or llvmpipe, whether bluetoothd sees an adapter, whether the shell
+functions and compose sequences are wired in. It prints what it found rather
+than a verdict.
+
+## What is different from here on
+
+Installing software is the first thing that will surprise you: the Install
+menu edits `~/.config/nixarchy/apps.nix` and builds nothing until you choose
+*Apply changes*. Read [the NixOS philosophy](philosophy.md) before anything
+else in this manual; every other difference follows from it.
+
+## Help if you're stuck
+
+Upstream's `#omarchy-help` on [the Discord](https://omarchy.org/discord) is
+for Arch. For nixarchy-specific trouble, run
+`nix run github:olafkfreund/nixarchy#doctor`, read
+[troubleshooting](troubleshooting.md), and open an issue on the repository with
+the output of `omarchy debug --no-sudo --print`.

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -1,0 +1,94 @@
+---
+title: The nixarchy manual
+---
+
+# The nixarchy manual
+
+nixarchy is [Omarchy](https://omarchy.org) vendored for NixOS. It runs Omarchy's
+real tree — the same commands, menus, themes, keybindings and shell — and
+replaces only what assumed Arch.
+
+**So this manual only covers what is different.** Of Omarchy's 51 manual pages,
+38 are word-for-word true here and are linked straight through to
+[omarchy.org/manual](https://omarchy.org/manual/). The 13 that are not are
+rewritten below, plus two that Omarchy has no reason to have.
+
+That is the same decision the port itself makes. Forking a manual you do not
+change means maintaining a copy that goes stale at every upstream release, and
+Omarchy releases often. Tracking upstream is a source bump, not a re-port — for
+the documentation as much as the code.
+
+## Start here if you are new to NixOS
+
+| | |
+|---|---|
+| [The NixOS philosophy, and what it changes](philosophy) | Why the Install menu *queues* instead of installing, where the line between `~/.config` and your flake falls, and why nothing installed imperatively survives |
+| [Updating NixOS](updating-nixos) | `omarchy update`, what it does underneath, generations, rollback, and why a rebuild does not change the session you are sitting in |
+
+## Every topic
+
+| topic | |
+|---|---|
+| Welcome to omarchy | same as Omarchy — [read there](https://omarchy.org/manual/welcome-to-omarchy/) |
+| **Getting started** | **differs on NixOS** — [read here](getting-started) |
+| Coming from mac or windows | same as Omarchy — [read there](https://omarchy.org/manual/coming-from-mac-or-windows/) |
+| Navigation | same as Omarchy — [read there](https://omarchy.org/manual/navigation/) |
+| The top bar | same as Omarchy — [read there](https://omarchy.org/manual/the-top-bar/) |
+| Themes | same as Omarchy — [read there](https://omarchy.org/manual/themes/) |
+| Hotkeys | same as Omarchy — [read there](https://omarchy.org/manual/hotkeys/) |
+| Unified clipboard history | same as Omarchy — [read there](https://omarchy.org/manual/unified-clipboard-history/) |
+| Reminders | same as Omarchy — [read there](https://omarchy.org/manual/reminders/) |
+| Notices | same as Omarchy — [read there](https://omarchy.org/manual/notices/) |
+| Text extraction dictation | same as Omarchy — [read there](https://omarchy.org/manual/text-extraction-dictation/) |
+| Screenshots recording | same as Omarchy — [read there](https://omarchy.org/manual/screenshots-recording/) |
+| Toggles idle screensaver | same as Omarchy — [read there](https://omarchy.org/manual/toggles-idle-screensaver/) |
+| Omarchy cli | same as Omarchy — [read there](https://omarchy.org/manual/omarchy-cli/) |
+| Terminal | same as Omarchy — [read there](https://omarchy.org/manual/terminal/) |
+| Neovim | same as Omarchy — [read there](https://omarchy.org/manual/neovim/) |
+| **Ai** | **differs on NixOS** — [read here](ai) |
+| **Development tools** | **differs on NixOS** — [read here](development-tools) |
+| Shell tools | same as Omarchy — [read there](https://omarchy.org/manual/shell-tools/) |
+| Shell functions | same as Omarchy — [read there](https://omarchy.org/manual/shell-functions/) |
+| Tuis | same as Omarchy — [read there](https://omarchy.org/manual/tuis/) |
+| Guis | same as Omarchy — [read there](https://omarchy.org/manual/guis/) |
+| Browsers | same as Omarchy — [read there](https://omarchy.org/manual/browsers/) |
+| Commercial apps services | same as Omarchy — [read there](https://omarchy.org/manual/commercial-apps-services/) |
+| Web apps | same as Omarchy — [read there](https://omarchy.org/manual/web-apps/) |
+| **Gaming** | **differs on NixOS** — [read here](gaming) |
+| Filling out pdfs | same as Omarchy — [read there](https://omarchy.org/manual/filling-out-pdfs/) |
+| Windows vm | same as Omarchy — [read there](https://omarchy.org/manual/windows-vm/) |
+| **Other packages** | **differs on NixOS** — [read here](other-packages) |
+| **Updates** | **differs on NixOS** — [read here](updates) |
+| **Dotfiles** | **differs on NixOS** — [read here](dotfiles) |
+| Shell plugins | same as Omarchy — [read there](https://omarchy.org/manual/shell-plugins/) |
+| Monitors | same as Omarchy — [read there](https://omarchy.org/manual/monitors/) |
+| Keyboard mouse trackpad | same as Omarchy — [read there](https://omarchy.org/manual/keyboard-mouse-trackpad/) |
+| Networking | same as Omarchy — [read there](https://omarchy.org/manual/networking/) |
+| System sleep | same as Omarchy — [read there](https://omarchy.org/manual/system-sleep/) |
+| Hardware authentication | same as Omarchy — [read there](https://omarchy.org/manual/hardware-authentication/) |
+| Fonts | same as Omarchy — [read there](https://omarchy.org/manual/fonts/) |
+| Backgrounds | same as Omarchy — [read there](https://omarchy.org/manual/backgrounds/) |
+| Prompt | same as Omarchy — [read there](https://omarchy.org/manual/prompt/) |
+| Branding | same as Omarchy — [read there](https://omarchy.org/manual/branding/) |
+| Common tweaks | same as Omarchy — [read there](https://omarchy.org/manual/common-tweaks/) |
+| **Making your own theme** | **differs on NixOS** — [read here](making-your-own-theme) |
+| Mac support | same as Omarchy — [read there](https://omarchy.org/manual/mac-support/) |
+| **Troubleshooting** | **differs on NixOS** — [read here](troubleshooting) |
+| Faq | same as Omarchy — [read there](https://omarchy.org/manual/faq/) |
+| **System snapshots** | **differs on NixOS** — [read here](system-snapshots) |
+| **Security** | **differs on NixOS** — [read here](security) |
+| Omarchy on | same as Omarchy — [read there](https://omarchy.org/manual/omarchy-on/) |
+| **Dual boot install** | **differs on NixOS** — [read here](dual-boot-install) |
+| **Unattended installs** | **differs on NixOS** — [read here](unattended-installs) |
+
+## The short version of the difference
+
+| Omarchy on Arch | nixarchy on NixOS |
+|---|---|
+| `pacman -S foo` | a line in a file you own, then a rebuild |
+| Install menu installs | Install menu *queues*; nothing is built until you apply |
+| `omarchy update` runs a pacman upgrade | `nix flake update` then `nixos-rebuild switch` |
+| Files in `/usr/share/omarchy/` | files in `$OMARCHY_PATH`, a read-only `/nix/store` path |
+| snapper snapshots | NixOS generations, in the boot menu |
+| AUR | no equivalent; `omarchy pkg aur add` explains instead of installing |
+| `ufw allow` | `networking.firewall.allowedTCPPorts` |

--- a/docs/manual/making-your-own-theme.md
+++ b/docs/manual/making-your-own-theme.md
@@ -1,0 +1,76 @@
+---
+title: Making your own theme
+---
+
+# Making your own theme
+
+The theme format is Omarchy's and nothing about it changes here: `colors.toml`
+drives the generated configs for the terminals, btop, Chromium, Hyprland,
+Neovim, Helix, VSCode, Obsidian and the whole Omarchy shell; `mode = "light"`
+pairs a theme with light mode; `icons.theme` names a Yaru icon set;
+`unlock.png` and `preview-unlock.png` put a theme under _Style > Unlock_;
+`~/.config/omarchy/themed/*.tpl` templates teach Omarchy to theme an app it
+does not cover; and a theme installed from a repo has its `.lua`, terminal
+configs and `vscode.json` dropped for the reasons upstream gives. Read
+[the upstream page](https://omarchy.org/manual/making-your-own-theme/) for all
+of that. This page covers only what is different.
+
+## Where the stock themes live, and why you cannot copy-edit them in place
+
+Upstream says: copy one of the existing themes from `/usr/share/omarchy/themes`
+as a base. Here the stock themes live under
+
+```
+$OMARCHY_PATH/themes/
+```
+
+That is a `/nix/store` path. It is not merely inadvisable to edit; the store
+is mounted read-only and the write fails. It also moves on every Omarchy or
+nixpkgs bump, so never write the resolved path into anything — always go
+through `$OMARCHY_PATH`.
+
+Your own themes go where they always did, `~/.config/omarchy/themes/`, and
+anything in that folder shows up in the theme picker. Two workflows, both
+starting from the store copy:
+
+**Overlay.** Create a directory with the *same slug* as a stock theme and put
+only the files you want to change in it. When the theme is applied, the stock
+theme is copied first and your files win on top.
+
+```sh
+mkdir -p ~/.config/omarchy/themes/catppuccin
+cp --no-preserve=mode "$OMARCHY_PATH"/themes/catppuccin/colors.toml \
+   ~/.config/omarchy/themes/catppuccin/
+# edit colors.toml, then re-apply the theme
+```
+
+**Fork.** Copy the whole theme under a new slug and treat it as yours.
+
+```sh
+cp -r --no-preserve=mode "$OMARCHY_PATH"/themes/catppuccin \
+   ~/.config/omarchy/themes/catppuccin-custom
+```
+
+`--no-preserve=mode` matters in both. Files in the store are read-only, and
+`cp` preserves that by default; without the flag your copy starts life
+unwritable and the first edit fails with a permissions error that looks like
+the store's, one directory over from where the store is.
+
+The overlay is the better default for small tweaks: the stock theme keeps
+tracking upstream when `omarchy update` moves the `nixarchy` input, and only
+your `colors.toml` stays pinned. A fork freezes everything at the version you
+copied.
+
+## Installing and distributing
+
+`omarchy theme install <url>` works unchanged. It clones at runtime into
+`~/.config/omarchy/themes/`, which is yours, so nothing about the store gets in
+its way — and the same `omarchy-[themename]-theme` naming convention and the
+submission route to [omarchy.org/themes](https://omarchy.org/themes/) apply.
+
+## Aether
+
+Upstream points you at Aether, its GUI theme builder, for playing with colours
+and searching for backgrounds. It is one of Omarchy's own applications rather
+than a nixpkgs package, so nixarchy does not preinstall it as upstream does.
+Editing `colors.toml` by hand, as the overlay above does, is the route here.

--- a/docs/manual/other-packages.md
+++ b/docs/manual/other-packages.md
@@ -1,0 +1,113 @@
+---
+title: Other packages
+---
+
+# Other packages
+
+Upstream's page is three paragraphs: pick a package from _Install > Package_,
+pick one from _Install > AUR_, remove one from _Remove > Package_. All three run
+pacman. None of that applies here, and the reasons are on the
+[philosophy page](philosophy.md), so this page is about what you do instead.
+
+## The apps the menu knows about
+
+The Install menu still exists and still has every row Omarchy ships. Each row
+has been mapped to how NixOS installs the thing: 56 apps in total, of which 41
+are plain nixpkgs packages, 5 are NixOS modules, 8 are built by nixarchy
+itself because nixpkgs does not carry them, and 2 have no equivalent and say
+so in the menu.
+
+Picking a row does not install anything. It uncomments one line in
+`~/.config/nixarchy/apps.nix`, which is a file nixarchy writes for you, fully
+populated with every app and every line commented out. Pick five rows and you
+have five uncommented lines. Then _Install > Apply changes_ runs
+`nixarchy-apply`, which copies that file to `nixarchy-apps.nix` in your flake
+directory and offers to run `sudo nixos-rebuild switch --flake <flake>`.
+
+The same thing from a terminal:
+
+```sh
+nixarchy-app-enable helix      # uncomment the line
+nixarchy-app-disable helix     # comment it back out
+nixarchy-apply                 # copy into the flake and rebuild
+```
+
+The ids are the ones in `apps.nix`; `omarchy pkg install` prints the file's
+location and nothing else, because it is the list.
+
+One thing has to be true for any of this to work: **your flake must import the
+file.**
+
+```nix
+imports = [ ./nixarchy-apps.nix ];
+```
+
+Without that line every app looks enabled in the menu and nothing is ever
+installed. `nixarchy-apply` checks for it and warns loudly, but it cannot add
+it for you — the flake is yours, and nixarchy does not edit it.
+
+## Why some rows are modules, not packages
+
+On Arch a package is a package. On NixOS a handful of the apps need more than
+files on disk, and for those the row enables a NixOS option instead:
+
+| App | Option | Why a package would not do |
+|---|---|---|
+| Steam | `programs.steam` | Needs an FHS wrapper to run at all |
+| 1Password | `programs._1password-gui` | Unlocking needs a setuid helper |
+| Tailscale | `services.tailscale` | It is a daemon |
+| Firefox | `programs.firefox` | Policies and extensions become declarative |
+| Xbox controllers | `hardware.xpadneo` | A kernel driver |
+
+Rows like these accept settings. `nixarchy-apps.nix` is an ordinary NixOS
+module, so you can write, for example,
+`programs.nixarchy.apps.tailscale.settings.useRoutingFeatures = "client";`
+directly beside the selection and it lands in `services.tailscale`.
+
+## Unfree software
+
+Chrome, VSCode, Cursor, Spotify, Steam and a few others are unfree in nixpkgs.
+An unfree package with `allowUnfree` off does not fail on its own; it aborts
+the whole evaluation, so nothing rebuilds. nixarchy warns at evaluation time
+when an enabled app is unfree and the flag is unset. The fix is one line in
+your own configuration:
+
+```nix
+nixpkgs.config.allowUnfree = true;
+```
+
+or `nixpkgs.config.allowUnfreePredicate` if you would rather list them.
+
+## Anything the menu does not offer
+
+Upstream answers "something else" with _Install > Package_ and a fuzzy list of
+every Arch package. There is no such list here — `omarchy pkg add <name>`
+prints the declarative route and exits 1 — because nixarchy owns the Omarchy
+installation and its apps, not your system configuration.
+
+Search [search.nixos.org/packages](https://search.nixos.org/packages) (also
+_Learn > Nixpkgs_ in the menu), then add it where the rest of your machine is
+declared:
+
+```nix
+environment.systemPackages = with pkgs; [ ripgrep-all ];
+```
+
+and rebuild. If you feed `omarchy pkg add` an Arch package name, it will often
+translate it: fonts are answered with `fonts.packages`, PHP extensions with
+`php.withExtensions`, the 32-bit graphics libraries with
+`hardware.graphics.enable32Bit`, because each of those is a different shape on
+NixOS and `systemPackages` would be the wrong answer.
+
+## Removing
+
+_Remove > App_ runs `nixarchy-app-remove`, a picker over whatever is
+currently enabled in `apps.nix`. It only ever deselects; then
+`nixarchy-apply` rebuilds without the app. Its files go away when the old
+generation is garbage-collected, and its config under `~/.config` stays, as on
+any system.
+
+Two things it deliberately will not do. It will not remove something you added
+in your own `systemPackages` — that is not this menu's to take away; delete the
+line yourself. And it will not run `omarchy pkg drop`, which still calls
+pacman and cannot work here.

--- a/docs/manual/philosophy.md
+++ b/docs/manual/philosophy.md
@@ -1,0 +1,120 @@
+---
+title: The NixOS philosophy, and what it changes
+---
+
+# The NixOS philosophy, and what it changes
+
+Omarchy assumes Arch. Arch installs software by running a command that changes
+the machine. NixOS does not work that way, and almost every difference in this
+manual falls out of that one fact.
+
+## The machine is described, not modified
+
+On Arch, `pacman -S ghostty` *changes your system*. The record that it happened
+is a log file.
+
+On NixOS, you write a line in a file:
+
+```nix
+environment.systemPackages = with pkgs; [ ghostty ];
+```
+
+and then build the machine that file describes. **The file is the system.** If
+the file does not say Ghostty, the next rebuild does not have Ghostty — no
+matter what you ran last week.
+
+That has one consequence worth putting in bold, because it is the single most
+common way to waste an afternoon here:
+
+> **Nothing you install imperatively survives.** Not `nix-env -i`, not
+> `nix profile install`, not a binary you drop in `~/.local/bin` and forget. The
+> first two create state no file records; the third survives, but nobody
+> including you will remember it is there.
+
+If you find yourself typing `nix-env`, the answer is a line in your
+configuration instead.
+
+## What this does to the Install menu
+
+Omarchy's Install menu runs `pacman -S`. Here it cannot, so it does the
+declarative equivalent: **it edits a file and stops.**
+
+```
+Install ▸ Brave          →  "brave queued — not installed yet"
+Install ▸ VSCode         →  "2 app(s) selected"
+Install ▸ Apply changes  →  nixos-rebuild switch --flake
+```
+
+Pick as many as you like; nothing is built until you apply. That is not a
+limitation being worked around — it is the point. You get to see everything you
+are about to change before any of it happens.
+
+`omarchy pkg add <pkg>` therefore **refuses**, deliberately, and exits non-zero.
+It prints the declarative route instead. It is a replacement script rather than
+a broken one: if it silently did nothing, a caller that went on to configure what
+it thought it had installed would half-complete. Failing loudly stops that.
+
+## The boundary: `~/.config` is yours, everything else is declared
+
+Two configuration systems coexist on a nixarchy machine, and knowing which one
+you are in is most of knowing what to do.
+
+| | |
+|---|---|
+| `~/.config/hypr/`, `~/.config/omarchy/shell.json`, themes, plugins | **Yours.** Imperative, edited in place, effective immediately. No rebuild. |
+| Packages, services, users, fonts, hardware, the firewall | **Declared** in your flake. Only changes at a rebuild. |
+
+Getting this backwards is the usual way to do something that silently does not
+last. Changing a keybinding is a text edit and takes effect on save. Installing
+the program that keybinding launches is a rebuild.
+
+Two exceptions worth knowing:
+
+- **A file under `~/.config/` that is a symlink into `/nix/store` is not
+  editable.** Home Manager owns it. Change it where it is declared.
+- **`~/.config/omarchy/extensions/omarchy-menu.jsonc`** is generated, and is the
+  one file under `~/.config/omarchy/` you cannot edit. It carries the rewrite
+  that points every `install.*` row at the Nix selection, so it has to track the
+  package. Add rows with `programs.nixarchy.menu.extraEntries` instead.
+
+## Rollback replaces the snapshot
+
+Omarchy takes a snapper snapshot before an update so you can undo it. NixOS does
+not need one: **every previous system is still on disk**, as a generation.
+
+```sh
+sudo nixos-rebuild --rollback switch   # back one generation, now
+```
+
+Or pick an older one from the boot menu. Nothing is lost by trying a change,
+which is why this manual keeps suggesting you try one.
+
+The corollary: `nix-collect-garbage -d` deletes those generations. It is the one
+command that removes your safety net, so do not run it to free space without
+meaning to.
+
+## The store is read-only, and that is stronger than "do not edit"
+
+Omarchy's manual says never to modify `/usr/share/omarchy/` because an update
+overwrites it. Here the equivalent is `$OMARCHY_PATH`, a `/nix/store` path, and
+the rule is not advice — **the filesystem is mounted read-only and the write
+fails**.
+
+Read it freely; it is the best documentation of how the commands work:
+
+```sh
+cat "$OMARCHY_PATH"/default/hypr/windows.lua
+cat $(which omarchy-theme-set)
+```
+
+Never write down the path itself. It changes on every Omarchy or nixpkgs bump,
+so a store hash copied into a config today is wrong after the next rebuild.
+Always resolve it through `$OMARCHY_PATH`.
+
+## Reproducibility is the point of all of it
+
+The reason to accept "edit a file and rebuild" over "run a command" is that at
+the end you have a machine you can rebuild from scratch, and a second machine
+that is genuinely the same. Your flake plus its lock file is the whole
+description. That is worth more than the convenience of `pacman -S`, and it is
+the trade nixarchy is asking you to make.

--- a/docs/manual/security.md
+++ b/docs/manual/security.md
@@ -1,0 +1,115 @@
+---
+title: Security
+---
+
+# Security
+
+Upstream's [security page](https://omarchy.org/manual/security/) lists five
+things Omarchy does for you. Here is how each of them lands on NixOS.
+
+| Upstream | nixarchy |
+|---|---|
+| Full-disk encryption, mandatory | Chosen when you install NixOS. LUKS is a checkbox in the installer; nixarchy has no installer and cannot add it afterwards. |
+| ufw, closed except 53317 | `networking.firewall`, closed except 53317. Same policy, different tool. |
+| Arch rolling updates | `nix flake update` moves nixpkgs; security fixes arrive with the next `omarchy update`. |
+| Omarchy's own package mirror | Everything comes from nixpkgs and this flake. There is no Omarchy repo and no AUR. |
+| Cloudflare in front of the ISOs | There are no ISOs. Builds are served by the nixarchy binary cache and cache.nixos.org. |
+
+## The firewall
+
+There is no `ufw` on NixOS. nixarchy sets
+
+```nix
+networking.firewall.enable = lib.mkDefault true;
+networking.firewall.allowedTCPPorts = [ 53317 ];
+networking.firewall.allowedUDPPorts = [ 53317 ];
+```
+
+which is a port of upstream's `install/config/firewall.sh` (`ufw default deny
+incoming`, then `ufw allow 53317` on both protocols for
+[LocalSend](https://localsend.org/)). Discovery over mDNS was never the
+missing part; `services.avahi` already opens 5353. Only the transfer port was.
+
+The `enable` is `mkDefault`, so a configuration that turns the firewall off
+wins. The port lists are not, deliberately: list options merge, so a port you
+open is added to LocalSend's rather than replacing it.
+
+To open a port, add it in your flake and rebuild:
+
+```nix
+networking.firewall.allowedTCPPorts = [ 8080 ];
+```
+
+`sudo ufw allow 8080` does not exist here, and a port opened by hand with
+`iptables` or `nft` is gone on the next rebuild, which is the point.
+
+Docker is enabled by default (`virtualisation.docker.enable = mkDefault true`)
+but upstream's `ufw-docker` lockdown is not ported, because it is a ufw script.
+A container published with `-p` is reachable through the firewall the way
+Docker's own iptables rules make it. If that matters to you, bind published
+ports to `127.0.0.1`.
+
+## SSH
+
+*Setup > Security > SSHD* in the menu is upstream's script, and it cannot
+finish here: its first step is `omarchy-pkg-add openssh`, which exits 1 by
+design (see [the philosophy](philosophy.md)), and the script runs under
+`set -e`. Declare it instead:
+
+```nix
+services.openssh.enable = true;
+users.users.you.openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAA... you@host" ];
+```
+
+`services.openssh.openFirewall` defaults to `true`, so port 22 opens with it.
+Upstream rate-limits port 22 with `ufw limit`; nothing equivalent is set here,
+so keep password authentication off (`settings.PasswordAuthentication =
+false`) rather than relying on rate limiting.
+
+## Fingerprint and FIDO2
+
+*Setup > Security > Fingerprint* and *FIDO2* do the enrolment they always did:
+`fprintd-enroll` really enrols a print, and `pamu2fcfg` really writes a
+credential to `/etc/fido2/fido2`. What they cannot do is edit `/etc/pam.d`,
+because on NixOS PAM is built, not edited. So the last step prints the lines
+to add and exits non-zero:
+
+```nix
+security.pam.u2f.enable = true;
+security.pam.u2f.settings.authfile = "/etc/fido2/fido2";
+security.pam.u2f.settings.cue = true;
+security.pam.services.sudo.u2fAuth = true;
+security.pam.services.polkit-1.u2fAuth = true;
+```
+
+or, for fingerprint, `services.fprintd.enable = true` plus
+`security.pam.services.sudo.fprintAuth = true` and the same for `polkit-1`.
+Rebuild, and the enrolled key or print is accepted.
+
+## Passwordless sudo
+
+Unchanged. `omarchy-sudo-passwordless` writes
+`/etc/sudoers.d/99-omarchy-nopasswd-$USER` and a systemd timer removes it
+after 15 minutes; pass a number of minutes to change that. NixOS manages
+`/etc/sudoers` but leaves `sudoers.d` alone, so this works as upstream
+describes. Upstream's warning applies in full: while it is on, anything
+running as your user is root.
+
+## Changing your passwords
+
+Your login password is `passwd`, or *Update > Password > User* in the menu.
+The drive passphrase, if you encrypted, is `cryptsetup luksChangeKey` on the
+LUKS device; NixOS does not manage that for you either.
+
+If you declared `users.users.you.hashedPassword` or `initialPassword` in your
+flake, that value is reapplied at every rebuild unless
+`users.mutableUsers` is `true` (the default). Check before wondering why a
+password change did not stick.
+
+## Passing on a machine, and signing keys
+
+*Setup > Reset Computer* restores the baseline snapshot the Omarchy ISO takes,
+so it needs an ISO install and does not work here. Hand a machine over by
+reinstalling NixOS, or by deleting the user and their home from your flake and
+rebuilding. Upstream's ISO and package signing key does not apply; nixarchy
+has no packages to sign, and the flake lock pins the source by hash.

--- a/docs/manual/system-snapshots.md
+++ b/docs/manual/system-snapshots.md
@@ -1,0 +1,105 @@
+---
+title: System snapshots
+---
+
+# System snapshots
+
+Omarchy takes a Btrfs snapshot with snapper before every update, and you boot
+into one from the Limine menu to undo a bad update. **None of that machinery
+exists here, and none of it is missing.** NixOS keeps every previous system on
+disk as a *generation*, and generations do everything the snapshot did.
+
+`omarchy-snapshot` still exists in the tree, but it checks for snapper and
+exits 127 when it is not there, which is always. `omarchy update` treats that
+exit code as "no snapshot available" and carries on.
+
+## What a generation is
+
+Every `nixos-rebuild switch` (which is what `omarchy update` runs) builds a
+complete new system in `/nix/store` and points
+`/nix/var/nix/profiles/system` at it. The old one is not overwritten; it is
+still there, complete, and it is still listed in the boot menu.
+
+```sh
+sudo nix-env --list-generations --profile /nix/var/nix/profiles/system
+```
+
+No snapshot is taken before an update because there is nothing to snapshot:
+the previous system was never modified in the first place.
+
+## Rolling back
+
+From a running desktop:
+
+```sh
+sudo nixos-rebuild --rollback switch   # back one generation, now
+```
+
+From a machine that will not reach a desktop: reboot, and pick the previous
+generation from the boot menu. Every generation is an entry there, labelled
+with its date and number.
+
+This is the one way generations are better than snapper, and it matters.
+Upstream's restore is a command you run from inside the booted snapshot, and
+a broken update that keeps the machine from booting at all leaves you with
+the Limine menu only if you are not using direct boot. Here the boot menu is
+where the generations live, so the recovery route works precisely when it is
+needed most: when the update cost you the screen, the GPU driver, or the
+login manager.
+
+To see what an update actually changed, before deciding whether to roll it
+back:
+
+```sh
+nix profile diff-closures --profile /nix/var/nix/profiles/system
+```
+
+## What a rollback does and does not touch
+
+The same boundary upstream describes for snapshots holds here, for the same
+reason:
+
+| | |
+|---|---|
+| Packages, services, kernel, drivers, the Omarchy tree | Rolled back with the generation |
+| `/home`, `~/.config`, your app selection file | Left exactly as they are |
+
+So a rollback fixes a broken system update and does not recover a deleted
+file. And if an application rewrote its config in a new format before you
+rolled back, the config stays in the new format; sort that out by hand, as
+upstream says.
+
+Rolling back also does not edit your flake. `flake.lock` still names the
+inputs that produced the broken generation, so the next `omarchy update` or
+`nixos-rebuild switch` builds it again. To make the rollback stick, revert the
+lock file too, most simply with `git checkout flake.lock` in your flake if it
+is under version control, or by updating only the input that did not break.
+
+## Testing a change without committing to it
+
+Snapshots exist to make an update safe to try. Generations make that a
+first-class option instead:
+
+```sh
+sudo nixos-rebuild boot --flake <flake>   # becomes the default at next boot, running system untouched
+sudo nixos-rebuild test --flake <flake>   # activates now, boot default untouched
+```
+
+`boot` is the one for anything that could cost you the screen; the previous
+generation stays one menu entry away. See
+[updating NixOS](updating-nixos.md).
+
+## The one command that deletes the safety net
+
+```sh
+nix-collect-garbage -d
+```
+
+`-d` deletes every generation but the current one. The disk space it frees is
+exactly the rollback history. Run it when you mean to, after the current
+system has been good for a while, and not as a reflex to free space. Without
+`-d`, `nix-collect-garbage` removes only store paths no generation references,
+which is safe.
+
+Direct boot, upstream's *Setup > Direct Boot*, is a Limine feature and has no
+meaning here; your boot loader's own timeout setting is the equivalent.

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -1,0 +1,124 @@
+---
+title: Troubleshooting
+---
+
+# Troubleshooting
+
+### Start with the doctor
+
+```sh
+nix run github:olafkfreund/nixarchy#doctor
+```
+
+It reads the running system and reports the things that are most often the
+actual problem on a NixOS host:
+
+| Report | What it means |
+|---|---|
+| Session | Your session runs an older Omarchy build than the system; log out and in (below) |
+| Default browser | `~/.config/mimeapps.list` is a store symlink, so *Setup > Default browser* is a silent no-op; or `$BROWSER` is set and shadows the default |
+| Hyprland config | Which of `~/.config/hypr/*.lua` are yours and which Home Manager owns |
+| Boot splash | Whether Omarchy's Plymouth theme is the one in use, or stylix's |
+| TLP | TLP is on, so power-profiles-daemon is off and `omarchy powerprofiles` cannot work |
+
+### I broke my system with an update!
+
+Roll back the generation, from the desktop or from the boot menu; see
+[system snapshots](system-snapshots.md). There is no `omarchy-snapshot` to
+restore here; the boot menu is the restore.
+
+Upstream's last resort is `omarchy-reinstall`. **It exists here and cannot
+finish.** It calls `omarchy-reinstall-pkgs`, whose first real step is
+`sudo pacman -Suu`; the pacman shim refuses with a message and exits 1, and
+`set -e` aborts the script before `omarchy-reinstall-configs` is reached. So
+it neither reinstalls packages (a rebuild does that) nor resets a config, and
+it is not a recovery route. Use instead:
+
+| Want | Run |
+|---|---|
+| The packages back as they were | `sudo nixos-rebuild --rollback switch`, or the boot menu |
+| One shipped config back to default | `omarchy refresh config <path>`, e.g. `omarchy refresh config hypr/bindings.lua`; it backs up your copy first |
+| A report to attach to an issue | `omarchy debug --no-sudo --print` |
+
+Always pass both flags to `omarchy debug`: `--no-sudo` skips `dmesg`, and
+`--print` writes to the terminal instead of trying to upload. The pacman
+lines in its output read `unknown`, which is expected.
+
+### My change rebuilt fine but the keybinding still runs the old thing
+
+`OMARCHY_PATH` and `PATH` are set at login. A rebuild produces a new store
+path and cannot change a session that is already running, so every
+`omarchy-*` command the desktop executes comes from the old build until you
+log out and back in.
+
+```sh
+echo "$OMARCHY_PATH"
+readlink -f /run/current-system/sw/bin/omarchy | sed 's|/bin/omarchy$||'
+```
+
+If those differ, log out. The doctor reports this under **Session**. It is the
+most misleading failure on this system, because running the new script by its
+full store path works while the keybinding does not.
+
+Related: if Home Manager deployed `~/.config/hypr/`, a rebuild swaps a
+symlink rather than changing a file, and Hyprland's auto-reload does not see
+it. Run `hyprctl reload`.
+
+### I picked an app in Install and it never appeared
+
+Three things to check, in order:
+
+1. Did you *Apply changes*? Picking only edits `~/.config/nixarchy/apps.nix`.
+2. Does your flake `imports = [ ./nixarchy-apps.nix ];`? Without it the
+   rebuild succeeds and installs nothing. `nixarchy-apply` warns when nothing
+   imports the file.
+3. Is the app one you already had? The menu dims rows for apps already on
+   `PATH`, and the doctor lists them under *Omarchy apps you already have*.
+
+### Why are some apps so large on my display?
+
+Unchanged from upstream: `GDK_SCALE` is 2 in `~/.config/hypr/monitors.lua`;
+set `local omarchy_gdk_scale = 2` to 1 for a 1x display. That file is yours
+and takes effect on save, no rebuild. See
+[monitors](https://omarchy.org/manual/monitors/).
+
+### Why isn't Caps Lock working?
+
+Unchanged: Caps Lock is the compose key. Remap it in `~/.config/hypr/input.lua`
+as upstream shows, `kb_options = "compose:ralt"`. Same file rule: yours, no
+rebuild.
+
+### My Wi-Fi, Bluetooth, audio, or trackpad just stopped working
+
+Unchanged: *Update > Hardware* restarts the subsystem, and the
+`omarchy-restart-*` commands behind those rows are upstream's.
+
+### Why can't I login or sudo with my password?
+
+Upstream's answer is `faillock --reset`, and it applies here too: switch to a
+TTY with `Ctrl+Alt+F2`, log in, and run
+`faillock --reset --user <you>`.
+
+If it is a password you set in your flake with `hashedPassword` or
+`initialPassword`, a rebuild reapplies that value when
+`users.mutableUsers = false`. That is a configuration, not a lockout.
+
+### Steam, 1Password or Tailscale is installed but does not work
+
+These are NixOS modules, not packages, and the app selection enables the
+module (`programs.steam`, `programs._1password-gui`, `services.tailscale`).
+If you added the package yourself to `environment.systemPackages` instead,
+Steam has no FHS wrapper and 1Password has no setuid helper. Remove the
+package and enable it through Install, or set the module option directly.
+
+### Something crashed and I want to know why
+
+`coredumpctl` has the dump. No public debuginfod serves nixpkgs builds, so
+symbolizing it needs `nixseparatedebuginfod` locally; the `diagnose-crash`
+agent skill nixarchy installs walks through it.
+
+### 1Password authorization prompts
+
+Unchanged from [upstream](https://omarchy.org/manual/troubleshooting/):
+hardware acceleration must be on in 1Password's settings, and the app must
+have been launched since boot.

--- a/docs/manual/unattended-installs.md
+++ b/docs/manual/unattended-installs.md
@@ -1,0 +1,41 @@
+---
+title: Unattended installs
+---
+
+# Unattended installs
+
+There is no nixarchy installer, so there is no unattended installer either.
+
+Omarchy's ISO watches for a second drive labelled `cidata`, reads the wizard's
+answers off it, and installs with nobody at the keyboard — which makes it a
+good base image for disposable VMs. nixarchy has no ISO at all. It is a flake
+you add to a machine that already runs NixOS, and it does not ship anything
+that boots. An installer is tracked as
+[issue #6](https://github.com/olafkfreund/nixarchy/issues/6), an epic with 14
+sub-issues; until it lands, the upstream `cidata` mechanism described on
+[the upstream page](https://omarchy.org/manual/unattended-installs/) has no
+counterpart here.
+
+## What to do instead
+
+The honest answer is that unattended provisioning is a NixOS problem with
+mature NixOS solutions, and nixarchy sits on top of whichever you pick:
+
+- **[disko](https://github.com/nix-community/disko)** describes the disk
+  layout declaratively, so partitioning and formatting are part of the
+  configuration rather than a wizard step.
+- **[nixos-anywhere](https://github.com/nix-community/nixos-anywhere)**
+  installs a NixOS flake configuration onto a remote machine over SSH, using
+  disko for the disks. Point it at a VM or a bare host booted into any Linux
+  with SSH, and it comes back as the system your flake describes.
+
+Add nixarchy as an input to that flake before the first install and the
+machine arrives with the desktop already declared — there is no second step
+to automate, because the flake is the whole description. How to add the input
+is on [the getting-started page](getting-started).
+
+This is also why the gap is smaller than it looks. Upstream's `cidata` drive
+exists to feed answers to an imperative wizard: a disk, a hostname, a user, a
+password hash, SSH keys. In a NixOS flake every one of those is already a line
+in a file, and the file is what nixos-anywhere ships. What nixarchy is missing
+is the boot medium, not the unattended part.

--- a/docs/manual/updates.md
+++ b/docs/manual/updates.md
@@ -1,0 +1,126 @@
+---
+title: Updates
+---
+
+# Updates
+
+_Update > Nixarchy_ in the Omarchy menu (`Super + Space`) — upstream labels it
+_Update > Omarchy_ — is still the one place to keep everything current. The
+row runs `omarchy update`, and this page is about what that means on NixOS and
+what happened to the rest of upstream's update machinery. The mechanics —
+`nix flake update`, the four rebuild modes, generations, rollback and the
+stale-session trap — are on [Updating NixOS](updating-nixos.md), and are not
+repeated here.
+
+## What an update is
+
+On Arch an update installs a new `omarchy` package, runs its migrations, and
+upgrades every system package from the Omarchy mirror. Those are three
+different mechanisms.
+
+Here they are one. Omarchy, nixpkgs and nixarchy are all inputs to your flake,
+and `flake.lock` pins each of them to an exact revision. `omarchy update`
+moves every pin forward and rebuilds:
+
+```sh
+nix flake update --flake <flake>
+sudo nixos-rebuild switch --flake <flake>
+```
+
+It asks first. A new Omarchy release arrives as a source bump of the `omarchy`
+input, so the menus, themes and commands come along with it. Your app
+selection is not touched: it lives in a file you own.
+
+Nothing is snapshotted before the update because the previous system is still
+on disk as a generation; see [rolling back](#rolling-back-bad-updates).
+
+The update-available icon next to the clock is upstream's, and it is driven by
+`omarchy-update-available`, which has been replaced to fit this model.
+
+## Channels do not exist here
+
+Upstream's four channels — stable, RC, edge, dev — are a choice of pacman
+repository and, for dev, a git checkout in `~/omarchy`. Neither exists on
+NixOS. Your "channel" is whatever the flake's `omarchy` input is pinned to,
+and the `nixpkgs` input decides whether your packages track a stable release
+or unstable.
+
+So _Update > Channel_ is hidden from the menu, and `omarchy-channel-set` is
+one of the roughly fifteen scripts that still shell out to pacman. Those get a
+shim that explains what replaced them and exits non-zero rather than
+`pacman: command not found`.
+
+If you want the equivalent of edge, point your `nixpkgs` input at
+`nixos-unstable` in `flake.nix`. If you want to develop nixarchy itself, point
+the `nixarchy` input at a local checkout. Both are edits to your own flake,
+which nixarchy does not make for you.
+
+## Firmware updates
+
+_Update > Firmware_ runs `omarchy-update-firmware`, which is upstream's
+script unchanged: it calls `fwupdmgr refresh --force` and `sudo fwupdmgr
+update`. Its first step is to install `fwupd` if `fwupdmgr` is missing, which
+goes through `omarchy-pkg-add` and therefore stops. Enable the service in
+your configuration once and the row works from then on:
+
+```nix
+services.fwupd.enable = true;
+```
+
+Plenty of firmware can only be written during a reboot, so expect to be asked
+for one. The step that copies an EFI binary into `/boot/EFI/arch/` looks for
+an Arch path that does not exist here and is skipped.
+
+## Direct updates, and why there is no guard
+
+Upstream stops a bare `pacman -Syu` because it would skip the snapshot and the
+migrations. Here there is nothing to guard: `nix flake update` followed by
+`nixos-rebuild switch` **is** the update, and running those two commands
+yourself is exactly what `omarchy update` does. The only thing you lose by
+running them by hand is the confirmation prompt.
+
+The more useful distinction is between updating everything and updating one
+input. `omarchy update` moves all of them; `nix flake update nixpkgs --flake
+<flake>` moves one. When you are chasing a specific fix, the second is the
+better habit — see [Updating NixOS](updating-nixos.md#the-long-way-and-when-you-want-it).
+
+## Rolling back bad updates
+
+The snapshot upstream restores from the boot menu is a generation here, and
+you have one for every rebuild you have ever done, not just the last update.
+
+```sh
+sudo nixos-rebuild --rollback switch
+```
+
+or pick the previous entry in the boot menu. To see what an update actually
+changed, before deciding whether to roll it back:
+
+```sh
+nix profile diff-closures --profile /nix/var/nix/profiles/system
+```
+
+`nix-collect-garbage -d` deletes old generations. It is how you get disk
+space back, and it is also the only command that removes your rollback path,
+so run it after an update has proved itself, not before.
+
+## `omarchy reinstall` is not a recovery route
+
+Upstream's answer to corrupted configuration is `omarchy reinstall`, which
+reinstalls the packages, downgrades to stable and resets every config file.
+The command exists here but cannot complete: its first act is `pacman -Suu`,
+the shim refuses, and `set -e` aborts before any configuration is touched.
+That is the right outcome — half of a reinstall would be worse than none —
+but it means the command does nothing.
+
+What replaces it depends on what broke:
+
+| Symptom | Do this |
+|---|---|
+| A rebuild left the desktop broken | Roll back the generation |
+| One app's config is wrong | `omarchy refresh <app>` restores that app's defaults |
+| `~/.config/hypr` or another Omarchy config is mangled | `omarchy refresh` for it, or `git checkout` if you keep `~/.config` in git |
+
+Nothing under `$OMARCHY_PATH` can be corrupted by you, because it is a
+read-only store path. If a file there is wrong, it was wrong in the release,
+and the fix is a bump of the `omarchy` or `nixarchy` input.

--- a/docs/manual/updating-nixos.md
+++ b/docs/manual/updating-nixos.md
@@ -1,0 +1,121 @@
+---
+title: Updating NixOS
+---
+
+# Updating NixOS
+
+## The short way
+
+```sh
+omarchy update
+```
+
+Omarchy's own update command, replaced here. Upstream's drives pacman — it
+prunes packages, takes a snapper snapshot, refreshes the keyring and demands
+10 GiB free before it will start. None of that exists on NixOS, so this one does
+what updating a NixOS host actually means:
+
+```sh
+nix flake update --flake /etc/nixos      # move every input forward
+sudo nixos-rebuild switch --flake /etc/nixos
+```
+
+It asks before doing either, and it tells you afterwards that the previous
+generation is still in the boot menu. No snapshot is taken because none is
+needed — see [rollback](#when-it-goes-wrong).
+
+Your flake is wherever `programs.nixarchy.flake` points, which is often *not*
+`/etc/nixos` — many people keep theirs in a git repo under `~`.
+
+## The long way, and when you want it
+
+`omarchy update` moves **every** input. Sometimes that is more than you want.
+
+```sh
+nix flake update nixpkgs --flake <flake>   # move one input
+nix flake update --flake <flake>           # move all of them
+sudo nixos-rebuild switch --flake <flake>
+```
+
+Updating a single input is the better habit when you are chasing a specific fix.
+Moving everything to solve one problem changes far more than the problem, and
+when something breaks you have no idea which input did it.
+
+`nix flake update` rewrites `flake.lock`, so the flake directory has to be
+writable by you. A root-owned `/etc/nixos` fails on the lock file.
+
+## switch, boot, test — pick the right one
+
+| | |
+|---|---|
+| `nixos-rebuild switch` | build, activate now, and make it the boot default |
+| `nixos-rebuild boot` | build and make it the boot default, but **do not** activate now |
+| `nixos-rebuild test` | build and activate now, but **do not** touch the boot default |
+| `nixos-rebuild build` | build only — no `sudo`, no activation |
+
+`build` is free to run and catches every evaluation and build error, so use it
+while iterating.
+
+**`boot` is the one to reach for when a change could cost you the screen** — a
+display manager, a GPU driver, a greeter. The running system stays up; you test
+by rebooting, and if it fails the previous generation is one boot-menu entry
+away.
+
+## When it goes wrong
+
+Every previous system is still on disk.
+
+```sh
+sudo nixos-rebuild --rollback switch      # back one generation, now
+sudo nix-env --list-generations --profile /nix/var/nix/profiles/system
+```
+
+Or pick an older generation from the boot menu — which is how you recover when
+the machine will not reach a desktop at all. Keep a TTY in mind too:
+`Ctrl+Alt+F2` gets you a login even when the graphical session is broken.
+
+To see what an update actually changed:
+
+```sh
+nix profile diff-closures --profile /nix/var/nix/profiles/system
+```
+
+That is the honest answer to "what did that update do", and better evidence than
+any package log.
+
+## A rebuild does not update the session you are sitting in
+
+This one costs people an evening, so it is worth stating plainly.
+
+`OMARCHY_PATH` and `PATH` are set **at login** and keep pointing at whichever
+store path was current then. A rebuild installs a new package at a *new* path and
+cannot reach into a session that is already running. So every `omarchy-*` command
+your desktop executes — every keybinding, every menu row — comes from the old
+build until you log out and back in.
+
+```sh
+echo "$OMARCHY_PATH"
+readlink -f /run/current-system/sw/bin/omarchy | sed 's|/bin/omarchy$||'
+```
+
+If those differ, log out and back in. `nixarchy-doctor` reports it under
+**Session**.
+
+On Arch this cannot happen: the tree lives at a fixed `/usr/share/omarchy`
+overwritten in place, and a running session picks up a new version at once. Here
+the path itself changes. It is the single most misleading failure on this system,
+because testing a fix by running the script at its full installed path *works*
+while the keybinding still does not.
+
+The same applies to Hyprland config deployed by Home Manager: a store **symlink
+swap** is not a content change, so Hyprland's auto-reload does not notice it. Run
+`hyprctl reload` after a rebuild that touched `~/.config/hypr/`.
+
+## Keeping Omarchy itself current
+
+nixarchy tracks Omarchy releases as a source bump. `nix flake update` moves the
+`nixarchy` input like any other, and a new Omarchy version arrives with it — the
+menus, themes and commands come along, because the port vendors upstream's real
+tree rather than reimplementing it.
+
+Your app selection is untouched by any of this. It lives in a file you own.


### PR DESCRIPTION
A GitHub Pages manual in the style of [omarchy.org/manual](https://omarchy.org/manual/), covering **what is different on NixOS** — and only that.

## Why not all 51 pages

I checked before writing. Of Omarchy's 51 manual pages:

| | |
|---|---|
| Contain Arch mechanics (`pacman`, `yay`, AUR, `ufw`, `snapper`, `archinstall`) | **6** |
| Diverge for reasons a grep misses (install, snapshots, troubleshooting, AI, gaming, dual-boot, unattended) | **~7** |
| **Word-for-word true here** | **38** |

Copying 38 pages we don't change means maintaining text that goes stale at every Omarchy release — and Omarchy releases often. *Tracking upstream is a source bump, not a re-port.* That reasoning applies to documentation as much as code; it's the same decision the port already makes.

## What's here

**16 pages** — 13 rewritten, 2 new, 1 index.

The **index lists all 51 topics**, each marked *"same as Omarchy →"* (deep link) or *"differs here →"* (ours). A reader always finds their topic; we maintain only the fifteen that are actually ours.

The two new pages are what a NixOS newcomer needs and upstream has no reason to write:

- **[The NixOS philosophy, and what it changes](docs/manual/philosophy.md)** — why the Install menu *queues* instead of installing, where the `~/.config` ↔ flake line falls, why nothing installed imperatively survives, why the store being read-only is stronger than "don't edit"
- **[Updating NixOS](docs/manual/updating-nixos.md)** — `omarchy update` and what it does underneath, the four rebuild modes and when `boot` is the right one, generations and rollback, `nix profile diff-closures`, and the trap that cost an evening this week: **a rebuild cannot change the session you're sitting in**

## Two deliberately short pages

`dual-boot-install` (37 lines) and `unattended-installs` (41 lines). Neither exists here — there is no ISO and no installer. They say so plainly, point at what to actually do, and reference the epic (#6, 14 sub-issues). They are not padded to look substantial.

## Verified, not assumed

- **Every** `omarchy-*` / `nixarchy-*` command named in the manual exists on the running system
- No page claims an ISO or installer that doesn't exist
- All three install-related pages state outright that there is no installer
- Every internal link resolves; the index links every page written
- All 16 pages have frontmatter and an H1

The three writers worked from a 100-line verified facts sheet rather than from memory, and were told that an invented command is the worst failure available.

## Build

Jekyll from `docs/` — GitHub renders it, no build tooling to maintain. **Pages needs enabling** on the repo (Settings → Pages → source `main` / `/docs`); I've left that to you rather than flipping a repo setting unasked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5