### PR TITLE
Every rebuild leaves the last one bootable, and nothing said so

### DIFF
--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -344,6 +344,20 @@ let
           description = "Every package, NixOS option and Omarchy app, in one picker";
         };
 
+        # Every rebuild leaves the last one bootable and nothing said so.
+        #
+        # A new row rather than an override: upstream's equivalent is
+        # System > Snapshots, which is snapper and limine and does not exist
+        # here. What NixOS has instead is a generation per rebuild, which is
+        # better and completely invisible until someone reboots and reads the
+        # boot menu.
+        "system.rollback" = {
+          icon = "󰕍";
+          label = "Roll back";
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-rollback";
+          description = "Switch to an earlier system generation. Your home directory is not touched";
+        };
+
         "install.aur" = {
           when = "false";
         };

--- a/pkgs/omarchy/nix-bin/nixarchy-rollback
+++ b/pkgs/omarchy/nix-bin/nixarchy-rollback
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+# nixarchy:new
+# omarchy:summary=Go back to an earlier system generation
+# omarchy:examples=nixarchy rollback | nixarchy rollback --list
+
+# Every rebuild leaves the last one behind, bootable, and nothing surfaces that.
+#
+# Upstream's answer to "undo this" is omarchy-snapshot, which is snapper and
+# limine -- neither of which exists here, so both that and
+# omarchy-system-factory-reset fail on a nixarchy machine. What NixOS gives
+# instead is better for the system half and completely invisible: a generation
+# per rebuild, each one a complete bootable system, selectable at boot or from
+# a running desktop. The boot menu already lists them; this is the same thing
+# without rebooting to read it.
+#
+# What a generation restores, exactly: the system closure and the /etc that Nix
+# generates. NOT your home directory, NOT /var/lib service state, and NOT the
+# files in your flake -- rolling back does not edit configuration.nix. If what
+# you broke is in ~/.config, this is the wrong tool and `omarchy refresh config
+# <file>` is the right one.
+#
+# Generations are garbage collected. host.nix keeps 5, and anything older than
+# 14 days, so this is an undo button with a horizon rather than an archive.
+
+set -euo pipefail
+
+profile=/nix/var/nix/profiles/system
+
+red() { printf '\033[0;31m%s\033[0m\n' "$1"; }
+dim() { printf '\033[0;90m%s\033[0m\n' "$1"; }
+bold() { printf '\033[1m%s\033[0m\n' "$1"; }
+
+usage() {
+  cat <<'EOF'
+usage: nixarchy-rollback [--list]
+
+  (no arguments)  pick a generation to switch to
+  --list          show them and exit
+
+Rolls back the SYSTEM. Your home directory is not touched -- for a config
+file you edited and regret, use `omarchy refresh config <path>` instead,
+which restores the shipped default and keeps a timestamped backup.
+EOF
+}
+
+list_generations() {
+  nixos-rebuild list-generations --json 2>/dev/null
+}
+
+table() {
+  list_generations | jq -r '
+    .[] | [
+      (if .current then "*" else " " end),
+      (.generation|tostring),
+      .date,
+      .nixosVersion,
+      ("kernel " + .kernelVersion)
+    ] | @tsv' | column -t -s"$(printf '\t')"
+}
+
+case "${1:-}" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  --list)
+    table
+    exit 0
+    ;;
+  "") ;;
+  *)
+    red "unknown argument: $1"
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if ! command -v jq >/dev/null 2>&1; then
+  red "jq is required."
+  exit 1
+fi
+
+generations=$(list_generations)
+count=$(printf '%s' "$generations" | jq 'length')
+if [ "$count" -lt 2 ]; then
+  dim "Only one generation exists. There is nothing to go back to yet."
+  exit 0
+fi
+
+current=$(printf '%s' "$generations" | jq -r '.[] | select(.current) | .generation')
+
+bold "System generations"
+echo
+table
+echo
+dim "* is the one running now. Your home directory is not affected by any of these."
+echo
+
+choice=$(
+  printf '%s' "$generations" |
+    jq -r '.[] | select(.current | not) |
+      "\(.generation)  \(.date)  \(.nixosVersion)  kernel \(.kernelVersion)"' |
+    gum choose --header "Switch to which generation?"
+) || exit 0
+[ -n "$choice" ] || exit 0
+
+target=${choice%% *}
+
+# The warning this command exists to give.
+#
+# A generation whose kernel differs from the running one activates fine and
+# then does not work properly: the modules loaded in memory came from the old
+# kernel and the userspace now on disk came from the new one. On an NVIDIA
+# machine that means the driver stops matching its module and the GPU goes
+# away until reboot -- measured, on a machine that lost its display stack for
+# an hour this way. switch-to-configuration cannot warn about this; it does
+# not know what you booted.
+target_kernel=$(printf '%s' "$generations" | jq -r --arg g "$target" '.[] | select(.generation == ($g|tonumber)) | .kernelVersion')
+running_kernel=$(uname -r | cut -d- -f1)
+
+if [ "$target_kernel" != "$running_kernel" ]; then
+  echo
+  red "Generation $target was built against kernel $target_kernel; you are running $running_kernel."
+  echo
+  echo "  Switching now activates it without rebooting, and anything that"
+  echo "  loaded a kernel module -- graphics drivers above all -- will be"
+  echo "  running userspace from one kernel against modules from another."
+  echo
+  echo "  Reboot and pick generation $target from the boot menu instead, or"
+  echo "  switch now and reboot promptly."
+  echo
+fi
+
+echo "What changes:"
+if command -v nvd >/dev/null 2>&1; then
+  nvd diff "$profile-$current-link" "$profile-$target-link" 2>/dev/null || true
+else
+  nix store diff-closures "$profile-$current-link" "$profile-$target-link" 2>/dev/null |
+    head -30 || dim "  (could not diff the closures)"
+fi
+echo
+
+gum confirm "Switch from generation $current to $target?" || {
+  dim "Nothing changed."
+  exit 0
+}
+
+# nixos-rebuild has --rollback, which only ever goes back one. Moving the
+# profile pointer and activating is the documented route to an arbitrary
+# generation, and it is two commands rather than one because the pointer and
+# the activation are genuinely separate things.
+sudo nix-env --switch-generation "$target" --profile "$profile"
+sudo "$profile/bin/switch-to-configuration" switch
+
+echo
+bold "Now on generation $target."
+dim "Your home directory was not touched. The generation you came from is still there."


### PR DESCRIPTION
NixOS keeps a generation per rebuild — a complete, bootable system, already in the boot menu. It is the strongest undo this project has, and until now the only way to use it was to reboot and read a menu, or to already know `nixos-rebuild --rollback` exists.

Upstream's equivalent is `omarchy-snapshot`, which is **snapper plus limine**. Neither is configured here, so that command and `omarchy-system-factory-reset` are on PATH and **fail** on a nixarchy machine. What replaces them is better for the system half and was invisible.

## What it does

```
$ nixarchy-rollback --list
*  2481  2026-09-01 19:58:53  26.11.20260831.34ab990  kernel 7.2.2
   2480  2026-09-01 19:12:19  26.11.20260831.34ab990  kernel 7.2.2
   2479  2026-09-01 08:16:36  26.11.20260831.34ab990  kernel 7.2.2
```

Pick one, see what changes, switch. Menu row under System.

## The warning it exists to give

A generation built against a **different kernel** activates without complaint and then does not work properly — modules in memory from the running kernel, userspace on disk from the other. On an NVIDIA machine the driver stops matching its module and the GPU goes away until reboot.

That is not hypothetical: it happened on p510 this week, doing exactly this, and cost an hour of display stack. `switch-to-configuration` cannot warn about it — it does not know what you booted. This compares the target's kernel to `uname -r` and tells you to use the boot menu instead.

## What it says it does not do

A rollback restores the system closure and the `/etc` Nix generates. **Not** `$HOME`, **not** `/var/lib` service state, and **not** the files in your flake — it does not edit `configuration.nix`. The help says so and points at `omarchy refresh config <path>` for the case people will actually hit: a config file they edited and regret.

Generations are garbage collected — `host.nix:46-51` keeps five, and anything newer than fourteen days. **An undo button with a horizon, not an archive**, and the comment says that too.

## Two commands rather than one

`nixos-rebuild --rollback` only ever goes back one. Reaching an arbitrary generation is `nix-env --switch-generation` to move the profile pointer, then activating — separate steps because they are separate things. There is no `--switch-generation` flag on `nixos-rebuild`; I checked rather than assumed.

## Verified

- `--list` and `--help` run against this machine's real generations
- `nix build .#omarchy` passes, including the guard that a `nix-bin` script replacing nothing upstream must declare `# nixarchy:new`
- `all 332 menu rows name commands that exist` still passes — the new row resolves to a real binary
- shellcheck clean

## Follow-up worth filing separately

`omarchy-snapshot` and `omarchy-system-factory-reset` remain on PATH and broken. They should either be stubbed with an explanation, the way `omarchy-migrate` is, or replaced with btrfs equivalents — the installer already creates `@`, `@home`, `@nix` and `@log`, so real snapshots are reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5