### PR TITLE
Snapshots for the half generations do not cover

### DIFF
--- a/installer/disk-config.nix
+++ b/installer/disk-config.nix
@@ -41,6 +41,29 @@ let
         mountpoint = "/var/log";
         inherit mountOptions;
       };
+
+      # Where snapper keeps snapshots, and it has to exist before snapper can
+      # take one: NixOS' snapper module does not create `.snapshots` itself
+      # (nixpkgs#34595; the fix, PR #368449, is still unmerged), so a machine
+      # without these subvolumes has a configured snapper that silently takes
+      # nothing.
+      #
+      # Separate subvolumes rather than plain directories, which is also the
+      # layout the ArchWiki recommends: a snapshot of `/` would otherwise
+      # contain every previous snapshot of `/`, nested, growing each time.
+      #
+      # No compression: the contents are already-compressed extents shared
+      # with the live subvolume, and snapshots cost nothing until the two
+      # diverge. Setting compress here would be describing a copy that does
+      # not happen.
+      "@snapshots" = {
+        mountpoint = "/.snapshots";
+        mountOptions = [ "noatime" ];
+      };
+      "@home-snapshots" = {
+        mountpoint = "/home/.snapshots";
+        mountOptions = [ "noatime" ];
+      };
     };
   };
 in

--- a/installer/host.nix
+++ b/installer/host.nix
@@ -146,6 +146,57 @@
 
   networking.hostName = hostname;
 
+  # Snapshots, for the half of the machine generations do not cover.
+  #
+  # A NixOS generation restores the system closure and the /etc Nix writes.
+  # It does not restore /home, and it does not restore /var/lib -- so the
+  # config a person spent an evening on, and the state their services keep,
+  # have had no undo at all. That is what this is for, and it is the only
+  # thing it is for: the system half is already better served by generations
+  # and nixarchy-rollback.
+  #
+  # Deliberately in host.nix and not in modules/nixos.nix. This file is
+  # imported only by flakes the installer generated, so snapper reaches
+  # machines nixarchy built and never a machine where somebody imported the
+  # module into a configuration of their own. Taking snapshots of somebody
+  # else's disk, on a schedule they did not ask for, is not this module's
+  # business.
+  #
+  # Upstream takes a snapshot before every update and offers to boot one.
+  # Neither transfers. `@` here holds almost no operating system -- the
+  # kernels are on the ESP and the system is in `@nix`, a separate subvolume
+  # that these snapshots exclude -- so booting a snapshot of `@` would get you
+  # the same system with older /etc. Generations already are the bootable
+  # snapshot, which is why the bootloader is unchanged and there is no
+  # limine-snapper-sync here.
+  services.snapper = {
+    # Hourly timeline snapshots of the user's data, and a snapper the desktop
+    # user can drive without sudo -- ALLOW_USERS is what makes `snapper -c
+    # home list` and an undo of their own file something they can do.
+    configs.home = {
+      SUBVOLUME = "/home";
+      ALLOW_USERS = [ username ];
+      TIMELINE_CREATE = true;
+      TIMELINE_CLEANUP = true;
+    };
+
+    # Root gets a snapshot at boot and no timeline. The timeline is for data
+    # that changes while you work; /var/lib changes when a service decides to,
+    # and an hourly snapshot of it is mostly noise. One per boot is the useful
+    # one: it is the state you were in before whatever you are about to do.
+    configs.root = {
+      SUBVOLUME = "/";
+      TIMELINE_CREATE = false;
+      TIMELINE_CLEANUP = false;
+    };
+    snapshotRootOnBoot = true;
+
+    # A laptop is asleep at some point every day, and a non-persistent timer
+    # skips what it missed rather than running it late. On a machine that is
+    # only ever awake this changes nothing.
+    persistentTimer = true;
+  };
+
   boot.loader = {
     systemd-boot.enable = true;
     efi.canTouchEfiVariables = true;

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -346,16 +346,36 @@ let
 
         # Every rebuild leaves the last one bootable and nothing said so.
         #
-        # A new row rather than an override: upstream's equivalent is
-        # System > Snapshots, which is snapper and limine and does not exist
-        # here. What NixOS has instead is a generation per rebuild, which is
-        # better and completely invisible until someone reboots and reads the
-        # boot menu.
+        # Under System because it is the system this restores. Upstream's
+        # nearest equivalent is a snapper snapshot picked from the boot menu,
+        # which is a different thing on NixOS: `@` here holds almost no
+        # operating system, so a generation is what carries one. The snapshot
+        # rows under Trigger cover the other half -- home, and service state
+        # -- which no generation touches.
         "system.rollback" = {
           icon = "󰕍";
           label = "Roll back";
           action = "omarchy-launch-floating-terminal-with-presentation nixarchy-rollback";
           description = "Switch to an earlier system generation. Your home directory is not touched";
+        };
+
+        # Snapshots under Trigger, beside the other "do a thing now" rows.
+        #
+        # Upstream's are taken by its updater and restored from the boot menu,
+        # and neither happens here. These are new rows, so they carry their
+        # own label and icon.
+        "trigger.snapshot" = {
+          icon = "󰆓";
+          label = "Snapshot home";
+          action = "omarchy-launch-floating-terminal-with-presentation omarchy-snapshot create";
+          description = "Save your home directory as it is now. Instant, and costs nothing until files change";
+        };
+
+        "trigger.snapshot.restore" = {
+          icon = "󰦛";
+          label = "Restore from snapshot";
+          action = "omarchy-launch-floating-terminal-with-presentation omarchy-snapshot restore";
+          description = "Open an earlier version of your home directory and copy back what you want";
         };
 
         "install.aur" = {

--- a/pkgs/omarchy/nix-bin/omarchy-snapshot
+++ b/pkgs/omarchy/nix-bin/omarchy-snapshot
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+# omarchy:summary=Snapshot your home directory, or go back to one
+# omarchy:examples=omarchy snapshot | omarchy snapshot create "before I broke it" | omarchy snapshot list
+
+# Replaces upstream's, which drives snapper through limine: `create` makes a
+# snapper snapshot per configured config, and `restore` execs
+# limine-snapper-restore so you can pick one from the boot menu.
+#
+# Half of that works here and half cannot. snapper is configured -- see
+# installer/host.nix -- but limine is not the bootloader and
+# limine-snapper-sync is not packaged for NixOS at all. More to the point it
+# would not do anything useful if it were: `@` on this machine holds almost no
+# operating system. The kernels are on the ESP and the whole system is in
+# `@nix`, a separate subvolume these snapshots exclude, so booting a snapshot
+# of `@` gets you the system you already have with an older /etc.
+#
+# NixOS generations already are the bootable snapshot, and `nixarchy-rollback`
+# is how you pick one. What snapshots are for here is the half generations do
+# not cover: /home, and the mutable state under /var/lib.
+#
+# So restore happens from the running system rather than from the boot menu,
+# which is also less dangerous: nothing is written to the ESP and a mistake
+# costs a reboot rather than a machine that will not start.
+
+set -euo pipefail
+
+red() { printf '\033[0;31m%s\033[0m\n' "$1"; }
+dim() { printf '\033[0;90m%s\033[0m\n' "$1"; }
+bold() { printf '\033[1m%s\033[0m\n' "$1"; }
+
+usage() {
+  cat <<'EOF'
+usage: omarchy snapshot [create [description] | list | restore]
+
+  create [desc]  snapshot /home now, with an optional description
+  list           show the snapshots that exist
+  restore        pick one and copy files back out of it
+
+Snapshots cover your home directory and service state. They do NOT cover the
+system -- that is what generations are for, and `nixarchy-rollback` picks one.
+
+Snapshots live on the same disk. They are an undo button, not a backup: they
+do not survive the disk failing.
+EOF
+}
+
+# Configured only on machines the nixarchy installer built. A machine where
+# somebody imported the module into their own configuration has no snapper
+# and should be told why rather than shown an error from snapper itself.
+if ! command -v snapper >/dev/null 2>&1; then
+  red "snapper is not installed on this machine."
+  echo
+  echo "  Snapshots are set up by the nixarchy installer, which configures"
+  echo "  snapper against the btrfs layout it creates. A machine that imported"
+  echo "  the nixarchy module into its own configuration keeps its own disk"
+  echo "  layout and its own backups, and nixarchy does not add either."
+  echo
+  echo "  For the system half, generations work everywhere: nixarchy-rollback."
+  exit 1
+fi
+
+case "${1:-list}" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+
+  create)
+    desc="${2:-manual}"
+    snapper --config home create --description "$desc" --cleanup-algorithm number
+    bold "Snapshotted /home."
+    dim "It costs nothing until the files change; see 'omarchy snapshot list'."
+    ;;
+
+  list)
+    bold "/home"
+    snapper --config home list 2>/dev/null || dim "  (none yet)"
+    echo
+    bold "/ (taken at boot)"
+    sudo snapper --config root list 2>/dev/null || dim "  (needs sudo, or none yet)"
+    ;;
+
+  restore)
+    # Copying files out, not swapping the subvolume.
+    #
+    # Swapping is what upstream does and it is the wrong default here: it
+    # replaces the whole of /home in one step, including everything written
+    # since the snapshot, and it cannot be done while the subvolume is
+    # mounted and in use. Someone reaching for this has usually broken one
+    # config file, and the honest answer to that is a file manager pointed at
+    # a directory, not a procedure that can lose a day's work.
+    line=$(snapper --config home list --columns number,date,description 2>/dev/null |
+      tail -n +3 | gum choose --header "Restore from which snapshot?") || exit 0
+    [ -n "$line" ] || exit 0
+    num=$(echo "$line" | awk '{print $1}')
+    path="/home/.snapshots/$num/snapshot"
+
+    [ -d "$path" ] || {
+      red "snapshot $num is not at $path"
+      exit 1
+    }
+
+    echo
+    bold "Snapshot $num is readable at:"
+    echo "  $path"
+    echo
+    echo "Your files as they were are under $path/$USER/."
+    echo "Copy back what you want:"
+    echo
+    dim "  cp -r $path/$USER/.config/hypr ~/.config/"
+    echo
+    echo "To see what changed since then:"
+    dim "  snapper --config home status $num..0"
+    echo
+    dim "Nothing has been changed. Copying back is yours to do, deliberately."
+    ;;
+
+  *)
+    red "unknown: $1"
+    usage >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Part of #112. Fixes half of #111 — `omarchy-snapshot` no longer fails.

A NixOS generation restores the system closure and the `/etc` Nix writes. It does **not** restore `/home` or `/var/lib` — so the config somebody spent an evening on, and the state their services keep, have had no undo at all.

## Not limine — and not because it is unpackaged

You asked for snapper *and* limine. I built snapper and left the bootloader alone, on an architectural finding rather than a preference:

**`@` on this machine holds almost no operating system.** The kernels and initrds are on the ESP — vfat, unsnapshottable — and the entire system is in `@nix`, a *separate subvolume these snapshots exclude*. Booting a snapshot of `@` would get you the system you already have with an older `/etc` and `/var`.

On Arch a root snapshot **is** the whole OS, which is why `limine-snapper-sync` makes sense there. Here, **NixOS generations already are the bootable snapshot** — and #110 makes them pickable.

Switching bootloaders is also the highest-blast-radius change available on a LUKS machine: an install that errors half way leaves a firmware shell. That would have bought a boot menu entry that boots the same system twice.

`limine-snapper-sync` is not in nixpkgs either, and neither is grub-btrfs — but that is the *second* reason, not the first.

## Where it goes, and where it does not

`installer/host.nix`, which only installer-generated flakes import. **Asserted, not assumed:**

```
snapper configs on a Mode A machine: ""
snapper timer units: 0
```

A machine where somebody added the module to a configuration of their own gets no snapper and no timers on a disk nixarchy did not lay out.

## The `.snapshots` gotcha

NixOS' snapper module does **not** create them — [nixpkgs#34595](https://github.com/NixOS/nixpkgs/issues/34595), with [PR #368449](https://github.com/NixOS/nixpkgs/pull/368449) still unmerged — so a configured snapper without them silently takes nothing.

Declared in `disk-config.nix` as subvolumes rather than directories, which is what the ArchWiki recommends: a snapshot of `/` would otherwise contain every previous snapshot of `/`, nested.

```
["/","/.snapshots","/boot","/home","/home/.snapshots","/nix","/var/log"]
```

**Existing machines need the subvolume created by hand** — disko runs at install time only. Noted for #112 rather than solved with an activation script that creates subvolumes on a running system.

## Restore copies files rather than swapping the subvolume

Upstream swaps. That replaces the whole of `/home` in one step — including everything written since — and cannot be done while the subvolume is mounted and in use. Someone reaching for restore has usually broken *one config file*, and the honest answer is a path they can copy out of plus `snapper status` to see what changed. Nothing is written on their behalf.

## Menu

`trigger.snapshot` and `trigger.snapshot.restore` under **Trigger**, as asked. `system.rollback` is in **System** via #110.

## Verified

```
all 332 menu rows name commands that exist
all 74 Install rows are mapped or accounted for
```

Plus shellcheck, `nix fmt`, and the Mode A evaluation above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5