### PR TITLE
Tell people they can download it

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,13 +776,39 @@ any conflict to warn you.
 
 ## Installing on a fresh machine
 
-There is an ISO now. Build it, write it to a stick, boot it, and answer nine
+There is an ISO now. Download it, write it to a stick, boot it, and answer nine
 questions.
 
+**[Releases](https://github.com/olafkfreund/nixarchy/releases)** carry prebuilt
+images from `v4.0.1-3` onward, built and install-tested by CI on the machine
+that runs the nightly checks. The large one is split, because GitHub will not
+take a single file that size:
+
 ```
-nix build github:olafkfreund/nixarchy#iso
+cat nixarchy-v*.iso.part-* > nixarchy.iso     # the 5.6 GB image only
+sha256sum -c --ignore-missing SHA256SUMS
+sudo dd if=nixarchy.iso of=/dev/sdX bs=4M status=progress oflag=sync
+```
+
+`--ignore-missing` because one `SHA256SUMS` covers both images and nobody
+downloads both.
+
+Or build it yourself, which is the same image from the same commit:
+
+```
+nix build --extra-experimental-features 'nix-command flakes' \
+  github:olafkfreund/nixarchy#iso
 sudo dd if=result/iso/nixarchy-*.iso of=/dev/sdX bs=4M status=progress oflag=sync
 ```
+
+The `--extra-experimental-features` flag is there because flakes are off by
+default on a stock Nix, and a machine that has never run one is exactly the
+machine someone builds an installer on. On NixOS with this module it is
+redundant and harmless. **Building on a non-NixOS host** also needs the Nix
+daemon running — `systemctl enable --now nix-daemon.socket`, and your user in
+the `nix-users` group on Arch. If `/nix/store` is missing, the Nix install did
+not finish; do not create it by hand, because a multi-user store wants
+`root:nixbld` and mode `1775` rather than whatever `mkdir` leaves behind.
 
 There are two images, and the difference is what they carry:
 
@@ -1319,6 +1345,10 @@ inputs.nixarchy = {
   inputs.nixpkgs.follows = "nixpkgs";
 };
 ```
+
+From `v4.0.1-3` on, a tag also publishes the two ISOs and a `SHA256SUMS` to
+the [Releases](https://github.com/olafkfreund/nixarchy/releases) page, so a tag
+is both something to pin and something to install from.
 
 **The version names the Omarchy it vendors**, because that is the first thing
 anyone needs to know about a packaging repo: `v4.0.1-1` is Omarchy 4.0.1. The


### PR DESCRIPTION
From [discussion #69](https://github.com/olafkfreund/nixarchy/discussions/69), where a user built the ISO on Arch/Omarchy and wrote up the setup they needed first.

## What they hit, and what was ours

**Flakes are off by default on a stock Nix.** The README's build command assumed they were on. `installer/install.sh:43` has passed `--extra-experimental-features "nix-command flakes"` on every call since it was written, for exactly this reason — a machine that has never run a flake is precisely the machine someone builds an installer on. The README now passes it too, inline, so nobody has to edit a config file to follow a quickstart.

**The daemon has to be running on a non-NixOS host.** One sentence, plus the `nix-users` group on Arch.

**`/nix/store` missing — this one I would not repeat.** Their write-up creates it with `mkdir` and `chown root:root`. A multi-user store wants `root:nixbld` and mode `1775`, so that leaves a store that works now and fails later somewhere unrelated. Its absence is a symptom of an unfinished Nix install, so the README says don't do it rather than how to do it.

## The bigger fix

The section opened with **"There is an ISO now. Build it"** and never mentioned that a tag publishes one. That was true when written and stopped being true this morning — so the first thing the README did was send someone off to build a 5.6 GB image they could have downloaded. It now leads with Releases, keeps the build as the equivalent alternative, and explains the `cat`/`--ignore-missing` dance the split image needs.

## Merge after the release publishes

This promises assets from `v4.0.1-3`, and that run is still going. **Hold it until the release page actually has the ISOs on it** — otherwise the README points at a download that isn't there.

## A correction on my own reporting

I initially told the owner this README also contradicted itself, claiming `#iso` needs a network. It does not: I grepped a worktree still sitting on the branch from #75 and read a two-day-old file. Main was correct and consistent. Nothing in this PR touches that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5