### PR TITLE
The wizard check follows the machine into hosts/

### DIFF
--- a/tests/installer-wizard.nix
+++ b/tests/installer-wizard.nix
@@ -280,17 +280,31 @@ pkgs.testers.runNixOSTest {
     assert work, "the dry run wrote no flake"
     print(machine.succeed(f"ls -a {work}"))
 
+    # The machine is a directory named for the hostname answer (#123), so
+    # finding it at all is the first assertion: flake.nix stays at the root
+    # and enumerates ./hosts, and everything the wizard collected lands one
+    # level down.
+    host = f"{work}/hosts/wizardbox"
+    machine.succeed(f"test -d {host}")
+
     flake = machine.succeed(f"cat {work}/flake.nix")
-    configuration = machine.succeed(f"cat {work}/configuration.nix")
+    default = machine.succeed(f"cat {host}/default.nix")
+    configuration = machine.succeed(f"cat {host}/configuration.nix")
     for text, where, name in [
-        ('hostname = "wizardbox"', flake, "hostname"),
-        ('username = "wizard"', flake, "username"),
-        ('device = "/dev/vdc"', flake, "device"),
-        ("encrypt = true", flake, "encryption"),
+        ('hostname = "wizardbox"', default, "hostname"),
+        ('username = "wizard"', default, "username"),
+        ('device = "/dev/vdc"', default, "device"),
+        ("encrypt = true", default, "encryption"),
         ('time.timeZone = "Europe/London"', configuration, "timezone"),
         ('console.keyMap = "us"', configuration, "keymap"),
     ]:
         assert text in where, f"the {name} answer never reached the flake"
+
+    # And the root flake names no machine itself -- it reads ./hosts. A
+    # hostname hardcoded back into it would still pass every assertion above.
+    assert "wizardbox" not in flake, (
+        "flake.nix names the machine; it is supposed to find machines by "
+        "reading ./hosts, so that adding one is adding a directory")
 
     # A dry run must not have touched anything. The disk it was pointed at is
     # the one to look at: still unpartitioned, still empty.


### PR DESCRIPTION
`main` is red. #137 and #141 were each green against a `main` that did not have the other, and broke together.

```
RequestedAssertionFailed: command `cat /tmp/tmp.8Gr3TVjQU3//configuration.nix` failed (exit code 1)
```

`checks.installer-wizard` reads the flake the dry run wrote. #141 moved `configuration.nix` into `hosts/<name>/` and split the machine's answers between `hosts/<name>/default.nix` and `hosts/<name>/configuration.nix`, so the test was reading paths that no longer exist.

### The fix makes the assertion stronger

The hostname answer is now the **directory name**, so finding it is itself a check:

```python
host = f"{work}/hosts/wizardbox"
machine.succeed(f"test -d {host}")
```

And one new assertion, because the layout's whole claim is that adding a machine is adding a directory:

```python
assert "wizardbox" not in flake, (
    "flake.nix names the machine; it is supposed to find machines by "
    "reading ./hosts, so that adding one is adding a directory")
```

A hostname hardcoded back into `flake.nix` would have satisfied every other assertion.

### Worth noting

Neither PR could have caught this: PR CI runs each branch against `main` as it was, not against `main` as it will be. `checks.install` has the same shape of gap for a different reason — it runs on `push: branches: [main]`, so it gates nothing on a PR either. I ran it by hand against #141 before merging, which is why the install itself is sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5