### PR TITLE
The password hash leaves the repo

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -585,7 +585,6 @@ write_flake() {
     subst "$f" '@device@' "$device"
     subst "$f" '@timezone@' "$timezone"
     subst "$f" '@keymap@' "$keymap"
-    subst "$f" '@password_hash@' "$password_hash"
     # Quoted in the template because a bare token is not parseable Nix; the
     # quotes go with the token. An encrypted disk has already authenticated the
     # user by the time a greeter would ask, so autologin follows encryption.
@@ -762,6 +761,24 @@ PIN
   } >"$file.pinned" && mv "$file.pinned" "$file"
 }
 
+# The login hash, written outside the flake directory.
+#
+# It used to be substituted into configuration.nix, which put it in a git
+# repository the user is then encouraged to push. Same umask discipline as the
+# LUKS passphrase file above, but this one stays: the installed machine needs
+# it at every activation, because users.users.<name>.hashedPasswordFile is read
+# then and not baked into the store.
+#
+# Root-owned and 0600. It is not a password, but a crypt hash is worth exactly
+# as much as the time somebody is willing to spend on it offline.
+write_password_hash() {
+  ( umask 077
+    mkdir -p /mnt/var/lib/nixarchy
+    printf '%s\n' "$password_hash" >/mnt/var/lib/nixarchy/password.hash )
+  chmod 0600 /mnt/var/lib/nixarchy/password.hash
+  chown 0:0 /mnt/var/lib/nixarchy/password.hash
+}
+
 install_flake_dir() {
   mkdir -p /mnt/etc
   mv "$work" /mnt/etc/nixos
@@ -927,6 +944,7 @@ main() {
     format_disk
     generate_hardware_config
     install_flake_dir
+    write_password_hash
     run_install
   } >>"$log" 2>&1 || rc=$?
   ui_dashboard_stop
@@ -965,8 +983,11 @@ main() {
 }
 
 # Guarded so the functions above can be sourced and exercised without running
-# an install: that is how write_flake's substitution is tested (a crypt hash
-# full of $ and & is exactly the input a naive implementation ruins).
+# an install. The substitution's original stress case -- a crypt hash full of
+# $ and & -- no longer passes through it, because the hash is written to a file
+# now rather than into the template. subst stays as it is anyway: it is proven,
+# and being literal on the replacement side is the correct behaviour for a
+# device path or a timezone too.
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then
   main "$@"
 fi

--- a/installer/template/configuration.nix
+++ b/installer/template/configuration.nix
@@ -28,5 +28,14 @@
     user = "@username@";
   };
 
-  users.users."@username@".hashedPassword = "@password_hash@";
+  # The hash is NOT in this file, and that is the point: this directory is a
+  # git repository, nixarchy-config-repo exists to push it to GitHub, and a
+  # crypt hash is offline-crackable at leisure by anyone who reads it. So it
+  # lives outside the repo and this file names where.
+  #
+  # /var/lib rather than /etc/nixarchy, which is a NixOS-managed directory --
+  # an unmanaged file dropped among generated symlinks survives today only
+  # because the /etc overlay is off, and the failure if that changes is that
+  # nobody can log in.
+  users.users."@username@".hashedPasswordFile = "/var/lib/nixarchy/password.hash";
 }

--- a/tests/install.nix
+++ b/tests/install.nix
@@ -463,6 +463,22 @@ pkgs.testers.runNixOSTest {
     installer.succeed("test -d /mnt/boot/EFI")
     print("install wrote a flake and an ESP")
 
+    # ---- the login hash is NOT in the repository -----------------------
+    #
+    # /etc/nixos is a git repository and nixarchy-config-repo exists to push
+    # it to GitHub, so a crypt hash written into configuration.nix is a hash
+    # published to whoever reads that repo. It used to be. Asserted from this
+    # side because the whole tree is visible here, including files a later
+    # step might add.
+    installer.fail("grep -rq '[$]6[$]' /mnt/etc/nixos")
+    installer.succeed("test -f /mnt/var/lib/nixarchy/password.hash")
+    mode = installer.succeed(
+        "stat -c '%a %U:%G' /mnt/var/lib/nixarchy/password.hash").strip()
+    assert mode == "600 root:root", (
+        f"the password hash is {mode}, not 600 root:root -- it is readable by "
+        "somebody it should not be")
+    print("the hash is outside the repo, 0600 root:root")
+
     # ---- make the result observable ------------------------------------
     # Everything above this line is the product. Everything below adds the
     # serial root shell the driver needs and nothing else; see the note on
@@ -530,6 +546,16 @@ pkgs.testers.runNixOSTest {
     target.wait_until_succeeds("systemctl is-active user@1000.service")
     target.wait_until_succeeds("pgrep -u 1000 -f Hyprland")
     print("the installed machine reaches a Hyprland session")
+
+    # That login is the proof the indirection works: hashedPasswordFile is read
+    # at activation rather than baked into the store, so a hash file that was
+    # missing, misplaced or unreadable would have failed authentication just
+    # now. Assert it survived the boot as well -- /var/lib is not managed by
+    # /etc activation, which is exactly why the file is there and not in
+    # /etc/nixarchy among the generated symlinks.
+    target.succeed("test -f /var/lib/nixarchy/password.hash")
+    target.fail("grep -rq '[$]6[$]' /etc/nixos")
+    print("the hash survived the boot, and the repo is still clean of it")
 
     # ---- the flake on disk is the user's -------------------------------
     target.succeed("git -C /etc/nixos rev-parse --is-inside-work-tree")


### PR DESCRIPTION
Closes #122. First child of #121, because every other story in that epic ends with the generated repo being pushed somewhere or handed to someone.

### The problem

`installer/template/configuration.nix` put the login hash straight into the git repository the installer creates:

```nix
users.users."@username@".hashedPassword = "@password_hash@";
```

`nixarchy-config-repo` exists specifically to push that repo to GitHub. A crypt hash is not a password, but it is offline-crackable at leisure by anyone who reads it.

### Where it goes instead

`/var/lib/nixarchy/password.hash`, written by the installer with `umask 077`, `0600 root:root`, outside the flake directory so it is never staged.

**Not `/etc/nixarchy/`**, which was the obvious choice and is wrong: that is a NixOS-*managed* directory — four generated symlinks into the store live there. An unmanaged file among them survives today only because `system.etc.overlay.enable` is `false`, and the failure mode if that ever flips is *nobody can log in* — worse than the problem being fixed. `/var/lib` is never touched by `/etc` activation, and #126 already plans to put its upgrade-failure marker there.

### Verified

`checks.install` boots the installed disk and types the password at the greeter, so the indirection is proven by an actual login — `hashedPasswordFile` is read at activation, not baked into the store, so a file that was missing, misplaced or unreadable would fail there:

```
install wrote a flake and an ESP
the hash is outside the repo, 0600 root:root
target # sddm[1328]: Authentication for user "omarchy" successful
the installed machine reaches a Hyprland session
the hash survived the boot, and the repo is still clean of it
```

New assertions: no `$6$` anywhere under `/etc/nixos` (checked installer-side, where the whole tree is visible), the file is exactly `600 root:root`, and both still hold after the boot. The grep pattern was checked against the old and new templates directly — it finds the hash in the pre-change shape and not in this one.

### Also

The trailing comment claiming `subst`'s stress case is a crypt hash full of `$` and `&` is no longer true, since the hash does not pass through it. Updated rather than left as a comment that describes something that stopped happening — `subst` stays, because being literal on the replacement side is right for a device path too.

`--dry-run` is unaffected (the write happens only on the real path), and `tests/install-iso.nix` needed no change — the answers file still takes `password_hash`, only its destination moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5