### PR TITLE
A release short enough to finish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,13 @@ concurrency:
 
 jobs:
   iso:
-    name: build, verify and publish the ISO
+    name: build and publish the ISO
     runs-on: [self-hosted, nixos, kvm, big]
-    # The ISO build, then an install from it, then splitting and uploading
-    # 5.6 GB. nightly.yml allows 180 minutes for the first two.
-    timeout-minutes: 300
+    # Two ISO builds, then splitting and uploading 5.6 GB. Was 300 minutes
+    # when this also installed from the image; that step moved to the nightly,
+    # and a smaller window is part of the point -- a job that cannot finish in
+    # ninety minutes has gone wrong rather than gone slowly.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v5
 
@@ -68,11 +70,31 @@ jobs:
       - name: Build the network ISO
         run: nix build .#iso-net --out-link result-net --print-build-logs
 
-      # The image nobody boots is the image that does not boot. This is the
-      # same check the nightly runs, against the same expression, so it costs
-      # an hour and buys the only guarantee that matters on a release page.
-      - name: Install from it, with no network device present
-        run: nix build .#checks.x86_64-linux.install-iso --no-link --print-build-logs
+      # checks.install-iso is deliberately NOT here, and the reasoning is
+      # about survivability rather than about trusting the image less.
+      #
+      # It boots the 5.6 GB image and installs a desktop from it, which takes
+      # about an hour, and it ran here because "the image nobody boots is the
+      # image that does not boot". That argument is right and this still holds
+      # it: the nightly runs the same check, against the same expression, on
+      # the same machine.
+      #
+      # What changed is the measured cost of a long release. On 2026-09-01 two
+      # release attempts died before publishing anything -- one when a deploy
+      # restarted the runner mid-job, one when both runners lost their
+      # connection to GitHub while p510 carried on building (the runner
+      # afterwards logged the job as Succeeded, eight minutes after GitHub had
+      # given up on it). Neither was a fault in the image or in this workflow.
+      # A four-hour job is simply a large target: anything that interrupts it
+      # discards four hours and publishes nothing.
+      #
+      # Twenty minutes of building is a target small enough to hit. The image
+      # is still install-tested every night, and a tag is cut from a commit
+      # that has been on main -- so in practice the ISO published here is one
+      # the nightly has already booted.
+      #
+      # If that stops being true -- if tags start being cut faster than
+      # nightlies run -- this decision is worth revisiting.
 
       - name: Split it into pieces GitHub will accept
         id: split


### PR DESCRIPTION
`release.yml` ran `checks.install-iso` before publishing, on the reasoning that *the image nobody boots is the image that does not boot*. That argument is right and this change still holds it — **the nightly runs the same check, against the same expression, on the same machine.**

What changed is the measured cost of being a four-hour job.

## Two release attempts died today, neither from a fault in the image

| tag | what happened |
|---|---|
| `v4.0.1-3` | killed at the install step when a deploy restarted the runner unit mid-job. Activation restarts the service; the service takes its job with it. |
| `v4.0.1-4` | both runners lost their connection to GitHub at 14:35 while p510 carried on building. GitHub marked the run failed — the runner logged `Job install completed with result: Succeeded` **eight minutes later**. No link event, no OOM, no crash; the machine never noticed. |

A four-hour job is a large target. Anything that interrupts it discards four hours and publishes nothing, and today that happened twice for two unrelated reasons. **Twenty minutes of building is a target small enough to hit.**

## The image does not become less tested

`checks.install-iso` runs nightly, and a tag is cut from a commit that has been on main — so in practice the ISO published from a tag is one the nightly has already booted and installed from. The comment left in the file says to revisit this if tags ever start being cut faster than nightlies run.

## Also

- `timeout-minutes` 300 → 90. A job that cannot finish in ninety minutes has gone wrong rather than gone slowly.
- The job is no longer called "verify". What it verifies now is that the tag names the Omarchy the flake vendors — a different and much smaller claim, and the name should say so.

## Note on the current run

`v4.0.1-4` is still executing under the old workflow and is unaffected by this. If it publishes, good; if it is interrupted again, the re-run picks up this version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5