### PR TITLE
The flake the installer writes, written once and correctly

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -207,6 +207,12 @@
         # Omarchy session. Everything in checks/ runs in a machine with no GPU,
         # no Bluetooth radio, no network and no sound; this asks the questions
         # that leaves unanswered.
+        # The flake the installer writes to /etc/nixos: the template files with
+        # their @tokens@ still in place, plus a lock derived from this repo's
+        # own so the installed machine resolves to exactly what was built.
+        # Requires a committed tree -- it pins nixarchy by commit.
+        flake-template = pkgsFor.${system}.callPackage ./installer/mkFlake.nix { inherit self; };
+
         verify = pkgsFor.${system}.writeShellApplication {
           name = "nixarchy-verify";
           runtimeInputs = with pkgsFor.${system}; [

--- a/installer/mkFlake.nix
+++ b/installer/mkFlake.nix
@@ -1,0 +1,90 @@
+# Builds the flake the installer writes to /etc/nixos.
+#
+# The template files carry @tokens@; the installer substitutes the answers it
+# collected. What cannot be a template file is the lock, so it is derived here.
+{
+  lib,
+  runCommand,
+  jq,
+  self,
+}:
+let
+  # Building from a dirty tree gives no rev, and the generated flake pins
+  # nixarchy by commit. Falling back to path:${self} would work offline and
+  # dirty, and would pin the user's machine to a store path with no guarantee
+  # of surviving garbage collection -- a machine that stops rebuilding one day
+  # for reasons nobody can reconstruct. Throwing is the honest failure.
+  rev =
+    self.rev
+      or (throw "flake-template: build from a committed tree; the generated flake pins nixarchy by commit");
+
+  url = "github:olafkfreund/nixarchy/${rev}";
+
+  # Every input of this repo becomes an input of the nixarchy node, so the
+  # generated lock is a pure superset of ours -- which is what keeps hyprland
+  # on hyprwm's cache rather than silently re-resolving through a follows.
+  inputNames = builtins.attrNames (builtins.fromJSON (builtins.readFile ../flake.lock))
+    .nodes.root.inputs;
+in
+runCommand "nixarchy-flake-template"
+  {
+    nativeBuildInputs = [ jq ];
+    inherit rev url;
+    inherit (self) narHash;
+    inputs = lib.concatStringsSep " " inputNames;
+    passthru = { inherit url rev; };
+  }
+  ''
+    mkdir -p $out
+    cp ${./template}/flake.nix          $out/flake.nix
+    cp ${./template}/configuration.nix  $out/configuration.nix
+    # Written rather than shipped as a template file, matching what
+    # vm/configuration.nix's activation script already does. The exact header
+    # is load-bearing: nixarchy-pkg-add matches `{ ... }:` to rewrite it to
+    # `{ pkgs, ... }:` when it needs to add a plain nixpkgs attribute
+    # (modules/apps.nix, ensure_block). statix would have this as `_:`, which
+    # parses the same and would silently break that rewrite -- so the file is
+    # generated here, where the linter cannot ask for it.
+    printf '{ ... }:\n{ }\n' > $out/nixarchy-apps.nix
+
+    # Verbatim, never hand-maintained: the user's flake carries its own disk
+    # layout so their fileSystems stay declarative without depending on
+    # nixarchy's copy moving under them.
+    cp ${../installer/disk-config.nix}  $out/disk-config.nix
+
+    # The lock is transformed rather than regenerated. `nix flake lock` on the
+    # target would re-resolve every input against whatever is current, so the
+    # first `nixos-rebuild switch` would build a different system from the one
+    # just installed -- and it needs a network the offline ISO does not have.
+    #
+    # So: keep every node exactly as built, add a `nixarchy` node pinned to
+    # this revision, and make it the root's only input.
+    jq --arg rev "$rev" \
+       --arg narHash "$narHash" \
+       --arg url "$url" \
+       --arg inputs "$inputs" '
+      ($inputs | split(" ")) as $names
+      | .nodes.nixarchy = {
+          inputs: ($names | map({ (.): . }) | add),
+          locked: {
+            type: "github",
+            owner: "olafkfreund",
+            repo: "nixarchy",
+            rev: $rev,
+            narHash: $narHash
+          },
+          original: {
+            type: "github",
+            owner: "olafkfreund",
+            repo: "nixarchy",
+            rev: $rev
+          }
+        }
+      | .nodes.root.inputs = { nixarchy: "nixarchy" }
+    ' ${../flake.lock} > $out/flake.lock
+
+    # So the installer does not have to recompute what this already knows.
+    printf '%s\n' "$url" > $out/.nixarchy-url
+
+    sed -i "s|@nixarchy_url@|$url|g" $out/flake.nix
+  ''

--- a/installer/template/configuration.nix
+++ b/installer/template/configuration.nix
@@ -1,0 +1,32 @@
+# Your machine. Everything Omarchy needs is in nixarchy's host module; this
+# file holds what the installer asked you, and whatever you add later.
+#
+# Edit, then run `nh os switch`.
+{ ... }:
+{
+  imports = [
+    ./hardware-configuration.nix
+    # nixarchy-apply copies your app selection here. Without this line the
+    # menu marks apps enabled and nothing is ever installed.
+    ./nixarchy-apps.nix
+  ];
+
+  time.timeZone = "@timezone@";
+  console.keyMap = "@keymap@";
+
+  # Most of what the Install menu offers is unfree. nixarchy defaults this on
+  # already; it is repeated here because it is your file, and a licence policy
+  # you cannot see is one you cannot change. Set it false for nixpkgs' own.
+  nixpkgs.config.allowUnfree = true;
+
+  # An encrypted disk has already authenticated you by the time the greeter
+  # would ask, so the installer turns this on for encrypted installs and off
+  # for unencrypted ones. Quoted for the same reason as the encrypt flag in
+  # flake.nix: the bare token would not parse.
+  services.displayManager.autoLogin = {
+    enable = "@autologin@";
+    user = "@username@";
+  };
+
+  users.users."@username@".hashedPassword = "@password_hash@";
+}

--- a/installer/template/flake.nix
+++ b/installer/template/flake.nix
@@ -1,0 +1,51 @@
+# Your machine, as the installer wrote it. This directory is yours to edit.
+#
+# The three commands that matter:
+#
+#   nh os switch            rebuild and activate after editing these files
+#   nixarchy-app-enable X   pick an app (the Install menu does this for you)
+#   nixarchy-apply          copy the selection here and rebuild
+#
+# It is a git repository because a flake inside a worktree sees only tracked or
+# staged files -- an untracked nixarchy-apps.nix produces "path does not exist"
+# the first time you apply. The installer staged everything; it deliberately
+# made no commit, because git needs an identity and choosing yours is not the
+# installer's business.
+{
+  # Pinned to the nixarchy revision this machine was installed from. Bump it
+  # deliberately with `nix flake update nixarchy`, then `nh os switch`.
+  inputs.nixarchy.url = "@nixarchy_url@";
+
+  outputs =
+    { nixarchy, ... }:
+    {
+      nixosConfigurations."@hostname@" = nixarchy.inputs.nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        # The module takes `inputs` and reads inputs.self for its own outputs,
+        # so hand it nixarchy's inputs with nixarchy standing in as self.
+        specialArgs = {
+          inputs = nixarchy.inputs // {
+            self = nixarchy;
+          };
+        };
+        modules = [
+          nixarchy.nixosModules.nixarchy
+          nixarchy.inputs.home-manager.nixosModules.home-manager
+          nixarchy.inputs.disko.nixosModules.disko
+          (import "${nixarchy}/installer/host.nix" {
+            hostname = "@hostname@";
+            username = "@username@";
+          })
+          (import ./disk-config.nix {
+            device = "@device@";
+            # Quoted deliberately: the bare token is not valid Nix -- the
+            # file would not parse, let alone format -- so the installer
+            # substitutes the quotes away along with it. The autologin flag in
+            # configuration.nix is quoted for the same reason.
+            encrypt = "@encrypt@";
+          })
+          ./configuration.nix
+        ];
+      };
+    };
+}


### PR DESCRIPTION
Closes #9. Third piece of the installer epic (#6), after #7 and #8.

Three things about the generated flake are easy to get wrong and expensive when wrong: it must reference nixarchy at the **exact revision the installer was built from**, carry a lock that resolves to what was **actually installed**, and contain `imports = [ ./nixarchy-apps.nix ];` — the line the README says is the user's job, and which, forgotten, makes the Install menu mark apps enabled and install nothing. Pre-writing all three is the fix.

### The lock is transformed, not regenerated

`nix flake lock` on the target would re-resolve nixpkgs, hyprland and the rest against whatever is current — so the user's first switch would build a *different system* from the one just installed (invariant 1 gone), and it needs a network the offline ISO won't have.

So `jq` copies every node exactly as built, adds a `nixarchy` node pinned to this revision with every one of our inputs beneath it, and makes it the root's only input. The generated lock is a pure superset of ours, which is also what keeps `hyprland` on hyprwm's cache rather than quietly re-resolving through a `follows`.

### Building dirty throws

Rather than falling back to `path:${self}`. The fallback works — and pins the user's machine to a store path with no guarantee of surviving garbage collection, i.e. a machine that stops rebuilding one day for reasons nobody can reconstruct. Verified by building from a dirty tree: it fails with the sentence explaining what to do.

### Two findings that changed the shape of this

- **A bare `@token@` in an expression position is not valid Nix.** Not merely unformattable — `nix-instantiate --parse` rejects it. So `encrypt` and `autologin` are quoted and the installer substitutes the quotes away along with the token. The files say so, where someone might otherwise tidy it.
- **`nixarchy-apps.nix` is generated by the derivation, not shipped as a template file** — matching what `vm/configuration.nix`'s activation script already does. Shipped, statix asks for `_:` instead of `{ ... }:`. That parses identically and would **silently break `nixarchy-pkg-add`**, which matches that exact header to rewrite it to `{ pkgs, ... }:` when adding a plain nixpkgs attribute. Generating it keeps the text and removes the argument.

### Verification

End to end, not by inspection — a substituted copy with every token filled:

```
programs.nixarchy.user                 "alice"
services.displayManager.autoLogin      true
cmp flake.lock                         identical — evaluation did not rewrite it
tokens remaining after substitution    0
```

`diff result/disk-config.nix installer/disk-config.nix` empty; the `nixarchy` node's rev is `HEAD`; its inputs are exactly our root inputs; `nixpkgs` resolves to the same revision in both locks. All nine checks build; `fmt --ci`, `statix`, `deadnix` clean.

### Note for #10

The installer's `sed` must substitute **`"@encrypt@"` and `"@autologin@"` including their quotes** (`s/"@encrypt@"/true/`), not just the token — the quotes exist only to keep the template parseable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5