### PR TITLE
A catalogue of services, and a check that it stays usable

### DIFF
--- a/data/services.nix
+++ b/data/services.nix
@@ -1,0 +1,106 @@
+# Services and system settings a desktop user actually asks for, mapped to how
+# NixOS turns them on.
+#
+# The companion to data/apps.nix, and deliberately shaped differently. An app is
+# a package: install it and it is there. A service is a decision about the
+# machine, and the useful ones are rarely a single option -- Docker without
+# group membership is a Docker you have to sudo at, printing without avahi finds
+# no printers, Tailscale without a trusted interface has a firewall in the way.
+#
+# ## Two kinds, and the difference is the whole design
+#
+#   kind = "plain"     A one-to-one toggle. nixarchy has nothing to add, so it
+#                      adds nothing: the generated file gets the real upstream
+#                      line, `services.openssh.enable = true;`, and there is no
+#                      nixarchy option at all. That line is what every wiki
+#                      page, forum answer and tutorial will show them, and a
+#                      second vocabulary is a thing to unlearn later.
+#
+#   kind = "bundled"   nixarchy genuinely integrates several options, so it
+#                      earns an option of its own in modules/services/<id>.nix.
+#                      The file gets `programs.nixarchy.services.docker.enable`.
+#
+# The bar for "bundled" is high on purpose. RFC 42 makes the argument against
+# copying upstream options: they go stale, upstream removals break the wrapper,
+# and an option cannot realistically be removed once added. So a wrapper has to
+# pay for itself in integration a newcomer would not find alone. If the answer
+# is one line, it is "plain".
+#
+# ## Fields
+#   label      Shown in the generated template and the menu.
+#   category   Groups rows in the template.
+#   kind       "plain" or "bundled", as above.
+#   option     Required for "plain": the upstream option path, written into the
+#              template as `<path>.enable = true;`. Meaningless for "bundled",
+#              whose module decides what to set.
+#   note       Anything a reader would otherwise discover the hard way. This is
+#              the field that does the teaching -- say what turning it on costs
+#              or opens, not what it is.
+#   unfree     Marks a service pulling unfree packages.
+{
+  # ── Network ─────────────────────────────────────────────────────────────
+  openssh = {
+    label = "OpenSSH server";
+    category = "Network";
+    kind = "plain";
+    option = [
+      "services"
+      "openssh"
+    ];
+    note = "Remote login. Opens port 22 and NixOS defaults to keys only, not passwords.";
+  };
+
+  tailscale = {
+    label = "Tailscale";
+    category = "Network";
+    kind = "bundled";
+    note = "A private network between your machines. Bundled because the firewall has to trust the interface or nothing reaches this host.";
+  };
+
+  # ── Virtualisation ──────────────────────────────────────────────────────
+  docker = {
+    label = "Docker";
+    category = "Virtualisation";
+    kind = "bundled";
+    note = "Bundled because the useful part is group membership: without it every command needs sudo.";
+  };
+
+  # ── Hardware ────────────────────────────────────────────────────────────
+  printing = {
+    label = "Printing";
+    category = "Hardware";
+    kind = "bundled";
+    note = "Bundled because a printer nobody can discover is not printing: cups alone finds nothing on a network.";
+  };
+
+  graphics32 = {
+    label = "32-bit graphics";
+    category = "Hardware";
+    kind = "plain";
+    option = [
+      "hardware"
+      "graphics"
+    ];
+    optionAttr = "enable32Bit";
+    note = "Wanted by Steam, Wine and older games. One switch covers every driver.";
+  };
+
+  # ── Desktop ─────────────────────────────────────────────────────────────
+  flatpak = {
+    label = "Flatpak";
+    category = "Desktop";
+    kind = "plain";
+    option = [
+      "services"
+      "flatpak"
+    ];
+    note = "For software nixpkgs does not carry. Then: flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo";
+  };
+
+  syncthing = {
+    label = "Syncthing";
+    category = "Desktop";
+    kind = "bundled";
+    note = "Syncs folders between your machines. Bundled because it runs as you, and upstream cannot know which user that is.";
+  };
+}

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -214,6 +214,53 @@ let
   # rather than about an option.
   vm = inputs.self.nixosConfigurations.vm.config.system.build.toplevel;
 
+  # ---- the services catalogue is shaped the way the generator expects ----
+  #
+  # data/apps.nix has no schema check at all: it is read with `app ? field`
+  # and a missing field simply produces a row nobody notices is wrong. That is
+  # tolerable for a file one person edits rarely and not for a catalogue meant
+  # to grow, so this one is checked.
+  #
+  # What is NOT checked here: that a bundled entry has a module in
+  # modules/services/. Those modules do not exist yet, and an assertion that
+  # fails until they do would mean this file cannot land before them.
+  services = import ../data/services.nix;
+
+  serviceProblems = pkgs.lib.flatten (
+    pkgs.lib.mapAttrsToList (
+      id: svc:
+      let
+        need = field: cond: pkgs.lib.optional (!cond) "  ${id}: ${field}";
+      in
+      [
+        (need "no label" (svc ? label && svc.label != ""))
+        (need "no category" (svc ? category && svc.category != ""))
+        (need "kind must be \"plain\" or \"bundled\"" (
+          svc ? kind
+          && builtins.elem svc.kind [
+            "plain"
+            "bundled"
+          ]
+        ))
+        # A plain entry IS its option path -- the whole point is that the real
+        # upstream line lands in the user's file rather than an alias. Without
+        # the path there is no line to write.
+        (need "kind=plain needs an option path" (
+          (svc.kind or "") != "plain" || (svc ? option && svc.option != [ ])
+        ))
+        # And a bundled entry must not carry one, because its module decides
+        # what to set. A stray path here reads as though it were honoured.
+        (need "kind=bundled must not set option; its module decides" (
+          (svc.kind or "") != "bundled" || !(svc ? option)
+        ))
+        # The note is where the teaching happens. An entry without one is a
+        # row that says what a thing is called and nothing about what turning
+        # it on costs.
+        (need "no note" (svc ? note && svc.note != ""))
+      ]
+    ) services
+  );
+
   broken = pkgs.lib.filterAttrs (_: c: !(c.on && !c.off)) cases;
 
   report = pkgs.lib.concatStringsSep "\n" (
@@ -228,13 +275,22 @@ pkgs.runCommand "nixarchy-options"
     inherit menuFile vm;
     omarchyPath = "${(pkgs.extend inputs.self.overlays.default).omarchy}/share/omarchy";
     mapped = pkgs.lib.concatStringsSep " " mappedRows;
+    serviceProblems = pkgs.lib.concatStringsSep "\n" serviceProblems;
+    serviceCount = builtins.toString (builtins.length (builtins.attrNames services));
     notApps = pkgs.lib.concatStringsSep " " notApps;
     nativeBuildInputs = [ pkgs.python3 ];
   }
   (
-    if broken == { } then
+    if serviceProblems != [ ] then
+      ''
+        echo "data/services.nix has entries the generator cannot use:" >&2
+        echo "$serviceProblems" >&2
+        exit 1
+      ''
+    else if broken == { } then
       ''
           echo "$report"
+          echo "the services catalogue is well formed ($serviceCount entries)"
           echo "every option adds what it should and removes it again"
 
           python3 ${./coverage.py}


### PR DESCRIPTION
Closes #91. First piece of #90.

`data/apps.nix` answers "how does NixOS install this app". Nothing answered the same question for a service, so anyone wanting Docker, a printer or SSH had to already know the option path — while `data/arch-extras.nix:95-125` has been carrying `services.openssh.enable`, `services.flatpak.enable` and `hardware.graphics.enable32Bit` as `kind = "nixos-option"` entries that `omarchy-pkg-add` prints as advice and nothing can select.

## Two kinds, and that split is the design

| kind | when | what the user's file gets |
|---|---|---|
| **plain** | a one-to-one toggle | the real upstream line: `services.openssh.enable = true;` |
| **bundled** | nixarchy integrates several options | `programs.nixarchy.services.docker.enable = true;` |

A **plain** entry gets **no nixarchy option at all**. The catalogue makes it discoverable and selectable, but what lands in the file is the line every wiki page and forum answer will show them — so the curated layer never becomes a second vocabulary to unlearn.

A **bundled** entry has to pay for itself in integration a newcomer would not find alone: Docker without group membership is a Docker you `sudo` at, printing without avahi finds no printers, Tailscale without a trusted interface has a firewall in the way.

The bar for bundled is high deliberately. [RFC 42](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md) argues against copying upstream options — they go stale, an upstream removal breaks the wrapper, and an option cannot realistically be removed once added. **If the answer is one line, it is plain.**

Seven entries to start: `openssh`, `flatpak`, `graphics32` plain; `docker`, `tailscale`, `printing`, `syncthing` bundled.

## The check is the other half

`data/apps.nix` has **no schema validation whatever** — it is read with `app ? field`, and a missing field yields a row nobody notices is wrong. Tolerable for a file one person edits rarely; not for a catalogue meant to grow.

`checks.options` now fails, by name, on: a missing `label`, `category`, `kind` or `note`; a `plain` entry with no option path; and a `bundled` entry that sets one (its module decides what to set — a stray path reads as though it were honoured).

**Verified by breaking it rather than by watching it pass:**

```
data/services.nix has entries the generator cannot use:
  docker: kind=bundled must not set option; its module decides
  flatpak: kind=plain needs an option path
```

and on the real file:

```
the services catalogue is well formed (7 entries)
```

## What this deliberately does not do

- **No assertion that a bundled entry has a module** under `modules/services/`. Those do not exist yet — #92 writes them — and an assertion failing until they do would mean this cannot land first.
- **Nothing reads the catalogue yet.** No template rows, no menu entries, no `nixarchy-service-enable`. That is #93 and #94. This is the data and its guard rail, landing first so the rest has something to build against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5