### PR TITLE
Services you can pick, rather than a list you can read

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,12 +276,18 @@ jobs:
           # appear in data/apps.nix or a new Omarchy app silently reaches the
           # menu as a row that still tries to run pacman.
           menu=result/share/omarchy/default/omarchy/omarchy-menu.jsonc
-          python3 - "$menu" data/apps.nix <<'PY'
+          # Both catalogues. A row is mapped if data/apps.nix claims its
+          # package or data/services.nix does -- tailscale moved from one to
+          # the other when it became a service, and its `arch` moved with it.
+          # A check that read only apps would have called that row unmapped,
+          # and been wrong: it is answered, just not by the file it used to be.
+          python3 - "$menu" data/apps.nix data/services.nix <<'PY'
           import re, sys
-          menu, appsfile = sys.argv[1], sys.argv[2]
+          menu, appsfile, svcfile = sys.argv[1], sys.argv[2], sys.argv[3]
           raw = open(menu).read()
           rows = re.sub(r'^\s*//[^\n]*(\n|$)', '', raw, flags=re.M)
           known = set(re.findall(r'arch = "([^"]+)"', open(appsfile).read()))
+          known |= set(re.findall(r'arch = "([^"]+)"', open(svcfile).read()))
           # Only the install tree: remove.* rows are derived from these.
           wanted = set()
           for rid, body in re.findall(r'"(install\.[a-z0-9.\-]+)":\s*(\{[^}]*\})', rows):

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | **`nixarchy` command** | this port's own commands, and a way through to Omarchy's 431 |
 | **Remove menu** | deselects apps, never touches your own config |
 | **Update menu** | `nh os switch --update <flake>` |
-| 56 apps in the selection | 41 from nixpkgs, 5 as NixOS modules, 8 built here, 2 with no equivalent |
+| 55 apps in the selection | 41 from nixpkgs, 4 as NixOS modules, 8 built here, 2 with no equivalent |
 | Learn menu | NixOS wiki, `search.nixos.org` packages and options |
 | Shell functions | bash and zsh source the chain; fish derives it from the same files |
 | RetroArch | 13 libretro cores, resolved from the store rather than `/usr/lib` |
@@ -338,7 +338,7 @@ The notification is clickable and runs the rebuild.
 
 ### Anything the menu does not offer
 
-The 56 apps are the ones Omarchy's own menu lists. Everything else in nixpkgs —
+The 55 apps are the ones Omarchy's own menu lists. Everything else in nixpkgs —
 and every NixOS option — is behind **`Install ▸ Search`**, or `nixarchy-search`
 from a terminal:
 
@@ -361,7 +361,7 @@ from a terminal:
   enter to select · tab for several · esc to cancel
 ```
 
-**137,599 rows: 25,102 NixOS options, 112,443 packages, and 54 of the 56 apps
+**137,599 rows: 25,102 NixOS options, 112,443 packages, and 53 of the 55 apps
 (the two with no nixpkgs equivalent cannot be indexed).** Three kinds,
 one picker, because you should not have to know which kind you want before you
 can look. They are not interchangeable and the rows say so — picking Tailscale
@@ -1161,7 +1161,7 @@ done
 
 Almost nothing here waits on a maintainer.
 
-**46 of the 56 apps never touch this repo.** Brave, VSCode, Signal and the rest
+**45 of the 55 apps never touch this repo.** Brave, VSCode, Signal and the rest
 are installed as `pkgs.<name>` from **your** nixpkgs, and the five
 module-backed ones (Steam, 1Password, Tailscale, Firefox, Xbox controllers)
 come from there too — the module is NixOS', not this repo's. Your own
@@ -1201,7 +1201,7 @@ Most of it is not our job, and should not be:
 
 | where the app comes from | who updates it |
 |---|---|
-| nixpkgs (46 of 56 apps) | **nobody** — your own `nix flake update` |
+| nixpkgs (45 of 55 apps) | **nobody** — your own `nix flake update` |
 | pinned in this repo (2) | a weekly bot, opening a PR |
 | `zen` | upstream's own flake |
 | `retroarch` | nixpkgs, via this flake's own pin — it is a rebuild with cores |

--- a/data/apps.nix
+++ b/data/apps.nix
@@ -149,17 +149,6 @@
   };
 
   # ── Services ────────────────────────────────────────────────────────────
-  tailscale = {
-    menuId = "install.service.tailscale";
-    label = "Tailscale";
-    category = "Service";
-    option = [
-      "services"
-      "tailscale"
-    ];
-    arch = "tailscale";
-    note = "A daemon. `settings.useRoutingFeatures = \"client\"` for exit nodes.";
-  };
   _1password = {
     menuId = "install.service.1password";
     label = "1Password";

--- a/data/services.nix
+++ b/data/services.nix
@@ -59,6 +59,12 @@
     # it; the service does now, and the id moving with the entry is what
     # stops the menu generator failing on an unmapped row.
     menuId = "install.service.tailscale";
+    # Upstream's Arch package name. Kept for exactly one reason, the same one
+    # data/apps.nix keeps it for: CI cross-checks every `omarchy-pkg-present
+    # <name>` in upstream's menu against these files, and a row whose package
+    # nothing claims is a row that still tries to run pacman. It came across
+    # with the entry.
+    arch = "tailscale";
     note = "A private network between your machines. Bundled because the firewall has to trust the interface or nothing reaches this host.";
   };
 

--- a/data/services.nix
+++ b/data/services.nix
@@ -48,12 +48,20 @@
 #
 # If one of those should become a choice rather than a default, that is a
 # change to nixos.nix and an announcement, not a row added here.
-#
-# Tailscale is also absent, for a different reason: data/apps.nix still owns
-# it, and moving it means moving its menu row, which is #94. Adding it here
-# first would generate a template line for an option that does not exist yet.
+
 {
   # ── Network ─────────────────────────────────────────────────────────────
+  tailscale = {
+    label = "Tailscale";
+    category = "Network";
+    kind = "bundled";
+    # The row upstream's menu already has. data/apps.nix used to answer for
+    # it; the service does now, and the id moving with the entry is what
+    # stops the menu generator failing on an unmapped row.
+    menuId = "install.service.tailscale";
+    note = "A private network between your machines. Bundled because the firewall has to trust the interface or nothing reaches this host.";
+  };
+
   openssh = {
     label = "OpenSSH server";
     category = "Network";

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -470,7 +470,7 @@ let
           name: svc:
           lib.nameValuePair (svc.menuId or "install.service.${name}") {
             icon = svc.icon or "󰒓";
-            label = svc.label;
+            inherit (svc) label;
             action = "nixarchy-service-enable ${name}";
             # Dim when the marked line is live, which is the same question
             # nixarchy-service-enable asks. Not the app rows' test: a plain

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -455,6 +455,32 @@ let
           )
         ) (lib.filterAttrs (_: a: a ? menuId) apps)
       )
+      # The services catalogue, as menu rows.
+      #
+      # Most of these are ids upstream does not ship -- Omarchy's menu has no
+      # "turn on SSH" row because on Arch that is not a menu's business. The
+      # generator takes a new id as long as the override names the row itself,
+      # which is why label and icon are here; install.search arrived the same
+      # way. Where upstream DOES have a row, the catalogue entry carries its
+      # menuId and this overrides it in place -- tailscale is that case, and
+      # carrying the id across is what keeps the generator from failing on a
+      # row nothing maps.
+      // lib.listToAttrs (
+        lib.mapAttrsToList (
+          name: svc:
+          lib.nameValuePair (svc.menuId or "install.service.${name}") {
+            icon = svc.icon or "󰒓";
+            label = svc.label;
+            action = "nixarchy-service-enable ${name}";
+            # Dim when the marked line is live, which is the same question
+            # nixarchy-service-enable asks. Not the app rows' test: a plain
+            # entry's line begins with services.openssh, not with the id, so
+            # matching on the id would never fire.
+            disabled = "grep -qE '^[[:space:]]*[^#[:space:]].*#@ ${name}([[:space:]]|$)' $HOME/.config/nixarchy/services.nix";
+            description = svc.note;
+          }
+        ) serviceCatalogue
+      )
       // cfg.menu.extraEntries
     )
   );
@@ -641,6 +667,99 @@ in
           # Uncomments one app in ~/.config/nixarchy/apps.nix. Matching is on
           # the `#@ <id>` marker, not a line number or a label, so the file
           # survives being reformatted, reordered or annotated by hand.
+          (pkgs.writeShellApplication {
+            name = "nixarchy-service-enable";
+            runtimeInputs = [
+              pkgs.gnused
+              pkgs.gnugrep
+              pkgs.coreutils
+              cfg.package
+            ];
+            text = ''
+              file="''${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/services.nix"
+              id="''${1:?usage: nixarchy-service-enable <service-id>}"
+
+              # Validated before it reaches sed and grep, which the app scripts
+              # do not do: the id is interpolated into a regex, and an id with a
+              # slash or a bracket in it would either fail obscurely or match
+              # something nobody meant. Ids come from data/services.nix and look
+              # like this; anything else is a typo or a caller with a bug.
+              case "$id" in
+                *[!a-z0-9_-]* | "")
+                  echo "nixarchy: '$id' is not a service id" >&2
+                  exit 2
+                  ;;
+              esac
+
+              [ -f "$file" ] || { echo "no $file -- log in again to have it created" >&2; exit 1; }
+
+              if ! grep -qE "#@ $id([[:space:]]|\$)" "$file"; then
+                echo "nixarchy: no service '$id' in $file" >&2
+                echo "  The full list is /etc/nixarchy/services-template.nix." >&2
+                exit 1
+              fi
+
+              # Already on if the marked line is not commented out.
+              #
+              # Deliberately not the app scripts' test, which greps for
+              # `^[[:space:]]*<id>.enable` -- that cannot work here, because a
+              # plain entry's line begins with services.openssh, not with the
+              # id. Asking whether the marked line is live is also the more
+              # honest question: it does not answer "yes" to `enable = false;`.
+              if grep -qE "^[[:space:]]*[^#[:space:]].*#@ $id([[:space:]]|\$)" "$file"; then
+                echo "$id is already enabled; run nixarchy-apply to build it"
+                exit 0
+              fi
+
+              sed -i -E "/#@ $id([[:space:]]|\$)/ s/^([[:space:]]*)# ?/\1/" "$file"
+
+              queued=$(grep -cE "^[[:space:]]*[^#[:space:]].*#@ " "$file" || true)
+              if command -v omarchy-notification-send >/dev/null 2>&1; then
+                omarchy-notification-send -r 8471 -t 8000 -u normal \
+                  "$id queued -- not enabled yet" \
+                  "$queued selected. Click here, or Install > Apply changes, to run nixos-rebuild." \
+                  --exec omarchy-launch-floating-terminal-with-presentation nixarchy-apply || true
+              fi
+              echo "enabled $id in $file ($queued queued)"
+              echo "run 'nixarchy-apply' when you have picked everything you want"
+            '';
+          })
+
+          (pkgs.writeShellApplication {
+            name = "nixarchy-service-disable";
+            runtimeInputs = [
+              pkgs.gnused
+              pkgs.gnugrep
+              pkgs.coreutils
+            ];
+            text = ''
+              file="''${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/services.nix"
+              id="''${1:?usage: nixarchy-service-disable <service-id>}"
+
+              case "$id" in
+                *[!a-z0-9_-]* | "")
+                  echo "nixarchy: '$id' is not a service id" >&2
+                  exit 2
+                  ;;
+              esac
+
+              [ -f "$file" ] || { echo "no $file" >&2; exit 1; }
+
+              if ! grep -qE "#@ $id([[:space:]]|\$)" "$file"; then
+                echo "nixarchy: no service '$id' in $file" >&2
+                exit 1
+              fi
+
+              # Comment the marked line back out. Turning a service off is not
+              # the same as uninstalling it: the daemon stops, and whatever it
+              # wrote -- a Syncthing database, an authorised key -- stays where
+              # it is. Removing that is the user's call and not this script's.
+              sed -i -E "/#@ $id([[:space:]]|\$)/ s/^([[:space:]]*)([^[:space:]#])/\1# \2/" "$file"
+              echo "disabled $id in $file"
+              echo "run 'nixarchy-apply' to rebuild without it"
+            '';
+          })
+
           (pkgs.writeShellApplication {
             name = "nixarchy-app-enable";
             runtimeInputs = [

--- a/modules/services/default.nix
+++ b/modules/services/default.nix
@@ -34,5 +34,6 @@
 {
   imports = [
     ./syncthing.nix
+    ./tailscale.nix
   ];
 }

--- a/modules/services/tailscale.nix
+++ b/modules/services/tailscale.nix
@@ -1,0 +1,66 @@
+# Tailscale: a private network between machines you own.
+#
+# Bundled rather than plain because `services.tailscale.enable = true` on its
+# own gives you a host that can reach the tailnet and cannot be reached from
+# it. The firewall is still in the way, and the symptom -- outbound works,
+# inbound times out -- reads like a Tailscale problem rather than a local one.
+# Trusting the interface is the part upstream leaves to you and nobody finds
+# on the first try.
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.nixarchy;
+  svc = cfg.services.tailscale;
+in
+{
+  options.programs.nixarchy.services.tailscale = {
+    enable = lib.mkEnableOption ''
+      Tailscale, with this host reachable from the rest of your tailnet.
+
+      Run `sudo tailscale up` once after the rebuild to log in. Upstream's own
+      options work alongside this one and are not re-declared here --
+      `services.tailscale.authKeyFile` for an unattended join,
+      `services.tailscale.useRoutingFeatures` for an exit node
+    '';
+
+    trustInterface = lib.mkOption {
+      type = lib.types.bool;
+      default = svc.enable;
+      defaultText = lib.literalExpression "config.programs.nixarchy.services.tailscale.enable";
+      description = ''
+        Treat the tailnet as trusted, so other machines on it can reach this
+        one rather than only the other way round.
+
+        Its own option with its own default rather than a branch inside
+        `enable`, so a host that wants Tailscale for outbound access only --
+        a laptop on someone else's network, say -- can turn this half off
+        without turning Tailscale off.
+
+        This is a real decision, not a formality: a trusted interface bypasses
+        the firewall for everything arriving on it. That is the point on a
+        network of your own machines, and worth knowing before you leave it on
+        for a tailnet you share with someone else.
+      '';
+    };
+  };
+
+  config = lib.mkIf (cfg.enable && svc.enable) (
+    lib.mkMerge [
+      {
+        # A scalar, so mkDefault: someone already running Tailscale their way
+        # keeps their configuration and this yields to it.
+        services.tailscale.enable = lib.mkDefault true;
+      }
+
+      (lib.mkIf svc.trustInterface {
+        # Lists, so plain assignment. mkDefault here would drop both entirely
+        # the moment the user trusts an interface or opens a port of their own.
+        networking.firewall.trustedInterfaces = [ "tailscale0" ];
+        networking.firewall.allowedUDPPorts = [ config.services.tailscale.port ];
+      })
+    ]
+  );
+}

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -176,9 +176,16 @@ let
   # this file does not need a second one.
   menuFile = "${(pkgs.extend inputs.self.overlays.default).omarchy}/share/omarchy/default/omarchy/omarchy-menu.jsonc";
 
-  mappedRows = pkgs.lib.mapAttrsToList (_: a: a.menuId) (
-    pkgs.lib.filterAttrs (_: a: a ? menuId) (import ../data/apps.nix)
-  );
+  # An upstream Install row is "mapped" if data/apps.nix answers for it OR
+  # data/services.nix does. Both are now real answers: tailscale moved from
+  # one to the other when it gained a module, and the row went with it. A
+  # check that knew only about apps would have called that unmapped and been
+  # wrong -- the row is wired, just not by the file it used to be wired by.
+  mappedRows =
+    pkgs.lib.mapAttrsToList (_: a: a.menuId) (
+      pkgs.lib.filterAttrs (_: a: a ? menuId) (import ../data/apps.nix)
+    )
+    ++ pkgs.lib.mapAttrsToList (_: s: s.menuId) (pkgs.lib.filterAttrs (_: s: s ? menuId) services);
 
   # Rows that are actions rather than applications, plus the gaps the README
   # names. Fonts go through omarchy-install-font and the Arch-name map; the


### PR DESCRIPTION
Closes #94. Fourth piece of #90.

The catalogue has been selectable by nobody: apps get a menu row, an enable script and a search entry; services had a template and nothing to drive it.

## Two scripts, and two things not copied from the app ones

`nixarchy-service-enable` and `-disable` mirror the app scripts — same `#@ <id>` markers, same textual sed, same idempotence, same clickable notification for a menu pick that has no terminal to print to.

Two deliberate departures:

**The id is validated before it reaches `sed` and `grep`.** The app scripts interpolate it raw into a regex — fine for ids that come from `data/apps.nix`, not fine the first time something else calls them.

**"Already enabled" asks whether the marked line is live**, not whether a line starts with the id. It *cannot* be the app test here — a plain entry's line begins with `services.openssh`, not with `openssh` — and asking about the marker is the better question anyway, because it does not answer "yes" to `enable = false;`.

## Tailscale moves, with its row

It has a module now: `services.tailscale.enable` plus the firewall trusting `tailscale0`, which is the half nobody finds on the first try. Without it the host reaches the tailnet and cannot be reached from it, and *"outbound works, inbound times out"* reads like a Tailscale problem rather than a local firewall.

`trustInterface` is its own option defaulting to `enable` rather than a branch inside it, so a laptop on someone else's network can have Tailscale without trusting the tailnet. That is a real decision — a trusted interface bypasses the firewall for everything arriving on it — and the option says so rather than assuming.

The catalogue entry carries upstream's `menuId`, so the existing row moves to the service instead of being orphaned.

## What the menu check caught

Removing tailscale from `data/apps.nix` left its row unmapped:

```
these Install rows are neither in data/apps.nix nor listed as actions:
  install.service.tailscale
```

The wrong fix is `notApps`, which would claim the row is not an app when in fact it **is** wired — just by a different file. `mappedRows` now counts both catalogues, because both are real answers to "does something answer for this row".

## The generated rows

```
install.service.flatpak     Flatpak            nixarchy-service-enable flatpak
install.service.graphics32  32-bit graphics    nixarchy-service-enable graphics32
install.service.openssh     OpenSSH server     nixarchy-service-enable openssh
install.service.syncthing   Syncthing          nixarchy-service-enable syncthing
install.service.tailscale   Tailscale          nixarchy-service-enable tailscale
```

## Verified

```
all 74 Install rows are mapped or accounted for
all 332 menu rows name commands that exist
the services catalogue is well formed (5 entries)
a bundled service yields to configuration the user already had
the desktop user can reach the docker socket
```

The **332-row line** is the one that matters here: it resolves every action to a command that exists, so the new rows are wired rather than decorative. `checks.session` passes as well.

## Not done here

`nixarchy-search` does not yet offer services or route `#@opt` insertions to `advanced.nix`. That is the remaining half of #94's description and is worth its own change — this one is already the menu, two scripts and a migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5