### PR TITLE
Separate the machine from the guest it was hiding in

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -466,6 +466,12 @@ jobs:
       - name: Build the VM system closure
         run: nix build .#checks.x86_64-linux.vm-toplevel --print-build-logs
 
+      - name: Build the installed-machine closure
+        # The reference host: what the installer produces, with a real
+        # bootloader and disko filesystems. Built here so the install path
+        # cannot rot unnoticed between releases.
+        run: nix build .#checks.x86_64-linux.reference-toplevel --print-build-logs
+
       - name: Drive a session and the app-selection loop
         # Boots a machine, picks two apps through nixarchy-app-enable, checks
         # the file still parses, and checks nixarchy-apply copies the

--- a/flake.nix
+++ b/flake.nix
@@ -350,6 +350,30 @@
         ];
       };
 
+      # The machine the installer produces, with the installer's own defaults.
+      # Built in CI so the install path cannot rot between releases, and baked
+      # into the ISO's store later so that installing copies rather than
+      # downloads -- which only works if this closure is a closure of something
+      # a real install actually produces.
+      #
+      # `device` is a placeholder: nothing here formats a disk. What matters is
+      # that the expensive derivations in this toplevel are the same ones a real
+      # install needs, and the device string is not one of them.
+      nixosConfigurations.reference = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        specialArgs = { inherit inputs; };
+        modules = [
+          self.nixosModules.nixarchy
+          home-manager.nixosModules.home-manager
+          inputs.disko.nixosModules.disko
+          (import ./installer/host.nix {
+            hostname = "nixarchy";
+            username = "omarchy";
+          })
+          (import ./installer/disk-config.nix { device = "/dev/vda"; })
+        ];
+      };
+
       devShells = eachSystem (system: {
         default = pkgsFor.${system}.callPackage ./shell.nix { };
       });
@@ -399,6 +423,11 @@
         };
 
         vm-toplevel = self.nixosConfigurations.vm.config.system.build.toplevel;
+
+        # The installed machine, as opposed to the smoke-test guest: a real
+        # bootloader, disko-provided filesystems, nothing faked. If this builds
+        # and vm-toplevel builds, the extraction has not let the two drift.
+        reference-toplevel = self.nixosConfigurations.reference.config.system.build.toplevel;
       });
     };
 }

--- a/installer/host.nix
+++ b/installer/host.nix
@@ -1,0 +1,99 @@
+# The Omarchy host, as installed. Imported by the generated flake the installer
+# writes, and by vm/configuration.nix, which layers qemu-only overrides on top.
+#
+# The boundary: anything true of a real machine belongs here; anything true only
+# of a throwaway guest stays in vm/. Extracting this rather than writing it fresh
+# is what stops the smoke test and the installed machine drifting apart --
+# checks.vm-toplevel keeps building the same module the installer ships.
+#
+# Deliberately absent: networkmanager, pipewire and SDDM. modules/nixos.nix
+# already sets all three at mkDefault, and a second definition here would be
+# dead config that reads like a decision.
+{
+  hostname,
+  username,
+}:
+{
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  programs.nixarchy = {
+    enable = true;
+
+    # Puts the user in the `input` group -- upstream's installer does
+    # `usermod -aG input`, and without it dictation and controllers cannot read
+    # their devices. The module cannot guess who logs in, so it is told.
+    user = username;
+
+    # Where nixarchy-apply copies the app selection before rebuilding. Stated
+    # even though modules/apps.nix defaults to the same path: on an installed
+    # machine this is the installer's decision, not a default it could later
+    # lose without anyone noticing.
+    flake = "/etc/nixos";
+  };
+
+  # `nh os switch` is the loop the user lives in, and it only works with no
+  # arguments if nh knows which flake it is switching -- otherwise it fails, or
+  # picks up $NH_FLAKE from somewhere else entirely.
+  #
+  # The GC timer is the part Arch has no equivalent of and NixOS badly needs.
+  # Without it a machine that updates weekly accumulates every old generation
+  # and the owner finds out when the disk fills. Fourteen days and five
+  # generations keeps rollback useful without unbounded growth.
+  programs.nh = {
+    enable = true;
+    flake = "/etc/nixos";
+    clean.enable = true;
+    clean.extraArgs = "--keep-since 14d --keep 5";
+  };
+
+  home-manager = {
+    useGlobalPkgs = true;
+    useUserPackages = true;
+    sharedModules = [ inputs.self.homeManagerModules.nixarchy ];
+    users.${username} = {
+      programs.nixarchy.enable = true;
+      home.stateVersion = "25.05";
+    };
+  };
+
+  users.users.${username} = {
+    isNormalUser = true;
+    extraGroups = [
+      "wheel"
+      "video"
+      "input"
+      "docker"
+      "i2c"
+    ];
+    # No password here. The installer writes hashedPassword into the generated
+    # configuration.nix; the VM sets a plaintext one as its own definition.
+  };
+
+  networking.hostName = hostname;
+
+  boot.loader = {
+    systemd-boot.enable = true;
+    efi.canTouchEfiVariables = true;
+  };
+
+  # mkDefault: the generated configuration.nix carries the answers the installer
+  # collected, and must win over these without needing mkForce.
+  time.timeZone = lib.mkDefault "UTC";
+  i18n.defaultLocale = lib.mkDefault "en_US.UTF-8";
+  console.keyMap = lib.mkDefault "us";
+
+  # Redundant with the module's own default since #57, and deliberately so: this
+  # file becomes the user's own configuration.nix, and a licence policy they
+  # cannot see is one they cannot change.
+  nixpkgs.config.allowUnfree = true;
+
+  # The flake on disk is a git repository, and nixarchy-apply needs git on PATH
+  # to stage the selection it copies in.
+  environment.systemPackages = [ pkgs.git ];
+
+  system.stateVersion = "25.05";
+}

--- a/vm/configuration.nix
+++ b/vm/configuration.nix
@@ -14,33 +14,30 @@
   # `virtualisation.vmVariant`: this configuration is never anything but a VM,
   # and the import is what supplies the root filesystem and bootloader that a
   # bare nixosSystem is missing.
-  imports = [ "${modulesPath}/virtualisation/qemu-vm.nix" ];
+  imports = [
+    "${modulesPath}/virtualisation/qemu-vm.nix"
 
-  programs.nixarchy.enable = true;
-
-  home-manager = {
-    useGlobalPkgs = true;
-    useUserPackages = true;
-    sharedModules = [ inputs.self.homeManagerModules.nixarchy ];
-    users.omarchy = {
-      programs.nixarchy.enable = true;
-      home.stateVersion = "25.05";
-    };
-  };
+    # The installed host, unchanged. Everything below this line is the
+    # difference between an Omarchy machine and a throwaway qemu guest, which
+    # is the only thing this file should still contain.
+    #
+    # The relative path resolves inside the store copy too, which matters: the
+    # activation script below writes a flake importing
+    # "${nixarchy}/vm/configuration.nix", and that copy must find
+    # ../installer/host.nix beside it. It does -- the flake source is one path.
+    (import ../installer/host.nix {
+      hostname = "nixarchy-vm";
+      username = "omarchy";
+    })
+  ];
 
   users.users.root.password = "omarchy"; # VM-only.
 
+  # Merged with host.nix's definition of the same user: it supplies the groups
+  # and isNormalUser, this supplies what only a throwaway guest should have.
   users.users.omarchy = {
-    isNormalUser = true;
     description = "Nixarchy smoke test";
     password = "omarchy"; # VM-only; never reachable off the host.
-    extraGroups = [
-      "wheel"
-      "video"
-      "input"
-      "docker"
-      "i2c"
-    ];
   };
 
   # Straight to a session -- a login prompt adds nothing to the smoke test.
@@ -130,8 +127,9 @@
   # The inputs are pinned by the same flake.lock this VM was built from, and
   # the nixarchy input is the store path that built it, so a rebuild resolves
   # everything already present and needs no network.
-  programs.nixarchy.flake = "/etc/nixos";
-
+  #
+  # programs.nixarchy.flake names this directory; host.nix sets it.
+  #
   # Written by an activation script rather than environment.etc, because
   # environment.etc produces read-only symlinks into the store and
   # nixarchy-apply has to copy the app selection into this directory.
@@ -182,10 +180,6 @@
   # because this VM is a throwaway; a real host should keep its prompt.
   security.sudo.wheelNeedsPassword = false;
 
-  # Unfree is on because most of what the Install menu offers is unfree, and
-  # discovering that through a licence error mid-rebuild helps nobody.
-  nixpkgs.config.allowUnfree = true;
-
   # Serial console keeps the journal readable from the host when the
   # graphical session is the thing that is broken.
   boot = {
@@ -202,14 +196,20 @@
     # boot.loader.external satisfies the assertion that some bootloader is
     # configured while installing nothing, which is right here: the next boot
     # comes from the host's run script, not from this disk.
-    loader.grub.enable = lib.mkForce false;
-    loader.external = {
-      enable = true;
-      installHook = lib.getExe (
-        pkgs.writeShellScriptBin "nixarchy-vm-no-bootloader" ''
-          echo "nixarchy VM: no bootloader to install (tmpfs root, booted via -kernel)"
-        ''
-      );
+    # Both, for the same reason: host.nix configures systemd-boot because a
+    # real machine needs one, and there is no disk here for either to install
+    # onto. Left enabled they are two bootloaders and the assertion fires.
+    loader = {
+      grub.enable = lib.mkForce false;
+      systemd-boot.enable = lib.mkForce false;
+      external = {
+        enable = true;
+        installHook = lib.getExe (
+          pkgs.writeShellScriptBin "nixarchy-vm-no-bootloader" ''
+            echo "nixarchy VM: no bootloader to install (tmpfs root, booted via -kernel)"
+          ''
+        );
+      };
     };
   };
 
@@ -245,15 +245,7 @@
     '';
   };
 
-  networking = {
-    hostName = "nixarchy-vm";
-    firewall.enable = lib.mkForce false;
-  };
+  networking.firewall.enable = lib.mkForce false;
 
-  environment.systemPackages = with pkgs; [
-    kitty
-    git
-  ];
-
-  system.stateVersion = "25.05";
+  environment.systemPackages = [ pkgs.kitty ];
 }


### PR DESCRIPTION
Closes #8. Second piece of the installer epic (#6), after #7.

`vm/configuration.nix` was already most of a real host — it enabled the module, wired Home Manager, created the user, named the flake directory — with no line anywhere between *"this is what an Omarchy machine looks like"* and *"this is what a throwaway qemu guest needs"*.

The installer needs the first half as a file it can import into the generated flake, and the ISO phase needs it as a `nixosConfiguration` whose closure can be baked into the image. A closure has to be a closure of something.

### Extracted, not written fresh

Written fresh, `host.nix` would start drifting from the VM the day after it landed and nothing would say so. Extracted, `checks.vm-toplevel` keeps building the same module the installer ships.

**What stayed out matters as much as what went in.** `networkmanager`, `pipewire` and SDDM are *not* restated — `modules/nixos.nix` already sets all three at `mkDefault`, and a second definition reads like a decision while being dead config. The acceptance criteria check they arrive anyway.

### One thing is new rather than moved

`programs.nh`. `nh os switch` is the loop the docs now tell people to live in, and with no `flake` set it either fails or picks up `$NH_FLAKE` from somewhere else — the command in the manual has to be the command that works. The GC timer beside it (`--keep-since 14d --keep 5`) is the thing Arch never needed: without it a machine that updates weekly keeps every generation, and the owner learns this when the disk fills.

### The VM gains exactly one line, for a reason the extraction created

`boot.loader.systemd-boot.enable = lib.mkForce false;` beside the existing grub force. `host.nix` configures systemd-boot because a real machine needs one; the VM has no disk for either, and left enabled they're two bootloaders and the assertion fires.

### Verification

Every criterion on the issue:

```
programs.nixarchy.user            "omarchy"        input group present  1
programs.nh.flake                 "/etc/nixos"     warnings             []
networkmanager (not restated)     true             pipewire             true
reference systemd-boot            true             vm systemd-boot      false
vm hostName                       "nixarchy-vm"
```

Both toplevels build; all nine checks (including the new `reference-toplevel`) evaluate and build; `fmt --ci`, `statix` and `deadnix` clean.

**The last criterion has no check behind it, so it was done by hand.** `nix run .#vm` headless still boots, still calls itself `nixarchy-vm`, and still streams `omarchy-shell`'s journal to the serial port — 22 lines of it. The VM tests use their own nodes rather than this file, so nothing automated would have caught losing that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5