### PR TITLE
Roadmap: remote desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1551,6 +1551,7 @@ is the shape.
 | [#6](https://github.com/olafkfreund/nixarchy/issues/6) | **bare metal to a desktop** — the installer, the ISO, the release | 18 of 22 done |
 | [#112](https://github.com/olafkfreund/nixarchy/issues/112) | **getting back** — snapshots, backup, restore | not started |
 | [#148](https://github.com/olafkfreund/nixarchy/issues/148) | **per-project developer environments** — devenv, and presets for it | not started |
+| [#159](https://github.com/olafkfreund/nixarchy/issues/159) | **remote desktop** — reaching the Hyprland session from elsewhere | not started |
 
 **Recently finished:**
 [many machines, one repo](https://github.com/olafkfreund/nixarchy/issues/121)


### PR DESCRIPTION
Adds the row for #159. Required: `build.yml` fails any PR while an open `epic`-labelled issue is missing from that table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5