### PR TITLE
Two ISOs, two names

### DIFF
--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -142,13 +142,13 @@ let
       # the same thing.
       pkgs.kmod.dev
     ];
-in
-let
+
   version = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.omarchy.version;
+
   # "" for the offline image: it is the default one, and the plain name is the
   # one people will be told to download.
   variant = lib.optionalString (!offline) "-net";
-  variant2 = lib.replaceStrings [ "-" ] [ "_" ] variant;
+  labelVariant = lib.replaceStrings [ "-" ] [ "_" ] (lib.toUpper variant);
 in
 {
   imports = [ "${modulesPath}/installer/cd-dvd/installation-cd-minimal.nix" ];
@@ -287,7 +287,7 @@ in
     # most 32 characters -- asserted below rather than left to a truncation
     # nobody notices until a stick fails to boot. Two nixarchy sticks of
     # different versions or variants no longer collide.
-    volumeID = "NIXARCHY_${lib.replaceStrings [ "." ] [ "_" ] version}${lib.toUpper variant2}";
+    volumeID = "NIXARCHY_${lib.replaceStrings [ "." ] [ "_" ] version}${labelVariant}";
     makeEfiBootable = true;
     makeUsbBootable = true;
 

--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -1,5 +1,6 @@
 {
   inputs,
+  config,
   lib,
   pkgs,
   modulesPath,
@@ -142,6 +143,13 @@ let
       pkgs.kmod.dev
     ];
 in
+let
+  version = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.omarchy.version;
+  # "" for the offline image: it is the default one, and the plain name is the
+  # one people will be told to download.
+  variant = lib.optionalString (!offline) "-net";
+  variant2 = lib.replaceStrings [ "-" ] [ "_" ] variant;
+in
 {
   imports = [ "${modulesPath}/installer/cd-dvd/installation-cd-minimal.nix" ];
 
@@ -246,10 +254,40 @@ in
   # until the built file is called nixos-minimal-*.iso anyway. The filename is
   # derived from image.baseName.
   # mkForce because installation-cd-base sets this too, at the same priority.
-  image.baseName = lib.mkForce "nixarchy-${inputs.self.shortRev or "dirty"}-x86_64";
+  # Version, then variant, then the commit. All three earn their place:
+  # the version is what a person calls the release, the variant is the
+  # difference between a 5.6 GB image and a 1.5 GB one, and the commit is the
+  # only thing that says which source an image can actually install from (see
+  # the published-commit note at the top of this file). Without the variant
+  # the two images were byte-for-byte different files with identical names.
+  #
+  # The version comes from the omarchy package rather than a second binding,
+  # so it cannot drift from what is actually on the image.
+  image.baseName = lib.mkForce "nixarchy-${version}${variant}-${
+    inputs.self.shortRev or "dirty"
+  }-x86_64";
+
+  # A volume ID that overflows 32 characters or carries a character outside
+  # [A-Z0-9_] is silently truncated or mangled by the ISO tooling, and the
+  # failure shows up as a stick that will not boot -- long after the build
+  # that caused it. Fail here instead.
+  assertions = [
+    {
+      assertion = builtins.stringLength config.isoImage.volumeID <= 32;
+      message = "isoImage.volumeID is ${toString (builtins.stringLength config.isoImage.volumeID)} characters, over the 32 the ISO 9660 label allows: ${config.isoImage.volumeID}";
+    }
+    {
+      assertion = builtins.match "[A-Z0-9_]+" config.isoImage.volumeID != null;
+      message = "isoImage.volumeID must be [A-Z0-9_] for the bootloader to find the root by label: ${config.isoImage.volumeID}";
+    }
+  ];
 
   isoImage = {
-    volumeID = "NIXARCHY";
+    # The label the bootloader finds the root by, so it is [A-Z0-9_] and at
+    # most 32 characters -- asserted below rather than left to a truncation
+    # nobody notices until a stick fails to boot. Two nixarchy sticks of
+    # different versions or variants no longer collide.
+    volumeID = "NIXARCHY_${lib.replaceStrings [ "." ] [ "_" ] version}${lib.toUpper variant2}";
     makeEfiBootable = true;
     makeUsbBootable = true;
 

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -478,6 +478,34 @@ pkgs.runCommand "nixarchy-options"
           exit 1
         }
         echo "fontconfig pins Omarchy's font choices"
+
+        # ---- the two images are tellable apart -----------------------------
+        #
+        # Interpolated rather than grepped, because reading these forces the
+        # ISO configurations to evaluate -- which is what makes the volumeID
+        # assertions in installer/cd.nix fire at PR time. Nothing else here
+        # evaluates them, and a release build finding it is a release too
+        # late.
+        #
+        # They were identical once: same filename, same label, for a 5.6 GB
+        # image and a 1.5 GB one.
+        isoName=${inputs.self.nixosConfigurations.iso.config.image.baseName}
+        netName=${inputs.self.nixosConfigurations.iso-net.config.image.baseName}
+        isoLabel=${inputs.self.nixosConfigurations.iso.config.isoImage.volumeID}
+        netLabel=${inputs.self.nixosConfigurations.iso-net.config.isoImage.volumeID}
+        test "$isoName" != "$netName" || {
+          echo "both ISOs build to the same filename ($isoName): copy them out and they collide" >&2
+          exit 1
+        }
+        test "$isoLabel" != "$netLabel" || {
+          echo "both ISOs carry the same volume label ($isoLabel): two sticks, one name" >&2
+          exit 1
+        }
+        case "$isoName" in
+          *${inputs.self.packages.${system}.omarchy.version}*) ;;
+          *) echo "the ISO filename does not carry the version: $isoName" >&2; exit 1 ;;
+        esac
+        echo "the two images are tellable apart by name and label ($isoLabel / $netLabel)"
           touch $out
       ''
     else


### PR DESCRIPTION
`image.baseName` and `isoImage.volumeID` were both unconditional, so `iso` and `iso-net` produced **the same filename and the same volume label** — for a 5.6 GB offline image and a 1.5 GB network one.

| | before | after |
|---|---|---|
| `iso` | `nixarchy-189641c-x86_64` / `NIXARCHY` | `nixarchy-4.0.1-189641c-x86_64` / `NIXARCHY_4_0_1` |
| `iso-net` | `nixarchy-189641c-x86_64` / `NIXARCHY` | `nixarchy-4.0.1-net-189641c-x86_64` / `NIXARCHY_4_0_1_NET` |

The version is read from the omarchy package rather than a second binding, so it cannot drift from what is actually on the image. The commit stays in the name — `installer/cd.nix` explains at length that it is the only thing saying which source an image can install from, and #18's proposed name would have dropped it.

Published asset names are unaffected: `release.yml` globs `result/iso/*.iso` and renames to `nixarchy-<tag>.iso`.

### The volume label is asserted, not hoped for

It is what the bootloader finds the root by. Over 32 characters or outside `[A-Z0-9_]` and the tooling truncates or mangles it, surfacing as a stick that will not boot long after the build that caused it. Both assertions verified by breaking them.

### And the assertions actually run

Nothing evaluated the ISO configurations at PR time, so they would have fired first during a *release* build. `checks.options` now reads both identities — which forces the evaluation — and fails if the images ever collapse back to one name. Verified by collapsing the variant:

```
> both ISOs build to the same filename (nixarchy-4.0.1-dirty-x86_64): copy them out and they collide
```

### What this deliberately does not do

The boot splash. `installer/cd.nix` already records why: *"shipping another project's logo on our boot screen is the wrong default even where the licence allows it. #46 draws ours; this gains `splash` then."* #18's instruction to set `programs.nixarchy.bootSplash` cannot be followed either — `cd.nix` deliberately does not import `nixosModules.nixarchy`, so the option is not in scope.

Refs #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5