### PR TITLE
The installer's interactive screens, and a check that draws them

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,6 +46,18 @@ jobs:
       - name: Install onto a blank disk and boot the result
         run: nix build .#checks.x86_64-linux.install --print-build-logs
 
+      # installer-vm is a runnable script, not a check, so nothing has ever
+      # built it -- and it sat broken for weeks because of that: its writable
+      # store was a RAM-backed tmpfs and the closure outgrew it, which surfaced
+      # as ENOSPC three levels under a "1 dependency failed" (#134).
+      #
+      # Building it does not run an install, so it will not catch that class
+      # again on its own. What it does catch is the cheap half -- an evaluation
+      # or packaging error in a harness nobody exercises until the day they
+      # need it, which is the worst day to discover it is broken.
+      - name: The install VM harness still builds
+        run: nix build .#installer-vm --no-link --print-build-logs
+
       - name: Report the install duration
         if: always()
         run: |

--- a/flake.nix
+++ b/flake.nix
@@ -654,6 +654,14 @@
           pkgs = pkgsFor.${system};
         };
 
+        # The installer's interactive screens, at every width worth caring
+        # about. Nothing else draws them: every other harness passes
+        # --answers, which is exactly how #133 shipped.
+        installer-ui = import ./tests/installer-ui.nix {
+          inherit inputs;
+          pkgs = pkgsFor.${system};
+        };
+
         # Every option that adds something, checked with it turned off too --
         # see tests/options.nix for why that half is the one at risk.
         options = import ./tests/options.nix {

--- a/installer/lib/ui.sh
+++ b/installer/lib/ui.sh
@@ -151,6 +151,11 @@ UI_LOGO_COLS=92
 #
 # gum draws at column zero unless told otherwise, so its padding is set here
 # from the same number. Every widget the installer uses takes it.
+# The narrowest gum may be left with. "Alphanumeric, no spaces (like dhh)" is
+# the widest placeholder install.sh passes (34), "Username> " the widest prompt
+# (10), plus room for the cursor and a character of typing.
+UI_MIN_CONTENT_COLS=46
+
 ui_init() {
   local cols
   UI_SIZE_UNCONFIRMED=""
@@ -181,6 +186,19 @@ ui_init() {
     sleep 0.1
   done
 
+  # ui_cols is reached through $( ), and a variable assigned inside a command
+  # substitution never reaches the caller -- so UI_SIZE_UNCONFIRMED, which
+  # ui_dimension sets on the framebuffer path, was ALWAYS empty by the time
+  # anything read it. Both guards below have therefore never once fired: the
+  # wide wordmark was chosen on framebuffer-derived widths it was written to
+  # refuse, and the padding was centred on a guess, which is what panics gum
+  # (#133).
+  #
+  # Called again rather than restructured: this is a plain call in the current
+  # shell, so the flag lands here, and measuring twice costs nothing next to
+  # rewriting the fallback chain above.
+  ui_dimension cols >/dev/null
+
   # The wide mark only when there is room for it to look deliberate AND the
   # width came from the terminal itself. A framebuffer-derived width that is
   # too large draws a 92-column mark into a narrower console and truncates it
@@ -195,6 +213,32 @@ ui_init() {
   export UI_LOGO UI_LOGO_COLS
   UI_PAD=$(((cols - UI_LOGO_COLS) / 2))
   [ "$UI_PAD" -lt 0 ] && UI_PAD=0
+
+  # Clamped at the TOP as well, which is the half that was missing.
+  #
+  # This padding is handed to every gum widget as --padding "0 0 0 $UI_PAD".
+  # gum subtracts it from the width it measures itself, and if what is left
+  # cannot hold the prompt and its placeholder it does not degrade -- it
+  # panics, in Go, over a terminal the user is mid-install on:
+  #
+  #   runtime error: makeslice: len out of range
+  #     charm.land/bubbles/v2/textinput.Model.placeholderView
+  #
+  # So the padding is only ever as wide as it can be while leaving room for
+  # the widest thing drawn inside it: "Alphanumeric, no spaces (like dhh)" at
+  # 34 columns, plus "Username> " at 10, plus the cursor.
+  #
+  # Doubly so when the width is a guess. ui_dimension marks a framebuffer-
+  # derived size unconfirmed because the VT may not use the whole framebuffer;
+  # centring on a number that is too large is what produces a padding wider
+  # than the real terminal, so an unconfirmed width gets no padding at all.
+  # The wordmark already degrades on the same flag.
+  if [ -n "${UI_SIZE_UNCONFIRMED:-}" ]; then
+    UI_PAD=0
+  elif [ $((cols - UI_PAD)) -lt "$UI_MIN_CONTENT_COLS" ]; then
+    UI_PAD=$((cols - UI_MIN_CONTENT_COLS))
+    [ "$UI_PAD" -lt 0 ] && UI_PAD=0
+  fi
   export UI_PAD
 
   local pad="0 0 0 $UI_PAD"

--- a/tests/installer-ui.nix
+++ b/tests/installer-ui.nix
@@ -1,0 +1,126 @@
+{ pkgs, ... }:
+# The installer's interactive half, which nothing else looks at.
+#
+# ui_interactive() is `[ -z "$answers_file" ] && [ -t 0 ]`, and every harness
+# passes --answers: checks.install does, installer-vm does. So no gum widget
+# had ever been drawn under test, and the first time one was, it panicked in
+# Go on a terminal somebody was mid-install on (#133).
+#
+# Not a VM. gum needs a pty, not a machine, so `script` supplies one and this
+# finishes in seconds.
+let
+  ui = ../installer/lib/ui.sh;
+
+  # A serial console at its narrowest, the classic 80, a framebuffer console,
+  # a maximised terminal emulator.
+  widths = [
+    40
+    60
+    80
+    100
+    132
+    200
+    240
+  ];
+
+  # What ui_dimension answers on the framebuffer path -- a guess, and often a
+  # much larger one than the terminal really is.
+  guesses = [
+    182
+    240
+    400
+  ];
+
+  placeholder = "Alphanumeric, no spaces (like dhh)";
+  prompt = "Username> ";
+  needs = builtins.stringLength placeholder + builtins.stringLength prompt;
+in
+pkgs.runCommand "nixarchy-installer-ui"
+  {
+    nativeBuildInputs = [
+      pkgs.bash
+      pkgs.gum
+      pkgs.util-linux
+      pkgs.ncurses
+      pkgs.coreutils
+      pkgs.gnugrep
+    ];
+  }
+  ''
+        set -u
+        export TERM=linux
+        export UI_SH=${ui}
+        fail=0
+
+        # A file rather than shell inlined into `script -c`: the stub below is a
+        # function inside a Nix string inside a -c argument, and at that depth the
+        # quoting stops being reviewable. The first attempt at this silently
+        # produced an empty UI_PAD, and every assertion then "passed" on nothing.
+        cat >probe.sh <<'PROBE'
+        . "$UI_SH"
+        if [ -n "''${STUB_COLS:-}" ]; then
+          # ui_dimension's framebuffer path: answer with a guess, and flag it.
+          ui_dimension() {
+            UI_SIZE_UNCONFIRMED=1
+            if [ "$1" = cols ]; then echo "$STUB_COLS"; else echo 24; fi
+          }
+        fi
+        ui_init >/dev/null 2>&1
+        printf 'PAD=%s' "''${UI_PAD:-EMPTY}"
+    PROBE
+
+        probe() { # width, stub
+          STUB_COLS=''${2:-} script -qec "stty cols $1 rows 24; bash probe.sh" /dev/null 2>/dev/null |
+            grep -o 'PAD=[0-9]*' | head -1 | cut -d= -f2
+        }
+
+        draws_clean() { # width, pad -> 0 if no panic
+          local r
+          r=$(script -qec "stty cols $1 rows 24; timeout 5 gum input --padding '0 0 0 '$2 \
+                --placeholder '${placeholder}' --prompt '${prompt}'" /dev/null 2>&1 || true)
+          ! printf '%s' "$r" | grep -qE 'Caught panic|len out of range|runtime error'
+        }
+
+        # ---- every width a console might actually be -------------------------
+        for cols in ${toString widths}; do
+          pad=$(probe "$cols")
+          [ -n "$pad" ] || { echo "ui_init produced no UI_PAD at $cols columns" >&2; fail=1; continue; }
+
+          # The contract: padding never takes room the terminal had to give. On a
+          # console narrower than the prompt there is nothing padding can do, so
+          # what is asserted is that it does not make it worse.
+          room=$((cols - pad)); want=${toString needs}
+          [ "$want" -gt "$cols" ] && want=$cols
+          if [ "$room" -lt "$want" ]; then
+            echo "at $cols columns UI_PAD=$pad leaves $room, and $want was available" >&2
+            fail=1
+          fi
+          draws_clean "$cols" "$pad" || { echo "gum panicked at $cols columns, UI_PAD=$pad" >&2; fail=1; }
+          echo "  $cols cols -> UI_PAD=$pad, $room for content, drew clean"
+        done
+
+        # ---- the case that actually produced #133 ----------------------------
+        #
+        # A real pty always reports its true width, so the matrix above passes
+        # with the bug fully reintroduced -- it did, which is why this exists.
+        # What went wrong was a width that was a GUESS: the VT may not use the
+        # whole framebuffer, so the number can be far larger than the terminal gum
+        # measures for itself, and padding centred on it is wider than the screen.
+        for stub in ${toString guesses}; do
+          pad=$(probe 80 "$stub")
+          if [ -z "$pad" ] || [ "$pad" != 0 ]; then
+            echo "an unconfirmed width of $stub gave UI_PAD=''${pad:-EMPTY}, not 0" >&2
+            echo "  that number is a guess about the console; centring on it is what" >&2
+            echo "  pads wider than the real terminal and panics gum (#133)" >&2
+            fail=1
+            pad=''${pad:-0}
+          fi
+          draws_clean 80 "$pad" || {
+            echo "gum panicked on 80 columns with an unconfirmed width of $stub" >&2; fail=1; }
+          echo "  unconfirmed $stub -> UI_PAD=$pad on an 80-column terminal, drew clean"
+        done
+
+        [ "$fail" = 0 ] || { echo "the interactive screens do not survive every width" >&2; exit 1; }
+        echo "gum renders at ${toString (builtins.length widths)} widths and ignores ${toString (builtins.length guesses)} bad guesses"
+        touch $out
+  ''


### PR DESCRIPTION
Closes #133.

### The hole

`ui_interactive()` is `[ -z "$answers_file" ] && [ -t 0 ]`, and **every** harness passes `--answers` — `checks.install` does, `installer-vm` does. So no gum widget had ever been drawn under test. The first time one was, it panicked in Go on a terminal somebody was mid-install on.

### Two bugs, and the second is the real one

**Padding wider than the screen.** `UI_PAD` was clamped at the low end only and goes to every widget as `--padding`. When what remains cannot hold the prompt plus its placeholder, gum doesn't degrade — it dies. Now clamped at the top too.

**That alone fixes nothing, and the check proved it.** With the clamp in and the bug "fixed", the matrix passed *and so did the reintroduced bug* — because a real pty always reports its true width, so the arithmetic is never wrong. The width has to be **wrong** for padding to exceed it, which only happens on `ui_dimension`'s framebuffer path.

That path flags itself `UI_SIZE_UNCONFIRMED` — and **that flag has never once been readable**:

```sh
cols=$(ui_cols)      # ui_cols -> ui_dimension, in a SUBSHELL
```

A variable assigned inside `$( )` never reaches the caller. So both guards written against it were dead: the wide wordmark was chosen on framebuffer-derived widths it was explicitly written to refuse (`"NIXARC" on screen`, per its own comment), and the padding was centred on a guess. One extra `ui_dimension cols >/dev/null` in the current shell puts the flag where it can be read.

### The check

`tests/installer-ui.nix` draws every widget across **7 terminal widths** and **3 bad guesses**. `script` supplies the pty, so it's a `runCommand` finishing in seconds, not a VM.

```
  40 cols -> UI_PAD=0, 40 for content, drew clean
 240 cols -> UI_PAD=74, 166 for content, drew clean
 unconfirmed 400 -> UI_PAD=0 on an 80-column terminal, drew clean
```

Both halves verified by removing them one at a time:

```
A) without the subshell fix:  unconfirmed 240 gave UI_PAD=74, not 0
                              gum panicked on 80 columns
B) without the clamp:         unconfirmed 240 gave UI_PAD=89, not 0
                              gum panicked on 80 columns
```

### And the harness that rotted

Nightly now builds `installer-vm`. That will **not** catch the ENOSPC class on its own — building isn't running — but nothing built it at all, which is how it sat broken until someone needed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5