### PR TITLE
Roadmap: Flatpaks are done

### DIFF
--- a/README.md
+++ b/README.md
@@ -1535,11 +1535,13 @@ is the shape.
 | epic | what it is for | |
 | --- | --- | --- |
 | [#6](https://github.com/olafkfreund/nixarchy/issues/6) | **bare metal to a desktop** — the installer, the ISO, the release | 18 of 22 done |
-| [#105](https://github.com/olafkfreund/nixarchy/issues/105) | **Flatpaks, declared** — for the software nixpkgs does not carry | not started |
 | [#112](https://github.com/olafkfreund/nixarchy/issues/112) | **getting back** — snapshots, backup, restore | not started |
 | [#121](https://github.com/olafkfreund/nixarchy/issues/121) | **many machines, one repo** — fleets, unattended installs, shared configs | not started |
 
-**Recently finished:** the app selection grew a
+**Recently finished:** [Flatpaks, declared](https://github.com/olafkfreund/nixarchy/issues/105)
+— for the handful of things nixpkgs cannot carry. Pickable from the menu,
+searchable against Flathub, and declared in the same file as everything else.
+Also the app selection grew a
 [services catalogue](https://github.com/olafkfreund/nixarchy/issues/90) —
 Docker, SSH, printing and the rest, pickable from the menu the way apps are.
 


### PR DESCRIPTION
#105 is closed with all four children in (#106, #107, #108, #109), so it moves out of the "planned" table and into the line above it.

Required, not cosmetic: `build.yml` checks both directions, and a **closed** epic still listed as planned fails the build exactly as a missing open one does. Both directions simulated locally before pushing — open epics `6 112 121`, roadmap `6 112 121`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5