### PR TITLE
The installer owns the screen, from the first frame to the last

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -237,6 +237,12 @@
             # is a class of bug that only shows up on that image.
             curl # the connectivity test -- can we reach the binary cache
             networkmanager # nmcli, for joining a wireless network
+            # The failure and finish screens offer a way out of both. Present
+            # on the live medium anyway; named here so `nix run .#install` on
+            # some other host does not discover them missing at the one moment
+            # a person needs them.
+            systemd # systemctl reboot / poweroff
+            bashInteractive # the shell the failure screen drops into
           ];
           # Spliced at build time the way doctor splices @apps@, so the script
           # never has to find these itself and `nix run` works from anywhere.

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -868,6 +868,7 @@ main() {
     validate_answers
     ask_network
   else
+    ui_greeter
     ask_network
     ask_keymap
     ask_identity
@@ -911,6 +912,15 @@ main() {
   mkdir -p /run/nixarchy-install
   printf '{"started":%s,"phase":"installing"}\n' "$started" \
     >/run/nixarchy-install/state.json
+
+  # An interrupt during the install has to land somewhere.
+  #
+  # Without this, Ctrl-C or a kill leaves the dashboard's redraw loop running,
+  # the cursor hidden and the screen owned by a program that is no longer
+  # there -- and the log, which is the only thing worth having at that point,
+  # unmentioned. The EXIT trap ui_dashboard_start sets restores the cursor;
+  # this adds the part that says what happened and where to read about it.
+  trap 'ui_dashboard_stop; ui_failed "$log" 130; exit 130' INT TERM
 
   ui_dashboard_start
   {

--- a/installer/lib/dashboard.sh
+++ b/installer/lib/dashboard.sh
@@ -112,6 +112,21 @@ ui_finished() {
   ui_centre "Reboot, then log in as \e[1m$username\e[0m." $((23 + ${#username}))
   ui_centre "\e[90mYour configuration is /etc/nixos -- a git repository, yours to edit.\e[0m" 67
   echo
+
+  # One button, because there is exactly one thing left to do. Telling somebody
+  # to reboot and leaving them at a prompt makes them find the command; the
+  # install knows it, so it offers it.
+  #
+  # Skipped when nobody is watching: checks.install finishes here, and a
+  # prompt would hang the test rather than fail it.
+  ui_interactive || return 0
+  local choice
+  choice=$(printf '%s\n' "Reboot now" "Leave it running" |
+    gum choose --padding "$(ui_gum_pad)" --header "") || return 0
+  if [ "$choice" = "Reboot now" ]; then
+    systemctl reboot
+  fi
+  return 0
 }
 
 # When it goes wrong, the log is the only thing worth showing, and it is the
@@ -131,4 +146,33 @@ ui_failed() {
   echo
   ui_left "\e[90mThe whole log is at $log. Nothing was rebooted.\e[0m"
   echo
+
+  # Twenty-five lines is enough to recognise a failure and rarely enough to
+  # diagnose one, so offer the rest rather than making somebody remember a
+  # path and a pager on a machine with no desktop yet.
+  #
+  # A loop: reading the log should return here, not end the installer. Only
+  # rebooting, powering off or leaving on purpose gets out.
+  ui_interactive || return 0
+  local choice
+  while :; do
+    choice=$(printf '%s\n' \
+      "View the whole log" "Open a shell" "Reboot" "Power off" |
+      gum choose --padding "$(ui_gum_pad)" --header "What now?") || return 0
+    case $choice in
+      "View the whole log")
+        # gum's pager, not less: gum is already a dependency and less is not,
+        # and a live medium is a poor place to discover a missing binary.
+        gum pager <"$log" || true
+        ;;
+      "Open a shell")
+        ui_left "\e[90mThe install is stopped. Type exit to come back here.\e[0m"
+        echo
+        "${SHELL:-bash}" || true
+        ;;
+      "Reboot") systemctl reboot; return 0 ;;
+      "Power off") systemctl poweroff; return 0 ;;
+      *) return 0 ;;
+    esac
+  done
 }

--- a/installer/lib/ui.sh
+++ b/installer/lib/ui.sh
@@ -269,6 +269,53 @@ ui_logo() {
   echo
 }
 
+# Is there a person out there?
+#
+# Every screen that waits for an answer has to ask this first. The installer
+# runs unattended in checks.install -- with --answers, no tty, and nobody to
+# press Return -- and a greeter that blocks there does not fail the test, it
+# hangs it, which is a far worse thing to debug. Learned the hard way: the
+# network prompt had to be re-gated for exactly this reason.
+#
+# Two conditions, not one. --answers says the caller means to be unattended;
+# the tty check catches a caller who forgot to say so.
+ui_interactive() {
+  [ -z "${answers_file:-}" ] && [ -t 0 ]
+}
+
+# The first thing anyone sees.
+#
+# Omarchy opens on its wordmark and waits for Return, and that pause is doing
+# real work: it says the machine is ready and the next thing that happens is
+# yours to start. Booting straight into a question makes an installer feel like
+# it began without asking.
+#
+# No animation. Upstream animates this with ttfx, which is packaged here as a
+# selectable app rather than as anything the live medium carries -- it is not
+# in the ISO's closure, so using it would mean adding a dependency to both
+# images for a decoration. The mark is drawn with ui_logo, which every other
+# screen already uses and which degrades correctly on a narrow console.
+ui_greeter() {
+  ui_interactive || return 0
+
+  ui_init
+  ui_clear
+  local rows pad
+  rows=$(ui_rows)
+  # Vertically centred, roughly: the mark is 6 lines and the text below it 4.
+  pad=$(((rows - 10) / 2))
+  [ "$pad" -lt 1 ] && pad=1
+  for ((i = 0; i < pad; i++)); do echo; done
+
+  ui_logo
+  ui_centre "\e[1mOmarchy, on NixOS.\e[0m" 18
+  echo
+  ui_centre "\e[90mPress Return to start the install.\e[0m" 34
+  # `|| true` because this is the function's last command and read returns
+  # non-zero at EOF. Under set -e that would end the install at the greeting.
+  read -r _ || true
+}
+
 # One screen: clear it, draw the mark, then the single line saying what this
 # screen is for. Every question the installer asks starts here, so a user is
 # never looking at a scrollback of what came before.


### PR DESCRIPTION
Closes #45, apart from the prewarm — now [#87](https://github.com/olafkfreund/nixarchy/issues/87), with the reasoning for deferring it.

## Most of #45 was already built

The dashboard, the 34-cell bar, the tip rotating every eight seconds, the progress model (store paths under `/mnt` against a build-time count, maxed with a time asymptote — exactly what the issue specifies), `state.json`, and a log that stays in a file. All shipped with the installer and never ticked off. What was missing was the beginning and the end.

## What this adds

**A greeter.** `ui_finished`'s comment has said *"mirrors the greeter"* since it was written — against a greeter that did not exist. Now it does.

**A failure screen that does something.** It showed the last 25 lines and stopped: enough to recognise a failure, rarely enough to diagnose one. It now offers the whole log through `gum pager`, a shell, reboot or power off, in a loop — reading the log returns to the menu rather than ending the installer.

**A trap.** #45 asks that killing the install lands on the failure screen with the log intact. There was no signal handler at all, so an interrupt left the redraw loop running and the screen owned by a program that had gone.

**A finish button.** Reboot now / Leave it running.

## `ui_interactive` is the load-bearing part

Every screen that waits for an answer is gated on it: no `--answers`, and a tty. Without it `checks.install` would not fail, it would **hang**, waiting for a Return nobody is there to press — and this week established at some length that a hung check is far worse to diagnose than a failed one. The network prompt had to be re-gated for this reason after the fact; here the guard was written first.

## Verified

- `checks.install` passes on this branch: `/nix/store/ki59cldqab9hy2wzlpv645vw03q1yywd-vm-test-run-nixarchy-install` — the unattended path is unaffected by the new prompts
- shellcheck passes at build time via `nix build .#install`
- two `set -e` hazards caught in review of my own diff before they shipped: `read` returning non-zero at EOF as a function's last command would have ended the install at the greeting, and a `[ ] && cmd` that reads as though it might exit

## No ttfx, deliberately

#45 calls for `ttfx colorshift` and `laseretch`, *"already packaged here"*. It is packaged — as a **selectable app**, not as anything the live medium carries; it is absent from the ISO's closure. Using it means adding a dependency to both images for a decoration, against a CLI this change did not verify. `ui_logo` draws the mark instead: every other screen already uses it, and it degrades correctly on a console too narrow for the wordmark.

## What is not covered by tests

The screens themselves. #45 says this outright and it is still true — Omarchy drives its own TUI through QMP screendumps and OCR, which is more machinery than this warrants. What the check does prove is the thing most likely to break: that none of it blocks an unattended install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5