### PR TITLE
A second image that downloads the desktop instead of carrying it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,13 @@ jobs:
       - name: Build the ISO
         run: nix build .#iso --out-link result --print-build-logs
 
+      # The smaller image, for people who would rather download 1.5 GB and let
+      # the install fetch the rest. Not separately install-tested: it shares
+      # every line of the installer with the image below, and what differs --
+      # downloading rather than copying -- is what checks.install already does.
+      - name: Build the network ISO
+        run: nix build .#iso-net --out-link result-net --print-build-logs
+
       # The image nobody boots is the image that does not boot. This is the
       # same check the nightly runs, against the same expression, so it costs
       # an hour and buys the only guarantee that matters on a release page.
@@ -74,9 +81,15 @@ jobs:
           # on a release's total size, so the image ships in parts. 1900 MiB
           # leaves room under the cap without making a fourth part likely.
           iso=$(echo result/iso/*.iso)
+          net=$(echo result-net/iso/*.iso)
           base="nixarchy-${GITHUB_REF_NAME}.iso"
+          netbase="nixarchy-${GITHUB_REF_NAME}-net.iso"
           rm -rf out && mkdir out
           split -b 1900M -- "$iso" "out/$base.part-"
+
+          # The network image is 1.5 GiB and ships whole. Only the image that
+          # cannot fit gets taken apart.
+          cp -- "$net" "out/$netbase"
 
           # One SHA256SUMS covering the parts *and* the assembled image, so a
           # single `sha256sum -c` after reassembly checks both the download and
@@ -93,11 +106,14 @@ jobs:
             # reports PASS without having checked the image.
             printf '%s  %s\n' \
               "$(sha256sum < "$OLDPWD/$iso" | cut -d' ' -f1)" "$base" >> SHA256SUMS
+            sha256sum "$netbase" >> SHA256SUMS
           )
 
           {
             echo "iso=$base"
+            echo "netiso=$netbase"
             echo "size=$(du -h "$iso" | cut -f1)"
+            echo "netsize=$(du -h "$net" | cut -f1)"
             echo "parts=$(find out -name "$base.part-*" | wc -l)"
           } >> "$GITHUB_OUTPUT"
 
@@ -106,24 +122,40 @@ jobs:
           OMARCHY: ${{ steps.version.outputs.omarchy }}
           ISO: ${{ steps.split.outputs.iso }}
           SIZE: ${{ steps.split.outputs.size }}
+          NETISO: ${{ steps.split.outputs.netiso }}
+          NETSIZE: ${{ steps.split.outputs.netsize }}
         run: |
           # A fixed preamble; --generate-notes appends the PR list under it.
           # The README is the manual, so this says only what someone holding
           # the download needs and links to the rest.
           cat > notes.md <<EOF
-          Omarchy $OMARCHY, packaged for NixOS. The image is $SIZE and carries
-          the whole system closure, so the install copies rather than downloads
-          and needs no network.
+          Omarchy $OMARCHY, packaged for NixOS. Two images, and the difference
+          is what they carry.
 
-          GitHub will not take a file this size, so the image is split. Put it
-          back together and check it:
+          **\`$ISO\`** — $SIZE, carries the whole system closure. The install
+          copies rather than downloads and needs no network at all. Take this
+          one unless the download is what you mind.
+
+          GitHub will not accept a file that size, so it is split. Put it back
+          together and check it:
 
           \`\`\`
           cat $ISO.part-* > $ISO
-          sha256sum -c SHA256SUMS
+          sha256sum -c --ignore-missing SHA256SUMS
           \`\`\`
 
-          Then write it to a USB stick and boot it. See
+          **\`$NETISO\`** — $NETSIZE, downloads the desktop as it installs.
+          One file, no reassembly, and it needs a working network: its first
+          screen offers Wi-Fi if there is no cable.
+
+          \`\`\`
+          sha256sum -c --ignore-missing SHA256SUMS
+          \`\`\`
+
+          (\`--ignore-missing\` because one SHA256SUMS covers both images, and
+          nobody downloads both.)
+
+          Then write one to a USB stick and boot it. See
           [Fresh-machine install](https://github.com/${{ github.repository }}#fresh-machine-install)
           for what happens next.
           EOF

--- a/README.md
+++ b/README.md
@@ -784,6 +784,18 @@ nix build github:olafkfreund/nixarchy#iso
 sudo dd if=result/iso/nixarchy-*.iso of=/dev/sdX bs=4M status=progress oflag=sync
 ```
 
+There are two images, and the difference is what they carry:
+
+| | Size | Needs a network | |
+|---|---|---|---|
+| `#iso` | 5.6 GB | no | carries the desktop; installs by copying |
+| `#iso-net` | 1.5 GB | yes | downloads the desktop as it installs |
+
+Take `#iso` unless the download is the thing you mind. It is the one the tests
+boot every night, it works on a machine that has never had a network, and it is
+faster once you have it. `#iso-net` is a quarter of the download and asks you
+to get online first — its first screen offers Wi-Fi if there is no cable.
+
 No boot menu, no login prompt: the installer is what comes up.
 
 ![Selecting a keyboard layout](docs/img/installer/step-01-keyboard.png)
@@ -811,11 +823,13 @@ Reboot and you are at the desktop. An encrypted install goes straight there —
 the passphrase you typed at boot already proved who you are, so there is no
 second password.
 
-**It does not need a network.** The image carries the desktop rather than
+**`#iso` does not need a network.** The image carries the desktop rather than
 downloading it — 5.6 GB of ISO holding a 15.3 GB closure — so an install is a
 store copy and an activation, not a download. Unplug the cable and it still
 works; `checks.install-iso` proves that by installing with no network device
-present at all. The 56 selectable apps are the exception, and are meant to be:
+present at all. `#iso-net` trades exactly this away: it fetches the same
+closure from `nixarchy.cachix.org` instead, which is why it is 1.5 GB rather
+than 5.6, and why it stops at a Wi-Fi prompt on a machine with no cable. The 56 selectable apps are the exception, and are meant to be:
 they come from the Install menu after first boot, from your own nixpkgs.
 
 **You can answer the questions ahead of time.** `nixarchy-install --answers

--- a/flake.nix
+++ b/flake.nix
@@ -230,6 +230,13 @@
             ncurses # clear and tput, which the screens are drawn with
             kbd # loadkeys, and the keymap list
             tzdata # the timezone list
+            # Both only used by ask_network, which the offline image returns
+            # from before it reaches either. Carried anyway rather than
+            # conditionally: this is one script, `nix run .#install` on a stock
+            # ISO needs them, and a runtime input that is missing on one image
+            # is a class of bug that only shows up on that image.
+            curl # the connectivity test -- can we reach the binary cache
+            networkmanager # nmcli, for joining a wireless network
           ];
           # Spliced at build time the way doctor splices @apps@, so the script
           # never has to find these itself and `nix run` works from anywhere.
@@ -404,6 +411,13 @@
         # network away.
         iso = self.nixosConfigurations.iso.config.system.build.isoImage;
 
+        # The same installer, without the desktop on it. Small enough to
+        # download over a hotel connection, and it fetches the closure from
+        # the binary caches instead of carrying it. Needs a working network
+        # before it can do anything, which is what the wizard's first screen
+        # is for.
+        iso-net = self.nixosConfigurations.iso-net.config.system.build.isoImage;
+
         # A VM that installs onto a blank disk, WITH a network -- which
         # checks.install cannot have, because it is a sandboxed derivation and
         # its whole point is that a rebuild afterwards cannot fetch anything.
@@ -439,7 +453,21 @@
         # The live image. See installer/cd.nix.
         iso = nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
-          specialArgs = { inherit inputs; };
+          specialArgs = {
+            inherit inputs;
+            offline = true;
+          };
+          modules = [ ./installer/cd.nix ];
+        };
+
+        # Same module, one argument different. See the `offline` parameter in
+        # installer/cd.nix for what it turns off.
+        iso-net = nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+          specialArgs = {
+            inherit inputs;
+            offline = false;
+          };
           modules = [ ./installer/cd.nix ];
         };
 

--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -3,6 +3,19 @@
   lib,
   pkgs,
   modulesPath,
+  # Whether this image carries the desktop or downloads it. True is the real
+  # product -- see the header. False builds the same installer over the network
+  # instead, which is the same install path the `install` check has always
+  # exercised: without the marker file at the bottom of this file, install.sh
+  # keeps the substituters it already has.
+  #
+  # Passed by both nixosConfigurations, with no default here on purpose. A
+  # module argument's default is not a function default: the module system
+  # cannot see one without consulting _module.args, which needs `config`,
+  # which is what is being evaluated -- so `offline ? true` fails the ISO
+  # build outright rather than defaulting. Making both callers say which
+  # image they want is also the honest reading of a flag this load-bearing.
+  offline,
   ...
 }:
 # The live image: boot it, answer the questions, get a machine.
@@ -252,11 +265,16 @@ in
     #
     # Not nixosConfigurations.vm: it imports qemu-vm.nix and carries guest
     # tooling nobody installs on metal.
-    storeContents =
+    #
+    # This is the whole difference between the two images. Dropped entirely
+    # when `offline` is false: the desktop then comes from the binary caches
+    # named under nix.settings below.
+    storeContents = lib.optionals offline (
       map (r: r.toplevel) references
       # The installer runs this before anything else, and it is not part of
       # any runtime closure.
-      ++ map (r: r.diskoScript) references;
+      ++ map (r: r.diskoScript) references
+    );
   };
 
   # Everything needed to EVALUATE the generated flake, and to build the few
@@ -265,9 +283,15 @@ in
   # extraDependencies rather than storeContents for these: the option's stated
   # purpose is "paths that must be in the store for this system to be usable",
   # which is exactly the claim being made.
+  #
+  # inputSources stays on BOTH images. It is the flake sources rather than the
+  # desktop, it costs little, and it means evaluation starts immediately
+  # instead of fetching a nixpkgs tarball before the first question. The build
+  # environment below is offline-only: with a network, anything missing is
+  # downloaded rather than built.
   system.extraDependencies =
     inputSources
-    ++ [
+    ++ lib.optionals offline [
       # nixos-install builds roughly twenty derivations for the real hostname,
       # user and disk -- etc, users-groups.json, system-path, the bootloader
       # entry, the toplevel -- and their build inputs are in no runtime
@@ -299,9 +323,27 @@ in
       pkgs.python3
       pkgs.jq
     ]
-    ++ buildInputsOfWhatChanges;
+    ++ lib.optionals offline buildInputsOfWhatChanges;
 
   nix.settings = {
+    # flake-registry is a flakes setting, and nix.conf is validated at build
+    # time: setting it without this fails the ISO build with "Ignoring setting
+    # 'flake-registry' because experimental feature 'flakes' is not enabled",
+    # which is at least an honest error rather than a silently ignored line.
+    #
+    # install.sh passes --extra-experimental-features on every nix call
+    # because a stock live medium may not have them. This is not a stock live
+    # medium.
+    experimental-features = [
+      "nix-command"
+      "flakes"
+    ];
+  }
+  # Everything below is one choice made twice. The offline image must be told
+  # there is nothing to fetch; the network image must be told where to fetch
+  # from. Neither set is a sensible default for the other, and the failure when
+  # they are crossed is a hang rather than an error.
+  // lib.optionalAttrs offline {
     # Nothing to fetch, and nothing that may try.
     #
     # An empty list is not the same as an unreachable one. With a substituter
@@ -349,18 +391,22 @@ in
     # that by construction has nothing to download.
     connect-timeout = 1;
     download-attempts = 0;
-
-    # flake-registry is a flakes setting, and nix.conf is validated at build
-    # time: setting it without this fails the ISO build with "Ignoring setting
-    # 'flake-registry' because experimental feature 'flakes' is not enabled",
-    # which is at least an honest error rather than a silently ignored line.
-    #
-    # install.sh passes --extra-experimental-features on every nix call
-    # because a stock live medium may not have them. This is not a stock live
-    # medium.
-    experimental-features = [
-      "nix-command"
-      "flakes"
+  }
+  // lib.optionalAttrs (!offline) {
+    # The same two caches install.sh already knows about and modules/nixos.nix
+    # gives every installed machine. They are not a nicety here: CI builds
+    # checks.reference-toplevel inside a cachix job, so the whole 15.3 GiB
+    # desktop is on nixarchy.cachix.org. Without these the install still
+    # succeeds and takes hours, because it compiles Hyprland.
+    substituters = [
+      "https://cache.nixos.org"
+      "https://nixarchy.cachix.org"
+      "https://hyprland.cachix.org"
+    ];
+    trusted-public-keys = [
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      "nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM="
+      "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE="
     ];
   };
 
@@ -368,9 +414,28 @@ in
   # from this image and must not reach for a substituter. A marker file rather
   # than a kernel parameter: the installer can also be run by hand from a
   # mounted image, and the file travels with the filesystem.
-  environment.etc."nixarchy-iso".text = ''
-    ${inputs.self.shortRev or "dirty"}
-  '';
+  #
+  # Its ABSENCE is what makes the network image work, and that is the whole
+  # mechanism -- install.sh already carries both cachix substituters and only
+  # clears them when it finds this file. So there is no second install path to
+  # keep working; there is one, and this file switches it.
+  environment.etc =
+    if offline then
+      {
+        "nixarchy-iso".text = ''
+          ${inputs.self.shortRev or "dirty"}
+        '';
+      }
+    else
+      {
+        # The mirror of the above, and the installer's cue to make sure there
+        # is a network before it asks anything else. A marker of its own rather
+        # than "no offline marker": the install check runs with neither, in a
+        # sandbox with no network, and must not be told to go and find one.
+        "nixarchy-iso-net".text = ''
+          ${inputs.self.shortRev or "dirty"}
+        '';
+      };
 
   system.stateVersion = "25.05";
 }

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -170,6 +170,116 @@ require_root_and_uefi() {
 # several hundred files including mod-dh-ansi-us-fatz-wide, which is not a
 # thing to offer a person who has just booted a disk. Upstream shows about
 # fifty human-readable layouts with English first; so does this.
+# Getting online, on the image that needs to be.
+#
+# The offline image carries the whole desktop and skips all of this: asking
+# someone to join a network so they can then not use it is a question with no
+# purpose. The network image cannot do anything without one, and the machine it
+# is installing onto may never have had a network configured -- the disk is
+# empty, and the desktop that would normally ask is the thing being installed.
+# So the installer has to ask, and this is the only place it can.
+#
+# Ethernet is not offered as a choice because it is not one. NetworkManager
+# takes DHCP on a plugged cable by itself, so a wired machine never sees this
+# screen, and a wired machine whose cable is not in yet wants "Try again"
+# rather than a menu entry.
+network_ready() {
+  # The real requirement, tested directly: not "is an interface up" and not
+  # NetworkManager's own connectivity check, which pings a URL that NixOS
+  # leaves unset and so reports "unknown" on a perfectly good network. What
+  # the install needs is the binary cache, so that is what is checked.
+  curl -sfI --max-time 8 https://cache.nixos.org/nix-cache-info >/dev/null 2>&1
+}
+
+connect_wifi() {
+  ui_screen "Let's get you on Wi-Fi..."
+  nmcli radio wifi on >/dev/null 2>&1 || true
+
+  # --rescan yes because the cached list is empty on a radio that came up
+  # seconds ago, which is every boot of a live image. Deduplicated on SSID:
+  # one network on three access points is three rows otherwise, and picking
+  # the wrong row of an identical three is a confusing way to fail.
+  local list ssid pw
+  list=$(nmcli -t -f SSID,SIGNAL,SECURITY device wifi list --rescan yes 2>/dev/null |
+    awk -F: 'NF && $1 != "" && !seen[$1]++ { printf "%s\t%s%%\t%s\n", $1, $2, ($3 == "" ? "open" : $3) }' |
+    sort -t"$(printf '\t')" -k2 -rn)
+
+  if [ -z "$list" ]; then
+    ui_left "\e[31mNo networks found.\e[0m"
+    ui_left "\e[90mA USB adapter may need a moment, or the driver may not be on this image.\e[0m"
+    sleep 3
+    return 1
+  fi
+
+  ssid=$(printf '%s\n' "$list" |
+    gum choose --height "$(ui_widget_height)" --padding "$(ui_gum_pad)" --header "Select a network" |
+    cut -f1)
+  [ -n "$ssid" ] || return 1
+
+  # Asked for every network, including open ones, where an empty answer is
+  # correct and is passed as no password at all. One prompt that handles both
+  # beats detecting the security column and being wrong about WEP.
+  ui_left "\e[90mLeave blank if the network is open.\e[0m"
+  pw=$(gum input --padding "$(ui_gum_pad)" --password --prompt "Password> ")
+
+  if [ -z "$pw" ]; then
+    nmcli device wifi connect "$ssid" || return 1
+  else
+    nmcli device wifi connect "$ssid" password "$pw" || return 1
+  fi
+}
+
+ask_network() {
+  # Only the network image asks. Keyed on that image's own marker rather than
+  # on the absence of the offline one, and the difference is not cosmetic:
+  # checks.install installs unattended, in a sandbox, with no network and no
+  # marker of either kind. It works because its store is seeded, so "no offline
+  # marker" would have made a passing check demand a network and fail. What
+  # this screen is for is the one image that genuinely cannot proceed without
+  # one, and that image says so itself.
+  if [ ! -f /etc/nixarchy-iso-net ]; then
+    return 0
+  fi
+
+  if network_ready; then
+    return 0
+  fi
+
+  # Unattended. There is nobody to ask, so say what is wrong rather than
+  # hanging on a prompt no one will answer.
+  if [ -n "$answers_file" ]; then
+    echo "nixarchy-install: this image installs over the network and there is none." >&2
+    echo "nixarchy-install: connect a cable, or use the offline image, or configure" >&2
+    echo "nixarchy-install: the network before running with --answers." >&2
+    exit 1
+  fi
+
+  while true; do
+    ui_screen "Let's get you online..."
+    ui_left "This image downloads the desktop as it installs, so it needs a network."
+    ui_left "\e[90mA wired connection is picked up on its own -- plug it in and try again.\e[0m"
+    echo
+
+    local choice
+    choice=$(printf '%s\n' "Wi-Fi" "Try again" |
+      gum choose --height "$(ui_widget_height)" --padding "$(ui_gum_pad)" --header "No network yet")
+
+    case $choice in
+      "Wi-Fi") connect_wifi || true ;;
+      # Nothing to do but re-test: a cable plugged in during the last screen
+      # has had DHCP running behind it the whole time.
+      "Try again") ;;
+      # gum returns nothing on an interrupt. Leave, rather than loop forever
+      # on a screen someone is trying to escape.
+      *) exit 1 ;;
+    esac
+
+    if network_ready; then
+      return 0
+    fi
+  done
+}
+
 ask_keymap() {
   ui_screen "Let's set up your keyboard..."
   local choice
@@ -756,7 +866,9 @@ main() {
   if [ -n "$answers_file" ]; then
     read_answers "$answers_file"
     validate_answers
+    ask_network
   else
+    ask_network
     ask_keymap
     ask_identity
     ask_device


### PR DESCRIPTION
The offline ISO is 5.6 GB because it carries the whole 15.3 GiB closure, which is the point of it. That is the right default and the wrong only option.

```
packages.iso        5.6 GB    carries the desktop, installs with no network
packages.iso-net    1.54 GiB  downloads it, needs one
```

Measured, not estimated — built and `stat`ed. It also fits under GitHub's 2 GiB single-asset cap with 460 MiB to spare, so it publishes as one file while the offline image ships in parts.

## One argument, not a second module

The offline behaviour was already concentrated in four places in `installer/cd.nix` — `storeContents`, `extraDependencies`, `nix.settings` and the marker file — and every one is a statement about whether there is a network. `inputSources` stays on both images: it is the flake sources rather than the desktop, so evaluation starts immediately instead of fetching a nixpkgs tarball before the first question.

**There is no second install path.** `install.sh` has always carried both cachix substituters and only clears them when it finds the offline marker, so the network image works by not being told to stop — the same path `checks.install` has exercised all along. CI already builds `reference-toplevel` inside a cachix job, so the whole desktop is on `nixarchy.cachix.org` and a network install downloads rather than compiles.

## Getting online

An image that downloads the desktop is useless on a machine with no network, and the machine being installed may never have had one — the disk is empty and the desktop that would normally ask is what is being installed. `ask_network` is the first screen on the network image: Wi-Fi via `nmcli`, or another try at the wire.

Ethernet is not a menu entry because it is not a choice — NetworkManager takes DHCP on a plugged cable by itself, so a wired machine never sees the screen.

## Three things that were not obvious

**`offline` takes no default.** A module argument's default is not a function default: the module system cannot see one without consulting `_module.args`, which needs `config`, which is what is being evaluated. `offline ? true` fails the ISO build rather than defaulting. Both callers now say which image they want.

**The screen is gated on the network image's own marker, not the absence of the offline one.** `checks.install` installs unattended, in a sandbox, with no network and neither marker — it passes because its store is seeded. Keying on "no offline marker" would have made that passing check demand a network and fail.

**Connectivity is tested by fetching `cache.nixos.org`**, not by asking NetworkManager, whose own check pings a URL NixOS leaves unset and reports "unknown" on a working network.

## Verified

- both images evaluate to distinct derivations; `storeContents` is 5 entries on the offline image and 1 (the live system itself) on the network one
- exactly one marker file per image, each on the right one
- `nix build .#install` passes, which runs shellcheck over the new code at build time
- `nix fmt` clean, `actionlint` clean apart from the pre-existing self-hosted label warnings
- `checks.install` re-run against this branch — see the comment below for the result

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5