### PR TITLE
A roadmap, and CI to stop it lying

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,51 @@ jobs:
       # data/apps.nix, and they silently went stale twice -- once when an app
       # was added, once when RetroArch moved to being built here -- so derive
       # them and fail rather than trust prose.
+      - name: The README's roadmap still matches the open epics
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          # A roadmap nobody updates is worse than none: it is the section a
+          # newcomer reads to judge whether the project is alive, and a stale
+          # one says it is not. The README claims CI keeps this honest, so
+          # this is that claim being true.
+          #
+          # Both directions. An epic opened and not listed means the roadmap
+          # is incomplete; an epic listed and since closed means it is lying.
+          # Only the table rows. The section also links a finished epic under
+          # "Recently finished" and issues for context, and neither is a claim
+          # about what is planned -- reading every link in the section flagged
+          # the finished one as a lie the first time this ran.
+          #
+          # Sorted lexically on both sides, not numerically: comm compares by
+          # collation, and `sort -n` on one side gives it input it says is
+          # unsorted.
+          open=$(gh issue list --state open --label epic --json number --jq '.[].number' | sort)
+          roadmap=$(sed -n '/^## Roadmap/,/^## /p' README.md |
+            grep -E '^\| \[#[0-9]+\]' | grep -oE 'issues/[0-9]+' | cut -d/ -f2 | sort -u)
+
+          missing=$(comm -23 <(echo "$open") <(echo "$roadmap") || true)
+          if [ -n "$missing" ]; then
+            for n in $missing; do
+              echo "::error::epic #$n is open and not in the README's Roadmap"
+            done
+            exit 1
+          fi
+
+          # A number in the roadmap that is not an open epic is either a
+          # closed epic still advertised as planned, or a plain issue linked
+          # for context. The second is fine, so only complain about epics.
+          for n in $roadmap; do
+            state=$(gh issue view "$n" --json state,labels \
+              --jq 'select([.labels[].name] | index("epic")) | .state' 2>/dev/null || true)
+            if [ "$state" = "CLOSED" ]; then
+              echo "::error::epic #$n is closed but the Roadmap still lists it as planned"
+              exit 1
+            fi
+          done
+          echo "the roadmap names every open epic and no closed one"
+
       - name: Check the README's app counts still match data/apps.nix
         run: |
           eval "$(nix eval --raw --impure --expr '

--- a/README.md
+++ b/README.md
@@ -1410,7 +1410,7 @@ the last run in CI on each push; the last is two machines that boot it.
 | | proven by |
 | --- | --- |
 | The session, bar, themes and wallpaper | `checks.session` logs in through SDDM's greeter and asserts the desktop *renders* -- it compares the screen against the wallpaper, because every other check passed once while it was black |
-| Installing on a blank machine | a real install from the ISO onto an empty disk: partitioned, closure copied, bootloader written, and the result booted into the desktop on its own. By hand, not in CI -- `checks.install` is written and not yet green, which is why this line says "two machines" above and not "every push" |
+| Installing on a blank machine | a real install from the ISO onto an empty disk: partitioned, closure copied, bootloader written, and the result booted into the desktop on its own. By hand, not in CI -- `checks.install` installs onto a blank disk in CI and boots the result, asserting that a rebuild immediately afterwards builds nothing |
 | Adding it to a machine you already run | `checks.integration` **builds** the module onto a config that overrides a package Omarchy also uses, pins its own Hyprland and already greets with greetd |
 | Sitting beside an existing Hyprland | `checks.coexist` boots the Omarchy session with a foreign `hyprland.lua` in place and asserts the bar comes up anyway |
 | The CLI | `omarchy commands --check`, plus a count the build refuses to let drift |
@@ -1420,7 +1420,7 @@ the last run in CI on each push; the last is two machines that boot it.
 | Themes installed from a git URL | `checks.session` runs `omarchy theme install` against a real published theme and asserts the desktop moved to it -- name, and a wallpaper that came out of the clone |
 | Nothing reaching into `/usr` | `checks.session` scans every shipped command for a `/usr` path in code, against a named list of the Arch-only ones that explain themselves |
 | Every Install row mapped | `checks.options` compares upstream's menu against `data/apps.nix` both ways -- a row added upstream that nobody maps fails, and so does one that no longer exists |
-| Every menu row's command existing | `checks.options` resolves all 129 `omarchy-*` commands the 323 rows name; a row whose command vanished draws normally and does nothing |
+| Every menu row's command existing | `checks.options` resolves all 129 `omarchy-*` commands the 332 rows name; a row whose command vanished draws normally and does nothing |
 | Migrations refusing to run | `checks.session` asserts `omarchy migrate` explains itself instead of running 86 Arch scripts that sudo into `/usr` |
 | The session under Hyprland's watchdog | `checks.coexist` greps the journal for the warning 0.56 logs when the compositor is exec'd directly instead of through `start-hyprland` |
 | The shell rc files locating themselves | `checks.session` sources each with `OMARCHY_PATH` unset and asserts it resolves to the store, not to a `/usr` path that cannot exist |
@@ -1526,6 +1526,43 @@ Known gaps in detail:
   from `/etc`, with no per-user equivalent, so this lets them set policy for
   every user of the machine -- fine alone, not fine shared. Light and dark
   follow the theme without it
+
+## Roadmap
+
+What is being worked on, and what is planned. The issues are the detail; this
+is the shape.
+
+| epic | what it is for | |
+| --- | --- | --- |
+| [#6](https://github.com/olafkfreund/nixarchy/issues/6) | **bare metal to a desktop** — the installer, the ISO, the release | 18 of 22 done |
+| [#105](https://github.com/olafkfreund/nixarchy/issues/105) | **Flatpaks, declared** — for the software nixpkgs does not carry | not started |
+| [#112](https://github.com/olafkfreund/nixarchy/issues/112) | **getting back** — snapshots, backup, restore | not started |
+
+**Recently finished:** the app selection grew a
+[services catalogue](https://github.com/olafkfreund/nixarchy/issues/90) —
+Docker, SSH, printing and the rest, pickable from the menu the way apps are.
+
+### What is deliberately not planned
+
+**Snap.** `nix-snapd` exposes three options and none of them is a package
+list, so a snap cannot be declared at all — it would be an imperative
+side-channel in a project whose whole claim is that nothing imperative
+survives a rebuild. It also ships a patch its own authors named
+`bubblewrap-insecure.patch`, and
+[fails on Hyprland](https://discourse.nixos.org/t/snap-apps-fail-with-d-bus-x11-errors-on-nixos-hyprland-nix-snapd/75544),
+which is the desktop this is. Nothing worth having is snap-only. See
+[#105](https://github.com/olafkfreund/nixarchy/issues/105) for the reasoning
+in full.
+
+**Anything that edits a configuration nixarchy did not write.** Adding the
+module to a machine you already run means nixarchy is one import among yours,
+and the backup and reset work in
+[#112](https://github.com/olafkfreund/nixarchy/issues/112) refuses to run
+there rather than warning about it.
+
+[Every open issue](https://github.com/olafkfreund/nixarchy/issues) is the
+authoritative list; this table is the summary and CI keeps it honest — an epic
+opened or closed without touching this section fails the build.
 
 ## License
 


### PR DESCRIPTION
The README says what works and what proves it. It says nothing about what is coming, so the only way to know was to read the issue tracker.

## What the section says

| epic | | |
|---|---|---|
| [#6](https://github.com/olafkfreund/nixarchy/issues/6) | bare metal to a desktop | 18 of 22 |
| [#105](https://github.com/olafkfreund/nixarchy/issues/105) | Flatpaks, declared | not started |
| [#112](https://github.com/olafkfreund/nixarchy/issues/112) | getting back — snapshots, backup, restore | not started |

Plus **what is deliberately not planned** — Snap, with the reasoning, because "why don't you support Snap" is worth answering once in the README rather than each time it is asked; and anything that edits a configuration nixarchy did not write.

## The check matters more than the section

A roadmap nobody updates is worse than none: it is what a newcomer reads to judge whether a project is alive, and a stale one answers *no*. CI now asserts **both directions** — an epic opened and not listed fails the build, an epic listed after being closed fails it too.

The README makes that claim in its own text; this is the claim being true.

**Writing the check found two bugs in it, both by running it rather than reading it:**

- It read *every* link in the section, so it flagged the finished epic under "Recently finished" as a lie. It now reads only the table rows, which are the actual claim about what is planned.
- It sorted one side numerically and the other lexically. `comm` rejects that outright: `comm: file 2 is not in sorted order`.

Verified both ways — passes on the real state, and catches a fictional open epic `999` that is not listed.

## Two stale claims fixed while here

**"`checks.install` is written and not yet green"** has been false since this morning. It installs onto a blank disk in CI, boots the result, and asserts a rebuild immediately afterwards builds nothing — green three times locally and once in CI today.

**"the 323 rows"** is 332 since the service rows arrived.

The `129` command count in the same sentence I could not verify cheaply, so I left it rather than change a number I have no evidence for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5