### PR TITLE
A wordmark, instead of the word

### DIFF
--- a/docs/_includes/logo.html
+++ b/docs/_includes/logo.html
@@ -1,0 +1,22 @@
+{%- comment -%}
+  The wordmark. Generated with figlet, font delta_corps_priest_1 -- the same
+  typeface Omarchy's banner uses, so the two sites read as relatives:
+
+      figlet -f delta_corps_priest_1 NIXARCHY
+
+  Nine rows, ninety-two columns. Regenerate rather than hand-edit; the sizing
+  in style.css is tuned to that column count and will need retuning if it
+  changes. role="img" with a label because a screen reader reading out the
+  block characters one by one is worse than useless.
+{%- endcomment -%}
+<pre class="logo" role="img" aria-label="nixarchy">
+███▄▄▄▄    ▄█  ▀████    ▐████▀    ▄████████    ▄████████  ▄████████    ▄█    █▄    ▄██   ▄
+███▀▀▀██▄ ███    ███▌   ████▀    ███    ███   ███    ███ ███    ███   ███    ███   ███   ██▄
+███   ███ ███▌    ███  ▐███      ███    ███   ███    ███ ███    █▀    ███    ███   ███▄▄▄███
+███   ███ ███▌    ▀███▄███▀      ███    ███  ▄███▄▄▄▄██▀ ███         ▄███▄▄▄▄███▄▄ ▀▀▀▀▀▀███
+███   ███ ███▌    ████▀██▄     ▀███████████ ▀▀███▀▀▀▀▀   ███        ▀▀███▀▀▀▀███▀  ▄██   ███
+███   ███ ███    ▐███  ▀███      ███    ███ ▀███████████ ███    █▄    ███    ███   ███   ███
+███   ███ ███   ▄███     ███▄    ███    ███   ███    ███ ███    ███   ███    ███   ███   ███
+ ▀█   █▀  █▀   ████       ███▄   ███    █▀    ███    ███ ████████▀    ███    █▀     ▀█████▀
+                                              ███    ███
+</pre>

--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -5,12 +5,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>nixarchy — {{ site.description }}</title>
 <meta name="description" content="{{ site.description }}">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&display=swap">
 <link rel="stylesheet" href="{{ '/assets/style.css' | relative_url }}">
 </head>
 <body class="home">
 
 <header class="masthead">
-  <span class="wordmark">nixarchy</span>
+  {% include logo.html %}
   <p class="tagline">{{ site.description }}</p>
 </header>
 

--- a/docs/_layouts/manual.html
+++ b/docs/_layouts/manual.html
@@ -5,12 +5,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{{ page.title }} — nixarchy manual</title>
 <meta name="description" content="{{ site.description }}">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&display=swap">
 <link rel="stylesheet" href="{{ '/assets/style.css' | relative_url }}">
 </head>
 <body>
 
 <header class="masthead">
-  <a class="wordmark" href="{{ '/' | relative_url }}">nixarchy</a>
+  <a class="logo-link" href="{{ '/' | relative_url }}">{% include logo.html %}</a>
   <p class="tagline">The Manual</p>
 </header>
 

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -8,8 +8,12 @@
   --link:      #8ab4f8;
   --rule:      #333747;
   --code-bg:   #1a1c24;
-  --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Fira Code",
-          Menlo, Consolas, "Liberation Mono", monospace;
+  /* JetBrains Mono first, and not only for looks: the wordmark is built from
+     block-drawing characters, and it only reads as solid in a font that draws
+     them edge to edge. A stack that falls through to a system mono can render
+     it with hairline seams. */
+  --mono: "JetBrains Mono", ui-monospace, "SF Mono", "Fira Code",
+          "DejaVu Sans Mono", Menlo, Consolas, monospace;
 }
 
 * { box-sizing: border-box; }
@@ -32,16 +36,39 @@ a:hover { text-decoration: underline; }
 
 .masthead { padding: 3.5rem 1.5rem 2.5rem; text-align: center; }
 
-.wordmark {
-  display: inline-block;
+/* The wordmark is 92 columns of block characters (see _includes/logo.html).
+   Its width is therefore font-size * column count, with nothing to reflow, so
+   the size is driven off the viewport and clamped: the ceiling keeps it from
+   dominating a wide screen, the floor keeps it legible on a phone. Regenerate
+   the art at a different width and these numbers need redoing. */
+.logo {
+  display: block;
+  /* Not a code block: undo the pre rule further down, which would otherwise
+     sit the wordmark on a grey card. */
+  margin: 0;
+  padding: 0;
+  background: none;
+  border-radius: 0;
+  overflow: visible;
+
   color: var(--accent);
-  font-size: clamp(2.6rem, 9vw, 5.5rem);
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: lowercase;
-  text-decoration: none;
+  font-size: clamp(0.3rem, 1.05vw, 0.88rem);
+  /* These two are not arbitrary and are not cosmetic. JetBrains Mono's full
+     block glyph does not quite meet its neighbours at fractional advances, so
+     at the honest values (0 and 1) the wordmark renders shot through with
+     hairline seams. The slight negative tracking and the over-1 line-height
+     pull the cells together until the strokes read as solid. Measured against
+     three alternatives; these are the only ones with no seams. Omarchy uses
+     the same pair, for the same reason. */
+  letter-spacing: -0.0425em;
+  line-height: 1.09375;
+  white-space: pre;
+  transition: color 0.15s ease;
 }
-.wordmark:hover { text-decoration: none; }
+
+.logo-link { display: inline-block; text-decoration: none; }
+.logo-link:hover { text-decoration: none; }
+.logo-link:hover .logo { color: var(--link); }
 
 .tagline { margin: 0.6rem 0 0; color: var(--link); font-size: 1rem; }
 
@@ -88,6 +115,13 @@ a:hover { text-decoration: underline; }
   max-height: 68vh;
   overflow-y: auto;
 }
+
+/* The default scrollbar renders as a bright bar against the dark theme, and
+   the nav is the one place here tall enough to show one. */
+.toc { scrollbar-width: thin; scrollbar-color: var(--rule) transparent; }
+.toc::-webkit-scrollbar { width: 6px; }
+.toc::-webkit-scrollbar-track { background: transparent; }
+.toc::-webkit-scrollbar-thumb { background: var(--rule); border-radius: 3px; }
 
 .toc li { counter-increment: item; margin: 0 0 0.35rem; }
 
@@ -139,6 +173,10 @@ code {
   padding: 0.1rem 0.35rem;
   border-radius: 3px;
   font-size: 0.9em;
+  /* Inline code is often a long path or attribute with no space in it, which
+     on a phone is wide enough to push the whole page sideways. It has no
+     scroller of its own, so it has to be allowed to break. */
+  overflow-wrap: anywhere;
 }
 
 pre {


### PR DESCRIPTION
The masthead was the word "nixarchy" set large in a mono font. Omarchy's is a block-character banner, and that is most of why their manual looks the way it does.

Theirs turns out to be neither an image nor a font — it is **ASCII art in a `<pre>`**. So this reproduces the *typeface*, not their artwork: figlet's `delta_corps_priest_1`, which matches their glyphs shape for shape once you account for a column of inner padding they trimmed by hand. `_includes/logo.html` records the command to regenerate it.

### Two bits of CSS that look wrong and are not

- **`letter-spacing: -0.0425em`, `line-height: 1.09375`.** JetBrains Mono's full-block glyph does not quite meet its neighbours at fractional advances, so at the honest values (`0` and `1`) the wordmark renders shot through with hairline seams. Compared four configurations on the real art; this pair is the only seam-free one. Omarchy uses the same numbers, presumably having hit the same wall.
- **The logo resets `background`/`padding`/`border-radius`.** It is a `<pre>`, so without that it inherits the code-block card and sits on a grey rectangle.

JetBrains Mono now comes from Google Fonts, for the same reason: the block characters must come from a font that draws them edge to edge, which a system mono stack does not guarantee.

### A bug this turned up

The merged theme let a long inline `code` string push the whole page sideways on a narrow screen — `documentElement.scrollWidth` exceeded `clientWidth` at 320px. `overflow-wrap: anywhere` on inline code fixes it; measured `overflow=false` at 320, 375 and 420 afterwards.

### Verification

Screenshotted headless at 420px and 1400px; built clean; logo present on every page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5