### PR TITLE
A size budget that fails, rather than a number in a comment

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,6 +80,16 @@ jobs:
           printf '| | |\n|---|---|\n| ISO | %s |\n| closure | %s |\n' \
             "$size" "$closure" | tee -a "$GITHUB_STEP_SUMMARY"
 
+      # The number the size report prints is only useful if something acts on
+      # it. This is that. It builds the network image too, which is the one
+      # with a hard ceiling: over 2 GiB it stops fitting in a release as a
+      # single asset.
+      - name: Both images are inside their budgets
+        run: |
+          set -o pipefail
+          nix build .#checks.x86_64-linux.iso-budget --no-link --print-build-logs 2>&1 \
+            | tail -5 | tee -a "$GITHUB_STEP_SUMMARY"
+
       - name: Install from it with no network device present
         run: nix build .#checks.x86_64-linux.install-iso --print-build-logs
 

--- a/flake.nix
+++ b/flake.nix
@@ -676,6 +676,60 @@
         # only one of them compiles the difference from source.
         reference-unencrypted-toplevel =
           self.nixosConfigurations.reference-unencrypted.config.system.build.toplevel;
+
+        # Both images, against the budgets recorded in installer/cd.nix.
+        #
+        # A check rather than a comment because a number nobody enforces is a
+        # number that drifts. The nightly runs this; it costs nothing beyond
+        # the ISO builds it already does.
+        #
+        # The iso-net budget is the load-bearing one, and it is not a taste
+        # question: GitHub refuses a release asset over 2 GiB, so an iso-net
+        # that crosses it stops being publishable as a single file and
+        # release.yml would have to start splitting it. Failing here says so
+        # while there is still something to do about it, rather than at the
+        # next tag.
+        iso-budget =
+          let
+            pkgs = pkgsFor.${system};
+            # MiB, as integers: nix has floats but this needs exact bytes, and
+            # 6656 is less to get wrong than 6.5 * 1073741824.
+            images = [
+              {
+                name = "iso";
+                drv = self.packages.${system}.iso;
+                mib = 6656; # 6.5 GiB, over a measured 5.6 GB
+              }
+              {
+                name = "iso-net";
+                drv = self.packages.${system}.iso-net;
+                mib = 2048; # GitHub's release-asset limit, not a preference
+              }
+            ];
+          in
+          pkgs.runCommand "iso-budget" { } (
+            "fail=0\n"
+            + nixpkgs.lib.concatMapStrings (i: ''
+              size=$(stat -Lc %s ${i.drv}/iso/*.iso)
+              budget=$((${toString i.mib} * 1048576))
+              awk -v n=${i.name} -v s="$size" -v b="$budget" \
+                'BEGIN { printf "%-8s %6.2f GiB   budget %5.2f GiB   %s\n", \
+                   n, s/1073741824, b/1073741824, (s > b ? "OVER" : "ok") }'
+              [ "$size" -le "$budget" ] || fail=1
+            '') images
+            + ''
+              if [ "$fail" -ne 0 ]; then
+                echo
+                echo "An image outgrew its budget. Either something large joined the"
+                echo "closure by accident, or the budget in installer/cd.nix needs"
+                echo "raising on purpose -- but iso-net's 2 GiB is GitHub's limit on"
+                echo "a release asset, and cannot be raised, only worked around by"
+                echo "splitting the image the way release.yml splits the other one."
+                exit 1
+              fi
+              touch $out
+            ''
+          );
       });
     };
 }

--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -269,6 +269,47 @@ in
     # This is the whole difference between the two images. Dropped entirely
     # when `offline` is false: the desktop then comes from the binary caches
     # named under nix.settings below.
+    #
+    # ## The size budget, measured 2026-09-01
+    #
+    #   reference closure   15.3 GiB unpacked   what the install produces
+    #   packages.iso         5.6 GB             this image, offline
+    #   packages.iso-net     1.54 GiB           the network image
+    #
+    # Budgets, enforced by checks.iso-budget rather than written down and
+    # forgotten:
+    #
+    #   iso       6.5 GiB   headroom over 5.6, tight enough to notice a jump
+    #   iso-net   2 GiB     NOT a preference. GitHub refuses a release asset
+    #                       over 2 GiB, so crossing this does not make the
+    #                       download annoying, it makes it impossible to
+    #                       publish as one file. See .github/workflows/
+    #                       release.yml, which splits the image above and
+    #                       ships this one whole.
+    #
+    # ## No apps on the image, deliberately
+    #
+    # The reference host enables no programs.nixarchy.apps.*, and should not
+    # start. The 52 selectable apps are a post-install concern, reached
+    # through the Install menu once the machine is the user's: several are
+    # unfree, several are hundreds of megabytes each, and baking even the free
+    # half would roughly double an image for apps most people never pick. The
+    # base desktop is what everyone gets and therefore what is worth carrying.
+    #
+    # ## Compression: nothing to tune here
+    #
+    # isoImage.squashfsCompression is `zstd -Xcompression-level 19` -- the
+    # nixpkgs default, already, so the argument for moving off xz (~100 MB/s
+    # decompressing a live root read cold, against zstd's ~900 MB/s) is one
+    # this image already wins. Level 19 over level 6 costs build time on a
+    # machine with plenty and saves a download for every user, which is the
+    # right way round.
+    #
+    # Storing the tree UNCOMPRESSED inside the squashfs -- what Omarchy does
+    # with its package mirror -- does not port. Theirs is already-compressed
+    # pacman packages, where the outer compression buys nothing. A Nix store
+    # is not: 15.3 GiB becomes 5.6 GB here, 2.7x. Uncompressed would mean a
+    # ~15 GB image to save decompression on a file read once.
     storeContents = lib.optionals offline (
       map (r: r.toplevel) references
       # The installer runs this before anything else, and it is not part of


### PR DESCRIPTION
Closes #17.

## The measurements it asks for, taken 2026-09-01

```
reference closure   15.3 GiB unpacked
packages.iso         5.6 GB
packages.iso-net     1.54 GiB
```

They now live in `installer/cd.nix` next to the line that causes them, along with two policies that were being followed without being written down: the image bakes no selectable apps, and should not start. `nix eval` confirms the reference host enables none.

## The budget is enforced, not recorded

`checks.iso-budget` fails when an image outgrows its allowance. `iso` gets 6.5 GiB — headroom over 5.6, tight enough to notice something large arriving by accident.

`iso-net` gets **2 GiB**, and that one is not a taste question: GitHub refuses a release asset over 2 GiB, so crossing it stops the small image being publishable as a single file and `release.yml` would have to start splitting it too. Failing in the nightly says so while there is still time to do something, rather than at the next tag.

## Two of the issue's premises were stale

Most of what #17 specifies is overtaken. It designs a CI job on `ubuntu-latest`, with the disk-freeing gymnastics and the `/mnt/nix` symlink a 14 GB runner needs for a 5.6 GB image carrying a 15.3 GiB closure. That does not fit and no longer has to — the ISO builds nightly on p510, and #19 publishes it.

Its amendment asks for a compression measurement on the premise that `isoImage.squashfsCompression` defaults to **xz**. It does not any more: `zstd -Xcompression-level 19` is what this image already gets, so the argument for moving off xz is one it has already won. Recorded in the file so nobody re-litigates it.

The other half of that amendment — store the tree uncompressed inside the squashfs, as Omarchy does with its package mirror — **does not port**, and the number says why. Theirs is already-compressed pacman packages, where the outer compression buys nothing. A Nix store is not: 15.3 GiB becomes 5.6 GB, **2.7×**. Uncompressed would mean a ~15 GB image, to save decompressing a file that is read once.

## Verified

- the derivation carries both budgets: `6656 * 1048576` and `2048 * 1048576`, both images named, fail path present
- the comparison logic proven against a deliberately oversized file — `OVER` detected, non-zero exit; `ok` under budget
- `nix fmt` clean; `actionlint` clean apart from the pre-existing self-hosted label notes
- a real build of the check is running; result posted below before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5