### PR TITLE
Name the splash after the thing it is splashing

### DIFF
--- a/pkgs/omarchy/default.nix
+++ b/pkgs/omarchy/default.nix
@@ -1176,6 +1176,25 @@ stdenvNoCC.mkDerivation {
                 # carrying artwork no one can account for.
                 magick -background none nixarchy-logo.svg -resize 800x       -fill '#a8cd76' -colorize 100       $out/share/plymouth/themes/omarchy/logo.png
 
+                # And the name the theme calls itself. Not drawn at boot -- the script
+                # renders logo.png and whatever message plymouth passes it -- but it is
+                # what `plymouth-set-default-theme --list` and omarchy-plymouth-current
+                # report, and a machine describing its own splash as another project's
+                # is wrong in the one place someone would go to check.
+                #
+                # The DIRECTORY stays `omarchy`. Renaming it means moving
+                # boot.plymouth.theme and themePackages together or NixOS asserts on a
+                # theme missing from the package list, which is the trap the bootSplash
+                # option's own comment already documents.
+                substituteInPlace $out/share/plymouth/themes/omarchy/omarchy.plymouth                   --replace-fail 'Name=Omarchy' 'Name=nixarchy'                   --replace-fail 'Description=Omarchy splash screen.' 'Description=nixarchy splash screen.'
+
+                # The rest of the theme -- progress_bar, progress_box, entry, lock,
+                # bullet -- is deliberately left alone. Measured: they are one to eleven
+                # colours of Tokyo Night chrome (#A9B1D6 bar, #292E42 track, #C0CAF5
+                # bullet), a padlock and a password dot. None carries a name or a mark,
+                # and replacing them would produce byte-different, pixel-identical
+                # files. Artwork nobody can tell apart is not branding, it is churn.
+
                 # The greeter's own compositor config, referenced by upstream's
                 # 10-wayland.conf. Nothing in the theme reaches outside its directory, so
                 # this is the only companion file it needs.


### PR DESCRIPTION
Closes #46.

The wordmark on the boot screen was already ours — Plymouth draws the screen a person types their **LUKS passphrase** into, and that was fixed alongside the ISO. What remained is what the theme calls itself:

```
Name=Omarchy
Description=Omarchy splash screen.
```

Not drawn at boot, but it's what `plymouth-set-default-theme --list` and `omarchy-plymouth-current` report — and a machine describing its own splash as another project's is wrong in the one place someone would go to check.

**The directory stays `omarchy`.** Renaming it means moving `boot.plymouth.theme` and `themePackages` together or NixOS asserts on a theme missing from the package list — the trap the `bootSplash` option's own comment already documents.

### The other five assets are deliberately untouched

This issue's acceptance was *"no Omarchy artwork remains"*, so I measured what's actually there before replacing anything:

```
progress_bar.png  300x10   one colour     #A9B1D6
progress_box.png  300x10   one colour     #292E42
bullet.png        14x14                   #C0CAF5
entry.png         286x48   four colours
lock.png          84x96    a padlock
```

Those are **Tokyo Night chrome** — the same palette the installer's own console uses — plus a padlock and a password dot. None carries a name or a mark. Replacing them would produce byte-different, pixel-identical files.

Artwork nobody can tell apart isn't branding, so the reasoning is recorded in `pkgs/omarchy/default.nix` rather than the work being done. If you'd rather have a genuinely separate `nixarchy` Plymouth theme, that's a larger change and worth deciding deliberately.

### Verification

`nix build .#omarchy` shows `Name=nixarchy`. All nine wired checks build; `fmt --ci`, `statix`, `deadnix` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5