### PR TITLE
programs.nixarchy.fleet: machines pull their own updates

### DIFF
--- a/modules/fleet.nix
+++ b/modules/fleet.nix
@@ -1,0 +1,120 @@
+# Machines that keep themselves current with a configuration repository.
+#
+# NixOS already does this. `system.autoUpgrade` with a flake URL is pull-based
+# GitOps, and nixos-rebuild resolves the attribute from the hostname -- so one
+# option value serves every machine in a fleet, and nothing here needs to know
+# how many there are or what they are called.
+#
+# So this is not a mechanism. It is an opt-in wrapper that fixes the two things
+# system.autoUpgrade gets wrong when nobody is watching, and otherwise gets out
+# of the way. No comin, no colmena, no clan: the native rung holds, and a
+# GitOps daemon on top of it would be re-solving a solved problem with a
+# dependency attached.
+#
+# Push deploy needs no code from us at all and gets none:
+#
+#   nixos-rebuild switch --flake github:me/config#laptop --target-host root@laptop
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.nixarchy.fleet;
+in
+{
+  options.programs.nixarchy.fleet = {
+    enable = lib.mkEnableOption ''
+      pulling this machine's configuration from a git repository on a timer.
+
+      OFF by default and deliberately so: a machine that rebuilds itself from
+      somewhere else is not a thing to switch on for somebody. Adding nixarchy
+      to a configuration you already run changes nothing here.
+
+      Note what enabling it means. The running system comes from the REMOTE
+      flake, so local edits under /etc/nixos that were never pushed are
+      reverted at the next pull, silently and without asking. That is the
+      point of a fleet and it is also the way to lose an afternoon's work
+    '';
+
+    url = lib.mkOption {
+      type = lib.types.str;
+      example = "github:me/config";
+      description = ''
+        The flake to pull from. Anything nixos-rebuild --flake accepts.
+
+        No default. A fleet URL is a decision about where this machine's
+        configuration lives, and a default would be a guess at somebody's
+        repository that fails at the first timer rather than at evaluation.
+      '';
+    };
+
+    dates = lib.mkOption {
+      type = lib.types.str;
+      default = "daily";
+      description = "systemd calendar expression, as system.autoUpgrade.dates.";
+    };
+  };
+
+  config = lib.mkIf (config.programs.nixarchy.enable && cfg.enable) {
+    assertions = [
+      {
+        assertion = cfg.url != "";
+        message = "programs.nixarchy.fleet.enable is on but fleet.url is empty; there is nowhere to pull from.";
+      }
+    ];
+
+    system.autoUpgrade = {
+      enable = true;
+      flake = cfg.url;
+      inherit (cfg) dates;
+
+      # --refresh, or a flakeref that names a branch is resolved from whatever
+      # is already in the evaluation cache and the machine "upgrades" to what
+      # it already has, indefinitely.
+      flags = [ "--refresh" ];
+
+      # persistent is NOT set here: nixpkgs already defaults it true, and a
+      # second definition saying the same thing is dead config that reads like
+      # a decision. checks.options asserts the value anyway -- the reasoning
+      # still has to hold, it just is not ours to state. A laptop asleep at the
+      # hour is the machine that most needs to catch up and the one a
+      # non-persistent timer never reaches.
+
+      # Spread a fleet out. Fifty machines waking at 03:00 to build the same
+      # closure is fifty times the load on whatever they are pulling from, for
+      # no gain to any of them.
+      randomizedDelaySec = "45min";
+    };
+
+    # The failure mode this option exists to survive.
+    #
+    # An unattended upgrade that starts failing stops delivering configuration,
+    # and nothing says so: the machine keeps running the system it already had,
+    # which looks exactly like a machine that is up to date. A fleet that has
+    # quietly stopped converging is worse than one that never started, because
+    # nobody is looking at it. See nixpkgs#349734 and nixpkgs#468878.
+    #
+    # A file, not just a log line: journald rotates, and the question "when did
+    # this machine last fail to update" should survive that and be answerable
+    # by nixarchy-doctor without parsing a journal.
+    systemd.services.nixos-upgrade.unitConfig.OnFailure = "nixarchy-upgrade-failed.service";
+
+    systemd.services.nixarchy-upgrade-failed = {
+      description = "Record that the unattended upgrade failed";
+      serviceConfig = {
+        Type = "oneshot";
+        # StateDirectory rather than mkdir: systemd creates it with the right
+        # ownership before the unit runs, and it is the same /var/lib/nixarchy
+        # the password hash lives in.
+        StateDirectory = "nixarchy";
+      };
+      script = ''
+        printf '%s upgrade from %s failed\n' \
+          "$(${pkgs.coreutils}/bin/date -Is)" "${cfg.url}" \
+          >> /var/lib/nixarchy/upgrade-failed
+      '';
+    };
+  };
+}

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -68,6 +68,7 @@ in
     inputs.hyprland.nixosModules.default
     (import ./apps.nix inputs)
     ./local-ai.nix
+    ./fleet.nix
     ./services
     ./flatpaks.nix
     inputs.nix-flatpak.nixosModules.nix-flatpak

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -240,6 +240,33 @@ let
       (configWith { flatpaks.uninstallUnmanaged = true; }).services.flatpak.uninstallUnmanaged;
   };
 
+  # ---- the fleet option, both ways --------------------------------------
+  #
+  # Both ends again. What a person sets is programs.nixarchy.fleet; what
+  # decides is system.autoUpgrade, and a passthrough that quietly stopped
+  # passing would leave a fleet that reads as enabled and never pulls.
+  #
+  # The off case is the one that matters most here: this is the only option in
+  # nixarchy that can revert somebody's unpushed work, so a machine that did
+  # not ask for it must not acquire a timer.
+  fleet = rec {
+    offByDefault = (configWith { }).system.autoUpgrade.enable;
+    on = configWith {
+      fleet = {
+        enable = true;
+        url = "github:me/config";
+      };
+    };
+    onWhenAsked = on.system.autoUpgrade.enable;
+    url = on.system.autoUpgrade.flake;
+    # A laptop asleep at 03:00 never catches up without this.
+    persistent = on.system.autoUpgrade.persistent;
+    # The whole reason the option exists rather than raw autoUpgrade: an
+    # upgrade that starts failing must leave a mark, or the fleet stops
+    # converging and looks exactly like a fleet that is up to date.
+    onFailure = on.systemd.services.nixos-upgrade.unitConfig.OnFailure or "";
+  };
+
   # ---- a bundled service yields to a user who already configured it ----
   #
   # This is the Mode A hazard in one assertion. Someone adds nixarchy to a
@@ -416,6 +443,11 @@ pkgs.runCommand "nixarchy-options"
     flatpakProblems = pkgs.lib.concatStringsSep "\n" flatpakProblems;
     flatpakCount = builtins.toString (builtins.length (builtins.attrNames flatpaks));
     flatpakRemotes = pkgs.lib.concatStringsSep " " flatpakRemotes;
+    fleetOff = pkgs.lib.boolToString fleet.offByDefault;
+    fleetOn = pkgs.lib.boolToString fleet.onWhenAsked;
+    fleetUrl = fleet.url;
+    fleetPersistent = pkgs.lib.boolToString fleet.persistent;
+    fleetOnFailure = fleet.onFailure;
     flatpakOurs = pkgs.lib.boolToString flatpakDefaults.ours;
     flatpakTheirs = pkgs.lib.boolToString flatpakDefaults.theirs;
     flatpakOn = pkgs.lib.boolToString flatpakDefaults.onWhenAsked;
@@ -641,6 +673,32 @@ pkgs.runCommand "nixarchy-options"
           exit 1
         }
         echo "the picker's flatpak rows are $(wc -l < "$rows") well-formed lines"
+
+        # ---- machines pull only when asked ---------------------------------
+        test "$fleetOff" = false || {
+          echo "system.autoUpgrade is on without programs.nixarchy.fleet.enable" >&2
+          echo "  a machine that did not ask for a fleet must not acquire a timer:" >&2
+          echo "  the next pull reverts anything under /etc/nixos that was not pushed" >&2
+          exit 1
+        }
+        test "$fleetOn" = true || {
+          echo "fleet.enable does not reach system.autoUpgrade; nothing would pull" >&2; exit 1; }
+        test "$fleetUrl" = "github:me/config" || {
+          echo "fleet.url did not reach system.autoUpgrade.flake: got '$fleetUrl'" >&2; exit 1; }
+        test "$fleetPersistent" = true || {
+          echo "the upgrade timer is not persistent; a laptop asleep at the hour never catches up" >&2
+          exit 1
+        }
+        case "$fleetOnFailure" in
+          *nixarchy-upgrade-failed*) ;;
+          *)
+            echo "nixos-upgrade has no OnFailure hook (got '$fleetOnFailure')" >&2
+            echo "  an upgrade that starts failing stops delivering configuration and" >&2
+            echo "  says nothing -- which is what this option exists to survive" >&2
+            exit 1
+            ;;
+        esac
+        echo "the fleet timer is off unless asked, and leaves a mark when it fails"
           touch $out
       ''
     else


### PR DESCRIPTION
Closes #126. Second child of #121 to land, and independent of the others.

NixOS already does pull-based GitOps — `system.autoUpgrade` with a flake URL, and `nixos-rebuild` resolving the attribute from the hostname, so **one value serves a whole fleet**. This is not a mechanism; it's an opt-in wrapper with the things that mechanism gets wrong when nobody is watching.

### Off by default, and the description says why

```
Note what enabling it means. The running system comes from the REMOTE
flake, so local edits under /etc/nixos that were never pushed are
reverted at the next pull, silently and without asking. That is the
point of a fleet and it is also the way to lose an afternoon's work
```

That belongs in the option, not only in docs — it's the only option in nixarchy that can revert someone's unpushed work.

### The reason to wrap autoUpgrade at all

An unattended upgrade that starts failing **stops delivering configuration and says nothing** — the machine keeps running what it had, which looks exactly like a machine that is up to date ([nixpkgs#349734](https://github.com/NixOS/nixpkgs/issues/349734), [#468878](https://github.com/NixOS/nixpkgs/issues/468878)). `OnFailure` writes a timestamped line to `/var/lib/nixarchy/upgrade-failed` — a file, not just a log line, because journald rotates and *"when did this last fail"* should outlive that.

### One correction to the issue

#126 asked for `persistent = true` on the grounds that NixOS doesn't do it. **It does** — nixpkgs defaults it true. I've left it unset, since a second definition saying the same thing is dead config that reads like a decision, and this repo says so elsewhere in as many words. The assertion stays, now guarding upstream's default rather than ours.

### Verified by breaking each one

| | |
|---|---|
| off by default | `system.autoUpgrade is on without programs.nixarchy.fleet.enable` |
| `OnFailure` | `nixos-upgrade has no OnFailure hook (got '')` |
| `persistent` | guards the upstream default; cannot fail while nixpkgs keeps it |

The off-by-default proof needed `url` given a temporary default first — otherwise the loosened gate dies at evaluation (`fleet.url was accessed but has no value defined`) before the assertion is reached. That's the no-default design working, and worth stating rather than reporting a proof that never ran.

Push deploy stays documented-only and needs no code: `nixos-rebuild switch --flake github:me/config#laptop --target-host root@laptop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5