### PR TITLE
A factory reset that says why it cannot, instead of failing

### DIFF
--- a/pkgs/omarchy/nix-bin/omarchy-system-factory-reset
+++ b/pkgs/omarchy/nix-bin/omarchy-system-factory-reset
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# omarchy:summary=Factory-reset this machine back to its freshly-installed state
+# omarchy:group=setup
+# omarchy:requires-sudo=true
+# omarchy:examples=sudo omarchy-system-factory-reset
+
+# Upstream's version swaps the running root for a fresh clone of an @factory
+# snapshot, then scrubs the machine's identity and re-keys LUKS for whoever
+# gets it next. It is a good design and it depends on one thing this installer
+# does not do: @factory is taken by the Omarchy Quattro ISO at install time,
+# and upstream already turns away machines that were upgraded rather than
+# installed from it.
+#
+# nixarchy's installer takes no such snapshot, so there is no baseline to
+# return to on any machine running today -- not one that could be created
+# retroactively either, since the point of the baseline is that it predates
+# everything the user did.
+#
+# Rather than fail with a btrfs error about a subvolume that was never made,
+# this says so, and says what does work. #112 tracks giving the installer a
+# baseline; until then a reinstall is the honest answer and, on a machine
+# whose configuration is a committed flake, a surprisingly complete one.
+set -euo pipefail
+
+cat >&2 <<'MSG'
+There is no factory snapshot on this machine to return to.
+
+  Upstream resets by swapping the running root for a clone of @factory, a
+  snapshot its installer takes before you ever log in. The nixarchy installer
+  does not take one, and it cannot be created now: a baseline made today would
+  contain everything you are trying to undo.
+
+  What does work, in order of how much it resets:
+
+    Your desktop config, one file at a time
+      omarchy refresh config hypr/bindings.lua
+    Restores the shipped default and keeps a timestamped backup beside it.
+
+    Your home directory, to an earlier point
+      omarchy snapshot list
+      omarchy snapshot restore
+    Snapper covers /home and service state. Not the system -- that is below.
+
+    The system, to an earlier build
+      nixarchy-rollback
+    Every rebuild left a generation behind. This picks one.
+
+    The whole machine
+      Reinstall from the ISO, then restore /etc/nixos from your git remote.
+    A committed flake makes this closer to a factory reset than it sounds:
+    the same commit produces the same system. It does not erase your data --
+    for a machine you are selling, wipe the disk rather than trusting this.
+
+  Whether your configuration is actually pushed anywhere:
+
+    nixarchy-config-repo
+
+MSG
+exit 1


### PR DESCRIPTION
Closes #111.

Two commands from the vendored tree were installed, reachable, and broken. `omarchy-snapshot` was the first and #114 made it work. This is the other.

## Why it cannot work here

Upstream resets by swapping the running root for a clone of **`@factory`** — a snapshot its ISO takes before the user ever logs in. nixarchy's installer takes no such snapshot. Upstream *already* turns away machines that were upgraded rather than installed from its ISO, for exactly this reason; every nixarchy machine is in that category.

**Nor can the baseline be made now.** The point of it is that it predates everything the user did, so a snapshot taken today is not a factory image — it is a picture of the mess.

## So it explains, the way `omarchy-migrate` does

Rather than failing with a btrfs error about a subvolume nobody created, it lists what *does* work, in order of how much it resets:

```
Your desktop config, one file at a time   omarchy refresh config hypr/bindings.lua
Your home directory, to an earlier point  omarchy snapshot restore
The system, to an earlier build           nixarchy-rollback
The whole machine                         reinstall + restore /etc/nixos from git
```

The last one says plainly that **it does not erase your data** — someone reading that message may be about to sell the machine, and "reinstall" is not "wiped".

## The worker is already inert, and worth knowing about

`omarchy-system-factory-reset-finish` is the first-boot half and is on PATH too. It guards itself — line 23 refuses unless the main script staged a `wipe-pending` marker — so with the main script refusing, **nothing can stage it.** Left alone rather than stubbed, for that reason.

But it deletes subvolumes and recreates `@home` **empty**, and it branches on `/.snapshots` — which **#114 has just created**. It is inert because of one marker file, on a machine that now looks more like what it expects than it did this morning. Recording that here rather than leaving it to be found.

## Verified

`nix build .#omarchy` passes, shellcheck clean. It replaces an upstream script, so no `# nixarchy:new` marker is needed — and the build enforces that either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5