### PR TITLE
Ollama the user already runs is theirs, not ours

### DIFF
--- a/modules/local-ai.nix
+++ b/modules/local-ai.nix
@@ -43,7 +43,13 @@ let
   # Read by modules/home.nix, which writes the agents' provider files: only it
   # knows where a user's home is. Exposed rather than recomputed there so the
   # address the server binds and the address the agents dial cannot drift.
-  endpoint = "http://${aiCfg.host}:${toString aiCfg.port}/v1";
+  #
+  # Read back off services.ollama rather than off our own options, because ours
+  # are only a default now: a host that already set services.ollama.port keeps
+  # its port, and the agents have to follow the server to wherever it actually
+  # listens.
+  ollamaCfg = config.services.ollama;
+  endpoint = "http://${ollamaCfg.host}:${toString ollamaCfg.port}/v1";
 
 in
 {
@@ -250,10 +256,21 @@ in
       package = ollamaPackage;
     };
 
+    # Defaults, not decisions. Someone who adds nixarchy to a machine that
+    # already runs Ollama would otherwise get "conflicting definition values"
+    # for merely importing this module, and their only escape would be mkForce
+    # on their OWN configuration -- the burden backwards.
+    #
+    # The scalars take lib.mkDefault. loadModels and environmentVariables do
+    # NOT, deliberately: they are listOf str and attrsOf str, which merge, and
+    # mkDefault on a merging type is a silent bug -- the lower priority is
+    # dropped before the merge, so our contribution would vanish the moment the
+    # user names a model or an environment variable of their own.
     services.ollama = {
-      enable = true;
-      package = ollamaPackage;
-      inherit (aiCfg) host port;
+      enable = lib.mkDefault true;
+      package = lib.mkDefault ollamaPackage;
+      host = lib.mkDefault aiCfg.host;
+      port = lib.mkDefault aiCfg.port;
       loadModels = lib.optional aiCfg.pullModel aiCfg.model;
 
       environmentVariables = {

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -242,6 +242,23 @@ let
     services.syncthing.dataDir = "/srv/sync";
   };
 
+  # The same hazard for the module that bundles Ollama (#96). Worth its own
+  # case rather than trusting the syncthing one: local-ai sets four upstream
+  # scalars, and the two options it deliberately leaves at plain priority --
+  # loadModels and environmentVariables -- merge, so a well-meant mkDefault
+  # there would drop our contribution the moment the user names one of their
+  # own. Reading the port back proves the scalars yield; reading the resolved
+  # endpoint proves the agents follow the server to the port that won, rather
+  # than dialling the one we asked for and nobody is listening on.
+  ollamaBeside = configBeside {
+    programs.nixarchy.localAi = {
+      enable = true;
+      allowCpu = true;
+    };
+    # What the user already had, at ordinary priority.
+    services.ollama.port = 21434;
+  };
+
   # And the group the desktop user gets, which is the other half of #92: docker
   # is enabled for every machine at nixos.nix:705 and was usable only on
   # machines the installer built.
@@ -318,6 +335,8 @@ pkgs.runCommand "nixarchy-options"
     mapped = pkgs.lib.concatStringsSep " " mappedRows;
     serviceProblems = pkgs.lib.concatStringsSep "\n" serviceProblems;
     syncthingDataDir = syncthingBeside.services.syncthing.dataDir;
+    ollamaPort = builtins.toString ollamaBeside.services.ollama.port;
+    ollamaEndpoint = ollamaBeside.programs.nixarchy.localAi.resolved.endpoint;
     dockerGroups = pkgs.lib.concatStringsSep " " dockerGroups;
     serviceCount = builtins.toString (builtins.length (builtins.attrNames services));
     notApps = pkgs.lib.concatStringsSep " " notApps;
@@ -343,6 +362,19 @@ pkgs.runCommand "nixarchy-options"
             exit 1
           }
           echo "a bundled service yields to configuration the user already had"
+
+          [ "$ollamaPort" = "21434" ] || {
+            echo "local-ai overrode a port the user had already set:" >&2
+            echo "  services.ollama.port is $ollamaPort, not 21434" >&2
+            echo "enable, package, host and port must all be lib.mkDefault." >&2
+            exit 1
+          }
+          [ "$ollamaEndpoint" = "http://127.0.0.1:21434/v1" ] || {
+            echo "the agents were pointed somewhere the server is not:" >&2
+            echo "  endpoint is $ollamaEndpoint, not http://127.0.0.1:21434/v1" >&2
+            exit 1
+          }
+          echo "local-ai yields the Ollama port and the agents follow it"
 
           case " $dockerGroups " in
             *" docker "*) echo "the desktop user can reach the docker socket" ;;


### PR DESCRIPTION
Closes #96.

`modules/local-ai.nix` set `services.ollama.enable`, `package`, `host` and `port` at plain priority. That is fine on a machine nixarchy installed and wrong on a machine nixarchy was added to: someone who already configures Ollama gets `The option 'services.ollama.enable' has conflicting definition values` for merely importing this module, and their only escape is `lib.mkForce` on their **own** configuration, to beat a module they did not ask to be authoritative. That is the burden backwards, and it is the documented failure mode in [disko #441](https://github.com/nix-community/disko/issues/441) and [home-manager #5870](https://github.com/nix-community/home-manager/issues/5870).

The rule, from [nixos-hardware's CONTRIBUTING](https://github.com/NixOS/nixos-hardware/blob/master/CONTRIBUTING.md): `mkDefault` unless the option must be set and an override deserves an error, or the setting merges with the user's. The four scalars deserve neither, so they take `mkDefault`.

`loadModels` and `environmentVariables` deliberately do not. They are `listOf str` and `attrsOf str`, which merge, and `mkDefault` on a merging type is a silent bug rather than a courtesy: the lower-priority definition is dropped before the merge runs, so the keep-alive and flash-attention settings would vanish the moment a user named one environment variable of their own, with no error to say so. Plain assignment is what makes them additive.

Yielding the port opened a second question the old code could not be asked, because the clash made it unreachable: whose port do the agents dial. The endpoint was built from our own options, so a host that kept its own port would have had opencode and pi configured to talk to a port nothing listens on. It now reads back off `services.ollama`, which is where the answer lives once ours is only a default.

`tests/options.nix` grows the case, beside the syncthing one it mirrors: a configuration that enables `localAi` and sets `services.ollama.port` to 21434 evaluates, keeps 21434, and resolves the endpoint to it. Evaluating at all is most of the proof — a priority clash is an evaluation error, not a wrong value. Removing one `mkDefault` turns the check red with the exact error from the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hd3azPeZ2ppfpU3HetKSgX