### PR TITLE
Roadmap: per-project developer environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1550,6 +1550,7 @@ is the shape.
 | --- | --- | --- |
 | [#6](https://github.com/olafkfreund/nixarchy/issues/6) | **bare metal to a desktop** — the installer, the ISO, the release | 18 of 22 done |
 | [#112](https://github.com/olafkfreund/nixarchy/issues/112) | **getting back** — snapshots, backup, restore | not started |
+| [#148](https://github.com/olafkfreund/nixarchy/issues/148) | **per-project developer environments** — devenv, and presets for it | not started |
 
 **Recently finished:**
 [many machines, one repo](https://github.com/olafkfreund/nixarchy/issues/121)


### PR DESCRIPTION
Adds the row for #148.

Not optional: `build.yml` fails any PR where an open `epic`-labelled issue is missing from that table, so **every** PR is red until this lands — related or not. Verified both directions locally: open epics `112 148 6`, roadmap `112 148 6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5