### PR TITLE
One disk layout, declared once

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,6 +33,27 @@
         "type": "github"
       }
     },
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768920986,
+        "narHash": "sha256-CNzzBsRhq7gg4BMBuTDObiWDH/rFYHEuDRVOwCcwXw4=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "de5708739256238fb912c62f03988815db89ec9a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "latest",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -483,6 +504,7 @@
     },
     "root": {
       "inputs": {
+        "disko": "disko",
         "home-manager": "home-manager",
         "hyprland": "hyprland",
         "nixpkgs": "nixpkgs_2",

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,18 @@
       flake = false;
     };
 
+    # The installer's one disk layout is a disko expression, and the installed
+    # machine imports the same file -- that is what keeps `fileSystems`
+    # declarative instead of frozen into a hardware-configuration.nix nobody
+    # re-derives. See installer/disk-config.nix and issue #7.
+    #
+    # `follows` is right here and wrong for hyprland above: disko needs little
+    # more than lib, and there is no binary cache to forfeit by overriding it.
+    disko = {
+      url = "github:nix-community/disko/latest";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # Zen is not in nixpkgs and upstream maintains its own flake, which tracks
     # Zen's releases far more closely than a derivation here ever would.
     zen-browser = {

--- a/installer/disk-config.nix
+++ b/installer/disk-config.nix
@@ -1,0 +1,93 @@
+# The one disk layout the installer offers. Imported by the installed system
+# too, so the layout is declared once and is what `fileSystems` derives from --
+# epic invariant 1 applied to the disk: text in the user's flake, not a side
+# effect of an install script.
+#
+# `device` is the whole disk. Installing beside an existing OS is a second
+# mode with a different shape, tracked as #47; it cannot reuse this GPT block,
+# because disko only clears a partition table on a disk with no signatures and
+# its partition numbers are positional. It reuses the `btrfs` block below,
+# which is the reason that block is a binding rather than written out twice.
+{
+  device,
+  encrypt ? true,
+}:
+let
+  # Omarchy's layout on Arch is @ @home @log and @pkg for pacman's cache.
+  # @nix replaces @pkg: the store is the thing worth its own subvolume here,
+  # and there is no package cache to keep.
+  mountOptions = [
+    "compress=zstd"
+    "noatime"
+  ];
+
+  btrfs = {
+    type = "btrfs";
+    extraArgs = [ "-f" ];
+    subvolumes = {
+      "@" = {
+        mountpoint = "/";
+        inherit mountOptions;
+      };
+      "@home" = {
+        mountpoint = "/home";
+        inherit mountOptions;
+      };
+      "@nix" = {
+        mountpoint = "/nix";
+        inherit mountOptions;
+      };
+      "@log" = {
+        mountpoint = "/var/log";
+        inherit mountOptions;
+      };
+    };
+  };
+in
+{
+  disko.devices.disk.main = {
+    inherit device;
+    type = "disk";
+    content = {
+      type = "gpt";
+      partitions = {
+        # /boot rather than /boot/efi: it is what boot.loader.systemd-boot
+        # expects with no further options, and what Omarchy does with Limine.
+        # 2G because a NixOS /boot holds every generation's kernel and initrd,
+        # and the usual 512M runs out quietly, mid-rebuild.
+        esp = {
+          size = "2G";
+          type = "EF00";
+          content = {
+            type = "filesystem";
+            format = "vfat";
+            mountpoint = "/boot";
+            mountOptions = [ "umask=0077" ];
+          };
+        };
+        root = {
+          size = "100%";
+          content =
+            if encrypt then
+              {
+                type = "luks";
+                name = "cryptroot";
+                # Read once, by the disko script, at format time. The installer
+                # writes it and removes it; the installed system never sees this
+                # path -- its initrd prompts for the passphrase instead, and
+                # nothing about this leaks into the closure. Never put it in the
+                # generated flake directory: that becomes /etc/nixos and a git
+                # repository.
+                passwordFile = "/tmp/nixarchy-luks.key";
+                # TRIM through LUKS. Upstream accepts the trade -- it makes the
+                # free-space pattern visible on the device -- and so do we.
+                settings.allowDiscards = true;
+                content = btrfs;
+              }
+            else
+              btrfs;
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Closes #7. First code on the installer epic (#6).

Nothing in this repo has ever described a real disk — the smoke-test VM boots through qemu's `-kernel` onto a tmpfs root. An installer needs one layout it can format without asking.

The reason to use disko rather than a `parted` sequence is that **the same file describes the disk to the installer and to the installed machine**. That's epic invariant 1 applied to storage: the layout is text in the user's flake, imported on the running system, and `fileSystems` derives from it — rather than being frozen once into a `hardware-configuration.nix` nobody re-derives.

GPT · 2G ESP at `/boot` · LUKS2 by default · btrfs with `@ @home @nix @log`.

### Two deliberate departures from Omarchy's Arch layout

- **`@nix` replaces their `@pkg`.** The store is what deserves its own subvolume here; there's no package cache to keep.
- **The ESP is 2G, not the usual 512M.** A NixOS `/boot` holds a kernel and initrd for *every generation*, and 512M runs out quietly, mid-rebuild, on a machine whose selling point is that you can roll back.

### Why `encrypt` is a parameter

The two layouts differ by exactly one nesting level, and copying the btrfs block is how they drift. That same binding is what **#47** reuses for free-space install — it can't reuse the GPT block (disko only clears a table on a disk with no signatures, and numbers partitions positionally) but the filesystem half is identical and should stay one definition.

`disko` follows nixpkgs. That's correct here and *wrong* for `hyprland`, which asks consumers not to override it and whose binary cache we'd forfeit — that input's comment is left alone.

### Verification

Both variants evaluate to `["/","/boot","/home","/nix","/var/log"]` — and, more usefully, they genuinely differ where it counts:

```
encrypt=true   boot.initrd.luks.devices = ["cryptroot"]
encrypt=false  boot.initrd.luks.devices = []
```

The `fileSystems` check from the issue is identical for both, so on its own it would not have caught an `encrypt` flag that did nothing.

`diskoScript` builds and contains the real `sgdisk`/`cryptsetup`/`mkfs.btrfs` calls. `flake.lock` gains `disko` and no other input moves. All eight checks build; `nix fmt --ci`, `statix` and `deadnix` clean.

### Note for #8

The reference host must include **both** `inputs.disko.nixosModules.disko` and `(import ./installer/disk-config.nix { device = "..."; })` in its module list — importing only the layout gives no `fileSystems`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5