### PR TITLE
Tell people what the catalogue learned since they installed

### DIFF
--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -667,6 +667,124 @@ in
           # Uncomments one app in ~/.config/nixarchy/apps.nix. Matching is on
           # the `#@ <id>` marker, not a line number or a label, so the file
           # survives being reformatted, reordered or annotated by hand.
+          # What the catalogue offers that your file has never heard of.
+          #
+          # The seeded files are written once and never touched again, which is
+          # correct -- they are the user's, and overwriting one would silently
+          # undo a selection. The consequence is that an entry added after a
+          # machine was installed never appears on it: no `#@` marker, so
+          # nixarchy-app-enable answers "no app 'x' in $file" and the menu row
+          # is dead. Until now the only way to find that out was to diff
+          # against /etc/nixarchy/apps-template.nix by hand, and nothing said
+          # so.
+          (pkgs.writeShellApplication {
+            name = "nixarchy-catalogue-diff";
+            runtimeInputs = [
+              pkgs.gnugrep
+              pkgs.gnused
+              pkgs.coreutils
+            ];
+            text = ''
+              add=false
+              case "''${1:-}" in
+                --add) add=true ;;
+                "") ;;
+                *)
+                  echo "usage: nixarchy-catalogue-diff [--add]" >&2
+                  exit 2
+                  ;;
+              esac
+
+              dir="''${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy"
+              total=0
+
+              for part in apps services advanced; do
+                user="$dir/$part.nix"
+                tpl="/etc/nixarchy/$part-template.nix"
+                [ -f "$user" ] && [ -f "$tpl" ] || continue
+
+                # Compared by marker, never by line: the file's own header
+                # invites reformatting, reordering and annotating, so anything
+                # positional would report a file somebody had tidied as full of
+                # holes. A marker with a space after #@ is a catalogue row; the
+                # others -- #@pkg, #@opt, #@pkgs-begin -- are the user's own and
+                # a template never has them.
+                missing=$(
+                  comm -23 \
+                    <(grep -oE "#@ [a-z0-9_.-]+" "$tpl" | sort -u) \
+                    <(grep -oE "#@ [a-z0-9_.-]+" "$user" | sort -u)
+                )
+                [ -n "$missing" ] || continue
+
+                count=$(printf '%s\n' "$missing" | grep -c . || true)
+                total=$((total + count))
+                echo "$part.nix is missing $count:"
+
+                rows=""
+                while IFS= read -r marker; do
+                  [ -n "$marker" ] || continue
+                  echo "  ''${marker#\#@ }"
+                  row=$(grep -F -- "$marker" "$tpl" | head -1)
+                  # App rows are written relative to programs.nixarchy.apps,
+                  # which they sit inside in the template. Appended at the end
+                  # of a file they would be outside it -- harmless while
+                  # commented and broken the moment somebody uncommented one.
+                  # Written in full they are correct wherever they land. A
+                  # second `programs.nixarchy.apps = { }` block would not be:
+                  # two definitions of one attribute in one set is an error,
+                  # not a merge.
+                  if [ "$part" = apps ]; then
+                    row=$(printf '%s' "$row" |
+                      sed -E "s/^([[:space:]]*#[[:space:]]*)/\1programs.nixarchy.apps./")
+                  fi
+                  rows="$rows$row
+              "
+                done <<MARKERS
+              $missing
+              MARKERS
+
+                if [ "$add" = true ]; then
+                  # Before the module's closing brace, not after it. Appending
+                  # to the end of the file puts the rows outside the attrset,
+                  # where they parse -- they are comments -- and stop parsing
+                  # the moment somebody uncomments one, because that is content
+                  # after the final `}`. Which is the same trap the full-path
+                  # rewrite above exists to avoid, one line further down.
+                  close=$(grep -n "^}" "$user" | tail -1 | cut -d: -f1)
+                  if [ -z "$close" ]; then
+                    echo "  $user has no closing brace on its own line;" >&2
+                    echo "  add these by hand rather than let this guess:" >&2
+                    printf '%s' "$rows" >&2
+                    continue
+                  fi
+                  tmp=$(mktemp)
+                  head -n "$((close - 1))" "$user" >"$tmp"
+                  {
+                    echo ""
+                    echo "  # ── Added by nixarchy-catalogue-diff, $(date +%Y-%m-%d) ──"
+                    printf '%s' "$rows"
+                  } >>"$tmp"
+                  tail -n "+$close" "$user" >>"$tmp"
+                  cat "$tmp" >"$user"
+                  rm -f "$tmp"
+                  echo "  appended to $user"
+                fi
+              done
+
+              if [ "$total" -eq 0 ]; then
+                echo "your files have everything the catalogue offers"
+                exit 0
+              fi
+
+              if [ "$add" = false ]; then
+                echo ""
+                echo "Run 'nixarchy-catalogue-diff --add' to append these as"
+                echo "commented-out lines. Nothing you have written changes:"
+                echo "only new lines, at the end, under a dated heading."
+              fi
+            '';
+          })
+
           (pkgs.writeShellApplication {
             name = "nixarchy-service-enable";
             runtimeInputs = [


### PR DESCRIPTION
Closes #95. Last piece of #90.

**Stacked on #100** — merge that first, and this retargets to main automatically.

`modules/home.nix:550-559` seeds each file **once** and never touches it again. That is correct: the files are the user's, and overwriting one would silently undo a selection.

The consequence is not correct at all. An entry added to a catalogue today never appears on a machine installed yesterday — no `#@` marker, so `nixarchy-app-enable` answers *"no app 'x' in $file"* and the menu row is dead. The only way to find out was to diff against `/etc/nixarchy/apps-template.nix` by hand, and nothing said so.

Three catalogues instead of one makes that three times as likely to bite, which is why it belongs with the epic rather than after it.

## Compared by marker, never by line

The generated file's own header invites reformatting, reordering and annotating. Anything positional would report a file somebody had tidied as full of holes.

## Two things that took looking at the output to get right

**Appended rows are written in full** — `programs.nixarchy.apps.zed.enable` rather than `zed.enable`. Template rows sit inside a `programs.nixarchy.apps = { }` block; appended elsewhere they would be outside it. A second block would not work either — two definitions of one attribute in one set is an error, not a merge.

**And they go before the module's closing brace.** My first version appended to the end of the file, which put them *after* it:

```nix
}                                    ← the module closes here

  # ── Added by nixarchy-catalogue-diff ──
    # programs.nixarchy.apps.helix.enable = true;
```

That parses — they are comments — and stops parsing the moment somebody uncomments one, because it is content after the final `}`. The same trap the full-path rewrite exists to avoid, reintroduced one line further down, and only visible by reading what the tool actually wrote.

## Verified against a stale file

A user file holding one entry, reordered and annotated, against a template holding three:

```
apps.nix is missing 2:
  helix
  zed
```

- both found **by marker**, despite the reordering
- `--add` put them inside the module, in full-path form
- **uncommenting an appended row still parses** — the property that matters
- a second run: `your files have everything the catalogue offers`
- the user's own comment is still there

## Not done

Surfacing the count from `nixarchy-doctor`, and having `nixarchy-app-enable`'s "no app 'x'" error name this command. Both are one-liners against a tool that now exists, and both are better in a change that can be reviewed for wording rather than mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5