### PR TITLE
A flatpak catalogue with a high bar and one entry

### DIFF
--- a/data/arch-extras.nix
+++ b/data/arch-extras.nix
@@ -108,10 +108,15 @@
   # GeForce NOW ships as a Flatpak. Flatpak on NixOS is a service, not just a
   # package: without the service there is no system-wide installation for it
   # to land in.
+  #
+  # The note used to end "then: flatpak install flathub com.nvidia.geforcenow"
+  # -- a shell command, run once, gone at the next reinstall and unknown to
+  # the machine's own configuration. data/flatpaks.nix carries it now, so it
+  # can be picked and declared like everything else.
   flatpak = {
     attr = "services.flatpak.enable = true";
     kind = "nixos-option";
-    note = "then: flatpak install flathub com.nvidia.geforcenow";
+    note = "GeForce NOW is in the flatpak selection; see nixarchy-apply";
   };
 
   # omarchy-setup-security-sshd opens with `omarchy-pkg-add openssh`, then

--- a/data/flatpaks.nix
+++ b/data/flatpaks.nix
@@ -1,0 +1,61 @@
+# Flatpaks worth curating, which is fewer than you would expect.
+#
+# The third catalogue, and the one with the highest bar. data/apps.nix lists
+# what nixpkgs installs; data/services.nix lists what NixOS turns on. This
+# lists software that neither can reach, and the test for an entry is exactly
+# that:
+#
+#   A flatpak belongs here only when nixpkgs genuinely cannot carry the thing.
+#
+# Not "is easier as a flatpak", not "is newer on Flathub". A flatpak of
+# software already in nixpkgs is strictly worse for someone on this system: it
+# lives outside the store, no generation rolls it back, it updates on a
+# schedule that is not yours, and `nixos-rebuild --rollback` restores the fact
+# that you asked for it rather than the version you had.
+#
+# Measured against that bar, most of what people reach for does not qualify.
+# Bottles, Zoom and OBS are all in nixpkgs. GeForce NOW is not, and there is
+# no plausible way to package it -- which is why it is here and why this file
+# starts with one entry rather than twenty.
+#
+# ## What "declared" means here, and what it does not
+#
+# The app ids below end up in the user's configuration and travel to their
+# next machine. The BITS do not: the same id resolves to whatever Flathub is
+# serving that day, unless an entry pins a commit. That is a weaker promise
+# than anything else in this repo makes, and the generated file says so where
+# a person will read it.
+#
+# ## Fields
+#   appId     The reverse-DNS application id. Not a package name --
+#             `com.usebottles.bottles`, never `bottles`. That is the mistake
+#             to expect.
+#   label     Shown in the generated template and the menu.
+#   category  Groups rows in the template.
+#   note      Why this one cannot come from nixpkgs. Every entry has to answer
+#             that, because the bar above is the whole point of the file.
+#   remote    Optional. Only for software that is NOT on Flathub, and it comes
+#             as a pair: the remote's `name` and its `location`, the
+#             .flatpakrepo URL that defines it. Omit for anything on Flathub,
+#             which is the common case.
+#
+# ## Not everything worth having is on Flathub
+#
+# GeForce NOW is the first entry and it is not a Flathub app: NVIDIA publishes
+# it from their own repository. So an entry can name a remote, and the module
+# declares it alongside Flathub rather than instead of it -- nix-flatpak's
+# `remotes` option defaults to a list containing only Flathub, and setting it
+# REPLACES that list rather than adding to it, which is the sort of thing that
+# removes Flathub from somebody's machine if nobody notices.
+{
+  geforce-now = {
+    appId = "com.nvidia.geforcenow";
+    label = "GeForce NOW";
+    category = "Gaming";
+    note = "Streams games from NVIDIA's servers. Not in nixpkgs and not packageable: a proprietary binary NVIDIA ships as a Flatpak. Not on Flathub either -- it comes from NVIDIA's own repository, which enabling this adds.";
+    remote = {
+      name = "GeForceNOW";
+      location = "https://international.download.nvidia.com/GFNLinux/flatpak/geforcenow.flatpakrepo";
+    };
+  };
+}

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -284,6 +284,49 @@ let
   dockerGroups =
     (configBeside { programs.nixarchy.user = "someone"; }).users.users.someone.extraGroups;
 
+  # ---- the flatpak catalogue, same discipline ----
+  flatpaks = import ../data/flatpaks.nix;
+
+  flatpakProblems = pkgs.lib.flatten (
+    pkgs.lib.mapAttrsToList (
+      id: fp:
+      let
+        need = field: cond: pkgs.lib.optional (!cond) "  ${id}: ${field}";
+      in
+      [
+        (need "no label" (fp ? label && fp.label != ""))
+        (need "no category" (fp ? category && fp.category != ""))
+        (need "no appId" (fp ? appId && fp.appId != ""))
+        # The predictable mistake is writing a package name where an
+        # application id belongs -- `bottles` instead of
+        # `com.usebottles.bottles`. It fails at install time on the user's
+        # machine, which is the wrong place to find out, and the shape is
+        # cheap to check: Flathub ids are reverse-DNS and always contain a dot.
+        (need "appId is not reverse-DNS (needs at least two dots)" (
+          (fp.appId or "") == "" || builtins.length (pkgs.lib.splitString "." (fp.appId or "")) >= 3
+        ))
+        # Every entry has to answer "why can nixpkgs not carry this", because
+        # that question is the whole reason the file exists. An entry without
+        # a note has not been asked it.
+        (need "no note saying why nixpkgs cannot carry it" (fp ? note && fp.note != ""))
+        # A remote is a name AND a location. Half of one silently means the
+        # app is looked for on Flathub, which for an entry that named a remote
+        # is exactly where it is not -- and the failure lands on the user's
+        # machine at install time rather than here.
+        (need "remote needs both name and location" (
+          !(fp ? remote) || ((fp.remote ? name) && (fp.remote ? location))
+        ))
+        (need "remote location must be a .flatpakrepo URL" (
+          !(fp ? remote)
+          || (
+            pkgs.lib.hasPrefix "https://" (fp.remote.location or "")
+            && pkgs.lib.hasSuffix ".flatpakrepo" (fp.remote.location or "")
+          )
+        ))
+      ]
+    ) flatpaks
+  );
+
   # ---- the services catalogue is shaped the way the generator expects ----
   #
   # data/apps.nix has no schema check at all: it is read with `app ? field`
@@ -353,6 +396,8 @@ pkgs.runCommand "nixarchy-options"
     omarchyPath = "${(pkgs.extend inputs.self.overlays.default).omarchy}/share/omarchy";
     mapped = pkgs.lib.concatStringsSep " " mappedRows;
     serviceProblems = pkgs.lib.concatStringsSep "\n" serviceProblems;
+    flatpakProblems = pkgs.lib.concatStringsSep "\n" flatpakProblems;
+    flatpakCount = builtins.toString (builtins.length (builtins.attrNames flatpaks));
     flatpakOurs = pkgs.lib.boolToString flatpakDefaults.ours;
     flatpakTheirs = pkgs.lib.boolToString flatpakDefaults.theirs;
     flatpakOn = pkgs.lib.boolToString flatpakDefaults.onWhenAsked;
@@ -365,7 +410,13 @@ pkgs.runCommand "nixarchy-options"
     nativeBuildInputs = [ pkgs.python3 ];
   }
   (
-    if serviceProblems != [ ] then
+    if flatpakProblems != [ ] then
+      ''
+        echo "data/flatpaks.nix has entries the generator cannot use:" >&2
+        echo "$flatpakProblems" >&2
+        exit 1
+      ''
+    else if serviceProblems != [ ] then
       ''
         echo "data/services.nix has entries the generator cannot use:" >&2
         echo "$serviceProblems" >&2
@@ -375,6 +426,7 @@ pkgs.runCommand "nixarchy-options"
       ''
           echo "$report"
           echo "the services catalogue is well formed ($serviceCount entries)"
+          echo "the flatpak catalogue is well formed ($flatpakCount entries)"
 
           # ---- flatpaks are not removed unless asked ---------------------
           if [ "$flatpakOurs" != "false" ] || [ "$flatpakTheirs" != "false" ]; then


### PR DESCRIPTION
Closes #107. Part of #105. **Stacked on #118** — merge that first and this retargets to main.

The third catalogue, and the one that has to justify itself hardest. `apps.nix` lists what nixpkgs installs; `services.nix` lists what NixOS turns on; this lists what neither can reach. The test for an entry is exactly that:

> **A flatpak belongs here only when nixpkgs genuinely cannot carry the thing.**

Not "is easier as a flatpak", not "is newer on Flathub". For someone on this system a flatpak of software already in nixpkgs is **strictly worse**: outside the store, no generation rolls it back, updated on a schedule that is not theirs, and a rollback restores the fact that they asked for it rather than the version they had.

## Held to that bar, almost nothing qualifies

Checked rather than assumed:

```
bottles      bottles-65.4          in nixpkgs -> fails the bar
zoom-us      zoom-7.1.5.4332       in nixpkgs -> fails the bar
obs-studio   obs-studio-32.2.2     in nixpkgs -> fails the bar
geforcenow   NOT in nixpkgs        qualifies
```

GeForce NOW is not there and is not packageable — NVIDIA ships a proprietary binary as a Flatpak and nothing else.

**So the file starts with one entry, and the header says why it is short.** A catalogue of twenty would mean the bar had not been applied.

## The check, and the mistake it expects

An `appId` is reverse-DNS — `com.nvidia.geforcenow`, never `geforcenow`. Writing a package name there fails at install time on the user's machine, which is the wrong place to find out. Verified by making that mistake:

```
data/flatpaks.nix has entries the generator cannot use:
  geforce-now: appId is not reverse-DNS (needs at least two dots)
```

Every entry also carries a note answering **"why can nixpkgs not carry this"** — that question is the whole reason the file exists, and an entry without one has not been asked it.

## And the advice it retires

`data/arch-extras.nix` said:

```nix
note = "then: flatpak install flathub com.nvidia.geforcenow";
```

A shell command, run once, gone at the next reinstall and unknown to the machine's own configuration. It now points at the selection.

## Verified

```
the flatpak catalogue is well formed (1 entries)
the services catalogue is well formed (5 entries)
flatpaks are left alone unless the machine's owner asks
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5