### PR TITLE
Three files to edit, one line to import

### DIFF
--- a/data/services.nix
+++ b/data/services.nix
@@ -48,6 +48,10 @@
 #
 # If one of those should become a choice rather than a default, that is a
 # change to nixos.nix and an announcement, not a row added here.
+#
+# Tailscale is also absent, for a different reason: data/apps.nix still owns
+# it, and moving it means moving its menu row, which is #94. Adding it here
+# first would generate a template line for an option that does not exist yet.
 {
   # ── Network ─────────────────────────────────────────────────────────────
   openssh = {
@@ -59,13 +63,6 @@
       "openssh"
     ];
     note = "Remote login. Opens port 22 and NixOS defaults to keys only, not passwords.";
-  };
-
-  tailscale = {
-    label = "Tailscale";
-    category = "Network";
-    kind = "bundled";
-    note = "A private network between your machines. Bundled because the firewall has to trust the interface or nothing reaches this host.";
   };
 
   # ── Hardware ────────────────────────────────────────────────────────────

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -193,6 +193,98 @@ let
     )
   );
 
+  # The catalogue from data/services.nix, as commented-out lines.
+  #
+  # Two shapes, because the catalogue has two kinds and the difference is the
+  # whole point. A "bundled" entry writes the nixarchy option, because nixarchy
+  # does something upstream does not. A "plain" entry writes the REAL upstream
+  # line -- `services.openssh.enable = true;` -- because there is nothing to
+  # add, and a nixarchy alias for a one-line toggle would only be a second
+  # vocabulary to unlearn the moment they read anyone else's configuration.
+  serviceCatalogue = import ../data/services.nix;
+
+  serviceRow =
+    name: svc:
+    let
+      suffix = if svc ? note then "  # ${svc.note}" else "";
+      line =
+        if svc.kind == "bundled" then
+          "programs.nixarchy.services.${name}.enable = true;"
+        else
+          "${lib.concatStringsSep "." svc.option}.${svc.optionAttr or "enable"} = true;";
+    in
+    "    # ${line}  #@ ${name}${suffix}\n";
+
+  serviceCategories = lib.unique (map (s: s.category) (lib.attrValues serviceCatalogue));
+
+  serviceCategoryBlock =
+    category:
+    let
+      rows = lib.filterAttrs (_: s: s.category == category) serviceCatalogue;
+      # A fixed rule rather than one padded to a column: the box-drawing
+      # character is three bytes and fixedWidthString counts bytes, so the
+      # arithmetic that looks right produces a negative width.
+      header = "    # ── ${category} ──────────────────────────────────────\n";
+    in
+    header + lib.concatStrings (lib.mapAttrsToList serviceRow rows) + "\n";
+
+  servicesTemplate = pkgs.writeText "nixarchy-services.nix" ''
+    # Services and system settings, as NixOS configuration.
+    #
+    # The companion to apps.nix. An app is a package; a service is a decision
+    # about the machine. Uncomment what you want -- or pick it from the menu --
+    # then run
+    #
+    #     nixarchy-apply
+    #
+    # Two kinds of line appear below and the difference is deliberate:
+    #
+    #   programs.nixarchy.services.X   nixarchy bundles several options here,
+    #                                  because turning the thing on usefully
+    #                                  takes more than one.
+    #
+    #   services.X.enable              the real NixOS option, because there was
+    #                                  nothing for nixarchy to add. This is the
+    #                                  line every wiki page will show you, and
+    #                                  it is the same line here.
+    #
+    # This file is a NixOS module and nothing stops you writing any option in
+    # it. Upstream's own settings work alongside ours -- if you enable
+    # syncthing below, `services.syncthing.settings.folders` still does what
+    # its documentation says.
+    #
+    # This file is yours. Nothing regenerates or overwrites it once created;
+    # the current full list is always at /etc/nixarchy/services-template.nix.
+    { ... }:
+    {
+    ${lib.concatStrings (map serviceCategoryBlock serviceCategories)}}
+  '';
+
+  # No catalogue, on purpose.
+  advancedTemplate = pkgs.writeText "nixarchy-advanced.nix" ''
+    # Anything at all.
+    #
+    # apps.nix is a list nixarchy generated and services.nix is a catalogue it
+    # curated. This file has neither, because at some point the answer to "how
+    # do I do X on NixOS" is a NixOS option nobody put on a list, and a curated
+    # desktop that has no room for that is a cage.
+    #
+    # It is an ordinary NixOS module. Every option in nixpkgs is available:
+    #
+    #   services.openssh.settings.PermitRootLogin = "no";
+    #   boot.kernelParams = [ "quiet" ];
+    #   users.users.you.extraGroups = [ "dialout" ];
+    #
+    # `nixarchy-search` writes here when you pick an option from it. Nothing
+    # else touches this file.
+    #
+    # If you find yourself writing the same thing here on every machine, that
+    # is worth an issue -- it probably belongs in the catalogue.
+    { ... }:
+    {
+    }
+  '';
+
   appsTemplate = pkgs.writeText "nixarchy-apps.nix" ''
     # Applications available through the Omarchy menu, as NixOS configuration.
     #
@@ -540,6 +632,8 @@ in
         # always diff their file against the current full list.
         environment.etc = {
           "nixarchy/apps-template.nix".source = appsTemplate;
+          "nixarchy/services-template.nix".source = servicesTemplate;
+          "nixarchy/advanced-template.nix".source = advancedTemplate;
           "nixarchy/omarchy-menu.jsonc".source = menuExtension;
         };
 
@@ -1212,12 +1306,72 @@ in
 
               # A flake cannot read a file outside its own tree, so the
               # selection is copied in rather than imported from $HOME.
-              if [ -f "$dest" ] && diff -q "$file" "$dest" >/dev/null; then
-                echo "$dest is already up to date."
+              #
+              # Three files now, into $flake/nixarchy/, with nixarchy-apps.nix
+              # left as a module that imports them. That last part is the whole
+              # reason for the indirection: the README has been telling people
+              # to add `imports = [ ./nixarchy-apps.nix ];` since the beginning,
+              # and on a machine nixarchy does not own, asking them to add two
+              # more lines is not a thing this project gets to do. The name they
+              # already wrote keeps working and gains two files behind it.
+              #
+              # Safe to overwrite because nixarchy-apps.nix has always been a
+              # copy this script regenerates, never something the user wrote --
+              # and the copy it used to hold is written to nixarchy/apps.nix in
+              # the same run, before the stub replaces it.
+              srcdir="''${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy"
+              mkdir -p "$flake/nixarchy"
+
+              imports=""
+              copied=""
+              for part in apps services advanced; do
+                src="$srcdir/$part.nix"
+                [ -f "$src" ] || continue
+                dst="$flake/nixarchy/$part.nix"
+                imports="$imports ./nixarchy/$part.nix"
+                if [ -f "$dst" ] && diff -q "$src" "$dst" >/dev/null; then
+                  continue
+                fi
+                cp "$src" "$dst"
+                copied="$copied $part"
+              done
+
+              # Only what exists is imported. A machine seeded before
+              # services.nix existed has two files, not three, and a stub
+              # importing a path that is not there fails to evaluate.
+              {
+                echo "# Generated by nixarchy-apply. Do not edit -- your files"
+                echo "# are ~/.config/nixarchy/{apps,services,advanced}.nix and"
+                echo "# this is regenerated from them on every apply."
+                echo "{"
+                echo "  imports = [$imports ];"
+                echo "}"
+              } >"$dest"
+
+              if [ -n "$copied" ]; then
+                echo "copied ->$copied"
               else
-                cp "$file" "$dest"
-                echo "copied selection -> $dest"
-                echo "(import it from your flake: imports = [ ./nixarchy-apps.nix ];)"
+                echo "$flake is already up to date."
+              fi
+
+              # Stage what was written, or a flake in a git worktree cannot see
+              # it. This is not a nicety: git makes untracked files invisible to
+              # the evaluator, so a fresh nixarchy/services.nix fails with "path
+              # does not exist" -- the trap installer/mkFlake.nix documents and
+              # the installer works around by staging at install time.
+              #
+              # Guarded: /etc/nixos is root-owned, and a failure to stage should
+              # print the fix rather than abort an apply that has already
+              # copied everything correctly.
+              if [ -e "$flake/.git" ]; then
+                git -C "$flake" add -A nixarchy nixarchy-apps.nix 2>/dev/null || {
+                  echo
+                  echo "NOTE: could not stage the copies in $flake."
+                  echo "  A flake in a git repository sees only tracked files,"
+                  echo "  so the rebuild may fail with \"path does not exist\"."
+                  echo "  Fix with: sudo git -C $flake add -A"
+                  echo
+                }
               fi
 
               # Whether anything in the flake actually imports it.

--- a/modules/home.nix
+++ b/modules/home.nix
@@ -568,12 +568,19 @@ in
                 # the user's picks, and clobbering it would silently undo them.
                 # /etc/nixarchy/apps-template.nix always holds the current full list,
                 # so a newly packaged app is discoverable with a diff against it.
+                # Three files now: apps.nix, services.nix and advanced.nix.
+                # Each seeded independently and only when absent, so a machine
+                # that predates the split gains the two new ones and keeps the
+                # apps.nix it already has.
                 run mkdir -p "${config.xdg.configHome}/nixarchy"
-                if [ ! -e "${config.xdg.configHome}/nixarchy/apps.nix" ] \
-                  && [ -e /etc/nixarchy/apps-template.nix ]; then
-                  run ${pkgs.coreutils}/bin/install -m600 /etc/nixarchy/apps-template.nix \
-                    "${config.xdg.configHome}/nixarchy/apps.nix"
-                fi
+                for part in apps services advanced; do
+                  if [ ! -e "${config.xdg.configHome}/nixarchy/$part.nix" ] \
+                    && [ -e "/etc/nixarchy/$part-template.nix" ]; then
+                    run ${pkgs.coreutils}/bin/install -m600 \
+                      "/etc/nixarchy/$part-template.nix" \
+                      "${config.xdg.configHome}/nixarchy/$part.nix"
+                  fi
+                done
 
                 # First-run theme. omarchy-theme-set is the only thing that may write
                 # this tree; running it headless avoids poking a shell that is not up.

--- a/tests/demo.nix
+++ b/tests/demo.nix
@@ -441,7 +441,8 @@ let
       # part of the flow this VM can actually complete, so it is the part
       # worth asserting.
       machine.succeed("test -f /etc/nixos/nixarchy-apps.nix")
-      print("selection reached /etc/nixos/nixarchy-apps.nix")
+      machine.succeed("test -f /etc/nixos/nixarchy/apps.nix")
+      print("selection reached /etc/nixos/nixarchy/apps.nix")
       print("=== preinstalled desktop applications ===")
       print(machine.succeed(
           "ls /run/current-system/sw/share/applications/ | head -40"))

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -284,6 +284,13 @@ let
         # row that says what a thing is called and nothing about what turning
         # it on costs.
         (need "no note" (svc ? note && svc.note != ""))
+        # #91 could not assert this: modules/services/ did not exist. It does
+        # now, and without this a bundled entry generates a template line for
+        # an option nobody declared -- which fails only when a user uncomments
+        # it, which is the worst moment to find out.
+        (need "kind=bundled needs modules/services/${id}.nix" (
+          (svc.kind or "") != "bundled" || builtins.pathExists ../modules/services/${id}.nix
+        ))
       ]
     ) services
   );

--- a/tests/session.nix
+++ b/tests/session.nix
@@ -167,8 +167,18 @@ pkgs.testers.runNixOSTest {
 
     # Answering "no" to the prompt asserts the copy, not a full rebuild.
     print(machine.succeed("su omarchy -c 'echo n | nixarchy-apply' 2>&1"))
-    machine.succeed("grep -q 'brave.enable' /etc/nixos/nixarchy-apps.nix")
-    print("selection reached /etc/nixos/nixarchy-apps.nix")
+    # Both halves of the layout, because either alone would pass while the
+    # machine was broken: the selection has to arrive in nixarchy/apps.nix,
+    # AND nixarchy-apps.nix has to import it. A copy nothing imports is the
+    # exact failure the warning in nixarchy-apply exists for -- apps marked
+    # enabled, a rebuild running to completion, and nothing installed.
+    machine.succeed("grep -q 'brave.enable' /etc/nixos/nixarchy/apps.nix")
+    machine.succeed("grep -q './nixarchy/apps.nix' /etc/nixos/nixarchy-apps.nix")
+    print("selection reached /etc/nixos/nixarchy/apps.nix, and the stub imports it")
+
+    # That the user's own configuration still imports nixarchy-apps.nix is
+    # asserted in tests/install.nix, on an installed machine that has a
+    # configuration.nix. This VM does not; its module comes from the flake.
 
     # ---- the greeter ---------------------------------------------------
     machine.wait_for_unit("display-manager.service")


### PR DESCRIPTION
Closes #93. Third piece of #90.

`~/.config/nixarchy/` gains `services.nix` and `advanced.nix` beside `apps.nix`. `apps.nix` is a generated list of one-line toggles; a service catalogue and arbitrary NixOS options do not belong in the same file.

## The import line does not multiply

`nixarchy-apply` copies the three into `$flake/nixarchy/` and leaves `nixarchy-apps.nix` as a module that imports them:

```nix
{ imports = [ ./nixarchy/apps.nix ./nixarchy/services.nix ./nixarchy/advanced.nix ]; }
```

**That indirection is the point of this change rather than a detail of it.** The README has told people to write `imports = [ ./nixarchy-apps.nix ];` since the beginning, and on a machine nixarchy does not own, asking them to add two more lines is not something this project gets to do. The name they already wrote keeps working and gains two files behind it.

Overwriting `nixarchy-apps.nix` is safe because it has always been a copy this script regenerates, never something the user wrote — and the content it held is written to `nixarchy/apps.nix` **in the same run**, before the stub replaces it.

**Verified by simulating a machine from before the split:**

```
=== the selection survived? ===
  YES - brave.enable is in nixarchy/apps.nix
=== user's import line untouched? ===
{ imports = [ ./nixarchy-apps.nix ]; }
=== everything staged ===
  M  nixarchy-apps.nix
  A  nixarchy/{advanced,apps,services}.nix
```

Only files that exist are imported, so a machine seeded before `services.nix` existed does not get a stub pointing at a missing path.

## Staging, which is not a nicety

A flake in a git worktree sees **only tracked files**, so a freshly copied `nixarchy/services.nix` is invisible to the evaluator and the rebuild fails with "path does not exist" — the trap `installer/mkFlake.nix:38-45` documents and the installer works around by staging at install time. `apply` now stages what it writes, guarded: `/etc/nixos` is root-owned, and failing to stage should print the fix rather than abort an apply that already copied everything correctly.

## The assertion #91 could not make

`modules/services/` did not exist then, so nothing checked that a **bundled** catalogue entry had a module. Writing the template generator produced exactly the bug that gap allows — the generated template offered:

```
# programs.nixarchy.services.tailscale.enable = true;
```

for an option nobody has declared. It fails only when a user uncomments it, which is the worst possible moment to find out. The check now asserts every bundled entry has `modules/services/<id>.nix`, and tailscale is out of the catalogue until #94 brings the module and its menu row together.

## The generated services template

```
# ── Desktop ──────────────
# services.flatpak.enable = true;  #@ flatpak  # For software nixpkgs does not carry...
# programs.nixarchy.services.syncthing.enable = true;  #@ syncthing  # Syncs folders...
# ── Hardware ─────────────
# hardware.graphics.enable32Bit = true;  #@ graphics32  # Wanted by Steam, Wine...
# ── Network ──────────────
# services.openssh.enable = true;  #@ openssh  # Remote login. Opens port 22...
```

The two kinds are visibly different, which is the intent: a **plain** entry shows the real upstream line, a **bundled** one shows nixarchy's.

## Not done here

No menu rows and no `nixarchy-service-enable` — #94. Enabling a service today means uncommenting the line by hand, which is what `apps.nix` was before its tooling existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5