### PR TITLE
Flatpaks you can declare, and one decision about deleting

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -431,6 +431,22 @@
         "type": "github"
       }
     },
+    "nix-flatpak": {
+      "locked": {
+        "lastModified": 1767983141,
+        "narHash": "sha256-7ZCulYUD9RmJIDULTRkGLSW1faMpDlPKcbWJLYHoXcs=",
+        "owner": "gmodena",
+        "repo": "nix-flatpak",
+        "rev": "440818969ac2cbd77bfe025e884d0aa528991374",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gmodena",
+        "ref": "v0.7.0",
+        "repo": "nix-flatpak",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1787360063,
@@ -507,6 +523,7 @@
         "disko": "disko",
         "home-manager": "home-manager",
         "hyprland": "hyprland",
+        "nix-flatpak": "nix-flatpak",
         "nixpkgs": "nixpkgs_2",
         "omarchy": "omarchy",
         "systems": "systems_2",

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,31 @@
       flake = false;
     };
 
+    # Declarative Flatpaks, for the software nixpkgs genuinely does not carry.
+    #
+    # nixpkgs' own services.flatpak is infrastructure only -- the daemon, the
+    # portals, polkit, FUSE -- and manages no applications. It does not even
+    # add the flathub remote. So the honest answer this repo has been giving
+    # is data/arch-extras.nix's `note = "then: flatpak install flathub ..."`,
+    # which is advice to do the one thing this project exists to prevent:
+    # install something imperatively that will not survive a rebuild.
+    #
+    # This adds `services.flatpak.packages`, overloading the same option
+    # namespace nixpkgs uses -- worth knowing, because a reader will look for
+    # `packages` in nixpkgs' module and not find it.
+    #
+    # Declared, not reproducible, and the distinction is real: the app IDS are
+    # in your configuration and travel to a new machine, but the BITS are
+    # whatever Flathub serves that day unless every entry pins a commit.
+    # Rollback restores the list, not the version. Upstream nixpkgs has
+    # declined to bless the equivalent (PR #347605, open since October 2024)
+    # on exactly that objection. We take it anyway, because the alternative on
+    # offer is a shell command in a comment.
+    #
+    # No `follows`: v0.7.0 has no inputs at all, which makes this the cheapest
+    # kind of dependency -- nothing to override, nothing to drift.
+    nix-flatpak.url = "github:gmodena/nix-flatpak/v0.7.0";
+
     # The installer's one disk layout is a disko expression, and the installed
     # machine imports the same file -- that is what keeps `fileSystems`
     # declarative instead of frozen into a hardware-configuration.nix nobody

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -402,12 +402,6 @@ in
       }
     ];
 
-    # Passed straight through: nix-flatpak's own option carries the behaviour,
-    # ours carries the decision and its reasoning. mkDefault so a user who
-    # sets services.flatpak.uninstallUnmanaged directly keeps their value --
-    # this is a convenience over an upstream option, not a replacement for it.
-    services.flatpak.uninstallUnmanaged = lib.mkDefault cfg.flatpaks.uninstallUnmanaged;
-
     # Most of what the Install menu offers is unfree: the browsers, the editors,
     # Steam, the AI clients, several of the fonts. Leaving licence policy to the
     # consumer sounded principled and in practice meant a new user picked an app,
@@ -634,6 +628,18 @@ in
     # mkForce their way out one option at a time. Their setting wins now, and
     # they lose only the feature that depended on it.
     services = {
+      # Passed straight through: nix-flatpak's own option carries the
+      # behaviour, ours carries the decision and its reasoning. mkDefault so a
+      # user who sets services.flatpak.uninstallUnmanaged directly keeps their
+      # value -- this is a convenience over an upstream option, not a
+      # replacement for it.
+      #
+      # In this block rather than as its own `services.flatpak...` line
+      # because statix rejects a second `services` key in the same attribute
+      # set, and it is right to: two places setting services is two places to
+      # look.
+      flatpak.uninstallUnmanaged = lib.mkDefault cfg.flatpaks.uninstallUnmanaged;
+
       # See programs.nixarchy.displayManager for why this is an option of our
       # own rather than a look at whether another greeter is already enabled.
       displayManager.sddm = {

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -69,6 +69,7 @@ in
     (import ./apps.nix inputs)
     ./local-ai.nix
     ./services
+    inputs.nix-flatpak.nixosModules.nix-flatpak
   ];
 
   options.programs.nixarchy = {
@@ -181,6 +182,33 @@ in
         the theme without this, through the settings portal rather than a
         policy file -- so the browser is themed either way, just not tinted.
       '';
+    };
+
+    flatpaks = {
+      uninstallUnmanaged = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Remove Flatpaks that this configuration does not declare, including
+          ones installed by hand with `flatpak install`.
+
+          On, the file is the truth: the machine's Flatpaks are exactly what
+          your configuration lists, and anything else is gone at the next
+          rebuild. That is the same promise nixarchy already makes about
+          packages, and it is the reason someone would want this.
+
+          Off by default, and the default is the point. Removing software a
+          person installed themselves is the one thing this project has said
+          it will not do -- the README puts it as "deselecting is the only
+          removal nixarchy is allowed to perform. An app that arrived from
+          your own configuration is not this menu's to take away." Turning
+          this on crosses that line, deliberately, on a machine where you have
+          decided the configuration is the only truth.
+
+          Neither answer is wrong. What would be wrong is deleting somebody's
+          software without their having asked.
+        '';
+      };
     };
 
     allowUnfree = lib.mkOption {
@@ -373,6 +401,12 @@ in
         '';
       }
     ];
+
+    # Passed straight through: nix-flatpak's own option carries the behaviour,
+    # ours carries the decision and its reasoning. mkDefault so a user who
+    # sets services.flatpak.uninstallUnmanaged directly keeps their value --
+    # this is a convenience over an upstream option, not a replacement for it.
+    services.flatpak.uninstallUnmanaged = lib.mkDefault cfg.flatpaks.uninstallUnmanaged;
 
     # Most of what the Install menu offers is unfree: the browsers, the editors,
     # Steam, the AI clients, several of the fonts. Leaving licence policy to the

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -221,6 +221,25 @@ let
   # rather than about an option.
   vm = inputs.self.nixosConfigurations.vm.config.system.build.toplevel;
 
+  # ---- nixarchy does not delete software somebody installed ----
+  #
+  # uninstallUnmanaged removes every Flatpak the configuration does not
+  # declare, including ones installed by hand. It is a real thing to want and
+  # it must never arrive by accident, so the default is asserted rather than
+  # trusted: this is precisely the kind of default that gets flipped later by
+  # someone tidying up who does not know what it costs.
+  #
+  # Both ends. The nixarchy option is what a person sets; the upstream option
+  # is what actually decides, and a passthrough that silently stopped passing
+  # would leave the first reading false while the second did the deleting.
+  flatpakDefaults = {
+    ours = (configWith { }).programs.nixarchy.flatpaks.uninstallUnmanaged;
+    theirs = (configWith { }).services.flatpak.uninstallUnmanaged;
+    # And that asking for it works, or the option is decoration.
+    onWhenAsked =
+      (configWith { flatpaks.uninstallUnmanaged = true; }).services.flatpak.uninstallUnmanaged;
+  };
+
   # ---- a bundled service yields to a user who already configured it ----
   #
   # This is the Mode A hazard in one assertion. Someone adds nixarchy to a
@@ -334,6 +353,9 @@ pkgs.runCommand "nixarchy-options"
     omarchyPath = "${(pkgs.extend inputs.self.overlays.default).omarchy}/share/omarchy";
     mapped = pkgs.lib.concatStringsSep " " mappedRows;
     serviceProblems = pkgs.lib.concatStringsSep "\n" serviceProblems;
+    flatpakOurs = pkgs.lib.boolToString flatpakDefaults.ours;
+    flatpakTheirs = pkgs.lib.boolToString flatpakDefaults.theirs;
+    flatpakOn = pkgs.lib.boolToString flatpakDefaults.onWhenAsked;
     syncthingDataDir = syncthingBeside.services.syncthing.dataDir;
     ollamaPort = builtins.toString ollamaBeside.services.ollama.port;
     ollamaEndpoint = ollamaBeside.programs.nixarchy.localAi.resolved.endpoint;
@@ -353,6 +375,20 @@ pkgs.runCommand "nixarchy-options"
       ''
           echo "$report"
           echo "the services catalogue is well formed ($serviceCount entries)"
+
+          # ---- flatpaks are not removed unless asked ---------------------
+          if [ "$flatpakOurs" != "false" ] || [ "$flatpakTheirs" != "false" ]; then
+            echo "uninstallUnmanaged defaults to on." >&2
+            echo "  programs.nixarchy.flatpaks.uninstallUnmanaged = $flatpakOurs" >&2
+            echo "  services.flatpak.uninstallUnmanaged          = $flatpakTheirs" >&2
+            echo "That deletes Flatpaks a person installed themselves." >&2
+            exit 1
+          fi
+          [ "$flatpakOn" = "true" ] || {
+            echo "asking for uninstallUnmanaged does not turn it on" >&2
+            exit 1
+          }
+          echo "flatpaks are left alone unless the machine's owner asks"
 
           # ---- composition: the user's definition wins -------------------
           [ "$syncthingDataDir" = "/srv/sync" ] || {


### PR DESCRIPTION
Closes #106. First piece of #105.

nixpkgs' `services.flatpak` is **infrastructure only** — daemon, portals, polkit, FUSE — and manages no applications. It does not even add the flathub remote.

So the answer this repo has been giving is `data/arch-extras.nix`'s `note = "then: flatpak install flathub ..."` — advice to do the one thing the project exists to prevent.

`nix-flatpak` adds `services.flatpak.packages`. The list lives in the user's configuration, survives a rebuild, and reproduces on a new machine.

**Declared, not reproducible**, and the difference is real: the app IDs travel, the *bits* are whatever Flathub serves that day unless every entry pins a commit, and a rollback restores the list rather than the version. nixpkgs has declined to bless the equivalent upstream ([PR #347605](https://github.com/NixOS/nixpkgs/pull/347605), open since Oct 2024) on exactly that objection. Taken anyway, because the alternative on offer is a shell command in a comment.

**v0.7.0 has no inputs at all** — so no `follows` to write and nothing to drift. The cheapest kind of dependency.

## The decision this issue existed for

`uninstallUnmanaged` removes every Flatpak the configuration does not declare, **including ones installed by hand**. That is the strongest form of "the file is the truth", and it crosses a line the README draws:

> "deselecting is the only removal nixarchy is allowed to perform. An app that arrived from your own configuration is not this menu's to take away."

**So it is an option, and it is off.** Someone who wants their machine fully described by their configuration turns it on knowing what it does. Neither answer is wrong; deleting somebody's software without their having asked would be.

## The check is the point of the default

A default like this is what gets tidied later by someone who does not know what it costs. `checks.options` asserts **both** the nixarchy option and the upstream one it feeds — a passthrough that silently stopped passing would leave the first reading `false` while the second did the deleting — and that asking for it still works, or the option is decoration.

**Verified by flipping it:**

```
uninstallUnmanaged defaults to on.
  programs.nixarchy.flatpaks.uninstallUnmanaged = true
That deletes Flatpaks a person installed themselves.
```

and on the real default:

```
flatpaks are left alone unless the machine's owner asks
```

## Not done here

No catalogue, no template rows, no menu — #107 and #108. A user can write `services.flatpak.packages = [ "com.nvidia.geforcenow" ];` in their own file today; making it selectable is the next piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5