### PR TITLE
Only trust a width from the terminal being drawn on

### DIFF
--- a/installer/lib/ui.sh
+++ b/installer/lib/ui.sh
@@ -62,6 +62,22 @@ ui_palette() {
 #   which is how a 92-column wordmark ended up at column zero.
 #
 # So: ask several sources, and believe none of them without a positive number.
+# Whether a size read from this source describes the terminal being drawn on.
+#
+# `-` is this process's own stdin and /dev/tty its controlling terminal: both
+# follow the process. /dev/tty1 and /dev/console are named devices that may
+# belong to nothing to do with us -- see the note in ui_dimension.
+#
+# A function rather than an inline case so a test can ask it directly: the
+# source is loop-local, and the alternative was asserting on the shape of the
+# code instead of its behaviour.
+ui_src_is_ours() {
+  case $1 in
+    - | /dev/tty) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 ui_dimension() {
   local field=$1 src size value
   for src in - /dev/tty /dev/tty1 /dev/console; do
@@ -83,6 +99,24 @@ ui_dimension() {
       '' | *[!0-9]*) continue ;;
     esac
     [ "$value" -gt 0 ] && {
+      # Whose terminal was that?
+      #
+      # `-` reads this process's own stdin and /dev/tty is its controlling
+      # terminal: both follow the process, so a size from either describes the
+      # terminal being drawn on. /dev/tty1 and /dev/console are named devices
+      # that may belong to nothing to do with us.
+      #
+      # That is not hypothetical. On a serial console `stty size` answers 0 0
+      # -- correctly rejected above -- and the loop then reaches /dev/tty1 and
+      # takes the framebuffer console's 160 columns. A real measurement, of a
+      # real terminal, that is not the 80-column line the installer is writing
+      # to. Padding centred on it is wider than the screen, and gum panics
+      # rather than degrading (#139, and #133 before it through another door).
+      #
+      # #133 marked only the framebuffer guess unconfirmed. The distinction
+      # that matters is not guessed-vs-measured, it is whether the number
+      # describes the terminal in front of the person.
+      ui_src_is_ours "$src" || UI_SIZE_UNCONFIRMED=1
       echo "$value"
       return
     }

--- a/tests/installer-ui.nix
+++ b/tests/installer-ui.nix
@@ -120,7 +120,34 @@ pkgs.runCommand "nixarchy-installer-ui"
           echo "  unconfirmed $stub -> UI_PAD=$pad on an 80-column terminal, drew clean"
         done
 
-        [ "$fail" = 0 ] || { echo "the interactive screens do not survive every width" >&2; exit 1; }
+        # ---- a width from somebody else's terminal ---------------------------
+    #
+    # #133 marked the framebuffer GUESS unconfirmed, and stopped there. On a
+    # serial console stty answers 0 0, the source loop moves on, and /dev/tty1
+    # answers 160 -- a real measurement of a real terminal that is not the one
+    # being written to. Nothing marked it, so the padding was centred on it and
+    # gum panicked exactly as before (#139).
+    #
+    # Asserted through ui_src_is_ours rather than by faking device nodes: a
+    # sandbox has no /dev/tty1 to read, and the classification is the decision
+    # that was wrong.
+    for src in - /dev/tty; do
+      script -qec "stty cols 80 rows 24; . $UI_SH; ui_src_is_ours '$src'" /dev/null >/dev/null 2>&1 || {
+        echo "ui_src_is_ours says $src is not this process's terminal; it is" >&2
+        fail=1
+      }
+    done
+    for src in /dev/tty1 /dev/console /dev/ttyS0; do
+      if script -qec "stty cols 80 rows 24; . $UI_SH; ui_src_is_ours '$src'" /dev/null >/dev/null 2>&1; then
+        echo "ui_src_is_ours trusts $src as this process's terminal" >&2
+        echo "  it is a named device, and a size read from it describes whatever" >&2
+        echo "  is attached to THAT -- not necessarily what is being drawn on" >&2
+        fail=1
+      fi
+    done
+    echo "  a size is only trusted from the terminal being drawn on"
+
+    [ "$fail" = 0 ] || { echo "the interactive screens do not survive every width" >&2; exit 1; }
         echo "gum renders at ${toString (builtins.length widths)} widths and ignores ${toString (builtins.length guesses)} bad guesses"
         touch $out
   ''


### PR DESCRIPTION
Closes #139 — the half of #133 that was still open.

### What #133 missed

It marked the **framebuffer guess** unconfirmed, and `ui_init` drops padding to zero when that flag is set. Correct, and incomplete.

On a serial console `stty size` answers `0 0` (rejected correctly), and the source loop then reaches **`/dev/tty1`** and takes the framebuffer console's 160 columns. Nothing marked it — because it isn't a guess. It's a real measurement of a real terminal. Just **not the one being written to**, which is 80 columns wide.

Padding centred on 160 is wider than the screen, and gum panics with the same `makeslice: len out of range` #133 was written to end.

### The distinction that actually matters

Not guessed-versus-measured — **whether the number describes the terminal in front of the person**:

| source | follows the process? |
|---|---|
| `-` (own stdin) | yes |
| `/dev/tty` (controlling terminal) | yes |
| `/dev/tty1`, `/dev/console` | **no** — named devices that may be someone else's terminal |

The last two are now unconfirmed, which routes them into the zero-padding path #133 already built.

### Testable, not just asserted in a comment

`ui_src_is_ours` is a function rather than an inline `case` because the source is loop-local — the alternative was asserting on the *shape* of the code instead of its behaviour. `checks.installer-ui` asks it directly.

Verified by reverting it to trust every source:

```
ui_src_is_ours trusts /dev/tty1 as this process's terminal
  it is a named device, and a size read from it describes whatever
ui_src_is_ours trusts /dev/console as this process's terminal
ui_src_is_ours trusts /dev/ttyS0 as this process's terminal
```

Found by `checks.installer-wizard` from #137, which hit the panic live on qemu's serial line — the first thing to ever draw those screens outside a framebuffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5