### PR TITLE
Run the checks that need a real machine on a real machine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -507,3 +507,48 @@ jobs:
         # -- so what this proves is that the seed leaves that directory
         # writable and the shell's IPC is reachable.
         run: nix build .#checks.x86_64-linux.plugin --print-build-logs
+
+  install:
+    name: install
+    # p510: 40 cores, 94 GB, /dev/kvm, and a pool with room for the images.
+    # This job boots a VM, installs a desktop onto a blank disk, boots the
+    # result on its own bootloader and asserts a rebuild builds nothing. None
+    # of that fits on a hosted runner -- fourteen gigabytes of disk and no KVM
+    # worth the name -- and it is the only check that exercises the artefact a
+    # person actually receives.
+    runs-on: [self-hosted, nixos, kvm, big]
+
+    # Not on pull_request. It takes ten minutes of a machine that has one of
+    # itself, and a PR that breaks it breaks the push to main a moment later,
+    # where this does run. The trade is a slightly later signal for a queue
+    # that keeps moving.
+    if: github.event_name != 'pull_request'
+
+    timeout-minutes: 45
+
+    # Queued, not cancelled. Half an install tells nobody anything, and the
+    # runner is single-tenant: a cancelled job that has already partitioned a
+    # virtual disk has still spent the time.
+    concurrency:
+      group: install-${{ github.ref }}
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # No installer action, no cachix. The runner is a NixOS machine with a
+      # warm store, which is most of why this is ten minutes rather than an
+      # hour.
+      - name: Install onto a blank disk and boot the result
+        run: nix build .#checks.x86_64-linux.install --print-build-logs
+
+      - name: Report what it cost
+        if: always()
+        run: |
+          # The installer's own figure, not the driver's, and the same one the
+          # finish screen shows. checks.install already fails above a budget;
+          # this puts the number in the summary so a slow trend is visible
+          # before it crosses the line.
+          nix log .#checks.x86_64-linux.install 2>/dev/null \
+            | grep -E '^(driver|install)_seconds=' \
+            | tee -a "$GITHUB_STEP_SUMMARY" || echo "no timing recorded"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,10 +9,10 @@ name: nightly
 # all, and installs a 15.3 GB closure into a qcow2. That is about an hour and
 # roughly 16 GB of build directory, on a machine with /dev/kvm.
 #
-# So they run here, nightly, on p510 -- 40 cores, 94 GB, KVM, and a pool with
-# room for the images. See hosts/p510/nixos/github-runner.nix in the NixOS
-# config repo for the runner itself, including why the nix daemon's TMPDIR is
-# moved off the root filesystem.
+# So they run here, nightly, on p510 -- 40 cores, 94 GB, KVM, and room for the
+# images: builds land in /home (its own disk, 829 GB free) and the ISO copies
+# below go on /mnt/img_pool (840 GB free). See hosts/p510/nixos/github-runner.nix
+# in the NixOS config repo for the runner itself.
 #
 # Nightly rather than per-push on purpose. An hour of wall clock per push would
 # make the queue the bottleneck, and what these protect against -- a package
@@ -130,10 +130,9 @@ jobs:
           body="$body
 
           Both jobs run on the self-hosted runner on p510. If the failure is
-          'no space left', check /mnt/img_pool. If it is a hang partway through
-          an install, check that the nix daemon's TMPDIR is still on the pool
-          rather than the root filesystem -- a VM test that runs out of room
-          there does not fail cleanly, it wedges."
+          'no space left', check both /home -- where the nix daemon builds --
+          and /mnt/img_pool, where the nightly ISO copies go. A VM test that
+          runs out of room does not fail cleanly, it wedges."
           existing=$(gh issue list --state open --search "$title in:title" \
             --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,143 @@
+name: nightly
+
+# The checks that cannot run on a hosted runner.
+#
+# `build.yml` covers everything that fits in fourteen gigabytes and ten
+# minutes. These two do not, and the numbers are the reason rather than a
+# preference: checks.install boots a VM and installs a desktop into it, and
+# checks.install-iso builds a 5.6 GB image, boots it with no network device at
+# all, and installs a 15.3 GB closure into a qcow2. That is about an hour and
+# roughly 16 GB of build directory, on a machine with /dev/kvm.
+#
+# So they run here, nightly, on p510 -- 40 cores, 94 GB, KVM, and a pool with
+# room for the images. See hosts/p510/nixos/github-runner.nix in the NixOS
+# config repo for the runner itself, including why the nix daemon's TMPDIR is
+# moved off the root filesystem.
+#
+# Nightly rather than per-push on purpose. An hour of wall clock per push would
+# make the queue the bottleneck, and what these protect against -- a package
+# falling out of the baked closure, an installer that stops booting -- does not
+# arrive between one push and the next. It arrives when an input moves.
+
+on:
+  schedule:
+    # 03:00 UTC. Late enough that a `nix flake update` merged during the day is
+    # covered, early enough that a failure is waiting in the morning.
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+# One at a time. These are long, they want the whole machine, and two installs
+# competing for the same pool is how a disk fills.
+concurrency:
+  group: nightly
+  cancel-in-progress: false
+
+jobs:
+  install:
+    name: install onto a blank disk
+    runs-on: [self-hosted, nixos, kvm, big]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
+
+      # No installer action and no cachix: this runner is a NixOS machine with
+      # nix already on it and the store already warm, which is most of why it
+      # is fast enough to do this nightly.
+      - name: Install onto a blank disk and boot the result
+        run: nix build .#checks.x86_64-linux.install --print-build-logs
+
+      - name: Report the install duration
+        if: always()
+        run: |
+          # checks.install prints the installer's own figure and fails above a
+          # budget; this surfaces it in the job summary so a slow trend is
+          # visible before it crosses the line.
+          nix log .#checks.x86_64-linux.install 2>/dev/null \
+            | grep -E '^(driver|install)_seconds=' \
+            | tee -a "$GITHUB_STEP_SUMMARY" || echo "no timing recorded"
+
+  install-iso:
+    name: install from the ISO, with no network
+    runs-on: [self-hosted, nixos, kvm, big]
+    # The ISO build dominates: the squashfs alone is most of it.
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build the ISO
+        run: nix build .#iso --no-link --print-build-logs
+
+      - name: Report the ISO size
+        run: |
+          iso=$(nix build .#iso --no-link --print-out-paths)/iso
+          size=$(du -h "$iso"/*.iso | cut -f1)
+          closure=$(nix path-info -Sh \
+            .#nixosConfigurations.reference.config.system.build.toplevel \
+            | awk '{print $2}')
+          printf '| | |\n|---|---|\n| ISO | %s |\n| closure | %s |\n' \
+            "$size" "$closure" | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Install from it with no network device present
+        run: nix build .#checks.x86_64-linux.install-iso --print-build-logs
+
+      - name: Keep a date-stamped copy
+        run: |
+          # On the pool, not as a workflow artifact. A 5.6 GB upload every
+          # night would pass GitHub's free artifact storage in two days and
+          # cost money on the third, to produce a file that already exists on
+          # the machine that built it. Publishing belongs to a tag, which is
+          # what the release workflow is for.
+          #
+          # A symlink into the store rather than a copy: the store path is
+          # already immutable and already there, so this costs nothing until
+          # the store is garbage collected, and `nix-store --add-root` is what
+          # stops that happening.
+          out=$(nix build .#iso --no-link --print-out-paths)
+          iso=$(echo "$out"/iso/*.iso)
+          stamp=$(date -u +%Y-%m-%d)
+          dir=/mnt/img_pool/nixarchy-iso
+          mkdir -p "$dir"
+          nix-store --add-root "$dir/nixarchy-$stamp.iso" --indirect -r "$out" >/dev/null
+          ln -sfn "$iso" "$dir/nixarchy-latest.iso"
+
+          # Fourteen nights. Enough to bisect "it worked last week" without
+          # letting a nightly build fill 840 GB over a year.
+          find "$dir" -maxdepth 1 -name 'nixarchy-????-??-??.iso' -mtime +14 -delete
+
+          printf '| nightly ISO | `%s` |\n' "$dir/nixarchy-$stamp.iso" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+  # A failure at 03:00 that nobody sees until someone opens the Actions tab is
+  # a failure that costs a day. This turns one into an issue.
+  report:
+    name: report a failure
+    runs-on: ubuntu-latest
+    needs: [install, install-iso]
+    if: failure()
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update an issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="nightly: the install checks are failing"
+          # One issue, reopened and commented, rather than a new one each
+          # night: a check broken for a week should read as one problem, not
+          # seven.
+          body="The nightly install checks failed: $RUN"
+          body="$body
+
+          Both jobs run on the self-hosted runner on p510. If the failure is
+          'no space left', check /mnt/img_pool. If it is a hang partway through
+          an install, check that the nix daemon's TMPDIR is still on the pool
+          rather than the root filesystem -- a VM test that runs out of room
+          there does not fail cleanly, it wedges."
+          existing=$(gh issue list --state open --search "$title in:title" \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Still failing: $RUN"
+          else
+            gh issue create --title "$title" --label installer --body "$body"
+          fi


### PR DESCRIPTION
Closes #13. Closes #53.

`checks.install` and `checks.install-iso` cannot run on a hosted runner, and the numbers are the reason rather than a preference:

| | |
|---|---|
| `checks.install` | boots a VM, installs a desktop, boots the result on its own bootloader — ~10 min |
| `checks.install-iso` | builds a 5.6 GB image, boots it with **no network device**, installs a 15.3 GB closure into a qcow2 — ~1 h, **~16 GB of build directory** |
| a hosted runner | 14 GB of disk, no KVM worth the name |

So they run on **p510**: 40 cores, 94 GB, `/dev/kvm`, 840 GB free on `/mnt/img_pool`. The runner itself is declared in that machine's NixOS config (`hosts/p510/nixos/github-runner.nix`); this PR is only the workflow half.

## `build.yml` gains an `install` job (#13)

On push to `main` and dispatch, **not** on `pull_request`: it takes ten minutes of a machine that has one of itself, and a PR that breaks it breaks the push a moment later, where this does run. A slightly later signal for a queue that keeps moving.

Queued rather than cancelled — half an install tells nobody anything, and a cancelled job that has already partitioned a virtual disk has still spent the time. The installer's own duration goes to the step summary, so a slow trend is visible before it crosses the budget `checks.install` already enforces.

## `nightly.yml` is new (#53)

ISO build → offline install → a date-stamped ISO kept for fourteen nights → an issue if any of it fails.

Nightly rather than per-push because what these protect against — a package falling out of the baked closure, an installer that stops booting — arrives when an input moves, not between one push and the next.

**The ISO is kept on the pool, not uploaded.** #17 asks for `gh run download --name nixarchy-iso`, and I did not implement that: a 5.6 GB artifact every night passes GitHub's free artifact storage in two days and costs money on the third, to produce a file that already exists on the machine that built it. It is stored as a **store root** rather than a copy, so it costs nothing until the store is collected, and pruned after fourteen nights — enough to bisect "it worked last week" without filling 840 GB over a year. Publishing belongs to a tag, which is #19's job. **Happy to add the upload if you want it; it seemed worth asking rather than quietly spending your quota.**

One issue on failure, commented rather than reopened nightly: a check broken for a week is one problem, not seven. The issue body names the two failure modes that are specific to this runner — a full `/mnt/img_pool`, and a nix daemon whose `TMPDIR` has drifted back to the root filesystem, which does not fail cleanly but wedges.

## Not yet green

Neither job can run until the runner is registered — that needs a token only you can create. Both workflows are `yamllint`-clean and the existing jobs are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5