### PR TITLE
checks.install gates pull requests

### DIFF
--- a/.github/workflows/install-check.yml
+++ b/.github/workflows/install-check.yml
@@ -12,16 +12,72 @@ name: install check
 # below is why I believed it had been protected.
 #
 # Splitting the file is the fix: this workflow has its own concurrency group,
-# nothing cancels it, and build.yml keeps its snappy PR behaviour.
+# nothing on main cancels it, and build.yml keeps its snappy PR behaviour.
+# (Pull requests are the one place where cancelling is right; see the
+# concurrency block below.)
+
+# It also runs on pull requests, and the filter below is a denylist on purpose.
+#
+# For most of this repo's life it did not. It ran on main and nightly, so the
+# first real gate on "does an install still work" was main itself, and every PR
+# touching the installer merged on faith. #123 is what that costs: the
+# hosts/<name>/ layout changed the module order, system-path hashed the new
+# order into a different derivation, and the installer node then tried to build
+# 517 derivations from hex0-seed in a sandbox with no network. PR CI was green
+# the whole way. It was caught by someone running it by hand, which is not a
+# process.
+#
+# The obvious fix is a `paths:` allowlist naming the installer -- and it is the
+# wrong shape. Work out what it would have to name and the answer is
+# everything: installer/ and tests/install.nix write and drive the install,
+# modules/ and pkgs/ and data/ and vm/ and flake.nix and flake.lock are the
+# closure it installs. #141, the PR that implemented #123, touched flake.nix,
+# installer/, modules/apps.nix and tests/install.nix -- four of those at once.
+# What is left over is documentation. An allowlist of everything-but-docs,
+# written as an allowlist, is a list that silently stops covering the next
+# directory somebody adds, and a filter that misses a path is worse than no
+# filter because it still reads like coverage. That is the same failure this
+# whole file is about, one level down.
+#
+# So: `**` first, and then the handful of paths that provably cannot change
+# what an install produces. A new top-level directory is covered on the day it
+# appears, and dropping something out of coverage takes a deliberate line here.
+# .github/** is excluded because no workflow file can break an install -- with
+# this one re-included on the next line, since a change to how the gate runs
+# should be tested by the gate running.
 
 on:
   push:
     branches: [main]
+  pull_request:
+    paths:
+      - '**'
+      - '!docs/**'
+      - '!README.md'
+      - '!.envrc'
+      - '!.gitignore'
+      - '!.github/**'
+      - '.github/workflows/install-check.yml'
   workflow_dispatch:
 
 concurrency:
   group: install-check-${{ github.ref }}
-  cancel-in-progress: false
+  # Not a constant, and #144 assumed it was one: it read this file as already
+  # having `cancel-in-progress`, and it has it set to false. On main that is
+  # right and deliberate -- the whole reason this file was split out of
+  # build.yml was that build.yml's workflow-level cancel-in-progress reaped the
+  # hour-long install every time something else landed, so it had never once
+  # finished in CI.
+  #
+  # On a pull request the same setting is wrong in the other direction. This
+  # runs on one self-hosted machine for ~15 minutes; with cancelling off, three
+  # pushes to a branch queue three installs of a tree nobody is going to merge,
+  # and the run that matters waits behind two that are already superseded. A PR
+  # only ever needs an answer about its current head.
+  #
+  # github.ref is refs/pull/<n>/merge on a PR, so each branch still has its own
+  # group and cancelling one never touches another, or main.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   install:
@@ -34,10 +90,12 @@ jobs:
     # person actually receives.
     runs-on: [self-hosted, nixos, kvm, big]
 
-    # No `if:` guarding pull_request, and no job-level concurrency: the `on:`
-    # and `concurrency:` at the top of this file already say both things, and
-    # saying them twice is how the first version came to look protected while
-    # being cancelled every time.
+    # No job-level concurrency: the `concurrency:` at the top of this file
+    # already says it, and saying it twice is how the first version came to
+    # look protected while being cancelled every time. (There used to be a line
+    # here noting there was no `if:` guarding pull_request either. There was
+    # nothing to guard: pull requests did not reach this file at all. They do
+    # now, and the `on:` block above is the only place that decides which.)
     timeout-minutes: 45
 
     steps:


### PR DESCRIPTION
Closes #144.

`checks.install` — the check that partitions a disk, installs, boots the result on the bootloader the installer wrote, and asserts a rebuild builds nothing — ran on `push: main`, nightly, and `workflow_dispatch`. Not on pull requests. So main was the first real gate, and #123 nearly went in broken with green PR CI throughout: the `hosts/<name>/` layout changed the module order, `system-path` hashed the new order into a different derivation, and the installer node tried to build 517 derivations from `hex0-seed` in a sandbox with no network.

### Why a denylist, not the `paths:` allowlist the issue leans toward

Work out what an allowlist would have to name and it is everything. `installer/` and `tests/install.nix` write and drive the install; `modules/`, `pkgs/`, `data/`, `vm/`, `flake.nix` and `flake.lock` are the closure it installs. #141 — the PR that implemented #123 — touched `flake.nix`, `installer/`, `modules/apps.nix` and `tests/install.nix`, four of those at once. What is left over is documentation.

An allowlist of everything-but-docs, written as an allowlist, silently stops covering the next top-level directory someone adds, and still reads like coverage. That is exactly the failure this file is about, one level down. So `**` first, then the handful of paths that provably cannot change what an install produces; dropping something out of coverage now takes a deliberate line.

Simulated against real changes (GitHub's ordered-negation semantics, last match wins):

| change | result |
|---|---|
| #141 (implements #123) | **runs** |
| #137 (installer-wizard check) | **runs** |
| #134 (installer-vm store disk) | **runs** |
| `flake.lock` bump | **runs** |
| `pkgs/` package change | **runs** |
| a brand-new top-level directory | **runs** |
| docs + one installer file | **runs** |
| this workflow itself | **runs** |
| #153 (roadmap, docs only) | skipped |
| `build.yml` alone | skipped |

`.github/**` is excluded because no workflow file can break an install, with `install-check.yml` re-included on the next line: a change to how the gate runs should be tested by the gate running. This PR is that case — it triggers the install check, ~15 minutes, which is the point.

### `cancel-in-progress` was not what the issue thought

#144 says the workflow "already has `concurrency: cancel-in-progress`, so pushes would not pile up". It has it set to **false**, deliberately: this file was split out of `build.yml` precisely because `build.yml`'s workflow-level `cancel-in-progress` reaped the hour-long install every time something else landed on main, so it had never once finished in CI.

That is right for main and wrong for a PR. With cancelling off, three pushes to a branch queue three 15-minute installs of a tree nobody will merge, on the one self-hosted machine that can run them. So it is now `${{ github.event_name == 'pull_request' }}`. `github.ref` is `refs/pull/<n>/merge` on a PR, so each branch keeps its own group and cancelling one never touches another, or main.

### The coverage guard in `build.yml` still passes

Verified under **bash**, not zsh — zsh does not word-split the unquoted `$names`, so the loop iterates once and gives a false PASS. Under bash it does 14 iterations, 2 exempt, 12 covered, none missing. Nothing was removed from this file, so `checks.x86_64-linux.install` is still named here.

### The hole one level up

The guard fails a check named by no workflow. It cannot see a check named only by a workflow that never runs on PRs — the same class of hole. After this change, the checks in that state are exactly two:

- `install-iso` — nightly, ~3h for the ISO build
- `iso-budget` — same job

Both are deliberate, and `nightly.yml` says so at length. So a second guard would be a grep for `pull_request` in the workflows naming each check, plus an exempt list of those two. It is worth having — the value of the first guard is that a deliberate exemption gets written down instead of happening by omission, and that argument does not weaken one level up. Not built here to keep this commit to one decision; happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HwBrqMo2UWkCenU1B6ebZH