### PR TITLE
The option index is not there to be found in a test VM

### DIFF
--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -166,6 +166,21 @@ let
   # flattened because the index this feeds is tab-separated and a note with a
   # newline in it would silently become three broken rows -- the same reason
   # templateRow collapses them.
+  # The NixOS option index, or "" when this system has no manual to take it
+  # from. `system.build.manual` is defined under documentation.nixos.enable,
+  # which is on by default but off in every NixOS test node -- so a hard
+  # reference here evaluates fine on a real machine and fails the session
+  # check, which is exactly how it got through review.
+  #
+  # Built rather than fetched, but built by nixpkgs: it substitutes from
+  # cache.nixos.org, so it costs a 2.6 MiB download rather than an evaluation
+  # of every option on the machine.
+  optionsJsonPath =
+    let
+      manual = config.system.build.manual.optionsJSON or null;
+    in
+    if manual == null then "" else "${manual}/share/doc/nixos/options.json";
+
   appIndexTable = pkgs.writeText "nixarchy-app-index.tsv" (
     lib.concatStrings (
       lib.mapAttrsToList (
@@ -875,7 +890,7 @@ in
               stamp="$cache/stamp"
 
               appindex=${appIndexTable}
-              optionsjson=${config.system.build.manual.optionsJSON}/share/doc/nixos/options.json
+              optionsjson=${optionsJsonPath}
               nixpkgs=${pkgs.path}
 
               reindex=0
@@ -901,23 +916,30 @@ in
                     $1 ".enable = true;"
                 }' "$appindex" > "$tmp"
 
-                jq -r '
-                  def val(x):
-                    if x == null then "(none)"
-                    elif (x | type) == "object" then (x.text // (x | tostring))
-                    else (x | tostring) end;
-                  to_entries[] | .key as $k | .value as $v |
-                  [ "opt", $k,
-                    (($v.description // "") | gsub("[\n\t ]+"; " ") | .[0:110]),
-                    ($v.type // ""),
-                    ( "NIXOS OPTION  " + $k
-                      + "\n\ntype:     " + ($v.type // "?")
-                      + "\ndefault:  " + val($v.default)
-                      + (if $v.example == null then "" else "\nexample:  " + val($v.example) end)
-                      + "\n\n" + ($v.description // "(undocumented)")
-                      + "\n\ndeclared in:\n  " + (($v.declarations // []) | join("\n  "))
-                    )
-                  ] | @tsv' "$optionsjson" >> "$tmp"
+                # Empty when this system builds no manual, in which case the
+                # picker is packages and apps only rather than not working at all.
+                if [ -n "$optionsjson" ] && [ -f "$optionsjson" ]; then
+                  jq -r '
+                    def val(x):
+                      if x == null then "(none)"
+                      elif (x | type) == "object" then (x.text // (x | tostring))
+                      else (x | tostring) end;
+                    to_entries[] | .key as $k | .value as $v |
+                    [ "opt", $k,
+                      (($v.description // "") | gsub("[\n\t ]+"; " ") | .[0:110]),
+                      ($v.type // ""),
+                      ( "NIXOS OPTION  " + $k
+                        + "\n\ntype:     " + ($v.type // "?")
+                        + "\ndefault:  " + val($v.default)
+                        + (if $v.example == null then "" else "\nexample:  " + val($v.example) end)
+                        + "\n\n" + ($v.description // "(undocumented)")
+                        + "\n\ndeclared in:\n  " + (($v.declarations // []) | join("\n  "))
+                      )
+                    ] | @tsv' "$optionsjson" >> "$tmp"
+                else
+                  echo "  no option index: documentation.nixos.enable is off on this" >&2
+                  echo "  system, so there is no options.json to read." >&2
+                fi
 
                 # The system's own nixpkgs, not the flake registry: an index that offers a
                 # package this machine cannot build is worse than no index. Slow enough to


### PR DESCRIPTION
Fixes the `system` job on `main`, broken by #43.

`nixarchy-search` read `config.system.build.manual.optionsJSON` directly. That
attribute is defined under `documentation.nixos.enable` — on by default, and
**off in every NixOS test node** — so the reference evaluated fine on a real
machine and took `checks.session` down with:

```
error: attribute 'manual' missing
at modules/apps.nix:878:29
```

Which is exactly how it got through: the checks run before merging #43 —
`omarchy`, `options`, `omarchy-runtime` — are the ones that do not boot a node,
and `nixosConfigurations.vm` has documentation like any real system.
`nix build .#checks.x86_64-linux.session` reproduces it in ten seconds.

Guarded, and degraded rather than broken: with no manual to read, the index is
packages and apps, and says so. An option picker is worth having on a desktop
and worth nothing in a test VM, so failing to build one there should not be
fatal.

## Verified

All eight checks built locally, including the one that failed:

| check | |
|---|---|
| `session` | pass — the failure |
| `integration` | pass |
| `coexist` | pass |
| `omarchy` | pass |
| `options` | pass |
| `omarchy-runtime` | pass |
| `plugin` | pass |
| `vm-toplevel` | pass |

And a documentation-enabled system still bakes in a real path:

```
optionsjson=/nix/store/2qgq…-options.json/share/doc/nixos/options.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaFe7Mq8idtgjRGkvoZaT8