### PR TITLE
Flathub in the picker, without giving up the offline index

### DIFF
--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -215,6 +215,33 @@ let
   # services.nix already holds things that are decisions about the machine
   # rather than packages, which is what enabling a flatpak is: it turns on a
   # daemon, adds a remote, and installs software the store does not hold.
+  # Curated flatpaks as picker rows, plus the one row that reaches the rest of
+  # Flathub. Written whole in Nix rather than transformed by awk at index time
+  # like the app rows: there are a handful of these and the preview text is
+  # prose, so a template is clearer than a transformation.
+  #
+  # Five tab-separated fields, matching every other source: kind, name,
+  # summary, option type (unused here), preview.
+  flatpakIndexRows = pkgs.writeText "nixarchy-flatpak-rows.tsv" (
+    lib.concatStrings (
+      lib.mapAttrsToList (name: fp: ''
+        flatpak	${name}	${fp.label} -- flatpak, from ${
+          if fp ? remote then fp.remote.name else "Flathub"
+        }		FLATPAK  ${name}\n\n${fp.label}\n${fp.note}\n\nDeclared, not reproducible: the id travels to your next machine, the version does not. Enabling this writes a line in your services selection:\n  programs.nixarchy.flatpaks.apps.${name}.enable = true;
+      '') flatpakCatalogue
+    )
+    # The way out of the catalogue. A row rather than a flag, because a flag
+    # nobody knows about is not a search anyone finds -- and this is precisely
+    # the row someone needs when the other three sources have failed them.
+    # Escaped \n, not a real one: the preview field keeps its newlines escaped
+    # like every other source, because the whole row must stay on ONE line. A
+    # real newline splits this into five rows, four of them nonsense, and the
+    # picker renders them without complaint.
+    + "flatpak	flathub	Search all of Flathub for something not listed here (needs a network)		"
+    + "SEARCH FLATHUB\\n\\nAsks flathub.org for anything, not just what nixarchy curates.\\n\\n"
+    + "This is the only row here that needs a network, and the only one that can offer an app nobody has checked. A hit that is in nixarchy's catalogue is enabled the normal way; anything else prints a line for you to paste, because writing an unchecked app id into your configuration is not this tool's call to make.\n"
+  );
+
   flatpakRow =
     name: fp:
     let
@@ -1297,6 +1324,7 @@ in
               pkgs.gawk
               pkgs.jq
               pkgs.fzf
+              pkgs.curl
               config.nix.package
             ];
             text = ''
@@ -1306,6 +1334,7 @@ in
               stamp="$cache/stamp"
 
               appindex=${appIndexTable}
+              flatpakrows=${flatpakIndexRows}
               optionsjson=${optionsJsonPath}
               nixpkgs=${pkgs.path}
 
@@ -1375,6 +1404,11 @@ in
                         + "environment.systemPackages = with pkgs; [ " + $a + " ];"
                       )
                     ] | @tsv' >> "$tmp"
+
+                # Curated flatpaks and the Flathub entry point. A plain cat:
+                # these rows are already in the index's five-field shape, and
+                # they are local, so building the index still needs no network.
+                cat "$flatpakrows" >> "$tmp"
 
                 mv "$tmp" "$index"
                 readlink -f /run/current-system > "$stamp"
@@ -1465,12 +1499,81 @@ in
                 scaffolded=$((scaffolded + 1))
               }
 
+              # Ask flathub.org directly.
+              #
+              # NOT `flatpak search`, which is columnar with no JSON output and
+              # needs both a configured remote and a downloaded appstream cache
+              # -- so it answers nothing on a machine that has not set flatpak
+              # up yet, which is exactly the machine asking.
+              #
+              # This is the one thing in the picker that needs a network. The
+              # index itself is still built entirely from local sources, so the
+              # other three kinds keep working on a machine with none; only
+              # this row fails, and it says so.
+              flathub_search() {
+                local query hits picked id line
+                read -r -p "Search Flathub for: " query || return 0
+                [ -n "$query" ] || return 0
+
+                # --fail so an HTTP error is an error rather than an error page
+                # parsed as zero results, which is the failure that looks like
+                # "nothing matched" and sends someone hunting for a typo.
+                if ! hits=$(curl -sS --fail -m 20 \
+                      -X POST https://flathub.org/api/v2/search \
+                      -H 'Content-Type: application/json' \
+                      -d "$(jq -nc --arg q "$query" '{query: $q, filters: []}')" 2>&1); then
+                  echo "nixarchy: could not reach flathub.org." >&2
+                  echo "  Searching Flathub needs a network; the other rows in this picker do not." >&2
+                  return 1
+                fi
+
+                picked=$(printf '%s' "$hits" |
+                  jq -r '.hits[]? | [.app_id, (.name // ""), ((.summary // "") | gsub("[\n\t]"; " "))] | @tsv' |
+                  fzf --multi --with-nth=2.. --delimiter='\t' \
+                      --prompt="flathub > " --height=80% \
+                      --preview='echo {1}' --preview-window=down,3) || return 0
+                [ -n "$picked" ] || { echo "nothing on Flathub matched '$query'"; return 0; }
+
+                while IFS=$'\t' read -r id _ _; do
+                  [ -n "$id" ] || continue
+                  # In the catalogue? Then it has been checked, and the normal
+                  # writer handles it.
+                  if grep -qE "^flatpak\t[^\t]+\t" "$index" &&
+                     awk -F'\t' -v i="$id" '$1=="flatpak" && $2==i {found=1} END {exit !found}' "$index"; then
+                    nixarchy-service-enable "$id" && changed=1
+                    continue
+                  fi
+                  # Otherwise print it rather than write it. Nixarchy has not
+                  # checked this app, and generating configuration for an id
+                  # nobody has looked at is not a thing to do on someone's
+                  # behalf.
+                  line="  services.flatpak.packages = [ \"$id\" ];"
+                  echo
+                  echo "$id is not in nixarchy's catalogue, so nothing was written."
+                  echo "Add this to ~/.config/nixarchy/advanced.nix yourself:"
+                  echo
+                  echo "$line"
+                done <<< "$picked"
+                echo
+                echo "then run 'nixarchy-apply'"
+              }
+
               while IFS=$'\t' read -r kind name _ type _; do
                 [ -n "$kind" ] || continue
                 case "$kind" in
                   app) nixarchy-app-enable "$name" && changed=1 ;;
                   pkg) nixarchy-pkg-add "$name" && changed=1 ;;
                   opt) add_option "$name" "$type" ;;
+                  # nixarchy-service-enable, not a flatpak-specific command:
+                  # the rows live in services.nix and carry the same #@ markers,
+                  # so the writer that already exists is the right one.
+                  flatpak)
+                    if [ "$name" = "flathub" ]; then
+                      flathub_search
+                    else
+                      nixarchy-service-enable "$name" && changed=1
+                    fi
+                    ;;
                 esac
               done <<< "$selection"
 

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -618,6 +618,29 @@ pkgs.runCommand "nixarchy-options"
           }
         done
         echo "every flatpak has a commented, marked row the existing tooling can enable"
+
+        # ---- the picker's flatpak rows are ONE line each ---------------------
+        #
+        # The index is tab-separated, five fields, one row per line. The preview
+        # field is prose and carries its newlines escaped for exactly that
+        # reason. Write a real newline into it and the row silently becomes
+        # several rows -- which the picker renders without complaint, as
+        # unselectable nonsense between the real entries. That shipped once
+        # during development and nothing but reading the file caught it.
+        rows=$(sed -n 's/.*flatpakrows=\(\/nix\/store[^ ]*\).*/\1/p' "$vm/sw/bin/nixarchy-search" | head -1)
+        test -n "$rows" || { echo "nixarchy-search names no flatpak rows file" >&2; exit 1; }
+        bad=$(awk -F'\t' 'NF != 5 {print NR": "NF" fields"}' "$rows")
+        if [ -n "$bad" ]; then
+          echo "the picker's flatpak rows are not all five tab-separated fields:" >&2
+          echo "$bad" >&2
+          echo "  a real newline in the preview field splits one row into several" >&2
+          exit 1
+        fi
+        awk -F'\t' '$1 != "flatpak" {print; exit 1}' "$rows" >/dev/null || {
+          echo "a flatpak row does not carry the flatpak kind, so routing will miss it" >&2
+          exit 1
+        }
+        echo "the picker's flatpak rows are $(wc -l < "$rows") well-formed lines"
           touch $out
       ''
     else


### PR DESCRIPTION
Closes #109 — and with it, epic #105.

`nixarchy-search` offered nixpkgs packages, NixOS options and curated apps. Flathub is the fourth source, and the one someone reaches for precisely when the first three have failed them.

### The tension, and why this splits in two

Every other source is local, and the picker works with no network — worth keeping for a project that just shipped an offline installer. So rather than picking a side:

| | |
|---|---|
| **Curated flatpaks** | ordinary index rows, generated from `data/flatpaks.nix` at build time. No network, searchable offline, routed to `nixarchy-service-enable` |
| **The rest of Flathub** | one row named `flathub` — asks for a query, calls the API live |

A row rather than a flag: a flag nobody knows about is not a search anyone finds.

**The issue said curated ids route to `nixarchy-flatpak-enable`.** That command was never built — #108 put the rows in `services.nix` specifically so the existing writer handles them. That decision pays off again here.

### Failing clearly

`curl --fail`, so an HTTP error page is an error rather than zero results parsed as "nothing matched" — the failure that looks like a typo and sends someone hunting. Verified against an unreachable host:

```
nixarchy: could not reach flathub.org.
  Searching Flathub needs a network; the other rows in this picker do not.
```

Not `flatpak search`: columnar, no JSON, and it needs both a configured remote and a downloaded appstream cache — so it answers nothing on a machine that has not set flatpak up yet, which is exactly the machine asking.

### An uncurated hit is printed, not written

Generating configuration for an app id nobody has checked is not this tool's call. It prints the `services.flatpak.packages` line and names the file to put it in.

### One bug worth recording

The `flathub` row first went in with **real** newlines instead of escaped ones — a Nix `"…"` string expands `\n`, the `''` block beside it does not. The row silently became five, four of them nonsense, and the picker rendered them without complaint. `checks.options` now asserts every flatpak row is five tab-separated fields; verified by putting the bug back:

```
> the picker's flatpak rows are not all five tab-separated fields:
> 3: 0 fields
> 4: 1 fields
>   a real newline in the preview field splits one row into several
```

The live API path was also exercised for real — `org.gimp.GIMP | GNU Image Manipulation Program | …` comes back as clean three-field TSV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5