### PR TITLE
A tag builds an ISO somebody can download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,149 @@
+name: release
+
+# A tag becomes something a person can download and write to a USB stick.
+#
+# Until now a release here has meant a git ref: the tag *is* the release, and
+# what you do with it is pin a flake input. An ISO changes that. It is five and
+# a half gigabytes that somebody downloads once and then trusts to overwrite
+# their disk, so it has to come from a tag, be built by a machine rather than a
+# laptop, and carry a checksum that was produced by the same run that produced
+# the image.
+#
+# This runs on p510 for the same reason nightly.yml does: a hosted runner has
+# 14 GB of disk, and the image alone is more than a third of that before the
+# 15.3 GB closure it carries. It deliberately mirrors nightly.yml rather than
+# build.yml -- no installer action, no cachix, because the runner is a NixOS
+# machine with a warm store. nightly.yml is the job that actually builds and
+# boots this image every night; if the release recipe drifts from anything, it
+# should be from that one.
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+# Never cancel a release mid-upload. A half-attached release is worse than a
+# late one, and two tags pushed together should queue rather than race.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  iso:
+    name: build, verify and publish the ISO
+    runs-on: [self-hosted, nixos, kvm, big]
+    # The ISO build, then an install from it, then splitting and uploading
+    # 5.6 GB. nightly.yml allows 180 minutes for the first two.
+    timeout-minutes: 300
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: The tag names the Omarchy the flake vendors
+        run: |
+          # v4.0.1-2 -> 4.0.1. The suffix counts our packaging revisions
+          # against an unchanged upstream, so only the first component is a
+          # claim about Omarchy.
+          vendored=$(nix eval --raw .#packages.x86_64-linux.omarchy.version)
+          tagged=${GITHUB_REF_NAME#v}
+          tagged=${tagged%-*}
+          if [ "$vendored" != "$tagged" ]; then
+            echo "::error::tag $GITHUB_REF_NAME claims Omarchy $tagged, the flake vendors $vendored"
+            exit 1
+          fi
+          echo "omarchy=$vendored" >> "$GITHUB_OUTPUT"
+        id: version
+
+      # --out-link, not --no-link: the result is a GC root for the rest of the
+      # job. An ISO collected between building it and uploading it would fail
+      # in a way that took an afternoon to understand.
+      - name: Build the ISO
+        run: nix build .#iso --out-link result --print-build-logs
+
+      # The image nobody boots is the image that does not boot. This is the
+      # same check the nightly runs, against the same expression, so it costs
+      # an hour and buys the only guarantee that matters on a release page.
+      - name: Install from it, with no network device present
+        run: nix build .#checks.x86_64-linux.install-iso --no-link --print-build-logs
+
+      - name: Split it into pieces GitHub will accept
+        id: split
+        run: |
+          # GitHub caps a single release asset at 2 GiB and there is no limit
+          # on a release's total size, so the image ships in parts. 1900 MiB
+          # leaves room under the cap without making a fourth part likely.
+          iso=$(echo result/iso/*.iso)
+          base="nixarchy-${GITHUB_REF_NAME}.iso"
+          rm -rf out && mkdir out
+          split -b 1900M -- "$iso" "out/$base.part-"
+
+          # One SHA256SUMS covering the parts *and* the assembled image, so a
+          # single `sha256sum -c` after reassembly checks both the download and
+          # the cat that put it back together. Checked in that order, because
+          # the image does not exist until the user makes it.
+          (
+            cd out
+            sha256sum "$base".part-* > SHA256SUMS
+            # Hashed from stdin so the store path never reaches the file, and
+            # the name is printed rather than edited in. Rewriting the path out
+            # of sha256sum's own output with sed is greedy and eats the hash
+            # too, which produces a line `sha256sum -c` calls "improperly
+            # formatted", skips, and still exits 0 -- a checksum file that
+            # reports PASS without having checked the image.
+            printf '%s  %s\n' \
+              "$(sha256sum < "$OLDPWD/$iso" | cut -d' ' -f1)" "$base" >> SHA256SUMS
+          )
+
+          {
+            echo "iso=$base"
+            echo "size=$(du -h "$iso" | cut -f1)"
+            echo "parts=$(find out -name "$base.part-*" | wc -l)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Write the release notes
+        env:
+          OMARCHY: ${{ steps.version.outputs.omarchy }}
+          ISO: ${{ steps.split.outputs.iso }}
+          SIZE: ${{ steps.split.outputs.size }}
+        run: |
+          # A fixed preamble; --generate-notes appends the PR list under it.
+          # The README is the manual, so this says only what someone holding
+          # the download needs and links to the rest.
+          cat > notes.md <<EOF
+          Omarchy $OMARCHY, packaged for NixOS. The image is $SIZE and carries
+          the whole system closure, so the install copies rather than downloads
+          and needs no network.
+
+          GitHub will not take a file this size, so the image is split. Put it
+          back together and check it:
+
+          \`\`\`
+          cat $ISO.part-* > $ISO
+          sha256sum -c SHA256SUMS
+          \`\`\`
+
+          Then write it to a USB stick and boot it. See
+          [Fresh-machine install](https://github.com/${{ github.repository }}#fresh-machine-install)
+          for what happens next.
+          EOF
+
+      # Pre-release, deliberately, and it stays that way until there is a 1.0.
+      # The README says there is not one yet; a release page should not imply
+      # otherwise.
+      - name: Publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" out/* \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file notes.md \
+            --generate-notes \
+            --prerelease
+
+      # 5.6 GB of parts on the runner's root filesystem, which is the small
+      # one. The workspace is cleaned at the start of the next run, but a
+      # failed release should not sit on the disk until then.
+      - name: Remove the split copies
+        if: always()
+        run: rm -rf out


### PR DESCRIPTION
Closes #19.

A tag has been the release until now: what you do with one is pin a flake input. An ISO is different — 5.6 GB that somebody downloads once and then trusts to overwrite their disk — so it has to be built from the tag by a machine, and carry a checksum produced by the same run that produced the image.

## Two places this departs from the issue, both from measurement

- The issue specifies `ubuntu-latest`. That has 14 GB of disk, for a 5.6 GB image carrying a 15.3 GB closure. This runs on p510.
- The issue says to copy `build.yml`'s cachix and disk-cleanup steps verbatim, with the rationale that a drifting recipe ships an image nobody tested. Agreed with the rationale, disagreed with the target: the runner has neither step and needs neither. This mirrors `nightly.yml`, which is the job that actually builds and boots this image every night — the one thing the release must not drift from. It also runs `checks.install-iso` before publishing.

## The 2 GiB wall

GitHub caps a single release asset at 2 GiB and places no cap on a release's total size, so the image ships in 1900 MiB parts with one `SHA256SUMS` covering both the parts and the reassembled whole.

The checksum step had a real bug on the way here, worth recording because it failed safe-looking: rewriting the store path out of `sha256sum`'s output with `sed "s|.*/|$base  |"` is greedy and eats the hash field too. The result is a line `sha256sum -c` calls "improperly formatted", **skips, and still exits 0** — a checksum file that prints PASS without ever checking the image. It now hashes from stdin and prints the name. Verified both ways: an honest download passes all four lines, and one flipped byte fails the part and the image with exit 1.

## Verified

- `actionlint`: no problems beyond the three custom self-hosted labels, identical to the ones `nightly.yml` already produces
- version guard: `nix eval --raw .#packages.x86_64-linux.omarchy.version` prints `4.0.1`, matching `v4.0.1-2`
- split/checksum/reassembly proven end to end against a real file, including the corruption case

## Not done

Step 5 of the issue — the throwaway-tag dry run. That needs a tag pushed to this repo and a real release created and then deleted, which is your call to make, not mine. It is also the only part that exercises `gh release create` for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5