### PR TITLE
Flatpaks in the file, the menu and the tooling

### DIFF
--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -202,6 +202,41 @@ let
   # add, and a nixarchy alias for a one-line toggle would only be a second
   # vocabulary to unlearn the moment they read anyone else's configuration.
   serviceCatalogue = import ../data/services.nix;
+  flatpakCatalogue = import ../data/flatpaks.nix;
+
+  # Flatpaks go in services.nix rather than a fourth file.
+  #
+  # They are applications, so apps.nix is the tempting home -- and the wrong
+  # one: that file's header promises "Applications available through the
+  # Omarchy menu, as NixOS configuration", meaning software from nixpkgs with
+  # everything that implies. A flatpak is a different tier with weaker
+  # promises, and mixing the two would make the file quietly dishonest.
+  #
+  # services.nix already holds things that are decisions about the machine
+  # rather than packages, which is what enabling a flatpak is: it turns on a
+  # daemon, adds a remote, and installs software the store does not hold.
+  flatpakRow =
+    name: fp:
+    let
+      remote = lib.optionalString (fp ? remote) " — from ${fp.remote.name}, not Flathub";
+    in
+    "    # programs.nixarchy.flatpaks.apps.${name}.enable = true;  #@ ${name}"
+    + "  # ${fp.note}${remote}\n";
+
+  flatpakBlock = lib.optionalString (flatpakCatalogue != { }) (
+    "    # ── Flatpak ──────────────────────────────────────\n"
+    + "    #\n"
+    + "    # Declared, not reproducible: the ids below travel to your next\n"
+    + "    # machine, the versions do not. A rollback restores this list, not\n"
+    + "    # the software that was installed from it, and the first switch\n"
+    + "    # after enabling one needs a network.\n"
+    + "    #\n"
+    + "    # Their data in ~/.var/app is yours and nixarchy never touches\n"
+    + "    # it: turning one off here removes the app, not what you did\n"
+    + "    # with it.\n"
+    + lib.concatStrings (lib.mapAttrsToList flatpakRow flatpakCatalogue)
+    + "\n"
+  );
 
   serviceRow =
     name: svc:
@@ -257,7 +292,7 @@ let
     # the current full list is always at /etc/nixarchy/services-template.nix.
     { ... }:
     {
-    ${lib.concatStrings (map serviceCategoryBlock serviceCategories)}}
+    ${lib.concatStrings (map serviceCategoryBlock serviceCategories)}${flatpakBlock}}
   '';
 
   # No catalogue, on purpose.
@@ -499,6 +534,18 @@ let
       # menuId and this overrides it in place -- tailscale is that case, and
       # carrying the id across is what keeps the generator from failing on a
       # row nothing maps.
+      // lib.listToAttrs (
+        lib.mapAttrsToList (
+          name: fp:
+          lib.nameValuePair "install.flatpak.${name}" {
+            icon = "󰏓";
+            inherit (fp) label;
+            action = "nixarchy-service-enable ${name}";
+            disabled = "grep -qE '^[[:space:]]*[^#[:space:]].*#@ ${name}([[:space:]]|$)' $HOME/.config/nixarchy/services.nix";
+            description = "Flatpak — declared in your configuration, but updated by Flathub rather than by a rebuild";
+          }
+        ) flatpakCatalogue
+      )
       // lib.listToAttrs (
         lib.mapAttrsToList (
           name: svc:

--- a/modules/flatpaks.nix
+++ b/modules/flatpaks.nix
@@ -1,0 +1,62 @@
+# The flatpak catalogue, as options.
+#
+# data/flatpaks.nix says what is on offer; this turns a selection into
+# services.flatpak.packages, and declares any remote those entries need.
+#
+# The bar for an entry lives in the data file's header and is the interesting
+# part: a flatpak belongs there only when nixpkgs cannot carry the thing. This
+# file just wires up whatever survived that test.
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.nixarchy;
+  flatpaks = import ../data/flatpaks.nix;
+
+  enabled = lib.filterAttrs (name: _: cfg.flatpaks.apps.${name}.enable) flatpaks;
+
+  # Flathub, plus whatever the enabled entries bring with them.
+  #
+  # The `++` is the whole point. nix-flatpak's `remotes` defaults to a list
+  # holding only Flathub, and it is a plain option default -- setting it
+  # REPLACES that list rather than adding to it. An entry from NVIDIA's
+  # repository declared carelessly would therefore remove Flathub from the
+  # machine, and nothing would say so: the apps already installed from it keep
+  # working, and the next one simply cannot be found.
+  flathub = {
+    name = "flathub";
+    location = "https://dl.flathub.org/repo/flathub.flatpakrepo";
+  };
+
+  extraRemotes = lib.unique (
+    lib.mapAttrsToList (_: fp: fp.remote) (lib.filterAttrs (_: fp: fp ? remote) enabled)
+  );
+in
+{
+  options.programs.nixarchy.flatpaks.apps = lib.mapAttrs (
+    _: fp:
+    lib.mkOption {
+      type = lib.types.submodule {
+        options.enable = lib.mkEnableOption "${fp.label} (${fp.category}), as a Flatpak";
+      };
+      default = { };
+      description = fp.note;
+    }
+  ) flatpaks;
+
+  config = lib.mkIf (cfg.enable && enabled != { }) {
+    # Only when something is actually selected. Turning the daemon on for a
+    # machine that has picked nothing would add a service, a set of portals
+    # and a system user to every install, for nothing.
+    services.flatpak = {
+      enable = true;
+      remotes = [ flathub ] ++ extraRemotes;
+      packages = lib.mapAttrsToList (_: fp: {
+        inherit (fp) appId;
+        origin = if fp ? remote then fp.remote.name else "flathub";
+      }) enabled;
+    };
+  };
+}

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -69,6 +69,7 @@ in
     (import ./apps.nix inputs)
     ./local-ai.nix
     ./services
+    ./flatpaks.nix
     inputs.nix-flatpak.nixosModules.nix-flatpak
   ];
 

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -284,6 +284,23 @@ let
   dockerGroups =
     (configBeside { programs.nixarchy.user = "someone"; }).users.users.someone.extraGroups;
 
+  # ---- enabling a custom remote must not remove Flathub ----
+  #
+  # nix-flatpak's `remotes` defaults to a list holding only Flathub, and it is
+  # a plain default: setting it REPLACES that list rather than adding to it.
+  # GeForce NOW comes from NVIDIA's own repository, so enabling it sets the
+  # option -- and a module that wrote `remotes = [ nvidia ]` would take
+  # Flathub off the machine.
+  #
+  # Nothing would say so. Flatpaks already installed from Flathub keep
+  # working, and the next one simply cannot be found. That is why this is a
+  # check and not a comment.
+  flatpakRemotes =
+    let
+      c = configWith { flatpaks.apps.geforce-now.enable = true; };
+    in
+    map (r: r.name) c.services.flatpak.remotes;
+
   # ---- the flatpak catalogue, same discipline ----
   flatpaks = import ../data/flatpaks.nix;
 
@@ -398,6 +415,7 @@ pkgs.runCommand "nixarchy-options"
     serviceProblems = pkgs.lib.concatStringsSep "\n" serviceProblems;
     flatpakProblems = pkgs.lib.concatStringsSep "\n" flatpakProblems;
     flatpakCount = builtins.toString (builtins.length (builtins.attrNames flatpaks));
+    flatpakRemotes = pkgs.lib.concatStringsSep " " flatpakRemotes;
     flatpakOurs = pkgs.lib.boolToString flatpakDefaults.ours;
     flatpakTheirs = pkgs.lib.boolToString flatpakDefaults.theirs;
     flatpakOn = pkgs.lib.boolToString flatpakDefaults.onWhenAsked;
@@ -427,6 +445,21 @@ pkgs.runCommand "nixarchy-options"
           echo "$report"
           echo "the services catalogue is well formed ($serviceCount entries)"
           echo "the flatpak catalogue is well formed ($flatpakCount entries)"
+
+          # ---- Flathub survives a custom remote ---------------------------
+          case " $flatpakRemotes " in
+            *" flathub "*) ;;
+            *) echo "enabling a flatpak from another remote removed flathub:" >&2
+               echo "  remotes = $flatpakRemotes" >&2
+               echo "nix-flatpak's remotes option replaces rather than appends." >&2
+               exit 1 ;;
+          esac
+          case " $flatpakRemotes " in
+            *" GeForceNOW "*) ;;
+            *) echo "the entry's own remote was not declared: $flatpakRemotes" >&2
+               exit 1 ;;
+          esac
+          echo "a flatpak from another remote keeps flathub ($flatpakRemotes)"
 
           # ---- flatpaks are not removed unless asked ---------------------
           if [ "$flatpakOurs" != "false" ] || [ "$flatpakTheirs" != "false" ]; then
@@ -558,6 +591,33 @@ pkgs.runCommand "nixarchy-options"
           *) echo "the ISO filename does not carry the version: $isoName" >&2; exit 1 ;;
         esac
         echo "the two images are tellable apart by name and label ($isoLabel / $netLabel)"
+
+        # ---- a flatpak is pickable, by the tooling that already exists ------
+        #
+        # The whole reason flatpaks went into services.nix rather than a fourth
+        # file is that nixarchy-service-enable then handles them unchanged --
+        # same #@ markers, and its "is the marked line live?" test is the one
+        # that works for a line not beginning with the id.
+        #
+        # That makes two things silently coupled: the row has to be IN the
+        # services template, and the menu row has to call service-enable. Move
+        # flatpaks to their own file and the menu still renders, still looks
+        # right, and answers "no service 'geforce-now'" when clicked. So assert
+        # the coupling rather than trusting it.
+        for id in ${toString (builtins.attrNames (import ../data/flatpaks.nix))}; do
+          grep -qE "#@ $id([[:space:]]|$)" "$vm/etc/nixarchy/services-template.nix" || {
+            echo "flatpak '$id' has no marked row in the services template:" >&2
+            echo "  nixarchy-service-enable $id will fail, and the menu row calls exactly that" >&2
+            exit 1
+          }
+          # And commented out to begin with -- a catalogue that installs itself
+          # is not a catalogue.
+          grep -qE "^[[:space:]]*#.*#@ $id([[:space:]]|$)" "$vm/etc/nixarchy/services-template.nix" || {
+            echo "flatpak '$id' is live in the template: it would install unasked" >&2
+            exit 1
+          }
+        done
+        echo "every flatpak has a commented, marked row the existing tooling can enable"
           touch $out
       ''
     else


### PR DESCRIPTION
Closes #108. The other half of #107: the catalogue listed what was on offer and nothing could pick any of it.

- `modules/flatpaks.nix` — a selection becomes `services.flatpak.packages`, and any remote those entries need gets declared
- rows in the generated `services.nix` template, carrying the same `#@ id` markers
- rows in the Install menu

### The rows go in `services.nix`, and that is the whole design

A flatpak line reads `programs.nixarchy.flatpaks.apps.X.enable` — which does **not** begin with the id, exactly like a plain service's `services.openssh.enable`. `nixarchy-service-enable` already asks the right question for that shape (*is the marked line live?*, not *does a line start with the id?*), so it handles flatpaks **with no changes at all** — and neither do `nixarchy-service-disable`, `nixarchy-catalogue-diff` or `nixarchy-apply`.

#108 said that if the existing tooling needed changing, the marker abstraction was wrong. It did not.

### What that couples, and the check for it

Two things are now silently coupled: the row must be **in** the services template, and the menu row must call `service-enable`. Move flatpaks to their own file and the menu still renders, still looks right, and answers `no service 'geforce-now'` when clicked.

`checks.options` asserts both, plus that every catalogue row arrives commented out — a catalogue that installs itself is not a catalogue. Verified by deleting the block:

```
> flatpak 'geforce-now' has no marked row in the services template:
>   nixarchy-service-enable geforce-now will fail, and the menu row calls exactly that
```

The enable path was also checked end to end against the built template: 0 → 1 live line, exactly one line changed, nothing else disturbed.

### The tier is stated, not hidden

```
# ── Flatpak ──────────────────────────────────────
#
# Declared, not reproducible: the ids below travel to your next
# machine, the versions do not. A rollback restores this list, not
# the software that was installed from it, and the first switch
# after enabling one needs a network.
#
# Their data in ~/.var/app is yours and nixarchy never touches
# it: turning one off here removes the app, not what you did
# with it.
```

The menu row's `description` says the same in one line, because a flatpak row sitting beside a nixpkgs app row should not look like the same kind of promise.

Also drops the unused `inputs` argument from `modules/flatpaks.nix` (deadnix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5