### PR TITLE
The manual looks like a manual now

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,10 @@
 title: nixarchy
 description: Omarchy, vendored for NixOS
-theme: jekyll-theme-primer
-show_downloads: false
+url: "https://olafkfreund.github.io"
+baseurl: "/nixarchy"
+
+# No theme gem. The layouts in _layouts/ and assets/style.css are the whole
+# site, so what builds on GitHub Pages is exactly what is in this directory.
 
 # Only the manual is a site. The screenshots and the demo gif live in docs/
 # too and are linked from the README, so they must not become pages.
@@ -16,4 +19,25 @@ defaults:
   - scope:
       path: "manual"
     values:
-      layout: default
+      layout: manual
+
+# The sidebar, in reading order. Alphabetical would open the manual on "AI"
+# and bury "Getting Started", so the order is stated rather than derived.
+# A page added to manual/ and not listed here will not appear in the nav.
+nav:
+  - { path: /manual/,                      title: Welcome to nixarchy }
+  - { path: /manual/philosophy,            title: The NixOS Philosophy }
+  - { path: /manual/getting-started,       title: Getting Started }
+  - { path: /manual/updating-nixos,        title: Updating NixOS }
+  - { path: /manual/updates,               title: Updates }
+  - { path: /manual/other-packages,        title: Packages }
+  - { path: /manual/dotfiles,              title: Dotfiles }
+  - { path: /manual/making-your-own-theme, title: Making Your Own Theme }
+  - { path: /manual/development-tools,     title: Development Tools }
+  - { path: /manual/ai,                    title: AI }
+  - { path: /manual/gaming,                title: Gaming }
+  - { path: /manual/security,              title: Security }
+  - { path: /manual/system-snapshots,      title: System Snapshots }
+  - { path: /manual/dual-boot-install,     title: Dual Boot Install }
+  - { path: /manual/unattended-installs,   title: Unattended Installs }
+  - { path: /manual/troubleshooting,       title: Troubleshooting }

--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>nixarchy — {{ site.description }}</title>
+<meta name="description" content="{{ site.description }}">
+<link rel="stylesheet" href="{{ '/assets/style.css' | relative_url }}">
+</head>
+<body class="home">
+
+<header class="masthead">
+  <span class="wordmark">nixarchy</span>
+  <p class="tagline">{{ site.description }}</p>
+</header>
+
+<main class="content content--centred">
+  {{ content }}
+</main>
+
+</body>
+</html>

--- a/docs/_layouts/manual.html
+++ b/docs/_layouts/manual.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{ page.title }} — nixarchy manual</title>
+<meta name="description" content="{{ site.description }}">
+<link rel="stylesheet" href="{{ '/assets/style.css' | relative_url }}">
+</head>
+<body>
+
+<header class="masthead">
+  <a class="wordmark" href="{{ '/' | relative_url }}">nixarchy</a>
+  <p class="tagline">The Manual</p>
+</header>
+
+<div class="page">
+  <nav class="sidebar" aria-label="Manual contents">
+    <input type="search" id="filter" class="filter" placeholder="Search" autocomplete="off" spellcheck="false">
+    <span class="filter-hint">/</span>
+
+    {%- comment -%}
+      page.url is /manual/foo.html (or /manual/ for the index). Normalise both
+      sides to a trailing slash so the current page highlights either way.
+    {%- endcomment -%}
+    {%- assign cur = page.url | remove: 'index.html' | remove: '.html' | append: '/' | replace: '//', '/' -%}
+    <ol class="toc">
+      {%- for item in site.nav -%}
+      {%- assign href = item.path | append: '/' | replace: '//', '/' -%}
+      <li{% if href == cur %} class="current"{% endif %}>
+        <a href="{{ item.path | relative_url }}">{{ item.title }}</a>
+      </li>
+      {%- endfor -%}
+    </ol>
+
+    <p class="offsite">
+      <a href="https://github.com/olafkfreund/nixarchy">Source</a> ·
+      <a href="https://omarchy.org/manual/">Omarchy's manual</a>
+    </p>
+  </nav>
+
+  <main class="content">
+    {{ content }}
+  </main>
+</div>
+
+<script src="{{ '/assets/manual.js' | relative_url }}"></script>
+</body>
+</html>

--- a/docs/assets/manual.js
+++ b/docs/assets/manual.js
@@ -1,0 +1,26 @@
+// Filter the table of contents. There is no search index and no fetch: the
+// whole nav is already in the DOM, so matching titles is the entire feature.
+(function () {
+  var box = document.getElementById('filter');
+  if (!box) return;
+  var items = Array.prototype.slice.call(document.querySelectorAll('.toc li'));
+
+  box.addEventListener('input', function () {
+    var q = box.value.trim().toLowerCase();
+    items.forEach(function (li) {
+      li.hidden = q !== '' && li.textContent.toLowerCase().indexOf(q) === -1;
+    });
+  });
+
+  // "/" focuses the box, Escape clears it -- the hint next to the box.
+  document.addEventListener('keydown', function (e) {
+    if (e.key === '/' && document.activeElement !== box) {
+      e.preventDefault();
+      box.focus();
+    } else if (e.key === 'Escape' && document.activeElement === box) {
+      box.value = '';
+      box.dispatchEvent(new Event('input'));
+      box.blur();
+    }
+  });
+})();

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1,0 +1,179 @@
+/* nixarchy manual — dark, monospace, sidebar. No framework, no theme gem. */
+
+:root {
+  --bg:        #22242e;
+  --fg:        #c9cddb;
+  --dim:       #6b7089;
+  --accent:    #a5cf5d;   /* the wordmark green */
+  --link:      #8ab4f8;
+  --rule:      #333747;
+  --code-bg:   #1a1c24;
+  --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Fira Code",
+          Menlo, Consolas, "Liberation Mono", monospace;
+}
+
+* { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--mono);
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+a { color: var(--link); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ---------- masthead ---------- */
+
+.masthead { padding: 3.5rem 1.5rem 2.5rem; text-align: center; }
+
+.wordmark {
+  display: inline-block;
+  color: var(--accent);
+  font-size: clamp(2.6rem, 9vw, 5.5rem);
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: lowercase;
+  text-decoration: none;
+}
+.wordmark:hover { text-decoration: none; }
+
+.tagline { margin: 0.6rem 0 0; color: var(--link); font-size: 1rem; }
+
+/* ---------- layout ---------- */
+
+.page {
+  display: grid;
+  grid-template-columns: 20rem minmax(0, 1fr);
+  gap: 3rem;
+  max-width: 78rem;
+  margin: 0 auto;
+  padding: 0 1.5rem 6rem;
+}
+
+/* ---------- sidebar ---------- */
+
+.sidebar { position: relative; align-self: start; position: sticky; top: 1.5rem; }
+
+.filter {
+  width: 100%;
+  padding: 0.4rem 1.5rem 0.6rem 0;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--rule);
+  color: var(--fg);
+  font: inherit;
+}
+.filter::placeholder { color: var(--dim); }
+.filter:focus { outline: none; border-bottom-color: var(--link); }
+
+.filter-hint {
+  position: absolute;
+  top: 0.4rem;
+  right: 0;
+  color: var(--dim);
+  pointer-events: none;
+}
+
+.toc {
+  list-style: none;
+  counter-reset: item;
+  margin: 1.6rem 0 0;
+  padding: 0;
+  max-height: 68vh;
+  overflow-y: auto;
+}
+
+.toc li { counter-increment: item; margin: 0 0 0.35rem; }
+
+/* The 01, 02, 03 gutter. Numbering follows the DOM, so a filtered list
+   keeps each page's real number rather than renumbering as you type. */
+.toc li::before {
+  content: counter(item, decimal-leading-zero);
+  display: inline-block;
+  width: 2.2rem;
+  color: var(--dim);
+}
+
+.toc li.current > a { color: var(--fg); font-weight: 700; }
+.toc li[hidden] { display: none; }
+
+.offsite { margin-top: 1.8rem; color: var(--dim); font-size: 0.85rem; }
+
+/* ---------- content ---------- */
+
+.content { min-width: 0; padding-top: 0.2rem; }
+
+.content--centred {
+  max-width: 46rem;
+  margin: 0 auto;
+  padding: 0 1.5rem 6rem;
+}
+
+.content h1 { font-size: 1.9rem; margin: 0 0 1.6rem; }
+.content h2 { font-size: 1.35rem; margin: 2.6rem 0 1rem; }
+.content h3 { font-size: 1.1rem; margin: 2rem 0 0.8rem; }
+.content h1, .content h2, .content h3 { line-height: 1.3; }
+
+.content p, .content li { max-width: 46rem; }
+.content ul, .content ol { padding-left: 1.4rem; }
+.content li { margin: 0.3rem 0; }
+
+/* Blockquotes here are callouts, not asides -- they carry the sentence the
+   page most wants read, so they are marked out rather than dimmed down. */
+.content blockquote {
+  margin: 1.4rem 0;
+  padding: 0.4rem 0 0.4rem 1.1rem;
+  border-left: 2px solid var(--accent);
+}
+
+.content hr { border: 0; border-top: 1px solid var(--rule); margin: 2.5rem 0; }
+
+code {
+  background: var(--code-bg);
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
+pre {
+  background: var(--code-bg);
+  padding: 1rem;
+  border-radius: 4px;
+  overflow-x: auto;      /* wide code scrolls itself, never the page */
+  line-height: 1.45;
+}
+pre code { background: none; padding: 0; font-size: 0.88rem; }
+
+/* Tables can be wide; give them their own scroller too. */
+.content table {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+  margin: 1.4rem 0;
+  font-size: 0.92rem;
+}
+.content th, .content td {
+  border: 1px solid var(--rule);
+  padding: 0.45rem 0.8rem;
+  text-align: left;
+  vertical-align: top;
+}
+.content th { color: var(--fg); background: var(--code-bg); }
+
+.content img { max-width: 100%; height: auto; }
+
+/* ---------- narrow screens ---------- */
+
+@media (max-width: 62rem) {
+  .page { grid-template-columns: minmax(0, 1fr); gap: 2rem; }
+  .sidebar { position: static; }
+  .toc { max-height: none; }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,7 @@
 ---
 title: nixarchy
+layout: home
 ---
-
-# nixarchy
 
 [Omarchy](https://omarchy.org) — the Hyprland desktop — vendored for NixOS, with
 its menus rewired to Nix instead of pacman.
@@ -25,7 +24,7 @@ New to NixOS? Start with
 
 ## Elsewhere
 
-| | |
+| Where | What is there |
 |---|---|
 | [Source and README](https://github.com/olafkfreund/nixarchy) | installation, module options, design notes, what is left |
 | [Omarchy's own manual](https://omarchy.org/manual/) | the desktop itself — 38 of its 51 pages are true here unchanged |

--- a/docs/manual/ai.md
+++ b/docs/manual/ai.md
@@ -7,10 +7,11 @@ title: AI
 Omarchy's agent tooling — the lazy-loaded launchers, the default agent, the
 agents panel in the top bar, crash diagnosis, the local-LLM recommendations —
 is upstream's tree running unchanged. `omarchy default agent <name>`,
-`Super + Shift + Ctrl + A`, `omarchy agent prompt "..."`, `omarchy agent crash
-<pid>`, `omarchy toggle crash-capture` and the `omarchy-agent-*` commands all
-work as [the upstream page](https://omarchy.org/manual/ai/) describes them, and
-that page is the reference for how to use them.
+`Super + Shift + Ctrl + A`, `omarchy agent prompt "..."`,
+`omarchy agent crash <pid>`, `omarchy toggle crash-capture` and the
+`omarchy-agent-*` commands all work as
+[the upstream page](https://omarchy.org/manual/ai/) describes them, and that
+page is the reference for how to use them.
 
 Two things differ, and the second matters more than it looks.
 

--- a/docs/manual/updates.md
+++ b/docs/manual/updates.md
@@ -80,8 +80,9 @@ yourself is exactly what `omarchy update` does. The only thing you lose by
 running them by hand is the confirmation prompt.
 
 The more useful distinction is between updating everything and updating one
-input. `omarchy update` moves all of them; `nix flake update nixpkgs --flake
-<flake>` moves one. When you are chasing a specific fix, the second is the
+input. `omarchy update` moves all of them;
+`nix flake update nixpkgs --flake <flake>` moves one. When you are chasing a
+specific fix, the second is the
 better habit — see [Updating NixOS](updating-nixos.md#the-long-way-and-when-you-want-it).
 
 ## Rolling back bad updates


### PR DESCRIPTION
Replaces `jekyll-theme-primer` with a hand-rolled dark, monospace layout and a numbered sidebar, in the shape of [Omarchy's manual](https://omarchy.org/manual/) but with nixarchy's own content.

`_layouts/` + `assets/style.css` are the whole site — no theme gem, no plugins — so what Pages builds is exactly what is in `docs/`.

### Two content bugs this surfaced

Both were already live and neither was visible on primer, because nobody had read past the index page:

- **`ai.md` and `updates.md` each wrapped a line so a placeholder (`<pid>`, `<flake>`) landed first on a line.** kramdown reads a line starting with `<` as an opening raw-HTML block, never finds a closing tag, and swallows the rest of the file — so every heading, fence and table after that point rendered as literal text. Both reflowed.
- **`index.md`'s *Elsewhere* table was headerless**, rendering an empty first row. Given headers.

### The one trade

Sidebar order is declared in `_config.yml`, not derived. Alphabetical opens the manual on "AI" and buries "Getting Started". The cost: a page added to `manual/` and not listed there will not appear in the nav.

### Verification

Built with jekyll and screenshotted:

- all 16 manual pages highlight exactly one nav entry
- every page renders headings, code blocks and tables as markup, not text
- assets resolve under the `/nixarchy` baseurl

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5