### PR TITLE
Two names, and the commands say which is which

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | `omarchy` CLI | all 429 subcommands, `omarchy commands --check` green |
 | **Install menu** | picks write to a Nix config, not pacman |
 | **Install ▸ Search** | one picker over 137k rows — every nixpkgs package, every NixOS option, and the app selection |
+| **`nixarchy` command** | this port's own commands, and a way through to Omarchy's 431 |
 | **Remove menu** | deselects apps, never touches your own config |
 | **Update menu** | `nh os switch --update <flake>` |
 | 56 apps in the selection | 41 from nixpkgs, 5 as NixOS modules, 8 built here, 2 with no equivalent |
@@ -55,6 +56,37 @@ More in [`docs/screenshots/`](docs/screenshots).
 | **LocalSend** | the firewall opens 53317 as upstream's `firewall.sh` does — Share ▸ Receive is reachable, not merely listening |
 | Disk Usage, screensaver | `dua` and `ttfx` are runtime dependencies, so the launcher row and `SUPER + Esc` do something |
 | Lock screen on sleep/wake | quickshell pinned to 0.3.1; 0.3.0 aborts on DPMS and leaves the compositor locked with no way in |
+
+## Two names, on purpose
+
+The desktop is Omarchy's. The port is nixarchy's. The commands say which is
+which, and `nixarchy` is the way in:
+
+```sh
+nixarchy                     # what this port adds, and what it defers to
+nixarchy search tailscale    # nixarchy-search
+nixarchy pkg add ripgrep     # nixarchy-pkg-add
+nixarchy apply               # nixarchy-apply
+nixarchy theme set catppuccin   # → omarchy theme set catppuccin, unchanged
+```
+
+Anything `nixarchy` does not own it `exec`s through to `omarchy`, so both names
+work and the exit status, terminal and signals stay the command's own.
+
+**Upstream's 431 commands keep upstream's name, deliberately.** `omarchy theme
+set` is the same script here as on Arch — a bug in it is a bug to report there,
+and renaming it would say otherwise. It would also cost the property this repo
+is built on: tracking a release is a source bump because nixarchy replaces 19
+scripts and patches ~100 strings, and renaming would make all 5,365 occurrences
+of `omarchy` a patch to re-apply on every bump. `omarchy.*` is also a reserved
+plugin namespace that `omarchy plugin validate` enforces and third-party
+plugins target.
+
+The branding you *do* see is nixarchy's: the session is **Nixarchy**, the menu
+button wears the snowflake, and the screensaver and About window carry the
+NIXARCHY banner. The session's id stays `omarchy` so a greeter that already
+remembers it keeps remembering it — `Name=` is what a greeter prints, the
+basename is what it stores.
 
 ## Why vendoring
 

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -1082,6 +1082,97 @@ in
             '';
           })
 
+          # One name for the commands this repo adds, and a way through to
+          # the 431 it vendors.
+          #
+          # Not a rename of Omarchy. Upstream's commands keep upstream's name,
+          # because they are upstream's -- `omarchy theme set` is the same
+          # script here as on Arch, and a bug in it is a bug to report there.
+          # What this names is the other half: the six commands nixarchy wrote,
+          # which until now were six binaries on PATH with nothing tying them
+          # together and no way to discover them.
+          #
+          # Anything this does not own falls through to omarchy unchanged, so
+          # `nixarchy theme set catppuccin` works and does exactly what
+          # `omarchy theme set catppuccin` does. The fallthrough is the point:
+          # you should not have to know which half of the desktop you are
+          # talking to before you can type a command.
+          (pkgs.writeShellApplication {
+            name = "nixarchy";
+            runtimeInputs = [
+              pkgs.coreutils
+              cfg.package # omarchy, for the fallthrough
+            ];
+            text = ''
+              # Routed by hand rather than by scanning a bin/ directory the way
+              # upstream's dispatcher does: these commands are separate
+              # derivations on PATH, not siblings in one tree, so there is no
+              # directory to scan. Six entries is not a table worth generating.
+              case "''${1:-}" in
+                search)   shift; exec nixarchy-search "$@" ;;
+                apply)    shift; exec nixarchy-apply "$@" ;;
+                # Not installed on the system, on purpose: the doctor exists
+                # to be run *before* nixarchy is an input anywhere, which is
+                # the only entry point someone deciding whether to adopt it
+                # actually has. Route to the command that works rather than to
+                # a binary that is not there.
+                doctor)
+                  if command -v nixarchy-doctor >/dev/null 2>&1; then
+                    shift; exec nixarchy-doctor "$@"
+                  fi
+                  echo "The doctor is not installed -- it runs from the flake, so that it" >&2
+                  echo "works on a machine that has not adopted nixarchy yet:" >&2
+                  echo >&2
+                  echo "  nix run github:olafkfreund/nixarchy#doctor" >&2
+                  exit 1
+                  ;;
+                pkg)
+                  case "''${2:-}" in
+                    add) shift 2; exec nixarchy-pkg-add "$@" ;;
+                  esac
+                  ;;
+                app)
+                  case "''${2:-}" in
+                    enable)  shift 2; exec nixarchy-app-enable "$@" ;;
+                    disable) shift 2; exec nixarchy-app-disable "$@" ;;
+                    remove)  shift 2; exec nixarchy-app-remove "$@" ;;
+                  esac
+                  ;;
+                ""|--help|-h|help)
+                  cat <<'USAGE'
+              nixarchy -- the Omarchy desktop, vendored for NixOS.
+
+              Commands this port adds:
+
+                nixarchy search [query]     Every package, NixOS option and app, in one picker
+                nixarchy pkg add <attr>     Add a nixpkgs package to the app selection
+                nixarchy app enable <id>    Select an app from the curated list
+                nixarchy app disable <id>   Deselect one
+                nixarchy app remove         Pick what to deselect, interactively
+                nixarchy apply              Copy the selection into your flake and rebuild
+                nixarchy doctor             What this machine needs to run nixarchy
+
+              Everything else is Omarchy's own, and reaches it unchanged:
+
+                nixarchy theme set <name>   = omarchy theme set <name>
+                nixarchy update             = omarchy update
+                omarchy commands            Every one of them
+
+              Both names work for those. They are the same scripts as on Arch,
+              which is why they keep Omarchy's name: a bug in one is a bug to
+              report upstream, not here.
+              USAGE
+                  exit 0
+                  ;;
+              esac
+
+              # Anything else is Omarchy's. Not a warning and not a wrapper:
+              # exec, so the exit status, the terminal and the signals are the
+              # command's own.
+              exec omarchy "$@"
+            '';
+          })
+
           # Copies the selection into the flake and switches. Kept separate
           # from enabling so several apps can be picked before anything builds.
           (pkgs.writeShellApplication {

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -38,14 +38,22 @@ let
   usingFcitx5 = config.i18n.inputMethod.enable && config.i18n.inputMethod.type == "fcitx5";
 
   # providedSessions has to match the .desktop basename or NixOS refuses it.
+  #
+  # The label is Nixarchy and the id stays `omarchy`, which is not an
+  # oversight. `Name=` is what a greeter prints; the basename is what it
+  # *remembers* -- SDDM, GDM and greetd all persist the last session by file
+  # id, so renaming the file would log everyone who already picked this
+  # session into whatever the greeter falls back to, once, with no
+  # explanation. A label costs nothing to change and an id costs a support
+  # thread.
   omarchySession =
     (pkgs.writeTextFile {
       name = "omarchy-wayland-session";
       destination = "/share/wayland-sessions/omarchy.desktop";
       text = ''
         [Desktop Entry]
-        Name=Omarchy
-        Comment=The Omarchy desktop, on Hyprland
+        Name=Nixarchy
+        Comment=Omarchy on NixOS, through Hyprland
         Exec=${omarchySessionLauncher}
         Type=Application
         DesktopNames=Hyprland
@@ -89,8 +97,10 @@ in
       type = lib.types.bool;
       default = true;
       description = ''
-        Register "Omarchy" as its own entry in wayland-sessions, so any
-        greeter can offer it alongside whatever else the machine runs.
+        Register "Nixarchy" as its own entry in wayland-sessions, so any
+        greeter can offer it alongside whatever else the machine runs. The
+        session id stays `omarchy`, so a greeter that already remembers this
+        session keeps remembering it.
 
         This is what makes nixarchy coexist with an existing Hyprland setup.
         The session names Omarchy's own hyprland.lua with Hyprland's --config,

--- a/pkgs/omarchy/skills/nixos/SKILL.md
+++ b/pkgs/omarchy/skills/nixos/SKILL.md
@@ -26,9 +26,15 @@ file edit and a rebuild instead.
 
 Three routes exist on a Nixarchy machine. Pick the highest one that fits.
 
+`nixarchy` with no arguments lists what this port adds; anything it does not own
+falls through to `omarchy` unchanged, so `nixarchy theme set <name>` and
+`omarchy theme set <name>` are the same command. The `nixarchy-*` binaries are
+still there and still work — `nixarchy pkg add` and `nixarchy-pkg-add` are the
+same thing.
+
 | The request | Route |
 |---|---|
-| An app Nixarchy already knows about | **`nixarchy-app-enable <id>`**, then `nixarchy-apply` |
+| An app Nixarchy already knows about | **`nixarchy app enable <id>`**, then `nixarchy apply` |
 | Any other package, service, or system setting | **`nixarchy-pkg-add <attr>`** for a plain package; otherwise **edit the flake**, then `nixos-rebuild switch` |
 | A one-off, throwaway try — not a change to the machine | **`nix shell nixpkgs#<pkg>`** |
 


### PR DESCRIPTION
The six commands this repo wrote were six binaries on PATH with nothing tying
them together and no way to find them. `nixarchy` is that name:

```sh
nixarchy                        # what this port adds, and what it defers to
nixarchy search tailscale       # nixarchy-search
nixarchy pkg add ripgrep        # nixarchy-pkg-add
nixarchy apply                  # nixarchy-apply
nixarchy theme set catppuccin   # → omarchy theme set catppuccin, unchanged
```

Anything it does not own it **`exec`s** through to `omarchy`, so the exit
status, terminal and signals stay the command's own. Both names work for those,
and `nixarchy-search` and friends still work unprefixed.

Routed by hand rather than by scanning a `bin/` directory the way upstream's
dispatcher does: these are separate derivations on PATH, not siblings in one
tree, so there is no directory to scan. Six entries is not a table worth
generating.

`nixarchy doctor` is the one row that is not a plain exec. The doctor is
deliberately **not installed on the system** — it runs from the flake so it
works on a machine that has not adopted nixarchy yet, which is the only entry
point someone deciding whether to adopt it actually has. So the row checks, and
names `nix run <flake>#doctor` rather than failing on a binary that was never
there. (I had it wrong the first time and routed straight to the binary.)

## Why upstream's 431 commands keep upstream's name

This is the point, not a shortfall. `omarchy-theme-set` is the same script here
as on Arch, so a bug in it is a bug to report *there*, and a rename would say
otherwise. Renaming would also cost the property this repo is built on:

| | |
|---|---|
| `omarchy-*` binaries | 431 |
| files mentioning `omarchy` | 788 |
| occurrences of the string | **5,365** |
| cross-calls between scripts by bare name | **1,260 sites, 353 commands** |
| `OMARCHY_*` env vars | 101 distinct |
| patches nixarchy carries today | ~103 |

Tracking a release is a source bump because nixarchy replaces 19 scripts and
patches about a hundred strings. Renaming makes all 5,365 occurrences a patch to
re-apply and re-review on every bump — that is a fork. And `omarchy.*` is a
reserved plugin namespace that `omarchy-plugin-validate:53` enforces and that
third-party plugins target through `firstPartyServiceFor("omarchy.idle")`.

## The session

```
Name=Nixarchy
Comment=Omarchy on NixOS, through Hyprland
```

The file stays `omarchy.desktop` and `providedSessions = [ "omarchy" ]`.
`Name=` is what a greeter prints; the basename is what it *remembers* — SDDM,
GDM and greetd all persist the last session by file id. Renaming the file would
log everyone who already picked this session into whatever the greeter falls
back to, once, with no explanation. A label costs nothing; an id costs a support
thread.

The rest of the branding was already nixarchy's: the menu button's snowflake,
and the NIXARCHY banner in the About window and screensaver.

## Verified

- `nixarchy` with no args prints the index; `nixarchy theme --help` prints
  Omarchy's real theme help; `nixarchy version` → `4.0.1`, exit 0;
  `nixarchy doctor` on a system without it explains and exits 1.
- The generated session entry reads `Name=Nixarchy` with the id unchanged.
- All three lint steps (`nix fmt -- --ci`, statix, deadnix) clean — run *before*
  pushing this time.
- `checks.session`, `omarchy`, `omarchy-runtime`, `options`, `integration` all
  build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaFe7Mq8idtgjRGkvoZaT8