### PR TITLE
Answer "is it already installed" with the table, not with PATH

### DIFF
--- a/data/arch-extras.nix
+++ b/data/arch-extras.nix
@@ -9,6 +9,12 @@
 # `kind` decides which option the advice names, because they are not
 # interchangeable: a font in environment.systemPackages is installed and still
 # not found by fontconfig.
+#
+# `binary` is optional and only needed when the command a package provides is
+# not its own name -- openssh provides sshd, not openssh. omarchy-pkg-add uses
+# it to tell "already installed" from "missing"; without it a package whose
+# name is not a command can never be found, and the caller aborts before the
+# configuration it was about to do. See #41.
 {
   # ── Style > Font ────────────────────────────────────────────────────────
   # Each row also calls omarchy-font-set with the family name, which works
@@ -106,6 +112,16 @@
     attr = "services.flatpak.enable = true";
     kind = "nixos-option";
     note = "then: flatpak install flathub com.nvidia.geforcenow";
+  };
+
+  # omarchy-setup-security-sshd opens with `omarchy-pkg-add openssh`, then
+  # configures sshd. On NixOS installing the package is not what starts the
+  # daemon, so the package advice would have been wrong even if it had been
+  # given -- and `binary` is what lets the guard see an already-running sshd.
+  openssh = {
+    attr = "services.openssh.enable = true";
+    kind = "nixos-option";
+    binary = "sshd";
   };
 
   # ── Install > AI ────────────────────────────────────────────────────────

--- a/pkgs/omarchy/default.nix
+++ b/pkgs/omarchy/default.nix
@@ -261,18 +261,24 @@ let
     # always present is exactly what the menu's dimming exists to prevent.
     ttfx
   ];
-  # arch-name<TAB>kind<TAB>attr<TAB>note, one per line. Apps come from
+  # arch-name<TAB>kind<TAB>attr<TAB>note<TAB>binary, one per line. Apps come from
   # data/apps.nix so the two cannot drift; everything the menu does not select
   # -- fonts, the packages omarchy-install-dev-env adds behind a language --
   # comes from data/arch-extras.nix.
+  #
+  # The fifth column is the command the package provides when that differs from
+  # its own name, and it is empty for almost every row. omarchy-pkg-add needs it
+  # to answer "is this already installed"; see #41.
   archTable =
     let
       apps = import ../../data/apps.nix;
       extras = import ../../data/arch-extras.nix;
-      appRows = lib.mapAttrsToList (name: app: "${app.arch}\tapp\t${name}\t") (
+      appRows = lib.mapAttrsToList (name: app: "${app.arch}\tapp\t${name}\t\t") (
         lib.filterAttrs (_: a: a ? arch) apps
       );
-      extraRows = lib.mapAttrsToList (arch: e: "${arch}\t${e.kind}\t${e.attr}\t${e.note or ""}") extras;
+      extraRows = lib.mapAttrsToList (
+        arch: e: "${arch}\t${e.kind}\t${e.attr}\t${e.note or ""}\t${e.binary or ""}"
+      ) extras;
     in
     writeText "nixarchy-arch-packages.tsv" (lib.concatStringsSep "\n" (appRows ++ extraRows) + "\n");
 in

--- a/pkgs/omarchy/nix-bin/omarchy-pkg-add
+++ b/pkgs/omarchy/nix-bin/omarchy-pkg-add
@@ -34,17 +34,64 @@ file="${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/apps.nix"
 # that goes on to configure something that was never installed should stop.
 #
 # But once you have enabled the app declaratively and rebuilt, the package IS
-# there, and the only thing still missing is exactly that configuration. Failing
-# then leaves an app installed and unconfigured with no way to finish the job
-# short of reading the script and running its tail by hand.
+# there, and the only thing still missing is exactly that configuration.
 #
-# So: yield when every named package resolves. The caller carries on and does
-# its configuration against a package that genuinely exists, which is the
-# behaviour upstream has and the reason those tails were written.
+# Deciding that needs more than `command -v <package name>`, which is what the
+# first version of this guard used and why it only ever worked for single
+# packages whose name happened to be their command. The callers do not look like
+# that:
 #
-# omarchy-pkg-present is the same check the rest of this family uses, suffix
-# handling included -- brave-bin provides `brave`.
-if [ $# -gt 0 ] && omarchy-pkg-present "$@"; then
+#   omarchy-pkg-add php composer php-sqlite xdebug
+#   omarchy-pkg-add dropbox dropbox-cli libappindicator-gtk3 python-gpgme ...
+#
+# php-sqlite and xdebug are PHP extensions and libappindicator-gtk3 is a
+# library: none of them is a command, so none can ever be "found", so the whole
+# set was permanently unresolvable and the tail never ran. Hence three outcomes
+# per argument rather than two:
+#
+#   present  a command it provides is on PATH
+#   missing  we know what it is and it is not here
+#   neutral  it is not the kind of thing that has a command, or we do not know
+#            what it is -- absence is not evidence either way
+#
+# The guard yields when something is present and nothing is missing. Neutral
+# arguments abstain.
+#
+# ponytail: neutral covers "unknown to the table" as well as "known to have no
+# command", so a genuinely missing package we have never heard of will not stop
+# the caller. That is deliberate -- the alternative is the bug this replaces --
+# but it is why the answer is a heuristic and not a fact. Adding the package to
+# data/arch-extras.nix, with `binary` if its command differs from its name,
+# moves it out of neutral and makes the answer exact.
+present=0
+missing=0
+
+for pkg in "$@"; do
+  row=$(grep -m1 -E "^${pkg}	" "$table" 2>/dev/null || true)
+  kind=$(printf '%s' "$row" | cut -f2)
+  bin=$(printf '%s' "$row" | cut -f5)
+
+  # brave-bin provides `brave`; zen-browser-stable provides `zen-browser`.
+  for candidate in "$bin" "$pkg" "${pkg%-bin}" "${pkg%-stable}"; do
+    [ -n "$candidate" ] || continue
+    if command -v "$candidate" >/dev/null 2>&1; then
+      present=$((present + 1))
+      continue 2
+    fi
+  done
+
+  case "$kind" in
+    # A font is registered rather than run, a nixos-option is not a package at
+    # all, and a PHP extension is compiled into the interpreter. Asking PATH
+    # about any of them is meaningless.
+    font | nixos-option | php-extension) ;;
+    # Not in the table: could be a library, could be missing. No opinion.
+    "") ;;
+    *) missing=$((missing + 1)) ;;
+  esac
+done
+
+if [ "$present" -gt 0 ] && [ "$missing" -eq 0 ]; then
   echo
   echo "[$*] already installed. Nothing to add -- carrying on."
   exit 0


### PR DESCRIPTION
Closes #41.

The guard merged in #43 fixed the single-package callers. It could not fix the rest, because it asked `command -v <package name>` and nothing else. The callers don't look like that:

```
omarchy-pkg-add php composer php-sqlite xdebug
omarchy-pkg-add dropbox dropbox-cli libappindicator-gtk3 python-gpgme nautilus-dropbox
omarchy-pkg-add openssh
```

`php-sqlite` and `xdebug` are PHP extensions, `libappindicator-gtk3` is a library, `openssh` provides `sshd`. None is a command named after itself, so none could ever be "found", so those sets were **permanently** unresolvable and the configuration tail the sixteen scripts exist for never ran.

### Three answers per argument, not two

| | |
|---|---|
| **present** | a command it provides is on PATH |
| **missing** | we know what it is and it is not here |
| **neutral** | not the kind of thing that has a command, or the table has never heard of it |

The guard yields when something is present and nothing is missing. The table already recorded which entries are `font`, `nixos-option` and `php-extension` — it simply was not being asked.

Adds a fifth column for the command a package provides when it differs from its name (empty on every row but one), and an **`openssh` row that was missing entirely** — so `omarchy-setup-security-sshd` got no advice *and* aborted. On NixOS it's `services.openssh.enable`, not a package, so the advice was wrong twice over.

### The honest limit

`neutral` covers "unknown to the table" as well as "known to have no command", so a genuinely missing package nothing has heard of will not stop the caller. That is deliberate — the alternative is the bug this replaces — but it is why this is a heuristic rather than a fact. Adding a row to `data/arch-extras.nix` moves a package out of neutral and makes the answer exact. Marked with a `ponytail:` comment naming the ceiling.

### Verification

Against the **built package**, not the source:

```
0  steam                                  0  git xdebug php-sqlite
0  openssh                                0  git lib32-nvidia-utils
0  1password 1password-cli                0  git ttf-fira-code-nerd
0  git libappindicator-gtk3 python-gpgme
1  git dropbox            (curated but absent — still aborts)
1  definitely-absent-xyz
1  libappindicator-gtk3 python-gpgme      (nothing present — still aborts)
```

`nix build .#omarchy`, `checks.omarchy` and `checks.options` pass; `nix fmt --ci` clean; the generated table is 71 rows, all five columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5