### PR TITLE
devenv in the catalogue: package, the hook in all three shells, the cache

### DIFF
--- a/data/services.nix
+++ b/data/services.nix
@@ -93,6 +93,21 @@
     note = "Wanted by Steam, Wine and older games. One switch covers every driver.";
   };
 
+  # ── Development ───────────────────────────────────────────────
+
+  devenv = {
+    label = "devenv";
+    category = "Development";
+    kind = "bundled";
+    # No menuId, and that is the whole convention rather than an omission.
+    # menuId means "override the upstream row with this id", and the staleness
+    # half of tests/coverage.py rejects an id upstream does not ship -- an
+    # install.development.devenv was tried first and failed there, correctly:
+    # Omarchy has no such row to override. So this takes the generated
+    # install.service.devenv, the way openssh and syncthing do.
+    note = "Per-project development environments that activate when you cd in. Bundled because it is a package plus an activation hook in each of bash, zsh and fish, and a cache to keep the first use from being a compile.";
+  };
+
   # ── Desktop ─────────────────────────────────────────────────────────────
   flatpak = {
     label = "Flatpak";

--- a/modules/services/default.nix
+++ b/modules/services/default.nix
@@ -33,6 +33,7 @@
 # and the user having to mkForce their own configuration to escape it.
 {
   imports = [
+    ./devenv.nix
     ./syncthing.nix
     ./tailscale.nix
   ];

--- a/modules/services/devenv.nix
+++ b/modules/services/devenv.nix
@@ -1,0 +1,141 @@
+# devenv: a per-project environment that activates when you cd into it.
+#
+# Bundled rather than plain because there is no upstream option at all --
+# devenv is a package, and a package alone does nothing. What makes it work is
+# the activation hook, and that hook has to be added by hand to each of the
+# three shells nixarchy already manages, in three different dialects. Plus the
+# substituter, without which the first `cd` into a project compiles a toolchain
+# that Cachix has already built.
+#
+# From nixpkgs (2.2.2 at the time of writing, tracked within weeks of
+# upstream), not from `inputs.devenv`. A flake input would put a fast-moving
+# pin in this repo's lock for everyone who imports nixosModules.nixarchy,
+# including people who never enable this. The escape hatch for someone who
+# needs a newer devenv is `package`, which costs them a line and costs nobody
+# else anything.
+#
+# Not enabled by default and not a small closure: devenv bundles its own Nix.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.nixarchy;
+  svc = cfg.services.devenv;
+
+  # `devenv`, not the store path, on purpose. The store path would keep working
+  # in a shell that outlived a deselect, which sounds like a kindness and is
+  # not: it would pin a generation the machine no longer has. The bare name
+  # plus the guard means such a session degrades to nothing instead.
+  #
+  # The guard is the whole reason these are written out rather than being a
+  # one-liner. Without it, every prompt in a session that started before the
+  # package went away prints "devenv: command not found" -- once per prompt,
+  # forever, with nothing on screen to say why.
+  posixHook = shell: ''
+    if command -v devenv >/dev/null 2>&1; then
+      eval "$(devenv hook ${shell})"
+    fi
+  '';
+
+  # fish is not a POSIX shell and none of the above is valid there.
+  # `command -q` is fish's own test; `| source` is what `devenv hook --help`
+  # documents. devenv's nixpkgs output ships share/fish/vendor_completions.d
+  # and nothing in vendor_conf.d, so fish does NOT pick the hook up by itself
+  # here despite what its help text suggests -- checked against 2.2.2.
+  fishHook = ''
+    if command -q devenv
+        devenv hook fish | source
+    end
+  '';
+in
+{
+  options.programs.nixarchy.services.devenv = {
+    enable = lib.mkEnableOption ''
+      devenv, with per-project environments activating on `cd` in bash, zsh
+      and fish.
+
+      A project is a `devenv.nix`; `devenv init` writes that and a
+      `devenv.yaml`, and the first shell writes the `devenv.lock` that pins
+      it. Nothing activates until you run `devenv allow` in that directory
+      once -- consent is per-user and stays interactive, which is why this
+      module does not pre-seed it.
+
+      Note what the lockfile means: a second set of pins beside the
+      system's, one per project, on its own update schedule. That is the
+      cost of a per-project environment and it is worth knowing before the
+      second nixpkgs is downloaded
+    '';
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.devenv;
+      defaultText = lib.literalExpression "pkgs.devenv";
+      description = ''
+        Which devenv. The default is nixpkgs', which is the point -- it
+        moves with the system's nixpkgs and nothing extra lands in this
+        repo's lock.
+
+        Override it if a feature you need has not reached nixpkgs yet. That
+        is one line in your own configuration rather than a flake input
+        every nixarchy user carries.
+      '';
+    };
+
+    binaryCache = lib.mkOption {
+      type = lib.types.bool;
+      default = cfg.binaryCaches;
+      defaultText = lib.literalExpression "config.programs.nixarchy.binaryCaches";
+      description = ''
+        Add Cachix's devenv.cachix.org as a substituter, so the first `cd`
+        into a project downloads what devenv's authors already built rather
+        than compiling it.
+
+        Follows programs.nixarchy.binaryCaches, because someone who turned
+        that off said something about trust and not about Hyprland. Its own
+        option so that decision can still be made per cache.
+      '';
+    };
+  };
+
+  config = lib.mkIf (cfg.enable && svc.enable) {
+    environment.systemPackages = [ svc.package ];
+
+    programs = {
+      # `lines`, which merges -- so this composes with the Omarchy rc chain
+      # that modules/nixos.nix already puts here, and with anything the user
+      # has written. mkDefault on a merging type would drop it entirely the
+      # moment anything else defined the option, which on a nixarchy machine
+      # is always.
+      #
+      # Deliberately NOT gated on programs.nixarchy.bashIntegration: that
+      # option is about Omarchy's aliases and functions, and someone who
+      # brings their own shell config still asked for devenv.
+      bash.interactiveShellInit = posixHook "bash";
+
+      # zsh and fish only when they are actually enabled, matching what
+      # modules/nixos.nix does for the same reason: writing an rc for a shell
+      # the machine does not have is a line nothing ever reads, and turning
+      # the shell on for someone who did not ask is not this module's call.
+      zsh.interactiveShellInit = lib.mkIf config.programs.zsh.enable (posixHook "zsh");
+      fish.interactiveShellInit = lib.mkIf config.programs.fish.enable fishHook;
+    };
+
+    # Lists, so plain assignment -- see the header of modules/services. These
+    # merge into whatever the machine already trusts.
+    #
+    # Whose cache this is: Cachix's, run by the same people who write devenv.
+    # Trusting it is the same decision as trusting nixarchy.cachix.org, made
+    # separately because it is a different party. See
+    # programs.nixarchy.services.devenv.binaryCache to decline it and compile
+    # locally instead.
+    nix.settings = lib.mkIf svc.binaryCache {
+      substituters = [ "https://devenv.cachix.org" ];
+      trusted-public-keys = [
+        "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
+      ];
+    };
+  };
+}

--- a/pkgs/doctor.sh
+++ b/pkgs/doctor.sh
@@ -316,6 +316,35 @@ case "${SHELL##*/}" in
     say "     and the desktop, and lose the aliases and functions."
     ;;
 esac
+
+# devenv, and specifically the rebuild-vs-session gap the README documents.
+# The hook line lands in /etc/bashrc (or /etc/zshrc, or fish's config) at
+# rebuild time; a shell that was already open when that happened has neither
+# read it nor picked up the package. The symptom is `cd` into a project doing
+# nothing at all, which reads as devenv being broken rather than as the
+# session being older than the configuration.
+#
+# This runs in its own process, so it cannot see whether the parent shell has
+# the hook function defined. What it CAN see is the pair that actually
+# disagrees: the rc the current system installed, against the PATH this
+# session inherited.
+devenv_rc=""
+case "${SHELL##*/}" in
+  bash) devenv_rc=/etc/bashrc ;;
+  zsh) devenv_rc=/etc/zshrc ;;
+  fish) devenv_rc=/etc/fish/config.fish ;;
+esac
+if [ -n "$devenv_rc" ] && [ -r "$devenv_rc" ] && grep -q 'devenv hook' "$devenv_rc"; then
+  if command -v devenv >/dev/null 2>&1; then
+    finding "devenv activates in ${SHELL##*/}" "$ok" "cd into a devenv allow'ed project"
+  else
+    finding "devenv is selected but not on this session's PATH" "$warn" ""
+    say "     ${devenv_rc} has the activation hook, so the rebuild landed."
+    say "     This shell started before it. Log out and back in; until then"
+    say "     cd into a project does nothing and says nothing."
+    notes+=("devenv is in your configuration but not in this session. The hook is guarded, so a stale shell stays silent rather than erroring at every prompt -- which also means nothing tells you to log out. This is that.")
+  fi
+fi
 say ""
 
 for unit in docker.service NetworkManager.service; do

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -267,6 +267,43 @@ let
     onFailure = on.systemd.services.nixos-upgrade.unitConfig.OnFailure or "";
   };
 
+  # ---- devenv, both halves --------------------------------------------
+  #
+  # The half that breaks quietly is "off". devenv is a package plus a line in
+  # three shell rcs plus a substituter, and each of those three arrives through
+  # a different mechanism -- so "it did not turn on" is loud, and "it turned on
+  # for someone who never asked" is silent. Mode A is the case: importing
+  # nixosModules.nixarchy must add no devenv, no hook line in any shell, and
+  # above all no substituter, because a substituter is trust granted without a
+  # conflict to warn anyone.
+  #
+  # zsh and fish are enabled explicitly here because the module gates their
+  # hooks on the shell actually existing. Without that, the on case would read
+  # the same as the off case for two of the three shells and prove nothing.
+  devenvOff = configWith { };
+
+  devenvOn = configBeside {
+    programs = {
+      nixarchy.services.devenv.enable = true;
+      zsh.enable = true;
+      fish.enable = true;
+    };
+  };
+
+  # The cache is a separate decision from the package. Someone who set
+  # binaryCaches = false said something about whose builds they run, and
+  # enabling devenv must not walk that back.
+  devenvNoCache = configBeside {
+    programs.nixarchy = {
+      binaryCaches = false;
+      services.devenv.enable = true;
+    };
+  };
+
+  hasDevenv = cfg: builtins.any (p: (p.pname or "") == "devenv") cfg.environment.systemPackages;
+  hasCache = cfg: builtins.elem "https://devenv.cachix.org" cfg.nix.settings.substituters;
+  hookIn = text: pkgs.lib.hasInfix "devenv hook" text;
+
   # ---- a bundled service yields to a user who already configured it ----
   #
   # This is the Mode A hazard in one assertion. Someone adds nixarchy to a
@@ -455,6 +492,27 @@ pkgs.runCommand "nixarchy-options"
     ollamaPort = builtins.toString ollamaBeside.services.ollama.port;
     ollamaEndpoint = ollamaBeside.programs.nixarchy.localAi.resolved.endpoint;
     dockerGroups = pkgs.lib.concatStringsSep " " dockerGroups;
+    devenvOffPackage = pkgs.lib.boolToString (hasDevenv devenvOff);
+    devenvOffBash = pkgs.lib.boolToString (hookIn devenvOff.programs.bash.interactiveShellInit);
+    devenvOffZsh = pkgs.lib.boolToString (hookIn devenvOff.programs.zsh.interactiveShellInit);
+    devenvOffFish = pkgs.lib.boolToString (hookIn devenvOff.programs.fish.interactiveShellInit);
+    devenvOffCache = pkgs.lib.boolToString (hasCache devenvOff);
+    devenvOnPackage = pkgs.lib.boolToString (hasDevenv devenvOn);
+    devenvOnBash = pkgs.lib.boolToString (hookIn devenvOn.programs.bash.interactiveShellInit);
+    devenvOnZsh = pkgs.lib.boolToString (hookIn devenvOn.programs.zsh.interactiveShellInit);
+    devenvOnFish = pkgs.lib.boolToString (hookIn devenvOn.programs.fish.interactiveShellInit);
+    devenvOnCache = pkgs.lib.boolToString (hasCache devenvOn);
+    devenvOnKey = pkgs.lib.boolToString (
+      builtins.elem "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=" devenvOn.nix.settings.trusted-public-keys
+    );
+    # The Omarchy rc chain still has to be there beside ours -- programs.bash
+    # .interactiveShellInit is a merging type, and a mkDefault on it would drop
+    # one of the two silently.
+    devenvOnOmarchyChain = pkgs.lib.boolToString (
+      pkgs.lib.hasInfix "default/bash/rc" devenvOn.programs.bash.interactiveShellInit
+    );
+    devenvNoCacheCache = pkgs.lib.boolToString (hasCache devenvNoCache);
+    devenvNoCachePackage = pkgs.lib.boolToString (hasDevenv devenvNoCache);
     serviceCount = builtins.toString (builtins.length (builtins.attrNames services));
     notApps = pkgs.lib.concatStringsSep " " notApps;
     nativeBuildInputs = [ pkgs.python3 ];
@@ -535,6 +593,51 @@ pkgs.runCommand "nixarchy-options"
                echo "groups: $dockerGroups" >&2
                exit 1 ;;
           esac
+          # ---- devenv: nothing at all until it is asked for ---------------
+          for pair in "package:$devenvOffPackage" "bash hook:$devenvOffBash" \
+            "zsh hook:$devenvOffZsh" "fish hook:$devenvOffFish" \
+            "substituter:$devenvOffCache"; do
+            if [ "''${pair#*:}" != "false" ]; then
+              echo "devenv is off, but its ''${pair%%:*} is on the machine anyway." >&2
+              echo "A configuration that never selects devenv must gain nothing." >&2
+              exit 1
+            fi
+          done
+          echo "devenv adds no package, no hook and no substituter until selected"
+
+          # ---- and everything once it is ----------------------------------
+          for pair in "package:$devenvOnPackage" "bash hook:$devenvOnBash" \
+            "zsh hook:$devenvOnZsh" "fish hook:$devenvOnFish" \
+            "substituter:$devenvOnCache" "public key:$devenvOnKey"; do
+            if [ "''${pair#*:}" != "true" ]; then
+              echo "devenv is enabled but its ''${pair%%:*} is missing." >&2
+              exit 1
+            fi
+          done
+          echo "devenv installs, hooks bash, zsh and fish, and trusts its cache"
+
+          # A merging type, so ours composes rather than replaces. If this
+          # fails the machine lost Omarchy's aliases and functions the moment
+          # devenv was selected, and nothing else would have said so.
+          [ "$devenvOnOmarchyChain" = "true" ] || {
+            echo "selecting devenv displaced Omarchy's bash chain from /etc/bashrc" >&2
+            exit 1
+          }
+          echo "the devenv hook composes with the shell chain rather than replacing it"
+
+          # ---- declining caches is not undone by selecting devenv ---------
+          [ "$devenvNoCacheCache" = "false" ] || {
+            echo "binaryCaches = false, yet devenv added devenv.cachix.org." >&2
+            echo "A substituter is trust, and it merges into the list with no" >&2
+            echo "conflict and no warning -- which is why it must be asked for." >&2
+            exit 1
+          }
+          [ "$devenvNoCachePackage" = "true" ] || {
+            echo "declining the cache also removed devenv itself" >&2
+            exit 1
+          }
+          echo "devenv respects binaryCaches = false and still installs"
+
           echo "every option adds what it should and removes it again"
 
           python3 ${./coverage.py}


### PR DESCRIPTION
Implements #149 (first child of #148).

## The issue's claims, checked before building

All three held:

| Claim | Verified |
| --- | --- |
| devenv is in nixpkgs at 2.2.2 | `2.2.2` from this repo's *pinned* nixpkgs, not just the registry |
| devenv 2.x ships `hook bash\|zsh\|fish` | ran all three against the built 2.2.2 binary; each exits 0 and emits a real hook. `devenv hook --help` documents exactly the three invocations the issue names |
| `devenv.cachix.org` and its key | cache serves `nix-cache-info`; the key from Cachix's own API is `devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=` |

One correction to upstream's own help text, worth knowing: `devenv hook --help` says fish loads the hook automatically when devenv is installed via Nix. The nixpkgs 2.2.2 output ships `share/fish/vendor_completions.d` and nothing in `vendor_conf.d`, so it does not — the explicit fish line is required, which is what the module does.

One thing in the issue that did not survive: it asks for an **Install ▸ Development** menu row. `install.development.devenv` is not a row Omarchy ships, and `tests/coverage.py`'s staleness half rejects a `menuId` upstream does not have — correctly, since `menuId` means "override that row". The entry therefore carries no `menuId` and takes the generated `install.service.devenv`, which is what every other new services row (openssh, syncthing, flatpak) does. Category stays Development, so it groups under Development in the generated `services.nix`.

## What this adds

- `data/services.nix` — a `devenv` entry, `kind = "bundled"`, category Development.
- `modules/services/devenv.nix` — the package, the hook in each of the three chains `modules/nixos.nix` already owns, and the substituter. `enable`, `package` and `binaryCache` options.
  - `binaryCache` defaults to `programs.nixarchy.binaryCaches`. Someone who turned that off said something about whose builds they run.
  - The hook is *not* gated on `bashIntegration`/`shellIntegration`: those are about Omarchy's aliases, and someone with their own shell config still asked for devenv. zsh and fish are gated on the shell actually being enabled, matching `nixos.nix`.
  - `interactiveShellInit` is a merging type, so plain assignment — see below for what `mkDefault` there does.
- `pkgs/doctor.sh` — names the rebuild-vs-session gap. The hook is guarded on `command -v devenv` so a stale session degrades to silence, which also means nothing tells you to log out.

## Verification

`nix build .#checks.x86_64-linux.options` passes:

```
devenv adds no package, no hook and no substituter until selected
devenv installs, hooks bash, zsh and fish, and trusts its cache
the devenv hook composes with the shell chain rather than replacing it
devenv respects binaryCaches = false and still installs
```

Each assertion was proved to fail by breaking what it checks:

| Break | Output |
| --- | --- |
| `enable` defaults to true | `devenv is off, but its package is on the machine anyway.` |
| `binaryCache` default `true` instead of `cfg.binaryCaches` | `binaryCaches = false, yet devenv added devenv.cachix.org.` |
| `lib.mkDefault` on the bash hook | `devenv is enabled but its bash hook is missing.` |
| fish hook removed | `devenv is enabled but its fish hook is missing.` |

The third is the merging-type bug `modules/services/default.nix` warns about, reproduced: `mkDefault` on `lines` dropped the hook entirely rather than losing a priority contest.

`nix fmt -- --ci`, `statix check`, `deadnix --fail` and `shellcheck pkgs/doctor.sh` all clean.

## Not done

Not booted. Every assertion here is about evaluation — a package in a list, a line in an rc, a string in `nix.settings` — so `tests/options.nix` is where the answer is. What is untested by machine is the end-to-end `cd` behaviour in a live session, which is the issue's own "Done when" list and needs a human at a prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZQsPDMpT4UMeHhza1LzMD