### PR TITLE
installer-vm: give its store a real disk

### DIFF
--- a/installer/vm.nix
+++ b/installer/vm.nix
@@ -66,12 +66,16 @@
   # The hash is "omarchy". This VM is a disposable test harness reachable only
   # from the host that started it.
   #
-  # /dev/vda, not /dev/vdb as in checks.install: this VM has an ephemeral tmpfs
-  # root and therefore no root drive at all, so the empty disk is the first
-  # virtio device rather than the second. The check's nodes have a real root
-  # disk, which shifts theirs along by one.
+  # /dev/vdb, the same as checks.install, and for the same reason: this VM has
+  # a real root disk, so the empty target is the SECOND virtio device.
+  #
+  # It was /dev/vda while the root was an ephemeral tmpfs and there was no root
+  # drive to come first. That changed when the writable store moved onto a real
+  # disk (see virtualisation below), and the two have to move together -- a
+  # root disk with device=/dev/vda still set points the installer at the
+  # machine it is running on.
   environment.etc."nixarchy/answers".text = ''
-    device=/dev/vda
+    device=/dev/vdb
     encrypt=no
     hostname=installed
     username=omarchy
@@ -97,7 +101,7 @@
       touch /tmp/nixarchy-install-done
       log=/tmp/nixarchy-install.log
       echo
-      echo "[nixarchy] installing onto /dev/vda"
+      echo "[nixarchy] installing onto /dev/vdb"
       echo
       # PIPESTATUS, not the pipeline's status. `cmd | tee` reports tee's exit
       # code, which is 0 whatever cmd did -- so a plain `if` here printed
@@ -131,14 +135,25 @@
     memorySize = 8192;
     cores = 4;
     useEFIBoot = true;
-    # The blank target. With no root drive it appears as /dev/vda.
-    emptyDiskImages = [ 20480 ];
-    # nixos-install copies a whole desktop closure into the target, and this
-    # VM's own store has to hold it first.
+    # The blank target: /dev/vdb, since the root disk below is /dev/vda.
+    emptyDiskImages = [ 40960 ];
+    # nixos-install builds the closure in THIS VM's store before copying it
+    # into the target, so this VM's store has to hold it first -- 13.7 GiB of
+    # it at the last count.
+    #
+    # diskSize does not provide that, and quietly has not for some time:
+    # diskImage = null means there is no disk for diskSize to size, so the
+    # writable store is the RAM-backed tmpfs below. The install then dies
+    # partway through with "No space left on device", three levels underneath
+    # a "1 dependency failed" that names none of it.
+    #
+    # So the store goes on a real disk (diskImage now defaults to a qcow2 in
+    # the working directory). That file persists between runs, which
+    # diskImage = null was avoiding -- but the property that mattered is the
+    # TARGET starting unpartitioned, and emptyDiskImages is recreated blank
+    # every run regardless. Delete the qcow2 to start the installer clean.
     diskSize = 32768;
-    # Ephemeral, so every run starts from an unpartitioned disk. That is the
-    # state a real install begins in and the only one worth testing from.
-    diskImage = null;
+    writableStoreUseTmpfs = false;
   };
 
   # Stop logind spawning a getty on tty1 at all. tty1 is the qemu window and


### PR DESCRIPTION
`nix run .#installer-vm` has been failing, and had been for a while. Found while using it to test something unrelated.

### What was wrong

```
error: write of 65536 bytes: No space left on device
error: path '…noto-fonts-2026.08.01' is required, but there is no substituter that can build it
error: some references of path '…fontconfig-conf' could not be realised
error: Cannot build '…-etc.drv'. Reason: 1 dependency failed.
```

What reaches the screen is the last line — a three-level `1 dependency failed` cascade that names none of the cause. The cause is the first line.

`nixos-install` builds the closure in the **installer's own** store before copying it to the target, which the file's own comment anticipated:

> nixos-install copies a whole desktop closure into the target, and this VM's own store has to hold it first.

But the setting meant to provide that space was inert. `diskImage = null` means there is **no disk** for `diskSize = 32768` to size, so the writable store fell back to the RAM-backed tmpfs — 8 GB against a **13.7 GiB** closure. It could never have fit; the closure simply grew past the ceiling at some point and nothing was watching.

### The fix

`writableStoreUseTmpfs = false`, so `diskSize` applies to a real qcow2. Target bumped to 40 GB while here.

The `diskImage = null` line was buying ephemerality. What actually mattered — the **target** starting unpartitioned — is unaffected: `emptyDiskImages` is recreated blank every run regardless. The VM's own root qcow2 now persists in the working directory; delete it to start clean, and the comment says so.

### The part that nearly caused a much worse bug

The file documented that the target is `/dev/vda` *specifically because* there was no root drive:

> this VM has an ephemeral tmpfs root and therefore no root drive at all, so the empty disk is the first virtio device rather than the second

Giving the VM a root disk shifts the blank disk to `/dev/vdb`. Leaving `device=/dev/vda` would have pointed the installer at **the machine it is running on**. Moved in the same commit, with the comment rewritten to say the two have to move together.

### Verified

This exact configuration completed an install end to end: `Installed nixarchy in 8m 4s`, `INSTALL OK`.

### Worth noting separately

**Nothing in CI runs `installer-vm`**, which is why this rotted unnoticed. Same blind spot let #133 through — the interactive path has no coverage at all, because every harness passes `--answers` and `ui_interactive()` then skips every gum screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5