### PR TITLE
The install check passed every time and never said so

### DIFF
--- a/tests/install.nix
+++ b/tests/install.nix
@@ -561,5 +561,19 @@ pkgs.testers.runNixOSTest {
     target.succeed("cd /etc/nixos && nixos-rebuild switch --flake .#installed")
     assert target.succeed("readlink -f /run/current-system").strip() == before
     print("a rebuild straight after install builds nothing (Invariant 1)")
+
+    # Shut the target down, or this check never finishes.
+    #
+    # `installer` is shut down above; `target` was not, and a machine made by
+    # create_machine is not reaped for us the way a declared node is. The test
+    # script would reach its end, every assertion passing, and the derivation
+    # would then sit forever with a qemu still running -- measured at nine
+    # hours against a script that finished in 510 seconds.
+    #
+    # That is why this check had never once produced a verdict: CI records the
+    # 45-minute timeout as `cancelled`, which reads like someone cancelled it
+    # rather than like a hang, so the passing test looked like an interrupted
+    # one every single time.
+    target.shutdown()
   '';
 }


### PR DESCRIPTION
`checks.install` has never once produced a verdict — not in CI, not locally. It has also been passing the whole time. Both are true, and the gap between them is one missing line.

## What happens

The test script runs to the end with every assertion green, including the one this epic turns on — a rebuild straight after install builds nothing. Then the derivation sits there:

```
target: nixos-rebuild switch --flake .#installed  → finished in 6.23 seconds
(finished: run the VM test script, in 509.89 seconds)
(finished: cleanup, in 0.00 seconds)
                                          ← then nothing, for nine hours
```

`installer` is shut down. `target` is not, and a machine made by `create_machine` is not reaped for us the way a declared node is, so a qemu stays alive and the builder never exits. I measured one at **9h15m** against a script that had finished in 510 seconds.

## Why it took two days to see

CI records a `timeout-minutes` kill as **`cancelled`**, not `failure`. That reads as though a person cancelled the job — so a passing test has looked like an interrupted one since the day it was written, and the job history is `cancelled`, `cancelled`, never `success`.

I misread it twice before looking properly: first as my own machine being busy, then as the workflow-level concurrency bug fixed in #83 — which was real, and was not this.

## Verified

With `target.shutdown()`, the check completes and the result is in the store:

```
target # shutdown[1]: Powering off.
(finished: run the VM test script, in 529.38 seconds)
/nix/store/rh5hljblyrjhk9hnsg0573d8dxzvxfdb-vm-test-run-nixarchy-install   BUILT
```

That is the first green verdict this check has ever produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5