### PR TITLE
Answers from a URL, and an ISO that can be told where to look

### DIFF
--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -149,6 +149,42 @@ let
   # one people will be told to download.
   variant = lib.optionalString (!offline) "-net";
   labelVariant = lib.replaceStrings [ "-" ] [ "_" ] (lib.toUpper variant);
+  # The installer, plus whatever the kernel command line asked for.
+  #
+  # The unit used to exec the installer with no arguments, so there was no way
+  # to tell this image anything: the boot menu is suppressed (timeout 0, and
+  # deliberately), and nothing read /proc/cmdline or scanned attached media. An
+  # unattended install therefore meant building a bespoke image.
+  #
+  # The kernel command line is how qemu (-append), PXE and cloud metadata all
+  # inject parameters, so an admin's fleet story becomes "netboot iso-net with
+  # three arguments" and needs no new infrastructure. That is also where
+  # unattended installs actually happen, which is why scanning attached media
+  # for a labelled answers file is NOT here -- it can be added when somebody
+  # with a physical fleet asks.
+  #
+  # With none of them present the behaviour is exactly what it was: an
+  # interactive install.
+  nixarchyInstallerLauncher = pkgs.writeShellScript "nixarchy-installer-launcher" ''
+    set -u
+    args=()
+
+    # Word-split the command line and match whole parameters. A substring
+    # match would find nixarchy.host= inside nixarchy.hostname= and hand the
+    # installer half of somebody else's argument.
+    for p in $(cat /proc/cmdline); do
+      case "$p" in
+        nixarchy.answers=*) args+=(--answers "''${p#nixarchy.answers=}") ;;
+        nixarchy.from=*) args+=(--from "''${p#nixarchy.from=}") ;;
+        nixarchy.host=*) args+=(--host "''${p#nixarchy.host=}") ;;
+      esac
+    done
+
+    exec ${
+      lib.getExe inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.install
+    } "''${args[@]+"''${args[@]}"}"
+  '';
+
 in
 {
   imports = [ "${modulesPath}/installer/cd-dvd/installation-cd-minimal.nix" ];
@@ -243,7 +279,7 @@ in
       TTYPath = "/dev/tty1";
       TTYReset = true;
       TTYVHangup = true;
-      ExecStart = lib.getExe inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.install;
+      ExecStart = nixarchyInstallerLauncher;
       # Finished, aborted or crashed, do not respawn a TUI in a loop.
       Restart = "no";
     };

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -128,7 +128,8 @@ nixarchy-install -- install nixarchy onto a disk.
   nixarchy-install              ask, then install
   nixarchy-install --dry-run    ask, write the flake to a temp directory,
                                 touch no disk, print the directory and stop
-  nixarchy-install --answers F  take every answer from F and ask nothing
+  nixarchy-install --answers F  take every answer from F and ask nothing;
+                                F may be an https:// URL
   nixarchy-install --from URL --host NAME
                                 install from a configuration repository that
                                 already exists, rather than generating a flake
@@ -493,6 +494,42 @@ confirm_summary() {
 # It also holds a plaintext password and a LUKS passphrase, unavoidably. The
 # installer never copies it anywhere that persists.
 # ---------------------------------------------------------------------------
+# An answers file that is not on this machine yet.
+#
+# --answers takes a path, which means somebody had to put the file there --
+# which is not unattended. A URL closes that: an image boots, fetches its
+# answers and installs, with nothing typed.
+#
+# https only. The file carries a password in clear, which usage() already
+# admits is inherent to installing without being asked; fetching it over
+# plaintext http would make that worse for nothing. A URL that cannot be
+# fetched is fatal here rather than later -- an unattended install that
+# silently falls back to asking questions nobody is there to answer is an
+# image that hangs at a prompt forever.
+resolve_answers() {
+  case $answers_file in
+    https://*) ;;
+    http://*)
+      echo "nixarchy-install: --answers over plain http is refused." >&2
+      echo "  The file carries a password. Use https." >&2
+      exit 2
+      ;;
+    *) return 0 ;;
+  esac
+
+  local url=$answers_file tmp
+  # umask, not chmod after the fact: between creation and the chmod the file
+  # would be readable, and the whole point of it is that it is not.
+  tmp=$(umask 077 && mktemp)
+  echo "fetching answers from $url"
+  curl --fail --silent --show-error --location --max-time 60 -o "$tmp" "$url" || {
+    echo "nixarchy-install: could not fetch $url" >&2
+    rm -f "$tmp"
+    exit 1
+  }
+  answers_file=$tmp
+}
+
 read_answers() {
   local file=$1 line key value lineno=0 password=""
   [ -r "$file" ] || {
@@ -1086,6 +1123,7 @@ main() {
   fi
 
   if [ -n "$answers_file" ]; then
+    resolve_answers
     read_answers "$answers_file"
     # --host names the machine, and clone_repo has already chosen $hostdir from
     # it. A hostname in the answers file cannot also name it: leaving both to


### PR DESCRIPTION
Closes #125. Fifth child of #121.

### Two halves

**`--answers` takes an https URL.** It took a path, so the file had to already be on the machine — which means somebody put it there, which is not unattended.

https only: the file carries a password in clear, which `usage()` already admits is inherent to installing without being asked, and plaintext would make that worse for nothing. A URL that cannot be fetched is **fatal**, not a fallback to asking — an unattended image that falls back to questions is an image hanging at a prompt nobody will answer.

**The ISO could not be told anything at all.** The unit exec'd the installer with no arguments, nothing read `/proc/cmdline`, nothing scanned attached media, and the boot menu is suppressed on purpose. An unattended install meant building a bespoke image.

A launcher now reads `nixarchy.answers=`, `nixarchy.from=` and `nixarchy.host=` off the kernel command line. That is how qemu (`-append`), PXE and cloud metadata all inject parameters, so a fleet story becomes *"netboot `iso-net` with three arguments"*. With none present, behaviour is exactly what it was.

### Whole parameters, not substrings

`nixarchy.hostname=` **contains** `nixarchy.host=`. A substring match would hand the installer half of somebody else's argument:

```
plain boot        -> ARGS:
answers only      -> ARGS: --answers https://e.co/a.txt
from+host         -> ARGS: --from github:me/c --host laptop
all three         -> ARGS: --answers https://e.co/a --from github:me/c --host lap
substring trap    -> ARGS:                          ← nixarchy.hostname= ignored
```

### Verified

| | |
|---|---|
| `http://` | refused — *"The file carries a password. Use https."* |
| unreachable `https://` | fatal, does not fall back to prompting |
| real fetch | lands at **mode 600**, 284 bytes |
| both ISOs | build; `iso 5.59/6.50 GiB ok`, `iso-net 1.54/2.00 GiB ok` |

### Deliberately absent

Scanning attached media for a labelled answers file. The kernel command line covers PXE and VM fleets, which is where unattended installs actually happen; the media path can be added when somebody with a physical fleet asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5