### PR TITLE
install-iso hangs the same way install did

### DIFF
--- a/tests/install-iso.nix
+++ b/tests/install-iso.nix
@@ -291,5 +291,24 @@ pkgs.testers.runNixOSTest {
     target.start()
     target.wait_for_console_text(r"isotest login:", timeout=900)
     print("the installed disk booted on its own bootloader")
+
+    # Kill it at the monitor, or this check never finishes.
+    #
+    # A machine made by create_machine is not reaped for us the way a declared
+    # node is: the script reaches its end with every assertion passing and the
+    # derivation then sits there forever with a qemu still running. That is
+    # not a hypothesis -- checks.install did exactly this for nine hours, and
+    # it presents as `cancelled` in CI because a timeout is recorded as a
+    # cancellation, which reads like a person stopped it rather than like a
+    # hang.
+    #
+    # `quit`, not shutdown(): this machine has no backdoor, which is why the
+    # line above waits on console text rather than asking it anything. Same
+    # treatment the installer machine gets above, and the same try/except --
+    # if qemu is already gone the monitor socket is gone with it.
+    try:
+        target.send_monitor_command("quit")
+    except Exception:
+        pass
   '';
 }


### PR DESCRIPTION
#84 made `checks.install` terminate. It applied to one of two `create_machine` sites and I did not check the other.

`checks.install-iso` ends:

```python
target.start()
target.wait_for_console_text(r"isotest login:", timeout=900)
print("the installed disk booted on its own bootloader")
```

`target` is never shut down. A machine made by `create_machine` is not reaped the way a declared node is, so the script finishes with every assertion passing and the derivation sits there with a qemu still running.

## This is currently happening

The `v4.0.1-3` release run is **3h49m** into a job with a 5-hour timeout. The ISO built, the network ISO built, the install-from-ISO finished. It will be recorded as `cancelled` — because a timeout is — and `Publish` will never run. That release will produce nothing.

## The fix

`send_monitor_command("quit")`, not `shutdown()`: this machine has no backdoor, which is precisely why the line above waits on console text instead of asking it anything. It is the same treatment the `installer` machine already gets twenty lines up, with the same `try`/`except` — if qemu has already gone, the monitor socket has gone with it.

## Both sites now accounted for

```
tests/install.nix:497      target      -> shutdown()          (#84)
tests/install-iso.nix:224  installer   -> typed poweroff + monitor quit
tests/install-iso.nix:287  target      -> monitor quit        (this PR)
```

That sweep is what should have happened in #84 rather than fixing the one in front of me.

## Verification, honestly

Not run end to end — `checks.install-iso` builds a 5.6 GB image and installs from it, and the machine that does that is currently occupied failing to finish the previous one. The fix is the identical change to the identical pattern that was **proven** to make `checks.install` terminate this morning, applied to the sibling. The next release or nightly is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5