### PR TITLE
Bundled services, and the discipline that keeps them out of the way

### DIFF
--- a/data/services.nix
+++ b/data/services.nix
@@ -37,6 +37,17 @@
 #              the field that does the teaching -- say what turning it on costs
 #              or opens, not what it is.
 #   unfree     Marks a service pulling unfree packages.
+# ## Not listed here, because they are already on
+#
+# modules/nixos.nix enables these for every nixarchy machine, at mkDefault, so
+# a catalogue entry would be an option that changes nothing:
+#
+#   virtualisation.docker.enable        nixos.nix:705
+#   services.printing.enable            nixos.nix:634
+#   services.avahi.{enable,nssmdns4}    nixos.nix:635-639
+#
+# If one of those should become a choice rather than a default, that is a
+# change to nixos.nix and an announcement, not a row added here.
 {
   # ── Network ─────────────────────────────────────────────────────────────
   openssh = {
@@ -57,21 +68,7 @@
     note = "A private network between your machines. Bundled because the firewall has to trust the interface or nothing reaches this host.";
   };
 
-  # ── Virtualisation ──────────────────────────────────────────────────────
-  docker = {
-    label = "Docker";
-    category = "Virtualisation";
-    kind = "bundled";
-    note = "Bundled because the useful part is group membership: without it every command needs sudo.";
-  };
-
   # ── Hardware ────────────────────────────────────────────────────────────
-  printing = {
-    label = "Printing";
-    category = "Hardware";
-    kind = "bundled";
-    note = "Bundled because a printer nobody can discover is not printing: cups alone finds nothing on a network.";
-  };
 
   graphics32 = {
     label = "32-bit graphics";

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -68,6 +68,7 @@ in
     inputs.hyprland.nixosModules.default
     (import ./apps.nix inputs)
     ./local-ai.nix
+    ./services
   ];
 
   options.programs.nixarchy = {
@@ -1008,7 +1009,22 @@ in
     # the alternative is guessing which of a machine's users logs into the
     # desktop.
     users.users = lib.optionalAttrs (cfg.user != null) {
-      ${cfg.user}.extraGroups = [ "input" ];
+      ${cfg.user}.extraGroups = [
+        "input"
+      ]
+      # Docker is enabled above, at mkDefault, for every machine. Enabled and
+      # unusable, until now: without this group every command wants sudo, and
+      # `docker ps` answers "permission denied while trying to connect to the
+      # Docker daemon socket" -- which reads like a broken install rather than
+      # a missing group.
+      #
+      # The installer has always put its user in `docker` directly
+      # (installer/host.nix), so this was only ever wrong for someone adding
+      # nixarchy to a machine they already run: they got the daemon and not
+      # the access. Conditioned on the option rather than set unconditionally,
+      # so turning Docker off does not leave a group behind that grants root
+      # to whatever installs a socket there later.
+      ++ lib.optional config.virtualisation.docker.enable "docker";
     };
 
     boot.plymouth = lib.mkMerge [

--- a/modules/services/default.nix
+++ b/modules/services/default.nix
@@ -1,0 +1,38 @@
+# The services nixarchy bundles, one module each.
+#
+# A module here has to earn its option. The catalogue in data/services.nix
+# splits every entry into "plain" and "bundled" precisely so that most of them
+# never reach this directory: if turning something on is one upstream line, the
+# user's file gets that line and nixarchy declares nothing. RFC 42 makes the
+# argument -- copied options go stale, an upstream removal breaks the wrapper,
+# and an option cannot realistically be removed once it exists.
+#
+# What earns a module is integration a newcomer would not find alone. Syncthing
+# needs to know which user it runs as, and upstream cannot know that.
+#
+# ## The rules, which exist because Mode A is real
+#
+# Someone may add nixarchy to a machine they already run and already configure.
+# Everything here composes with configuration that is theirs and predates ours:
+#
+#   scalars, bools, enums   lib.mkDefault, always. Their plain definition
+#                           outranks ours and wins silently, which is the
+#                           correct outcome and the one they expect.
+#
+#   lists and attrsets      plain assignment. mkDefault on a merging type is a
+#                           silent bug: lower-priority definitions are dropped
+#                           BEFORE the merge, so our contribution disappears
+#                           the moment the user adds an element of their own.
+#
+#   mkForce                 never. It is a one-way door -- the user then needs
+#                           mkOverride 49 to get past us, and no error message
+#                           NixOS produces will ever tell them that.
+#
+# The failure this prevents is documented rather than hypothetical: disko #441
+# and home-manager #5870 are both a module setting a scalar at plain priority
+# and the user having to mkForce their own configuration to escape it.
+{
+  imports = [
+    ./syncthing.nix
+  ];
+}

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -1,0 +1,99 @@
+# Syncthing: folders kept in step between your own machines.
+#
+# Bundled rather than plain because `services.syncthing.enable = true` alone
+# gives you a daemon running as the `syncthing` user, syncing into
+# /var/lib/syncthing, which is not where anybody's files are. It has to run as
+# the person using the desktop, and upstream cannot know who that is -- this
+# module does, because nixarchy already asks.
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.nixarchy;
+  svc = cfg.services.syncthing;
+in
+{
+  options.programs.nixarchy.services.syncthing = {
+    enable = lib.mkEnableOption ''
+      Syncthing, running as the desktop user rather than as a system account.
+
+      The web interface is at http://127.0.0.1:8384 once it is up. Folders and
+      devices are configured there, or declaratively through upstream's own
+      `services.syncthing.settings` -- which works alongside this and is not
+      re-declared here, because upstream's option is better than a copy of it
+      would be
+    '';
+
+    user = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = cfg.user;
+      defaultText = lib.literalExpression "config.programs.nixarchy.user";
+      description = ''
+        Who Syncthing runs as. Defaults to the desktop user, which is the
+        answer in every case this module exists for.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = svc.enable;
+      defaultText = lib.literalExpression "config.programs.nixarchy.services.syncthing.enable";
+      description = ''
+        Open the ports Syncthing needs to reach your other machines: 22000 for
+        sync traffic and 21027 for discovery on the local network.
+
+        A separate option with its own default rather than a branch inside the
+        one above, so that a machine which syncs only over Tailscale can turn
+        this half off without turning Syncthing off.
+      '';
+    };
+  };
+
+  config = lib.mkIf (cfg.enable && svc.enable) (
+    lib.mkMerge [
+      {
+        assertions = [
+          {
+            assertion = svc.user != null;
+            message = ''
+              programs.nixarchy.services.syncthing is enabled but no user is set,
+              and a Syncthing that runs as a system account syncs a directory
+              nobody keeps files in.
+
+              Set programs.nixarchy.user, which is what this follows, or set
+              programs.nixarchy.services.syncthing.user directly.
+            '';
+          }
+        ];
+
+        # Scalars, so mkDefault: someone who already runs Syncthing their way
+        # keeps their configuration and this yields to it silently.
+        services.syncthing = {
+          enable = lib.mkDefault true;
+          user = lib.mkDefault svc.user;
+          dataDir = lib.mkDefault "/home/${svc.user}";
+          configDir = lib.mkDefault "/home/${svc.user}/.config/syncthing";
+
+          # NOT mkDefault. Upstream's default is true, and true here means
+          # "delete any folder or device the Nix configuration does not mention"
+          # -- which silently discards everything added through the web
+          # interface, the way most people actually use Syncthing.
+          overrideFolders = false;
+          overrideDevices = false;
+        };
+      }
+
+      # Lists, so plain assignment. mkDefault here would drop these entirely the
+      # moment the user opens a port of their own.
+      (lib.mkIf svc.openFirewall {
+        networking.firewall.allowedTCPPorts = [ 22000 ];
+        networking.firewall.allowedUDPPorts = [
+          22000
+          21027
+        ];
+      })
+    ]
+  );
+}

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -214,6 +214,33 @@ let
   # rather than about an option.
   vm = inputs.self.nixosConfigurations.vm.config.system.build.toplevel;
 
+  # ---- a bundled service yields to a user who already configured it ----
+  #
+  # This is the Mode A hazard in one assertion. Someone adds nixarchy to a
+  # machine they already run and already configure; if a module here sets a
+  # scalar at plain priority, they get "conflicting definition values" and
+  # their only escape is mkForce on their OWN configuration -- the burden
+  # backwards, and exactly what disko #441 and home-manager #5870 are.
+  #
+  # Evaluating at all is most of the proof: a priority clash is an evaluation
+  # error, so a regression here does not produce a wrong value, it produces a
+  # configuration that will not build. Reading the value back checks the other
+  # half, that ours yielded rather than merely tying.
+  syncthingBeside = configBeside {
+    programs.nixarchy = {
+      user = "someone";
+      services.syncthing.enable = true;
+    };
+    # What the user already had, at ordinary priority.
+    services.syncthing.dataDir = "/srv/sync";
+  };
+
+  # And the group the desktop user gets, which is the other half of #92: docker
+  # is enabled for every machine at nixos.nix:705 and was usable only on
+  # machines the installer built.
+  dockerGroups =
+    (configBeside { programs.nixarchy.user = "someone"; }).users.users.someone.extraGroups;
+
   # ---- the services catalogue is shaped the way the generator expects ----
   #
   # data/apps.nix has no schema check at all: it is read with `app ? field`
@@ -276,6 +303,8 @@ pkgs.runCommand "nixarchy-options"
     omarchyPath = "${(pkgs.extend inputs.self.overlays.default).omarchy}/share/omarchy";
     mapped = pkgs.lib.concatStringsSep " " mappedRows;
     serviceProblems = pkgs.lib.concatStringsSep "\n" serviceProblems;
+    syncthingDataDir = syncthingBeside.services.syncthing.dataDir;
+    dockerGroups = pkgs.lib.concatStringsSep " " dockerGroups;
     serviceCount = builtins.toString (builtins.length (builtins.attrNames services));
     notApps = pkgs.lib.concatStringsSep " " notApps;
     nativeBuildInputs = [ pkgs.python3 ];
@@ -291,6 +320,22 @@ pkgs.runCommand "nixarchy-options"
       ''
           echo "$report"
           echo "the services catalogue is well formed ($serviceCount entries)"
+
+          # ---- composition: the user's definition wins -------------------
+          [ "$syncthingDataDir" = "/srv/sync" ] || {
+            echo "a bundled service overrode a value the user had already set:" >&2
+            echo "  services.syncthing.dataDir is $syncthingDataDir, not /srv/sync" >&2
+            echo "every scalar a service module sets must be lib.mkDefault." >&2
+            exit 1
+          }
+          echo "a bundled service yields to configuration the user already had"
+
+          case " $dockerGroups " in
+            *" docker "*) echo "the desktop user can reach the docker socket" ;;
+            *) echo "docker is enabled but the desktop user is not in its group" >&2
+               echo "groups: $dockerGroups" >&2
+               exit 1 ;;
+          esac
           echo "every option adds what it should and removes it again"
 
           python3 ${./coverage.py}


### PR DESCRIPTION
Closes #92. Second piece of #90.

## Three of the four planned modules were not needed

The epic named docker, tailscale, printing and syncthing. Reading `modules/nixos.nix` first says otherwise:

```
virtualisation.docker.enable        mkDefault true   nixos.nix:705
services.printing.enable            mkDefault true   nixos.nix:634
services.avahi.{enable,nssmdns4}    mkDefault true   nixos.nix:635-639
```

Docker and printing-with-discovery are **already on for every nixarchy machine**. An option to "enable Docker" would have been an option that changes nothing, and a printing module would have duplicated config that already exists — the catalogue rot RFC 42 warns about, self-inflicted on day one. Both are dropped from `data/services.nix`, with a note at the top recording what is already enabled and where, so nobody re-adds them.

**Tailscale keeps its `data/apps.nix` entry for now.** Moving it means moving its menu row, and #94 is where service menu rows arrive; migrating here would take the row away from users in the meantime.

That leaves **syncthing**, which genuinely needs wrapping: enabled on its own it runs as a system account syncing `/var/lib/syncthing`, which is not where anybody's files are.

## The Docker gap this uncovered — a real defect

`nixos.nix:705` enables Docker for everyone. `nixos.nix:1011` granted the desktop user exactly one group, `input`. So on any machine **the installer did not build**, Docker was enabled and unusable — every command wanting `sudo`, `docker ps` answering *"permission denied while trying to connect to the Docker daemon socket"*, which reads like a broken install rather than a missing group.

`installer/host.nix` has always added `docker` directly, which is why this only ever hurt Mode A — someone adding nixarchy to a machine they already run. Fixed, conditioned on Docker actually being enabled so turning it off does not leave a group behind.

## The rules, written where the next module will read them

`modules/services/default.nix` carries them, because Mode A is real:

| | |
|---|---|
| scalars, bools, enums | `lib.mkDefault`, always |
| lists and attrsets | plain assignment — `mkDefault` on a merging type is a silent bug, since lower-priority definitions are dropped **before** the merge |
| `mkForce` | never — a one-way door; the user would need `mkOverride 49` and no error will tell them so |

One exception is marked as such: `overrideFolders` and `overrideDevices` are set plainly to `false`, because upstream defaults them **true**, and true means "delete any folder the Nix configuration does not mention" — silently discarding everything added through the web interface, which is how most people use Syncthing.

## Verified by breaking it

`checks.options` now asserts a user who already set `services.syncthing.dataDir` keeps their value. Removing one `mkDefault` produces exactly what a Mode A user would see:

```
error: The option `services.syncthing.dataDir' has conflicting definition values
```

and the check goes red. It also asserts the desktop user is in the `docker` group — which would have caught the defect above.

```
the services catalogue is well formed (5 entries)
a bundled service yields to configuration the user already had
the desktop user can reach the docker socket
```

## Not done here

No template rows, no menu entries, no `nixarchy-service-enable` — #93 and #94. Enabling syncthing today means writing the option into your configuration by hand, which is the same state `programs.nixarchy.localAi` has always been in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5