### PR TITLE
The front page never mentioned you can search for anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ the parts that assume Arch, rather than reimplementing it in Nix.
 Tracking an upstream release is a source bump, not a re-port.
 
 What that buys you: the Install menu writes to a Nix config instead of running
-pacman, **56 applications** are selectable that way, plugins and themes still
-install from a git URL at runtime the way upstream intends, and every command
-that assumed `/usr` either points at what NixOS uses or says why it cannot.
+pacman, **56 applications** are selectable that way, **every other package and
+NixOS option is one `Install ▸ Search` away**, plugins and themes still install
+from a git URL at runtime the way upstream intends, and every command that
+assumed `/usr` either points at what NixOS uses or says why it cannot.
 
 ![A tour of nixarchy: the greeter, the menus, themes and the app selection](docs/nixarchy-demo.gif)
 
@@ -39,6 +40,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | Hyprland session, QuickShell bar, 22 themes | as upstream ships them |
 | `omarchy` CLI | all 429 subcommands, `omarchy commands --check` green |
 | **Install menu** | picks write to a Nix config, not pacman |
+| **Install ▸ Search** | one picker over 137k rows — every nixpkgs package, every NixOS option, and the app selection |
 | **Remove menu** | deselects apps, never touches your own config |
 | **Update menu** | `nh os switch --update <flake>` |
 | 56 apps in the selection | 41 from nixpkgs, 5 as NixOS modules, 8 built here, 2 with no equivalent |
@@ -158,6 +160,84 @@ Install ▸ Apply changes  →  nh os switch <flake>
 ```
 
 The notification is clickable and runs the rebuild.
+
+### Anything the menu does not offer
+
+The 56 apps are the ones Omarchy's own menu lists. Everything else in nixpkgs —
+and every NixOS option — is behind **`Install ▸ Search`**, or `nixarchy-search`
+from a terminal:
+
+```
+  nixarchy > tailscale
+  ┌──────────────────────────────────────────┬──────────────────────────────────┐
+  │ app  tailscale    Tailscale (Service)    │ NIXOS OPTION                     │
+  │ pkg  tailscale    Node agent for Tails…  │ services.tailscale.enable        │
+  │ opt  services.tailscale.enable           │                                  │
+  │ opt  services.tailscale.useRoutingFea…   │ type:     boolean                │
+  │ opt  services.tailscale.authKeyFile      │ default:  false                  │
+  │ …                                        │ example:  true                   │
+  │                                          │                                  │
+  │                                          │ Whether to enable Tailscale      │
+  │                                          │ client daemon.                   │
+  │                                          │                                  │
+  │                                          │ declared in:                     │
+  │                                          │   nixos/modules/services/…       │
+  └──────────────────────────────────────────┴──────────────────────────────────┘
+  enter to select · tab for several · esc to cancel
+```
+
+**137,599 rows: 25,102 NixOS options, 112,443 packages, and 54 of the 56 apps
+(the two with no nixpkgs equivalent cannot be indexed).** Three kinds,
+one picker, because you should not have to know which kind you want before you
+can look. They are not interchangeable and the rows say so — picking Tailscale
+from the app rows gets you `services.tailscale` with its daemon; picking
+`tailscale` from the package rows gets you the CLI and nothing running.
+
+Selecting routes to whichever writer is right:
+
+| row | what it writes |
+|---|---|
+| `app` | `<name>.enable = true;` in the app selection — the module, if the app needs one |
+| `pkg` | an entry in `environment.systemPackages`, validated against nixpkgs first |
+| `opt` | the option itself, as a line of its own |
+
+Or by hand, if you already know the name:
+
+```sh
+nixarchy-pkg-add ripgrep fd     # refuses anything nixpkgs does not have
+nixarchy-apply                  # one rebuild for these and your menu picks
+```
+
+**Options are only written where they can be written honestly.** An option's
+value is arbitrary Nix — a submodule, a function, a package, a list of them — so
+booleans and enums get a value picker and land uncommented, and anything more
+complicated is written *commented out*, with its type, default, example,
+description and declaring file as comments beside it:
+
+```nix
+  services.tailscale.enable = true;  #@opt services.tailscale.enable
+
+  # NIXOS OPTION  services.nginx.virtualHosts
+  #
+  # type:     attribute set of (submodule)
+  # default:  { localhost = { }; }
+  #
+  # Declarative vhost config
+  #
+  # declared in:
+  #   nixos/modules/services/web-servers/nginx/default.nix
+  # services.nginx.virtualHosts = ;  #@opt services.nginx.virtualHosts
+```
+
+The tool does the discovery and the placement; the expression stays yours.
+Neither form can break a build — the scaffold is inert, and every edit is
+reverted as a unit if `nix-instantiate` cannot parse the result.
+
+**The index is built from this machine, not from search.nixos.org.** Its own
+nixpkgs and its own options — about a minute, once per system generation, and
+it buys the one property that matters: the picker cannot offer you a package
+that this machine then refuses to build. The options half substitutes from
+`cache.nixos.org`, so only the nixpkgs half is real work.
 
 ### Naming the user who runs the desktop
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,36 @@ parts that assume Arch, rather than reimplementing it in Nix.
 
 Tracking an upstream release is a source bump, not a re-port.
 
+## Search everything, install declaratively
+
+Omarchy's Install menu offers 56 applications. **Install ▸ Search** offers the
+rest of NixOS — one fuzzy picker over **137,599 rows**: every nixpkgs package,
+every NixOS option, and the app selection, with each entry's type, default and
+documentation in a preview pane.
+
+```
+nixarchy > tailscale
+app  tailscale                          Tailscale (Service)
+pkg  tailscale                          Node agent for Tailscale, a mesh VPN …
+opt  services.tailscale.enable          Whether to enable Tailscale client daemon
+opt  services.tailscale.authKeyFile     A file containing the auth key …
+```
+
+The three kinds are not interchangeable, and the rows say so: the app row gets
+you `services.tailscale` with its daemon, the package row gets you the CLI and
+nothing running. Picking routes to whichever writer is right — an app is
+enabled as an app, a package is validated and appended, an option is written as
+a line of its own. Booleans and enums get a value picker; anything more
+complicated is written commented out with its type and docs beside it, because
+an option's value is arbitrary Nix and a form that pretended otherwise would
+write plausible-looking wrong configuration.
+
+Nothing is built until you apply. The index comes from *this machine's* nixpkgs
+and options rather than from search.nixos.org, so it can never offer something
+the machine will then refuse to build.
+
+See **[other packages](manual/other-packages)** for the whole flow.
+
 ## → [The nixarchy manual](manual/)
 
 What is different here, and only that. Omarchy's manual covers the desktop; this


### PR DESCRIPTION
Both the README and the site said the Install menu offers 56 apps and stopped
there — which is now the smaller half of what it does. Everything else in
nixpkgs, and every NixOS option, is one `Install ▸ Search` away, and nothing
said so.

## README

A row in *What works*, a line in the opening pitch, and a new
`### Anything the menu does not offer` section where the app selection is
already explained. It covers what the three kinds of row are, that they are not
interchangeable — the Tailscale **app** row is the daemon, the `tailscale`
**package** row is the CLI and nothing running — what each one writes, and why
an option's value is only filled in when it can be filled in honestly.

## Site

`docs/index.md` gets the short version above the manual link, since that is the
page anyone arrives on.

## On the numbers

Every figure and every quoted string was read off the built index rather than
written:

| claim | source |
|---|---|
| 137,599 rows | `wc -l index.tsv` |
| 25,102 options / 112,443 packages / 54 apps | `cut -f1 \| sort \| uniq -c` |
| "Node agent for Tailscale, a mesh VPN built on WireGuard" | the package's real `meta.description` |
| "Whether to enable Tailscale client daemon." | `options.json` |

The first draft had invented a plausible package description; it is replaced
with the real one. The 54-vs-56 gap is stated rather than left as an apparent
contradiction — two apps have no nixpkgs equivalent and so cannot be indexed.

## Verified

- The repo's own README app-count check passes (`fail=0`).
- `checks.session`, `checks.omarchy`, `checks.options` all build.

## Not covered

There is no **screenshot** of the picker — the README leans on real screenshots
elsewhere and an ASCII mock is weaker. Adding it to the `nix build .#demo`
screencast is the obvious follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaFe7Mq8idtgjRGkvoZaT8