### PR TITLE
Docs: many machines, one repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,16 +876,30 @@ keymap=us
 `tests/install.nix` is the working reference for it.
 
 **What you get is a flake you own.** `/etc/nixos` is a git repository holding a
-`flake.nix`, a `configuration.nix`, the `disk-config.nix` that formatted the
-disk, a `nixarchy-apps.nix` for your app selection, and the `flake.lock` the
-image was built with — not a fresh one, because regenerating it would make your
-first boot differ from what was actually installed. `imports = [
-./nixarchy-apps.nix ];` is already written for you: forgetting that line is the
-silent failure the section below warns about for machines you configure by
-hand, and the installer does not let you make it. Edit it and run
-`nh os switch`. Nothing the installer did is
+`flake.nix`, the `disk-config.nix` that formatted the disk, the `flake.lock`
+the image was built with — not a fresh one, because regenerating it would make
+your first boot differ from what was actually installed — and your machine as
+a directory under `hosts/`:
+
+```
+/etc/nixos
+├── flake.nix              finds machines by reading ./hosts
+├── flake.lock
+├── disk-config.nix
+└── hosts/nixarchy/        default.nix, configuration.nix,
+                           hardware-configuration.nix, nixarchy-apps.nix
+```
+
+A second machine is a second directory; `flake.nix` reads `./hosts` and there
+is nothing in it to edit. `imports = [ ./nixarchy-apps.nix ];` is already
+written for you: forgetting that line is the silent failure the section below
+warns about for machines you configure by hand, and the installer does not let
+you make it. Edit it and run `nh os switch`. Nothing the installer did is
 hidden from that directory, which is the point: a rebuild immediately after
 install builds nothing, because everything it did is described there.
+
+Installing a second machine from that same repository, and letting them keep
+themselves current, is [many machines, one repo](docs/manual/many-machines.md).
 
 **Four caveats worth knowing before you write the stick.**
 
@@ -1536,9 +1550,13 @@ is the shape.
 | --- | --- | --- |
 | [#6](https://github.com/olafkfreund/nixarchy/issues/6) | **bare metal to a desktop** — the installer, the ISO, the release | 18 of 22 done |
 | [#112](https://github.com/olafkfreund/nixarchy/issues/112) | **getting back** — snapshots, backup, restore | not started |
-| [#121](https://github.com/olafkfreund/nixarchy/issues/121) | **many machines, one repo** — fleets, unattended installs, shared configs | not started |
 
-**Recently finished:** [Flatpaks, declared](https://github.com/olafkfreund/nixarchy/issues/105)
+**Recently finished:**
+[many machines, one repo](https://github.com/olafkfreund/nixarchy/issues/121)
+— a machine is a directory, a second one is installed from the same
+repository with `nixarchy-install --from`, and they keep themselves current
+if you ask them to. Also
+[Flatpaks, declared](https://github.com/olafkfreund/nixarchy/issues/105)
 — for the handful of things nixpkgs cannot carry. Pickable from the menu,
 searchable against Flathub, and declared in the same file as everything else.
 Also the app selection grew a

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -80,6 +80,7 @@ the documentation as much as the code.
 | **Security** | **differs on NixOS** — [read here](security) |
 | Omarchy on | same as Omarchy — [read there](https://omarchy.org/manual/omarchy-on/) |
 | **Dual boot install** | **differs on NixOS** — [read here](dual-boot-install) |
+| **Many machines, one repo** | **nixarchy only** — [read here](many-machines) |
 | **Unattended installs** | **differs on NixOS** — [read here](unattended-installs) |
 
 ## The short version of the difference

--- a/docs/manual/many-machines.md
+++ b/docs/manual/many-machines.md
@@ -1,0 +1,130 @@
+---
+title: Many machines, one repo
+---
+
+# Many machines, one repo
+
+Everything below is about a machine the nixarchy installer wrote. If you added
+nixarchy to a NixOS configuration you already run, **none of this touches it**
+— your flake is yours, nothing here changes its shape, and the one option that
+could rebuild your machine from somewhere else is off unless you turn it on.
+
+## The shape
+
+`/etc/nixos` is a git repository, and each machine is a directory in it:
+
+```
+/etc/nixos
+├── flake.nix              finds machines by reading ./hosts
+├── flake.lock
+├── disk-config.nix
+└── hosts/
+    ├── desk/
+    │   ├── default.nix                username, disk, encryption
+    │   ├── configuration.nix          timezone, keymap, and whatever you add
+    │   ├── hardware-configuration.nix generated on that machine
+    │   └── nixarchy-apps.nix          this machine's app selection
+    └── laptop/…
+```
+
+Adding a machine is adding a directory. There is nothing to edit in
+`flake.nix` — it reads `./hosts` and builds one `nixosConfiguration` per
+directory it finds.
+
+**`git add` is not a tidiness rule.** A flake in a git worktree sees only
+tracked or staged files, so an unstaged `hosts/laptop/` does not exist as far
+as evaluation is concerned — and the error says the path is missing, not that
+it is untracked.
+
+## The loop
+
+**1. Get the first machine into git.**
+
+```
+nixarchy config repo
+```
+
+It commits, creates the remote, adds a CI workflow and pushes. Everything it
+does is idempotent, so a repository you set up half by hand gets the other
+half rather than an argument.
+
+**2. Install the second machine from that repository.**
+
+```
+nixarchy-install --from github:you/config --host laptop
+```
+
+If `hosts/laptop/` is already there, the repository decides the disk, the
+username and the rest, and you are asked only for a password. If it is not,
+you are asked the usual questions and the machine is written into the
+repository beside the others.
+
+**3. Commit its hardware back.**
+
+`hardware-configuration.nix` is generated on the machine, because hardware is
+the one thing a repository written elsewhere cannot know. Run
+`nixarchy config repo` on the new machine to push it.
+
+**4. Let them keep themselves current.**
+
+```nix
+programs.nixarchy.fleet = {
+  enable = true;
+  url = "github:you/config";
+};
+```
+
+A timer pulls and rebuilds. `nixos-rebuild` picks the configuration matching
+the machine's hostname, so **one value serves every machine** — you do not
+list them anywhere.
+
+> **The running system comes from the remote flake.** Local edits under
+> `/etc/nixos` that you never pushed are reverted at the next pull, silently.
+> That is the point of a fleet, and it is also the way to lose an afternoon.
+
+If an upgrade fails, the machine writes a timestamped line to
+`/var/lib/nixarchy/upgrade-failed`. That exists because the documented way
+unattended upgrades go wrong is that they start failing and then stop
+delivering configuration, and nothing says so — a fleet that has quietly
+stopped converging looks exactly like one that is up to date.
+
+## Pushing instead of pulling
+
+Nothing in nixarchy is involved. `nixos-rebuild` does it:
+
+```
+nixos-rebuild switch --flake github:you/config#laptop --target-host root@laptop
+```
+
+For more than a handful of machines, or for anything with roles and tags,
+use a tool built for it — [colmena](https://github.com/zhaofengli/colmena),
+[deploy-rs](https://github.com/serokell/deploy-rs) or
+[clan](https://clan.lol/). nixarchy does not reimplement them and does not
+need to: the repository is an ordinary NixOS flake and they all take one.
+
+## Using somebody else's configuration
+
+There is no template mechanism, and there does not need to be one. Point the
+installer at their repository with a machine name it has never heard of:
+
+```
+nixarchy-install --from github:them/config --host mine
+```
+
+The questions are asked as usual, your machine is written in beside theirs,
+and everything else they wrote — themes, extra modules, their app selection —
+comes with it. Then `git remote set-url origin <yours>` and it is your
+repository.
+
+This is only safe to offer because the login hash does not live in the
+repository. It is at `/var/lib/nixarchy/password.hash`, outside git, so a
+configuration is safe to push and safe to hand to somebody.
+
+> **`--from` runs their Nix as root.** Their `disk-config.nix` is what
+> formats your disk. This is the same trust as `nix run github:...`, and it
+> is worth saying out loud rather than leaving implied. The installer asks
+> before it clones.
+
+## Unattended
+
+See [unattended installs](unattended-installs).

--- a/docs/manual/unattended-installs.md
+++ b/docs/manual/unattended-installs.md
@@ -4,16 +4,13 @@ title: Unattended installs
 
 # Unattended installs
 
-There is no nixarchy installer, so there is no unattended installer either.
+An image that boots, installs and reboots with nobody at the keyboard.
 
-Omarchy's ISO watches for a second drive labelled `cidata`, reads the wizard's
-answers off it, and installs with nobody at the keyboard — which makes it a
-good base image for disposable VMs.
+## The answers file
 
-**nixarchy has the answers file but not yet the drive.** `nixarchy-install
---answers <file>` takes every answer the wizard asks for and installs with
-nobody at the keyboard — one `key=value` per line, parsed rather than sourced,
-and it names every missing key in one go instead of one per attempt:
+`nixarchy-install --answers <file>` takes every answer the wizard asks for.
+One `key=value` per line, **parsed rather than sourced**, and every missing or
+malformed key is named in one pass instead of one per attempt:
 
 ```ini
 device=/dev/vda
@@ -27,31 +24,62 @@ timezone=Europe/London
 keymap=us
 ```
 
-What is missing is the `cidata` half: the ISO does not yet look for a labelled
-drive and feed itself from it. That is
-[issue #14's follow-up](https://github.com/olafkfreund/nixarchy/issues/14) —
-the code path exists and only the detection is absent.
+It holds a password in clear. That is inherent to installing without being
+asked, and nothing copies it onto the installed machine.
 
-## What to do instead
+`<file>` may also be an **`https://` URL**, which is what makes it unattended
+rather than merely unprompted — otherwise somebody had to put the file on the
+machine first. Plain `http` is refused, because of that password. A URL that
+cannot be fetched stops the install rather than falling back to asking: an
+image that falls back to questions is an image waiting at a prompt nobody is
+going to answer.
 
-The honest answer is that unattended provisioning is a NixOS problem with
-mature NixOS solutions, and nixarchy sits on top of whichever you pick:
+## Telling the image, without building an image
+
+The ISO takes three parameters on the kernel command line:
+
+```
+nixarchy.answers=https://example.com/answers.txt
+nixarchy.from=github:you/config
+nixarchy.host=laptop
+```
+
+With none of them present it is an ordinary interactive install.
+
+That is how qemu (`-append`), PXE and cloud metadata all inject parameters, so
+a fleet of VMs is a netboot with three arguments and no bespoke image:
+
+```
+qemu-system-x86_64 -cdrom nixarchy-net.iso \
+  -append "nixarchy.answers=https://example.com/answers.txt"
+```
+
+Combine them and the whole thing is one line: `--from` says which
+configuration, `--answers` supplies the machine's secrets, and together they
+are an enrolment with nothing typed. See
+[many machines, one repo](many-machines).
+
+**Scanning a labelled drive is deliberately absent.** Omarchy's ISO watches
+for a second drive labelled `cidata`; nixarchy does not. The kernel command
+line covers PXE and VM fleets, which is where unattended installs actually
+happen, and the media path is worth adding when somebody with a physical fleet
+asks for it rather than before.
+
+## The other way, which is often the right one
+
+Unattended provisioning is a NixOS problem with mature NixOS answers, and
+nixarchy sits on top of whichever you pick:
 
 - **[disko](https://github.com/nix-community/disko)** describes the disk
-  layout declaratively, so partitioning and formatting are part of the
-  configuration rather than a wizard step.
+  layout declaratively. nixarchy's installer already uses it — the same
+  `disk-config.nix` your machine imports is what formatted the disk.
 - **[nixos-anywhere](https://github.com/nix-community/nixos-anywhere)**
-  installs a NixOS flake configuration onto a remote machine over SSH, using
-  disko for the disks. Point it at a VM or a bare host booted into any Linux
-  with SSH, and it comes back as the system your flake describes.
+  installs a flake configuration onto a remote machine over SSH, using disko
+  for the disks. Point it at anything booted into Linux with SSH and it comes
+  back as the system your flake describes — no ISO, no boot medium, nothing to
+  write to a stick.
 
-Add nixarchy as an input to that flake before the first install and the
-machine arrives with the desktop already declared — there is no second step
-to automate, because the flake is the whole description. How to add the input
-is on [the getting-started page](getting-started).
-
-This is also why the gap is smaller than it looks. Upstream's `cidata` drive
-exists to feed answers to an imperative wizard: a disk, a hostname, a user, a
-password hash, SSH keys. In a NixOS flake every one of those is already a line
-in a file, and the file is what nixos-anywhere ships. What nixarchy is missing
-is the boot medium, not the unattended part.
+Add nixarchy as an input to that flake and the machine arrives with the
+desktop already declared. There is no second step to automate, because the
+flake is the whole description. How to add the input is on
+[the getting-started page](getting-started).

--- a/docs/manual/updates.md
+++ b/docs/manual/updates.md
@@ -89,6 +89,23 @@ input. `omarchy update` moves all of them;
 specific fix, the second is the
 better habit — see [Updating NixOS](updating-nixos.md#the-long-way-and-when-you-want-it).
 
+## Machines that update themselves
+
+A machine can pull its configuration from a git repository on a timer instead
+of waiting to be told:
+
+```nix
+programs.nixarchy.fleet = {
+  enable = true;
+  url = "github:you/config";
+};
+```
+
+Off unless you turn it on, and worth understanding before you do: the running
+system then comes from the **remote** flake, so local edits under `/etc/nixos`
+that were never pushed are reverted at the next pull. See
+[many machines, one repo](many-machines).
+
 ## Rolling back bad updates
 
 The snapshot upstream restores from the boot menu is a generation here, and


### PR DESCRIPTION
Closes #127, and with it **epic #121**.

### The new page

`docs/manual/many-machines.md` — the loop the last five changes add up to. Get the first machine into git with `nixarchy config repo`, install the next with `--from`, commit its hardware back, and enable `programs.nixarchy.fleet` if you want them to keep themselves current.

### `unattended-installs.md` was wrong, not merely incomplete

It opened with:

> There is no nixarchy installer, so there is no unattended installer either.

and went on to explain that the missing half was Omarchy's `cidata` drive. Both were true when written; neither is now. Rewritten to say what the answers file does, that it takes an `https://` URL, and what the three kernel command line parameters are.

The nixos-anywhere section stays. For a lot of people that genuinely is the better answer, and saying so is not a concession.

### README

Its description of what the installer leaves behind still listed a flat directory — stale since #123. Now shows the `hosts/<name>/` shape.

Roadmap: #121 moves out of the planned table and into the line above it. **#121 is already closed**, so this must land or the roadmap check fails the other way — verified both directions locally before pushing (`open epics: 112 6 | roadmap: 112 6`).

### Three things put where somebody will meet them

Not only in an option description:

- a fleet machine's unpushed local edits are **reverted at the next pull**
- `--from` runs somebody else's Nix **as root** — their `disk-config.nix` formats your disk
- none of this touches a configuration nixarchy did not write

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5