### PR TITLE
A check that answers the installer's questions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -551,6 +551,14 @@ jobs:
         # README tells people with an existing Hyprland to use.
         run: nix build .#checks.x86_64-linux.coexist --print-build-logs
 
+      - name: Answer the installer's questions
+        # The interactive path, which every other harness skips by passing
+        # --answers: the greeter, the six questions, the two validators and the
+        # summary, typed at over a serial line. --dry-run, so it costs about
+        # half a minute of test script rather than the install checks.install
+        # already covers.
+        run: nix build .#checks.x86_64-linux.installer-wizard --print-build-logs
+
       - name: Add third-party plugins from real repos
         # `omarchy plugin add <url> --enable` for two published plugins, then
         # disable and remove. The plugin system is the one deliberately

--- a/flake.nix
+++ b/flake.nix
@@ -689,6 +689,15 @@
           pkgs = pkgsFor.${system};
         };
 
+        # The other half of the installer: the questions themselves, answered
+        # over a serial line. checks.installer-ui proves a widget can be drawn;
+        # this proves the wizard can be answered, which no harness passing
+        # --answers has ever done. See tests/installer-wizard.nix.
+        installer-wizard = import ./tests/installer-wizard.nix {
+          inherit inputs;
+          pkgs = pkgsFor.${system};
+        };
+
         # Every option that adds something, checked with it turned off too --
         # see tests/options.nix for why that half is the one at risk.
         options = import ./tests/options.nix {

--- a/tests/installer-wizard.nix
+++ b/tests/installer-wizard.nix
@@ -1,0 +1,301 @@
+{ inputs, pkgs }:
+# The questions a first-time user actually answers.
+#
+# ui_interactive() is `[ -z "$answers_file" ] && [ -t 0 ]`, and every other
+# harness passes --answers: checks.install does, installer-vm does. So the
+# greeter, all six questions, the validation and the summary had never run
+# under test -- only the unattended path had. checks.installer-ui covers
+# whether a gum widget can be DRAWN (#133); nothing covered whether the wizard
+# can be ANSWERED.
+#
+# --dry-run rather than an install: it asks every question, writes the flake to
+# a temp directory and touches no disk. checks.install already proves an
+# install is correct, and reinstalling a machine to find out whether a prompt
+# re-asks a rejected username is ten minutes for an answer this gets in one.
+#
+# Driven over the serial line, not the framebuffer. send_chars is qemu's
+# virtual keyboard and lands on tty1, whose only readback is OCR; a serial
+# console gives send_console for input and wait_for_console_text for output,
+# so every assertion here is on text the installer actually wrote rather than
+# on a guess at what a screenshot says. That is also why the installer runs as
+# a service on /dev/ttyS0 -- test-instrumentation disables the getty there, and
+# a unit with StandardInput=tty is how installer/cd.nix starts it on the real
+# medium anyway.
+let
+  install = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.install;
+in
+pkgs.testers.runNixOSTest {
+  name = "nixarchy-installer-wizard";
+
+  nodes.machine = _: {
+    environment.systemPackages = [ install ];
+
+    virtualisation = {
+      memorySize = 2048;
+      # Below ask_device's 8 GiB floor, deliberately. The root disk is not an
+      # install target and the wizard must not offer it; making it too small
+      # to qualify turns "the list is right" into something this test can
+      # assert without pressing arrow keys at an ordering it cannot pin.
+      diskSize = 4096;
+      # 1 GiB is under the floor as well and 12 GiB is over it, so exactly
+      # one device -- /dev/vdc -- may appear on the disk screen.
+      emptyDiskImages = [
+        1024
+        12288
+      ];
+    };
+
+    # Not wantedBy anything: the test starts it once the machine is up, so a
+    # unit that dies during boot cannot be mistaken for a wizard that reached
+    # a question and stopped.
+    systemd.services.wizard = {
+      description = "the installer, on the line the test driver can type at";
+      environment.TERM = "linux";
+      serviceConfig = {
+        # qemu's serial line reports no window size at all -- `stty size` on
+        # it answers "0 0" -- and a real serial terminal is the one that has
+        # to say. Without this the wizard reproduced #133 on its first gum
+        # input: ui_dimension fell past the 0x0 answer to /dev/tty1, took the
+        # framebuffer console's 160 columns as confirmed, and centred gum's
+        # padding on a number belonging to a different terminal. That is a
+        # finding about ui_dimension's fallback chain and it is not this
+        # check's subject, so the line is given the size a terminal would
+        # have negotiated and the wizard is measured against the console it
+        # is actually drawing on.
+        ExecStartPre = "${pkgs.coreutils}/bin/stty rows 40 cols 120";
+        Type = "idle";
+        StandardInput = "tty";
+        StandardOutput = "tty";
+        StandardError = "tty";
+        TTYPath = "/dev/ttyS0";
+        TTYReset = true;
+        ExecStart = "${pkgs.lib.getExe install} --dry-run";
+        Restart = "no";
+      };
+    };
+  };
+
+  testScript = ''
+    import datetime as dt
+    import time
+
+    machine.wait_for_unit("multi-user.target")
+    machine.succeed("systemctl start --no-block wizard")
+
+
+    def screen(text, seconds=180):
+        """Wait for a line the installer printed itself.
+
+        Every anchor used here is a line ui_screen or gum style wrote with a
+        newline on the end. That matters: the driver's serial reader iterates
+        over lines, so a gum widget's own frame -- which ends on the cursor,
+        with no newline -- may sit unflushed for as long as the widget is
+        waiting. Anchoring on the heading above the widget rather than on the
+        widget itself is the difference between a test that waits and a test
+        that hangs.
+        """
+        machine.wait_for_console_text(text, dt.timedelta(seconds=seconds))
+
+
+    def gum(widget, previous=None):
+        """Block until a gum widget is running AND reading, and return its pid.
+
+        Not a sleep. A fixed wait here is a guess about how fast the VM is, and
+        the same guess was wrong twice already in this repo's other tests.
+
+        Two conditions, because the process existing is not the same as the
+        process listening: typing at a gum that had started but had not yet
+        taken the terminal lost the first characters of the answer, and the
+        wizard then sat on a username of "Alwiz" waiting for an Enter that had
+        gone to the old line discipline. gum puts the tty in raw mode as it
+        starts reading, so `-icanon` on the line is the readiness condition
+        that "a process exists" only approximates.
+
+        `previous` distinguishes the input that REJECTED an answer from the one
+        it re-asked with, which is what the validation assertions below turn
+        on. pgrep -f matches on the whole command line, including that of the
+        shell the driver runs this in -- so the pattern is written with a
+        bracket that the shell's own copy cannot match.
+        """
+        reading = "stty -F /dev/ttyS0 -a | grep -q -- -icanon"
+        running = f"pgrep -n -f 'gum[ ]{widget}'"
+        fresh = "" if previous is None else f' && [ "$p" != {previous} ]'
+        machine.wait_until_succeeds(
+            f'p=$({running}) && [ -n "$p" ]{fresh} && {reading}')
+        return machine.succeed(running).strip()
+
+
+    def answer(chars):
+        r"""Type at the installer, one character at a time.
+
+        Carriage return, not newline. gum puts the terminal in raw mode, where
+        Enter is CR -- bubbletea reads a bare LF as ctrl+j and does nothing
+        with it, which looked exactly like a wizard hung on its first question.
+        The greeter's `read` is in canonical mode and ICRNL turns the same byte
+        into the newline it wants, so one form works for both.
+
+        And slowly. qemu's 16550 has a sixteen-byte FIFO and drops what
+        overflows it, so a whole answer written in one go arrived at the wizard
+        with characters missing -- "wizard" became "Alwiz". This is not a
+        guess-the-timing sleep: it is the line's own rate, and the readiness
+        conditions above are what the test actually waits on.
+        """
+        for char in chars.replace("\n", "\r"):
+            machine.send_console(char)
+            time.sleep(0.05)
+
+
+    # ---- the greeter ---------------------------------------------------
+    # A blank screen accepts Return just as happily as a drawn one, so what is
+    # asserted is the text, not that the wizard moved on.
+    screen("Omarchy, on NixOS")
+    screen("Press Return to start the install")
+    answer("\n")
+
+    # ---- keyboard ------------------------------------------------------
+    screen(r"Let's set up your keyboard")
+    gum("choose")
+    # The first entry of installer/brand/keymaps.txt, which is English (US).
+    answer("\n")
+
+    # ---- identity ------------------------------------------------------
+    screen(r"Let's set up your user account")
+
+    # Two rejections, one per branch of validate_username: a name the regex
+    # refuses and a name the regex allows but the system has already taken.
+    # Asserting the message is not enough on its own -- an installer that
+    # printed the complaint and then carried on with the bad name would pass
+    # that -- so each one also waits for a NEW gum input, which only exists
+    # because the loop went round again.
+    pid = gum("input")
+    answer("BadName\n")
+    screen("not a usable Linux username")
+    pid = gum("input", previous=pid)
+
+    answer("root\n")
+    screen("that name is taken by the system")
+    pid = gum("input", previous=pid)
+
+    answer("wizard\n")
+
+    # Password, mistyped first: the confirmation exists to catch exactly this.
+    pid = gum("input", previous=pid)
+    answer("hunter2\n")
+    pid = gum("input", previous=pid)
+    answer("hunter3\n")
+    screen("Those do not match")
+    pid = gum("input", previous=pid)
+    answer("hunter2\n")
+    pid = gum("input", previous=pid)
+    answer("hunter2\n")
+
+    # Hostname, rejected once for a leading hyphen.
+    pid = gum("input", previous=pid)
+    answer("-nope\n")
+    screen("letters, digits and hyphens")
+    pid = gum("input", previous=pid)
+    answer("wizardbox\n")
+
+    # Timezone. gum filter opens with --value UTC, so the value is cleared
+    # first: three deletes, then a zone typed in full, so what lands in the
+    # flake is a value this test chose rather than whatever the fuzzy match
+    # happened to rank first.
+    gum("filter")
+    answer("\x7f\x7f\x7f")
+    answer("Europe/London")
+    answer("\n")
+
+    # ---- disk ----------------------------------------------------------
+    screen(r"Let's choose where to install nixarchy")
+    gum("choose")
+    answer("\n")
+
+    # ---- encrypt, then the summary -------------------------------------
+    screen("Everything on /dev/vdc will be overwritten")
+    gum("confirm")
+    answer("\n")
+
+    # The line gum confirm draws after the table, so waiting on it is waiting
+    # for the whole summary. Not the rows themselves: wait_for_console_text
+    # CONSUMES what it reads, and "Hostname" and "wizardbox" are on one row, so
+    # matching the first swallowed the second and the wait never returned. The
+    # rows are asserted from the full console log further down instead.
+    screen("Does this look right")
+    gum("confirm")
+    answer("\n")
+
+    screen("dry run: no disk touched")
+
+    # ---- did it finish, and did it finish cleanly? ---------------------
+    machine.wait_until_fails("systemctl is-active wizard")
+    status = machine.succeed(
+        "systemctl show -p ExecMainStatus --value wizard").strip()
+    assert status == "0", f"the wizard exited {status}, not 0"
+
+    # ---- the summary screen said what was typed ------------------------
+    #
+    # From the full console log rather than another wait: wait_for_console_text
+    # consumes the queue it reads, so re-reading a line an earlier assertion
+    # already matched is not possible. gum table's output is printed, not
+    # driven, so every row of it is on this log. Named console_log because the driver
+    # already has a `log`, which is its logger.
+    console_log = machine.get_console_log()
+
+    def row(setting, value):
+        """gum table draws one row per setting; both halves have to be on it.
+
+        Searched as a pair rather than separately because "true" and "wizard"
+        appear elsewhere on a console this chatty, and a summary that showed
+        the right words against the wrong settings is precisely the bug this
+        screen exists to catch.
+        """
+        for line in console_log.splitlines():
+            if setting in line and value in line:
+                return
+        raise AssertionError(f"the summary has no {setting} row reading {value}")
+
+    row("Hostname", "wizardbox")
+    row("Username", "wizard")
+    row("Timezone", "Europe/London")
+    row("Keyboard", "us")
+    row("Disk", "/dev/vdc")
+    row("Encrypted", "true")
+    row("Password", "********")
+    # The disks the size floor was supposed to hide. /dev/vda is this machine's
+    # own root and /dev/vdb is a gigabyte; an installer offering either is the
+    # bug ask_device's floor exists for.
+    disk_screen = console_log[console_log.index("Let's choose where to install"):]
+    for hidden in ["/dev/vda", "/dev/vdb"]:
+        assert hidden not in disk_screen, (
+            f"{hidden} is under the 8 GiB floor and was offered as an install target")
+
+    # ---- the answers reached the flake ---------------------------------
+    #
+    # The point of the whole wizard: every answer ends up as text in the
+    # generated flake. A screen that accepted a value and dropped it would
+    # satisfy every assertion above.
+    work = machine.succeed(
+        "ls -d /tmp/tmp.*/ | while read -r d; do "
+        "[ -f \"$d/flake.nix\" ] && echo \"$d\"; done | head -1").strip()
+    assert work, "the dry run wrote no flake"
+    print(machine.succeed(f"ls -a {work}"))
+
+    flake = machine.succeed(f"cat {work}/flake.nix")
+    configuration = machine.succeed(f"cat {work}/configuration.nix")
+    for text, where, name in [
+        ('hostname = "wizardbox"', flake, "hostname"),
+        ('username = "wizard"', flake, "username"),
+        ('device = "/dev/vdc"', flake, "device"),
+        ("encrypt = true", flake, "encryption"),
+        ('time.timeZone = "Europe/London"', configuration, "timezone"),
+        ('console.keyMap = "us"', configuration, "keymap"),
+    ]:
+        assert text in where, f"the {name} answer never reached the flake"
+
+    # A dry run must not have touched anything. The disk it was pointed at is
+    # the one to look at: still unpartitioned, still empty.
+    machine.fail("blkid /dev/vdc")
+    print("the wizard asked six questions, rejected three bad answers, and "
+          "wrote a flake carrying the rest")
+  '';
+}


### PR DESCRIPTION
`ui_interactive()` is `[ -z "$answers_file" ] && [ -t 0 ]`, and every harness passes `--answers` -- `checks.install` and `installer-vm` both do. So the greeter, the six questions, their validation and the summary had never run under test. `checks.installer-ui` (#135) covers whether a widget can be **drawn**; nothing covered whether the wizard can be **answered**.

`checks.installer-wizard` drives `nixarchy-install --dry-run` in a VM: it asks everything, writes the flake to a temp directory and touches no disk. 36 seconds of test script, so it belongs on every PR rather than in nightly -- wired into `build.yml` next to the other VM checks.

What it asserts:

- every screen actually drew, on text the installer wrote (a blank screen accepts Return just as happily)
- `BadName` and `root` are both rejected, with the right message, and each rejection is followed by a **new** `gum input` -- an installer that complained and carried on with the bad name would not pass that
- a mistyped password confirmation and a hostname starting with a hyphen are re-asked
- the disk screen offers only the device over the 8 GiB floor -- neither the 4 GiB root nor the 1 GiB spare appears
- the summary shows each answer against the right setting, and the password as stars
- every answer reaches the generated flake, and `/dev/vdc` is still unpartitioned

Driven over the serial line rather than the framebuffer, so assertions are on console text instead of OCR. Three things had to be got right, each of which first looked like a wizard that had hung, and each is written down in the test:

- gum reads Enter as CR; a bare LF is `ctrl+j` and does nothing
- qemu's 16550 drops what overflows its FIFO, so an answer sent in one write arrived with characters missing ("wizard" became "Alwiz") -- it is typed a character at a time
- a gum that has started is not yet a gum that is reading; readiness is `-icanon` on the line plus a fresh pid, never a sleep

Proven to fail, both times with the assertion that should catch it:

- `validate_username` loosened to accept capitals -> `waiting for not a usable Linux username ... timed out`, with the console showing the wizard had moved on to `Password>`
- `write_flake` no longer substituting the timezone -> `AssertionError: the timezone answer never reached the flake`

One finding in passing, not fixed here: qemu's serial line reports no window size, and `ui_dimension` then answered with `/dev/tty1`'s 160 columns and marked it confirmed -- gum centred its padding on a number belonging to a different terminal and reproduced #133's panic. The test gives the line a size; the fallback chain trusting a size from a terminal that is not the one being drawn on is worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEKYJncLrP6eiGRJJdkgxX