### PR TITLE
Say when the machine is rebuilding

### DIFF
--- a/pkgs/omarchy/default.nix
+++ b/pkgs/omarchy/default.nix
@@ -1200,6 +1200,40 @@ stdenvNoCC.mkDerivation {
                 # this is the only companion file it needs.
                 install -Dm644 ${src}/default/sddm/hyprland.lua $out/share/sddm/hyprland.lua
 
+                # Say when the machine is rebuilding.
+                #
+                # The one bar indicator that is ours rather than upstream's,
+                # and it exists because of the difference this distribution is
+                # built on: on Arch the Install menu finishes in seconds, here
+                # it starts a rebuild that runs for minutes behind a desktop
+                # that looks idle. See the file.
+                #
+                # An indicator is a bare .qml in indicators/ -- no manifest --
+                # picked up by name from the list in Indicators.qml, so adding
+                # one means installing the file and naming it there.
+                install -Dm644 ${./switch-indicator.qml} \
+                  $out/share/omarchy/shell/plugins/bar/indicators/SystemSwitch.qml
+
+                # The four properties the indicator inherits and sets. QML
+                # resolves them at runtime, so an upstream rename does not
+                # break the build -- it produces a bar with a dead icon on it,
+                # found by whoever next waits ten minutes for a rebuild with no
+                # sign it started. Checked here instead, where it is a build
+                # failure naming the property that moved.
+                for prop in active activeText inactiveText indicatorHost; do
+                  grep -q "property.* $prop\b" \
+                    $out/share/omarchy/shell/Ui/BarIndicator.qml \
+                    || { echo "BarIndicator no longer has '$prop'; SystemSwitch.qml needs updating" >&2; exit 1; }
+                done
+
+                # --replace-fail: if upstream reorders or renames this list,
+                # the build stops rather than quietly dropping the indicator
+                # and leaving rebuilds invisible again.
+                substituteInPlace $out/share/omarchy/shell/plugins/bar/widgets/Indicators.qml \
+                  --replace-fail \
+                  '[ "Dictation", "ScreenRecording", "Reminder", "NightLight", "Dnd", "StayAwake" ]' \
+                  '[ "SystemSwitch", "Dictation", "ScreenRecording", "Reminder", "NightLight", "Dnd", "StayAwake" ]'
+
                 # Wear the snowflake.
                 substitute ${./menu-bar-widget.qml} \
                   $out/share/omarchy/shell/plugins/menu/BarWidget.qml \

--- a/pkgs/omarchy/switch-indicator.qml
+++ b/pkgs/omarchy/switch-indicator.qml
@@ -1,0 +1,98 @@
+import QtQuick
+import Quickshell.Io
+import qs.Ui
+
+// A bar indicator that spins while the system is being switched.
+//
+// Upstream has no equivalent because on Arch a package install is over in
+// seconds and prints to the terminal it was typed in. Here the Install menu's
+// "Apply changes" runs `nh os switch`, which can take minutes, and until it
+// finishes there is nothing on screen to say the machine is doing anything at
+// all -- someone who picked an app from the menu is left with a desktop that
+// looks idle and an app that has not appeared. This is that missing signal.
+//
+// Modelled on ScreenRecording.qml, which is the same shape: a transient
+// indicator that polls for a process and shows itself while it is running.
+BarIndicator {
+  id: root
+
+  property bool switching: false
+  property int frame: 0
+
+  // Material Design's circle slices, in Nerd Fonts' private use area, which is
+  // the font the rest of the bar's glyphs already come from. Eight frames of a
+  // filling pie: a spinner that is legibly a spinner at bar size, where a
+  // rotating single glyph mostly reads as a smudge.
+  readonly property var frames: ["󰪞", "󰪟", "󰪠", "󰪡", "󰪢", "󰪣", "󰪤", "󰪥"]
+
+  active: switching
+  activeText: frames[frame % frames.length]
+  // The inactive glyph is never drawn -- BarIndicator hides an indicator that
+  // is not active unless the bar is revealing them -- but it has to be a
+  // constant, or the hidden slot changes width as the animation runs.
+  inactiveText: "󰪥"
+  activeTooltipText: "Rebuilding the system..."
+  inactiveTooltipText: "System rebuild"
+
+  // Whether anything is switching the system right now.
+  //
+  // Deliberately not a state file written by nixarchy-apply: a rebuild the
+  // user typed themselves is exactly as worth showing as one the menu started,
+  // and a file only knows about the second. pgrep knows about both.
+  //
+  // ponytail: a cmdline match, so an editor holding a file called
+  // nixos-rebuild.md in its arguments will light this up. Cheap, and wrong in
+  // the harmless direction -- it over-reports rather than staying dark while
+  // the machine is busy, which is the failure that matters.
+  function refresh() {
+    if (!root.bar || statusProc.running) return;
+    statusProc.command = ["pgrep", "-f",
+      "nixos-rebuild|nixarchy-apply|switch-to-configuration|(^|/)nh( |$)"];
+    statusProc.running = true;
+  }
+
+  onBarChanged: refresh()
+  Component.onCompleted: refresh()
+
+  Connections {
+    target: root.indicatorHost
+    ignoreUnknownSignals: true
+    function onRefreshRequested() {
+      root.refresh();
+    }
+  }
+
+  Process {
+    id: statusProc
+    onExited: function (exitCode) {
+      root.switching = exitCode === 0;
+    }
+  }
+
+  // Two rates, because they answer different questions. The slow one asks
+  // whether a rebuild has started, and runs forever; polling for that faster
+  // would spawn a pgrep every second for the whole life of the session to
+  // catch something that happens a few times a day. The fast one only runs
+  // while a rebuild is in flight and only turns the animation.
+  Timer {
+    interval: 3000
+    repeat: true
+    running: true
+    onTriggered: root.refresh()
+  }
+
+  Timer {
+    interval: 125
+    repeat: true
+    running: root.switching
+    onTriggered: root.frame = root.frame + 1
+  }
+
+  // Clicking it shows what is happening, rather than offering to stop it: a
+  // half-applied switch is a worse place to be than a slow one, and nothing
+  // here can safely interrupt an activation.
+  onPressed: function () {
+    if (root.bar)
+      root.bar.run("omarchy-launch-floating-terminal-with-presentation journalctl -f -u nix-daemon.service");
+  }
+}


### PR DESCRIPTION
Picking an app from the Install menu and choosing **Apply changes** starts a rebuild that can run for minutes. Nothing on the desktop says so.

Upstream has no equivalent indicator because on Arch the same click is over in seconds and prints to the terminal it was typed in. Here the terminal is somewhere behind the window you were using, and the desktop looks idle while the machine is busy — which is the one moment this distribution most needs to say something.

One bar indicator, spinning while a switch is in flight, dark otherwise.

## Verified in a VM

Same node as `checks.session`, driven to a live Hyprland session, with a process spawned whose cmdline the indicator matches:

| | centre of the bar |
|---|---|
| idle | `Monday 11:49` |
| rebuilding | `◐ Monday 11:49` |

and `journalctl | grep -i quickshell` reports no `Indicator loader error` and nothing about `SystemSwitch` — the QML loads clean.

## Decisions

**It watches any system switch, not only the ones the menu starts.** A rebuild someone typed themselves is exactly as worth showing, and a state file written by `nixarchy-apply` would only know about the first. It is a cmdline match, so an editor holding a file called `nixos-rebuild.md` in its arguments will light it up — cheap, and wrong in the harmless direction: it over-reports rather than staying dark while the machine is busy.

**Clicking it shows what is happening rather than offering to stop it.** A half-applied switch is a worse place to be than a slow one, and nothing here can safely interrupt an activation.

**Two poll rates.** The slow one (3s) asks whether a rebuild has started and runs forever; polling that faster would spawn a `pgrep` every second for the whole life of the session to catch something that happens a few times a day. The fast one (125ms) only runs while a rebuild is in flight and only turns the animation.

## How it is wired

An indicator is a bare `.qml` in `indicators/` with no manifest, picked up by name from a list in `Indicators.qml` — so this installs the file and names it there with `--replace-fail`.

QML resolves inherited properties at runtime, so an upstream rename would *not* break the build; it would produce a bar with a dead icon, found by whoever next waits ten minutes for a rebuild with no sign it started. The four properties it relies on are checked at build time instead — the same guard the theme assets already use. Confirmed by deliberately renaming one and watching the build fail with `BarIndicator no longer has 'indicatorHost'`.

## Gate

`nix fmt --ci`, statix, deadnix clean; `nix flake check --no-build` passes; `omarchy`, `omarchy-runtime`, `session`, `coexist`, `options`, `integration`, `plugin` all build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5