### PR TITLE
Stop warning on every evaluation of the install check

### DIFF
--- a/installer/vm.nix
+++ b/installer/vm.nix
@@ -35,7 +35,7 @@
   imports = [ "${modulesPath}/virtualisation/qemu-vm.nix" ];
 
   environment.systemPackages = [
-    inputs.self.packages.${pkgs.system}.install
+    inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.install
     pkgs.git
   ];
 

--- a/tests/install.nix
+++ b/tests/install.nix
@@ -162,7 +162,11 @@ let
       instrumented ? false,
     }:
     (inputs.nixpkgs.lib.nixosSystem {
-      inherit (pkgs) system;
+      # Not `inherit (pkgs) system`: pkgs.system is deprecated in favour of
+      # stdenv.hostPlatform.system, and nixpkgs warns on every evaluation of
+      # this check. Written out rather than inherited because the inherit form
+      # is what hid it -- a grep for `pkgs.system` does not find it.
+      system = pkgs.stdenv.hostPlatform.system;
       specialArgs = { inherit inputs; };
       modules = [
         inputs.self.nixosModules.nixarchy
@@ -250,7 +254,7 @@ pkgs.testers.runNixOSTest {
       ];
 
       environment.systemPackages = [
-        inputs.self.packages.${pkgs.system}.install
+        inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.install
         pkgs.git
       ];
 


### PR DESCRIPTION
```
evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
```

Printed on **every** eval of `checks.install`, and only that check — `options`, `omarchy` and `install-iso` are all quiet.

## Three uses, and the third is the one that mattered

`installer/vm.nix` and `tests/install.nix` both did `inputs.self.packages.${pkgs.system}.install`. Correct to fix, and **not the source** — which is how I found out, by fixing them and watching the warning survive.

`tests/install.nix:165` did:

```nix
(inputs.nixpkgs.lib.nixosSystem {
  inherit (pkgs) system;
```

Same deprecated attribute, **invisible to a grep for `pkgs.system`** — which is exactly why it survived the first pass. Written out longhand now, with a comment saying why it is not inherited, because the inherit form is what hid it.

## Verified

```
before: warnings: 1
after:  warnings: 0
```

And `options`, `omarchy`, `install-iso` were checked to confirm the warning was specific to this check rather than something in a dependency.

Cosmetic — a warning, not an error — but this is the noisiest place it could be: a check whose whole value is that its log is worth reading, opening with a deprecation notice the reader cannot act on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5