### PR TITLE
Add nixarchy-pkg-add, and drive rebuilds through nh

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | `omarchy` CLI | all 429 subcommands, `omarchy commands --check` green |
 | **Install menu** | picks write to a Nix config, not pacman |
 | **Remove menu** | deselects apps, never touches your own config |
-| **Update menu** | `nix flake update` + `nixos-rebuild switch --flake` |
+| **Update menu** | `nh os switch --update <flake>` |
 | 56 apps in the selection | 41 from nixpkgs, 5 as NixOS modules, 8 built here, 2 with no equivalent |
 | Learn menu | NixOS wiki, `search.nixos.org` packages and options |
 | Shell functions | bash and zsh source the chain; fish derives it from the same files |
@@ -154,7 +154,7 @@ declarative system:
 ```
 Install ▸ Brave          →  "brave queued — not installed yet"
 Install ▸ VSCode         →  "2 app(s) selected"
-Install ▸ Apply changes  →  nixos-rebuild switch --flake
+Install ▸ Apply changes  →  nh os switch <flake>
 ```
 
 The notification is clickable and runs the rebuild.

--- a/docs/manual/other-packages.md
+++ b/docs/manual/other-packages.md
@@ -24,6 +24,20 @@ have five uncommented lines. Then _Install > Apply changes_ runs
 `nixarchy-apply`, which copies that file to `nixarchy-apps.nix` in your flake
 directory and offers to run `nh os switch <flake>`.
 
+## Finding it in the first place
+
+`nixarchy-search`, or _Install > Search_, is one fzf picker over every nixpkgs
+package, every NixOS option and the curated app list, with each entry's type,
+default and description in a preview pane. Picking a row routes it: an app is
+enabled as an app, a package is appended as a package, and an option is written
+as a line of its own -- booleans and enums get a value picker, anything more
+complicated is written commented out with its type and docs beside it, for you
+to fill in.
+
+The index comes from this machine's own nixpkgs and its own options rather than
+from search.nixos.org, which costs about a minute once per system generation and
+means the picker can never offer something this machine cannot build.
+
 The same thing from a terminal:
 
 ```sh

--- a/docs/manual/other-packages.md
+++ b/docs/manual/other-packages.md
@@ -22,7 +22,7 @@ Picking a row does not install anything. It uncomments one line in
 populated with every app and every line commented out. Pick five rows and you
 have five uncommented lines. Then _Install > Apply changes_ runs
 `nixarchy-apply`, which copies that file to `nixarchy-apps.nix` in your flake
-directory and offers to run `sudo nixos-rebuild switch --flake <flake>`.
+directory and offers to run `nh os switch <flake>`.
 
 The same thing from a terminal:
 

--- a/docs/manual/philosophy.md
+++ b/docs/manual/philosophy.md
@@ -42,7 +42,7 @@ declarative equivalent: **it edits a file and stops.**
 ```
 Install ▸ Brave          →  "brave queued — not installed yet"
 Install ▸ VSCode         →  "2 app(s) selected"
-Install ▸ Apply changes  →  nixos-rebuild switch --flake
+Install ▸ Apply changes  →  nh os switch <flake>
 ```
 
 Pick as many as you like; nothing is built until you apply. That is not a

--- a/docs/manual/updates.md
+++ b/docs/manual/updates.md
@@ -23,9 +23,13 @@ and `flake.lock` pins each of them to an exact revision. `omarchy update`
 moves every pin forward and rebuilds:
 
 ```sh
-nix flake update --flake <flake>
-sudo nixos-rebuild switch --flake <flake>
+nh os switch --update <flake>
 ```
+
+That is one command for both halves. `nh` is a front end to the same
+nixos-rebuild machinery, so the result is identical -- what it adds is a live
+view of what is building and a diff of the packages that actually changed,
+which on an update is the only question worth asking.
 
 It asks first. A new Omarchy release arrives as a source bump of the `omarchy`
 input, so the menus, themes and commands come along with it. Your app

--- a/docs/manual/updating-nixos.md
+++ b/docs/manual/updating-nixos.md
@@ -16,9 +16,11 @@ prunes packages, takes a snapper snapshot, refreshes the keyring and demands
 what updating a NixOS host actually means:
 
 ```sh
-nix flake update --flake /etc/nixos      # move every input forward
-sudo nixos-rebuild switch --flake /etc/nixos
+nh os switch --update /etc/nixos    # move every input forward, then rebuild
 ```
+
+`nh` is a front end to nixos-rebuild, so nothing about the result differs; it
+reports the build as it happens and diffs the packages that changed at the end.
 
 It asks before doing either, and it tells you afterwards that the previous
 generation is still in the boot menu. No snapshot is taken because none is

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -145,6 +145,23 @@ let
     lib.mapAttrsToList (_: a: "#   ${a.label} — ${a.unavailable}\n") unavailable
   );
 
+  # Every nixpkgs attribute the curated list already covers, mapped back to
+  # its app id. nixarchy-pkg-add checks this first: typing `firefox` should
+  # get you `nixarchy-app-enable firefox`, which sets programs.firefox and
+  # brings policies and extensions with it, not a bare package in
+  # systemPackages that does none of that. Both the app id and its attribute
+  # are listed, because either is a plausible thing to type.
+  appAttrTable = pkgs.writeText "nixarchy-app-attrs.tsv" (
+    lib.concatStrings (
+      lib.mapAttrsToList (
+        name: app:
+        lib.concatMapStrings (key: "${key}\t${name}\n") (
+          lib.unique ([ name ] ++ lib.optional (app ? attr) app.attr)
+        )
+      ) available
+    )
+  );
+
   appsTemplate = pkgs.writeText "nixarchy-apps.nix" ''
     # Applications available through the Omarchy menu, as NixOS configuration.
     #
@@ -214,7 +231,7 @@ let
         "update.omarchy" = {
           icon = "󰭌";
           label = "Nixarchy";
-          description = "nix flake update, then nixos-rebuild switch --flake";
+          description = "nh os switch --update: move every flake input forward, then rebuild";
         };
 
         # Omarchy's release channels are a pacman repository choice. Here the
@@ -611,6 +628,193 @@ in
             '';
           })
 
+          # The answer to "I want a package the menu does not offer". Upstream's
+          # `omarchy pkg add` runs pacman; there is no imperative equivalent
+          # here, so this does the declarative thing instead -- appends the
+          # attribute to a list in the same file the menu already edits, so
+          # one `nixarchy-apply` builds curated apps and extras together.
+          #
+          # It deliberately does NOT touch the user's own NixOS configuration,
+          # which nixarchy does not own. ~/.config/nixarchy/apps.nix is already
+          # a full NixOS module, so a systemPackages list can sit beside the
+          # app selection with no new file and no new option.
+          (pkgs.writeShellApplication {
+            name = "nixarchy-pkg-add";
+            runtimeInputs = [
+              pkgs.coreutils
+              pkgs.gnugrep
+              pkgs.gnused
+              pkgs.gawk
+              pkgs.jq
+              config.nix.package
+              cfg.package # omarchy-notification-send
+            ];
+            text = ''
+              file="''${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/apps.nix"
+              table=${appAttrTable}
+              nixpkgs=${pkgs.path}
+
+              if [ $# -eq 0 ]; then
+                echo "usage: nixarchy-pkg-add <nixpkgs-attribute>..." >&2
+                echo "  e.g. nixarchy-pkg-add ripgrep fd" >&2
+                exit 1
+              fi
+
+              [ -f "$file" ] || { echo "no $file -- log in again to have it created" >&2; exit 1; }
+
+              # Every edit below is reverted as a unit if the result will not parse. The
+              # file is the user's own NixOS module; leaving it broken would take the whole
+              # system's evaluation down with it, not just this feature.
+              backup=$(mktemp)
+              cp "$file" "$backup"
+              trap 'rm -f "$backup"' EXIT
+              restore() { cp "$backup" "$file"; }
+
+              # The list this appends to does not exist in a freshly generated file: the
+              # template is all curated apps and nothing else. Create it once, in place,
+              # before the module's closing brace.
+              ensure_block() {
+                grep -q '#@pkgs-end' "$file" && return 0
+
+                # systemPackages needs `pkgs`, and the generated template takes `{ ... }:`.
+                if ! sed -n '/^{/{p;q}' "$file" | grep -q 'pkgs'; then
+                  sed -i -E '0,/^\{[[:space:]]*\.\.\.[[:space:]]*\}:[[:space:]]*$/s//{ pkgs, ... }:/' "$file"
+                fi
+
+                tmp=$(mktemp)
+                awk '
+                  !ins && /^}[[:space:]]*$/ {
+                    print "";
+                    print "  # ── Extra packages ──────────────────────────────────────────────";
+                    print "  # Plain nixpkgs attributes, added by nixarchy-pkg-add. These are";
+                    print "  # not part of the curated app list above: the Omarchy menu does";
+                    print "  # not offer them and will not remove them. The file stays yours --";
+                    print "  # reformat and annotate freely, the tool only ever inserts one";
+                    print "  # line before the end marker.";
+                    print "  environment.systemPackages = with pkgs; [  #@pkgs-begin";
+                    print "  ];  #@pkgs-end";
+                    ins = 1;
+                  }
+                  { print }
+                ' "$file" > "$tmp"
+                mv "$tmp" "$file"
+
+                if ! grep -q '#@pkgs-end' "$file"; then
+                  echo "nixarchy: could not find the closing '}' of $file." >&2
+                  echo "Add this to it by hand, then run this again:" >&2
+                  echo >&2
+                  echo "  environment.systemPackages = with pkgs; [  #@pkgs-begin" >&2
+                  echo "  ];  #@pkgs-end" >&2
+                  restore
+                  exit 1
+                fi
+
+                if ! sed -n '/^{/{p;q}' "$file" | grep -q 'pkgs'; then
+                  echo "nixarchy: $file does not take a 'pkgs' argument, so the list just" >&2
+                  echo "added cannot refer to it. Change its first line to:  { pkgs, ... }:" >&2
+                fi
+              }
+
+              added=()
+
+              for attr in "$@"; do
+                case "$attr" in
+                  "" | -* | .* | *..* | *[!A-Za-z0-9_.-]*)
+                    echo "'$attr' is not a nixpkgs attribute name." >&2
+                    exit 1
+                    ;;
+                esac
+
+                # The curated list first. Typing `firefox` should get you the app, which is
+                # a NixOS module and brings policies and extensions with it, not a bare
+                # package in systemPackages that does none of that.
+                app=$(awk -F'\t' -v a="$attr" '$1 == a { print $2; exit }' "$table")
+                if [ -n "$app" ]; then
+                  echo "$attr is on the curated app list, as '$app'. Enable it that way --"
+                  echo "that route knows whether it needs a NixOS module rather than a package:"
+                  echo
+                  echo "  nixarchy-app-enable $app"
+                  echo
+                  continue
+                fi
+
+                if grep -q "#@pkg $attr\$" "$file"; then
+                  echo "$attr is already in $file"
+                  continue
+                fi
+
+                # Resolved against the system's own nixpkgs rather than the flake registry,
+                # so the answer matches what a rebuild would actually build, and it works
+                # with no network. nix-instantiate rather than `nix eval`: no pure-eval mode
+                # to fight over an absolute store path, and no experimental flag to require.
+                # allowUnfree only so an unfree package reports as unfree instead of
+                # throwing here; nothing in this script decides your licence policy.
+                if ! info=$(nix-instantiate --eval --strict --json --expr "
+                  let
+                    p = import $nixpkgs { config.allowUnfree = true; };
+                    q = p.$attr;
+                    ls = if q.meta ? license then
+                           (if builtins.isList q.meta.license then q.meta.license else [ q.meta.license ])
+                         else [ ];
+                  in {
+                    inherit (q) name;
+                    description = q.meta.description or \"\";
+                    unfree = !(builtins.all (l: if builtins.isAttrs l then (l.free or true) else true) ls);
+                    broken = q.meta.broken or false;
+                  }" 2>/dev/null); then
+                  echo "nixpkgs has no package '$attr'." >&2
+                  echo >&2
+                  echo "Search for the right name:" >&2
+                  echo "  nix search nixpkgs $attr" >&2
+                  echo "  https://search.nixos.org/packages" >&2
+                  exit 1
+                fi
+
+                ensure_block
+                sed -i "/#@pkgs-end/i\\    $attr  #@pkg $attr" "$file"
+
+                # sed reports success when its address matches nothing, which would leave
+                # this reporting a package it never wrote. Check the line is really there.
+                if ! grep -q "#@pkg $attr\$" "$file"; then
+                  restore
+                  echo "nixarchy: failed to write $attr into $file. Nothing was changed." >&2
+                  exit 1
+                fi
+                added+=("$attr")
+
+                echo "added $attr ($(jq -r .name <<<"$info")) -- $(jq -r '.description // ""' <<<"$info")"
+                if [ "$(jq -r .unfree <<<"$info")" = true ]; then
+                  echo "  unfree: needs nixpkgs.config.allowUnfree in your configuration, or the build fails."
+                fi
+                if [ "$(jq -r .broken <<<"$info")" = true ]; then
+                  echo "  marked broken in nixpkgs: expect the build to fail."
+                fi
+              done
+
+              [ ''${#added[@]} -gt 0 ] || exit 0
+
+              if ! nix-instantiate --parse "$file" >/dev/null 2>&1; then
+                restore
+                echo "nixarchy: that would have left $file unparseable. Nothing was changed." >&2
+                exit 1
+              fi
+
+              count=$(grep -c '#@pkg ' "$file" || true)
+
+              # A menu pick runs with no terminal attached, so stdout goes nowhere. Say it
+              # on the desktop instead, clickable, because a rebuild is what is still owed.
+              if command -v omarchy-notification-send >/dev/null 2>&1; then
+                omarchy-notification-send -r 8471 -t 8000 -u normal \
+                  "''${added[*]} queued -- not installed yet" \
+                  "$count extra package(s) selected. Click here, or Install > Apply changes, to run nixos-rebuild." \
+                  --exec omarchy-launch-floating-terminal-with-presentation nixarchy-apply || true
+              fi
+
+              echo
+              echo "run 'nixarchy-apply' when you have picked everything you want"
+            '';
+          })
+
           # Copies the selection into the flake and switches. Kept separate
           # from enabling so several apps can be picked before anything builds.
           (pkgs.writeShellApplication {
@@ -619,7 +823,14 @@ in
               pkgs.coreutils
               pkgs.diffutils
               pkgs.gnugrep
-              pkgs.nixos-rebuild
+              # nh rather than nixos-rebuild: a progress view that says what is
+              # building and how far along it is, and a package diff against the
+              # running generation once it lands. Both matter more here than
+              # anywhere else -- this is the command a menu pick runs, in front
+              # of someone who just clicked "install" and has no other signal
+              # that anything is happening. It is also the smaller closure of
+              # the two, by about 200 MiB.
+              pkgs.nh
             ];
             text = ''
               file="''${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/apps.nix"
@@ -683,8 +894,16 @@ in
 
               read -r -p "Build and switch now? [y/N] " reply
               case "$reply" in
-                [yY]*) exec sudo nixos-rebuild switch --flake "$flake" ;;
-                *) echo "Not switching. Run: sudo nixos-rebuild switch --flake $flake" ;;
+                # No sudo: nh elevates itself, and wrapping it means the
+                # elevation happens before nh can decide how to do it.
+                #
+                # The flake is passed explicitly rather than left to nh's own
+                # default. nh reads $NH_FLAKE, which plenty of people already
+                # export at whatever configuration they usually work on -- and
+                # an app selection copied into one flake then switched into
+                # another is a failure that looks like nothing happening.
+                [yY]*) exec nh os switch "$flake" ;;
+                *) echo "Not switching. Run: nh os switch $flake" ;;
               esac
             '';
           })

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -162,6 +162,22 @@ let
     )
   );
 
+  # The curated list as search rows: id, label, category, note. Notes are
+  # flattened because the index this feeds is tab-separated and a note with a
+  # newline in it would silently become three broken rows -- the same reason
+  # templateRow collapses them.
+  appIndexTable = pkgs.writeText "nixarchy-app-index.tsv" (
+    lib.concatStrings (
+      lib.mapAttrsToList (
+        name: app:
+        let
+          flat = lib.replaceStrings [ "\n" "\t" ] [ " " " " ];
+        in
+        "${name}\t${app.label}\t${app.category}\t${flat (app.note or "")}\n"
+      ) available
+    )
+  );
+
   appsTemplate = pkgs.writeText "nixarchy-apps.nix" ''
     # Applications available through the Omarchy menu, as NixOS configuration.
     #
@@ -210,6 +226,17 @@ let
           action = "omarchy-launch-editor $HOME/.config/nixarchy/apps.nix";
           description = "Every Omarchy app, as NixOS options";
         };
+        # A new row, not an override: upstream has no equivalent because on
+        # Arch there is nothing to search that pacman does not already answer.
+        # The generator accepts an id upstream does not ship as long as the
+        # override names the row itself, which is why label and icon are here.
+        "install.search" = {
+          icon = "󰍉";
+          label = "Search";
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-search";
+          description = "Every package, NixOS option and Omarchy app, in one picker";
+        };
+
         "install.aur" = {
           when = "false";
         };
@@ -812,6 +839,224 @@ in
 
               echo
               echo "run 'nixarchy-apply' when you have picked everything you want"
+            '';
+          })
+
+          # Search everything this machine could install, and route the choice
+          # to whichever writer is right for it.
+          #
+          # The three kinds are not interchangeable and the whole point of one
+          # picker over them is that you do not have to know which is which:
+          # an app becomes programs.<name>, a package becomes a systemPackages
+          # entry, an option becomes a line of its own. Picking Firefox from
+          # the app rows and picking `firefox` from the package rows are
+          # genuinely different configurations, and the rows say so.
+          #
+          # The index is built from this system's own nixpkgs and its own
+          # options, not from search.nixos.org. It is slower to build and it
+          # cannot go stale against the machine, which is the trade that
+          # matters: an index that offers a package nixarchy-pkg-add will then
+          # refuse is worse than no index.
+          (pkgs.writeShellApplication {
+            name = "nixarchy-search";
+            runtimeInputs = [
+              pkgs.coreutils
+              pkgs.gnugrep
+              pkgs.gnused
+              pkgs.gawk
+              pkgs.jq
+              pkgs.fzf
+              config.nix.package
+            ];
+            text = ''
+              file="''${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/apps.nix"
+              cache="''${XDG_CACHE_HOME:-$HOME/.cache}/nixarchy"
+              index="$cache/index.tsv"
+              stamp="$cache/stamp"
+
+              appindex=${appIndexTable}
+              optionsjson=${config.system.build.manual.optionsJSON}/share/doc/nixos/options.json
+              nixpkgs=${pkgs.path}
+
+              reindex=0
+              [ "''${1:-}" = "--reindex" ] && { reindex=1; shift; }
+
+              # One index, four tab-separated fields: kind, name, one-line summary, option
+              # type, and the preview text with its newlines escaped. The preview is carried
+              # in the line rather than looked up on selection because fzf runs the preview
+              # command on every keystroke, and a jq pass over 19 MB of package metadata is
+              # not something to do sixty times a second.
+              build_index() {
+                mkdir -p "$cache"
+                tmp=$(mktemp)
+
+                # Curated apps first, so they sort above the raw nixpkgs attribute of the
+                # same name. Enabling `firefox` as an app gets you programs.firefox; adding
+                # it as a package does not.
+                awk -F'\t' -v OFS='\t' '{
+                  note = ($4 == "" ? "" : "\\n\\n" $4)
+                  print "app", $1, $2 " (" $3 ")", "",
+                    "OMARCHY APP  " $1 "\\n\\n" $2 "\\n" $3 \
+                    note "\\n\\nEnabling this writes a line in your app selection:\\n  " \
+                    $1 ".enable = true;"
+                }' "$appindex" > "$tmp"
+
+                jq -r '
+                  def val(x):
+                    if x == null then "(none)"
+                    elif (x | type) == "object" then (x.text // (x | tostring))
+                    else (x | tostring) end;
+                  to_entries[] | .key as $k | .value as $v |
+                  [ "opt", $k,
+                    (($v.description // "") | gsub("[\n\t ]+"; " ") | .[0:110]),
+                    ($v.type // ""),
+                    ( "NIXOS OPTION  " + $k
+                      + "\n\ntype:     " + ($v.type // "?")
+                      + "\ndefault:  " + val($v.default)
+                      + (if $v.example == null then "" else "\nexample:  " + val($v.example) end)
+                      + "\n\n" + ($v.description // "(undocumented)")
+                      + "\n\ndeclared in:\n  " + (($v.declarations // []) | join("\n  "))
+                    )
+                  ] | @tsv' "$optionsjson" >> "$tmp"
+
+                # The system's own nixpkgs, not the flake registry: an index that offers a
+                # package this machine cannot build is worse than no index. Slow enough to
+                # be worth saying so -- about a minute, once per system generation.
+                echo "  indexing nixpkgs (this takes about a minute)..." >&2
+                nix search --json --extra-experimental-features 'nix-command flakes' \
+                  "path:$nixpkgs" ^ 2>/dev/null |
+                  jq -r '
+                    to_entries[] | (.key | sub("^legacyPackages\\.[^.]+\\."; "")) as $a | .value as $v |
+                    [ "pkg", $a,
+                      (($v.description // "") | gsub("[\n\t ]+"; " ") | .[0:110]),
+                      "",
+                      ( "NIXPKGS PACKAGE  " + $a
+                        + "\n\nversion:  " + ($v.version // "?")
+                        + "\n\n" + ($v.description // "(no description)")
+                        + "\n\nAdding this writes it into your app selection:\n  "
+                        + "environment.systemPackages = with pkgs; [ " + $a + " ];"
+                      )
+                    ] | @tsv' >> "$tmp"
+
+                mv "$tmp" "$index"
+                readlink -f /run/current-system > "$stamp"
+              }
+
+              if [ "$reindex" = 1 ] || [ ! -s "$index" ] ||
+                 [ "$(cat "$stamp" 2>/dev/null)" != "$(readlink -f /run/current-system)" ]; then
+                echo "Building the search index. This happens once per system generation." >&2
+                build_index
+              fi
+
+              selection=$(fzf --multi \
+                --delimiter='\t' --with-nth=1,2,3 --nth=2,3 \
+                --preview 'printf "%b\n" {5}' \
+                --preview-window='right,58%,wrap' \
+                --prompt='nixarchy > ' \
+                --header='enter to select · tab for several · esc to cancel' \
+                --query="''${*:-}" < "$index") || exit 0
+              [ -n "$selection" ] || exit 0
+
+              [ -f "$file" ] || { echo "no $file -- log in again to have it created" >&2; exit 1; }
+
+              backup=$(mktemp)
+              cp "$file" "$backup"
+              trap 'rm -f "$backup"' EXIT
+
+              changed=0
+              scaffolded=0
+              written=0
+
+              # Options are written at the module's top level, before its closing brace.
+              # Nothing here parses Nix: the brace is found textually and the result is
+              # checked with nix-instantiate before anything is kept.
+              insert_line() {
+                tmp=$(mktemp)
+                awk -v payload="$1" '
+                  !ins && /^}[[:space:]]*$/ { printf "%s", payload; ins = 1 }
+                  { print }
+                ' "$file" > "$tmp"
+                mv "$tmp" "$file"
+              }
+
+              add_option() {
+                path=$1
+                type=$2
+
+                if grep -q "#@opt $path\$" "$file"; then
+                  echo "$path is already in $file"
+                  return 0
+                fi
+
+                value=""
+                case "$type" in
+                  boolean)
+                    value=$(printf 'true\nfalse\n' | fzf --height=6 --prompt="$path = ") || return 0
+                    ;;
+                  "one of "*)
+                    value=$(printf '%s' "''${type#one of }" | grep -oE '"[^"]*"' |
+                      fzf --height=12 --prompt="$path = ") || return 0
+                    ;;
+                esac
+
+                if [ -n "$value" ]; then
+                  insert_line "\n  $path = $value;  #@opt $path\n"
+                  echo "set $path = $value"
+                  changed=1
+                  written=$((written + 1))
+                  return 0
+                fi
+
+                # Anything else. An option's value is arbitrary Nix -- a submodule, a
+                # function, a package, a list of them -- and a picker that pretended
+                # otherwise would write plausible-looking wrong configuration. So it writes
+                # what it does know, commented out, in the right file, and leaves the
+                # expression to you.
+                {
+                  printf '\n'
+                  grep -P "^opt\t\Q$path\E\t" "$index" | head -1 |
+                    cut -f5 | sed 's/\\n/\n/g' | sed 's/^/  # /'
+                  printf '  # %s = ;  #@opt %s\n' "$path" "$path"
+                } > "$cache/scaffold.$$"
+                insert_line "$(cat "$cache/scaffold.$$")
+              "
+                rm -f "$cache/scaffold.$$"
+                echo "scaffolded $path (commented out -- set the value and uncomment it)"
+                changed=1
+                written=$((written + 1))
+                scaffolded=$((scaffolded + 1))
+              }
+
+              while IFS=$'\t' read -r kind name _ type _; do
+                [ -n "$kind" ] || continue
+                case "$kind" in
+                  app) nixarchy-app-enable "$name" && changed=1 ;;
+                  pkg) nixarchy-pkg-add "$name" && changed=1 ;;
+                  opt) add_option "$name" "$type" ;;
+                esac
+              done <<< "$selection"
+
+              [ "$changed" = 1 ] || exit 0
+
+              if ! nix-instantiate --parse "$file" >/dev/null 2>&1; then
+                cp "$backup" "$file"
+                echo "nixarchy: that would have left $file unparseable. Nothing was changed." >&2
+                exit 1
+              fi
+
+              if [ "$scaffolded" -gt 0 ]; then
+                echo
+                echo "$scaffolded option(s) are commented out in $file. Edit them first:"
+                echo "  omarchy-launch-editor $file"
+              fi
+
+              # Only when this script wrote something itself: nixarchy-app-enable and
+              # nixarchy-pkg-add each print this line already, and saying it twice reads
+              # like two separate things happened.
+              if [ "$written" -gt 0 ]; then
+                echo
+                echo "run 'nixarchy-apply' when you have picked everything you want"
+              fi
             '';
           })
 

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -342,7 +342,7 @@ in
     ];
 
     nix.settings = {
-      # nixarchy-apply runs `nixos-rebuild switch --flake`, so flakes are not
+      # nixarchy-apply runs `nh os switch <flake>`, so flakes are not
       # optional here. mkDefault leaves a user free to manage this themselves.
       experimental-features = lib.mkDefault [
         "nix-command"

--- a/pkgs/omarchy/default.nix
+++ b/pkgs/omarchy/default.nix
@@ -109,6 +109,10 @@
   ttfx,
   # Branding: this is a NixOS port, so the menu button wears the snowflake.
   nixos-icons,
+  # omarchy-update drives the rebuild through nh. Unlike `nix` and
+  # `nixos-rebuild`, which every NixOS machine already has on PATH, nh is not
+  # guaranteed to be installed, so it has to be carried here.
+  nh,
 }:
 let
   # Everything the 438 scripts in bin/ invoke. Kept explicit rather than
@@ -165,6 +169,7 @@ let
     bluez
     networkmanager
     fastfetch
+    nh
     btop
     ripgrep
     fd

--- a/pkgs/omarchy/nix-bin/omarchy-pkg-add
+++ b/pkgs/omarchy/nix-bin/omarchy-pkg-add
@@ -24,6 +24,32 @@ set -euo pipefail
 table=@table@
 file="${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/apps.nix"
 
+# Already installed? Then say so and get out of the way.
+#
+# Sixteen shipped scripts open with this command under `set -e` --
+# omarchy-install-gaming-retroarch, -steam, -lutris, omarchy-setup-security-sshd
+# and the rest -- so exiting non-zero aborts them before the work that follows.
+# For retroarch that work is ~/Games, two config keys and the line telling you
+# where to put roms. Refusing was right when the package is missing; a caller
+# that goes on to configure something that was never installed should stop.
+#
+# But once you have enabled the app declaratively and rebuilt, the package IS
+# there, and the only thing still missing is exactly that configuration. Failing
+# then leaves an app installed and unconfigured with no way to finish the job
+# short of reading the script and running its tail by hand.
+#
+# So: yield when every named package resolves. The caller carries on and does
+# its configuration against a package that genuinely exists, which is the
+# behaviour upstream has and the reason those tails were written.
+#
+# omarchy-pkg-present is the same check the rest of this family uses, suffix
+# handling included -- brave-bin provides `brave`.
+if [ $# -gt 0 ] && omarchy-pkg-present "$@"; then
+  echo
+  echo "[$*] already installed. Nothing to add -- carrying on."
+  exit 0
+fi
+
 known=0
 unknown=()
 
@@ -86,12 +112,19 @@ if [ ${#unknown[@]} -gt 0 ]; then
   echo "If Omarchy's Install menu offers it, pick it there -- that uncomments a"
   echo "line in $file, and Apply changes rebuilds with it."
   echo
-  echo "Otherwise add it to your own configuration as environment.systemPackages"
-  echo "and rebuild. Search for it first:"
+  echo "Otherwise add it by nixpkgs attribute -- that appends it to the same"
+  echo "file and one apply builds it with everything else:"
+  echo
+  echo "  nixarchy-pkg-add ${unknown[*]}"
+  echo "  nixarchy-apply"
+  echo
+  echo "If that reports no such package, search for the right name:"
+  echo "  nix search nixpkgs ${unknown[0]}"
   echo "  https://search.nixos.org/packages"
   echo
 fi
 
-# Always non-zero: nothing was installed, and a caller that carries on to
-# configure what it thinks it just installed should stop here.
+# Non-zero, because nothing was installed and something is genuinely missing: a
+# caller that carries on to configure what it thinks it just installed should
+# stop here. The already-installed case returned 0 above, before any of this.
 exit 1

--- a/pkgs/omarchy/nix-bin/omarchy-pkg-install
+++ b/pkgs/omarchy/nix-bin/omarchy-pkg-install
@@ -18,5 +18,10 @@ echo
 echo "Uncomment what you want -- or pick it from the Install menu, which"
 echo "uncomments it for you -- then run 'nixarchy-apply' to build and switch."
 echo
-echo "For something the menu does not offer, add it to your own configuration"
-echo "as environment.systemPackages."
+echo "For something the menu does not offer, add it by nixpkgs attribute:"
+echo
+echo "  nixarchy-pkg-add ripgrep"
+echo "  nixarchy-apply"
+echo
+echo "That appends it to the same file, so one apply builds it alongside the"
+echo "apps you picked from the menu."

--- a/pkgs/omarchy/nix-bin/omarchy-update
+++ b/pkgs/omarchy/nix-bin/omarchy-update
@@ -11,6 +11,12 @@
 # Updating a NixOS host means moving the flake inputs forward and rebuilding,
 # so that is what this does. Rollback is `nixos-rebuild --rollback` or the boot
 # menu, which is why no snapshot is taken.
+#
+# Both halves are one `nh os switch --update`. nh is a front end to the same
+# nixos-rebuild machinery, so nothing about the result differs -- what differs
+# is the reporting: a live view of what is building, and a diff of the packages
+# that actually changed once it lands. On an update that is the whole question,
+# and plain nixos-rebuild answers it with a wall of store paths.
 
 set -euo pipefail
 
@@ -50,14 +56,17 @@ case "$reply" in
 esac
 
 echo
-echo "==> nix flake update"
-nix flake update --flake "$flake"
-
-echo
-echo "==> nixos-rebuild switch"
+echo "==> nh os switch --update $flake"
+# No sudo: nh elevates itself, and wrapping it takes that decision away.
+#
+# The flake is named explicitly rather than left to nh's default, which reads
+# $NH_FLAKE -- exported on plenty of machines at whatever configuration its
+# owner usually works on. Updating the wrong flake is not a failure anyone
+# would read as one.
+#
 # Not exec'd: upstream's presentation wrapper prints a completion banner after
 # this returns, and exec would take that away.
-sudo nixos-rebuild switch --flake "$flake"
+nh os switch --update "$flake"
 
 echo
 echo "Updated. The previous generation is still in the boot menu if you need it."

--- a/pkgs/omarchy/skills/nixos/SKILL.md
+++ b/pkgs/omarchy/skills/nixos/SKILL.md
@@ -99,6 +99,20 @@ their configuration in a git repo under `~`. Confirm before editing anything.
 
 ### Adding a package
 
+Do not know the attribute name? `nixarchy-search` is an fzf picker over every
+nixpkgs package, every NixOS option and the curated app list at once, with the
+type, default and description in a preview pane. It routes what you pick to the
+right writer, so it covers all three routes below:
+
+```bash
+nixarchy-search            # or the Install > Search menu row
+nixarchy-search tailscale  # start with a query
+```
+
+The index is built from this system's own nixpkgs and options -- about a minute,
+once per system generation -- so it never offers something this machine cannot
+build.
+
 For a plain package with no options to set, route 2 does the edit for you. It
 validates the attribute against the system's own nixpkgs, appends it to
 `~/.config/nixarchy/apps.nix` — the same file the Install menu writes — and

--- a/pkgs/omarchy/skills/nixos/SKILL.md
+++ b/pkgs/omarchy/skills/nixos/SKILL.md
@@ -29,7 +29,7 @@ Three routes exist on a Nixarchy machine. Pick the highest one that fits.
 | The request | Route |
 |---|---|
 | An app Nixarchy already knows about | **`nixarchy-app-enable <id>`**, then `nixarchy-apply` |
-| Any other package, service, or system setting | **Edit the flake**, then `nixos-rebuild switch` |
+| Any other package, service, or system setting | **`nixarchy-pkg-add <attr>`** for a plain package; otherwise **edit the flake**, then `nixos-rebuild switch` |
 | A one-off, throwaway try — not a change to the machine | **`nix shell nixpkgs#<pkg>`** |
 
 Never reach past route 1 for an app it covers: it writes the same file the Install
@@ -59,7 +59,8 @@ nixarchy-apply                   # copy the selection into the flake, then rebui
 
 `nixarchy-apply` does three things: prints what is enabled, copies
 `~/.config/nixarchy/apps.nix` to `<flake>/nixarchy-apps.nix`, and offers to run
-`sudo nixos-rebuild switch --flake <flake>`.
+`nh os switch <flake>` (a front end to nixos-rebuild; no `sudo`, it elevates
+itself).
 
 **The copy is necessary and the import is the user's job.** A flake cannot read a
 file outside its own tree, so the selection has to be copied in. Something in the
@@ -85,7 +86,7 @@ needs an FHS wrapper, 1Password a setuid helper, Tailscale a daemon, Firefox its
 policy module. `nixarchy-app-enable` already knows which is which; that is why it
 exists rather than a `systemPackages` line.
 
-## Route 2: Edit the Flake
+## Route 2: Add a Package, or Edit the Flake
 
 For everything else. First, find where the configuration lives:
 
@@ -97,6 +98,23 @@ echo "${NIXARCHY_FLAKE:-/etc/nixos}"       # what Nixarchy's own commands use
 their configuration in a git repo under `~`. Confirm before editing anything.
 
 ### Adding a package
+
+For a plain package with no options to set, route 2 does the edit for you. It
+validates the attribute against the system's own nixpkgs, appends it to
+`~/.config/nixarchy/apps.nix` — the same file the Install menu writes — and
+leaves the rebuild to `nixarchy-apply`, so menu picks and hand-added packages
+build together:
+
+```bash
+nixarchy-pkg-add ripgrep jq
+nixarchy-apply
+```
+
+It refuses an attribute nixpkgs does not have, and redirects to
+`nixarchy-app-enable` for anything the curated list already covers as a module.
+
+Editing the flake by hand is the same thing, and is what you want when the
+package needs an override or belongs somewhere other than the machine-wide set:
 
 ```nix
 environment.systemPackages = with pkgs; [
@@ -236,7 +254,7 @@ evidence than a package log.
 ## Example Requests
 
 - "Install Brave" -> `nixarchy-app-enable brave && nixarchy-apply` (route 1)
-- "Install ripgrep" -> add to `environment.systemPackages`, rebuild (route 2)
+- "Install ripgrep" -> `nixarchy-pkg-add ripgrep && nixarchy-apply` (route 2)
 - "Enable Tailscale" -> `services.tailscale.enable = true;` — the module, not the package
 - "Try out helix quickly" -> `nix shell nixpkgs#helix`, and say it is temporary
 - "My package disappeared after reboot" -> it was installed imperatively; declare it properly


### PR DESCRIPTION
Two gaps on the declarative install path.

## `nixarchy-pkg-add <attr>...`

"Install a package the menu does not offer" had no answer but *edit your flake by hand* — a different file, a different command and a different mental model from everything else the Install menu does.

`~/.config/nixarchy/apps.nix` is already a full NixOS module, so a `systemPackages` list can sit beside the app selection with no new file and no new option. `nixarchy-pkg-add` validates the attribute, appends it there, and leaves the rebuild to `nixarchy-apply` — so a menu pick and a hand-added package build together in one apply.

```console
$ nixarchy-pkg-add ripgrep
added ripgrep (ripgrep-15.2.0) -- Utility that combines the usability of The Silver Searcher with the raw speed of grep

run 'nixarchy-apply' when you have picked everything you want
```

- **Resolves against the system's own nixpkgs** (`pkgs.path`), not the flake registry, so the answer matches what a rebuild would actually build and works offline. `nix-instantiate` rather than `nix eval`: no pure-eval mode to fight over a store path, no experimental flag to require. ~0.35s.
- **Redirects to `nixarchy-app-enable`** for anything the curated list already covers. Typing `firefox` should get you `programs.firefox`, which brings policies and extensions, not a bare package that does none of that. The attr → app id table is generated from `data/apps.nix`.
- **Package markers are `#@pkg <attr>`,** deliberately distinct from the app markers. `nixarchy-app-enable` matches `#@ <id>`, and a `#@ firefox` on a package line would have had it uncomment the wrong thing.
- **Adds `pkgs` to the module header,** which the generated template does not take, and creates the list *before* the closing brace rather than at end of file, which is trailing comments.
- **Every edit is reverted as a unit if the result will not parse.** The file is the user's own NixOS module; leaving it broken takes the whole system's evaluation down, not just this feature.

`omarchy pkg add` and `omarchy pkg install` now name it, instead of pointing at search.nixos.org and wishing you luck.

## nh instead of nixos-rebuild

`nixarchy-apply` and `omarchy update` both drive `nh os switch` now. Same machinery, so the result is identical; what it adds is a live view of what is building and a diff of the packages that actually changed. That matters most exactly here — `nixarchy-apply` is what a menu pick runs, in front of someone who just clicked *install* and has no other signal that anything is happening.

| | before | after |
|---|---|---|
| `nixarchy-apply` | `sudo nixos-rebuild switch --flake $flake` | `nh os switch "$flake"` |
| `omarchy update` | `nix flake update` **+** `sudo nixos-rebuild switch --flake` | `nh os switch --update "$flake"` |

- **No `sudo`.** nh picks its own elevation strategy; wrapping it takes that decision away before it can make it.
- **The flake is passed positionally** rather than left to nh's default, which reads `$NH_FLAKE` — exported on plenty of machines at whatever configuration its owner usually works on. An app selection copied into one flake and switched into another is a failure that looks like nothing happening.
- **nh replaces nixos-rebuild** in `nixarchy-apply`'s `runtimeInputs`, a ~200 MiB smaller closure, and joins the omarchy package's `runtimeDeps` because its scripts take PATH from the session and nh — unlike `nix` and `nixos-rebuild` — is not already on every NixOS box.

## Verification

- `nixosConfigurations.vm` evaluates; `checks.omarchy`, `checks.options`, `checks.omarchy-runtime` all green.
- Both derivations build, so shellcheck passes on the new script.
- The built `nixarchy-pkg-add` binary was exercised end to end against a copy of a real `apps.nix`: curated redirect, unknown attribute (exit 1), injection attempt rejected, unfree warning, nested attr (`python3Packages.requests`), idempotent re-add, and the result parses and evaluates as a module.

## Not covered

`nixarchy-pkg-remove` (delete the line; `nixarchy-app-remove` only covers curated apps), and a menu row for either. The generic "editing your own flake" docs still say `nixos-rebuild`, deliberately — that advice is still correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaFe7Mq8idtgjRGkvoZaT8
