### PR TITLE
`nixarchy dev init <preset>`: a working project from one command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,33 @@ jobs:
       - name: deadnix
         run: nix run nixpkgs#deadnix -- --fail .
 
+  # Every preset in data/devenv-presets.nix, scaffolded with the real
+  # `nixarchy dev init` and handed to a real devenv to evaluate.
+  #
+  # A job rather than a flake check, which is not where #150 expected it to
+  # land. Evaluating a devenv project fetches the inputs devenv.yaml names and
+  # goes through import-from-derivation to get them; a sandboxed derivation has
+  # neither a network nor IFD, so this cannot be a `checks` entry at all. See
+  # the header on packages.devenv-presets in flake.nix.
+  #
+  # Its own job because it is the only thing here that wants devenv.cachix.org:
+  # without that substituter every preset compiles a toolchain from source and
+  # the run stops being a CI job and starts being an afternoon.
+  devenv-presets:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/cachix-action@v15
+        with:
+          name: nixarchy
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extraPullNames: devenv
+
+      - name: Every preset still evaluates
+        run: nix run .#devenv-presets
+
   omarchy:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ nixarchy                     # what this port adds, and what it defers to
 nixarchy search tailscale    # nixarchy-search
 nixarchy pkg add ripgrep     # nixarchy-pkg-add
 nixarchy apply               # nixarchy-apply
+nixarchy dev init react      # nixarchy-dev-init — a devenv project, here
 nixarchy theme set catppuccin   # → omarchy theme set catppuccin, unchanged
 ```
 
@@ -1550,7 +1551,7 @@ is the shape.
 | --- | --- | --- |
 | [#6](https://github.com/olafkfreund/nixarchy/issues/6) | **bare metal to a desktop** — the installer, the ISO, the release | 18 of 22 done |
 | [#112](https://github.com/olafkfreund/nixarchy/issues/112) | **getting back** — snapshots, backup, restore | not started |
-| [#148](https://github.com/olafkfreund/nixarchy/issues/148) | **per-project developer environments** — devenv, and presets for it | not started |
+| [#148](https://github.com/olafkfreund/nixarchy/issues/148) | **per-project developer environments** — devenv, and presets for it | 2 of 4 done |
 | [#159](https://github.com/olafkfreund/nixarchy/issues/159) | **remote desktop** — reaching the Hyprland session from elsewhere | not started |
 
 **Recently finished:**

--- a/data/devenv-presets.nix
+++ b/data/devenv-presets.nix
@@ -1,0 +1,127 @@
+# What `nixarchy dev init <preset>` writes into a fresh project's devenv.nix.
+#
+# The fourth catalogue, and the only one whose output is not a NixOS module:
+# data/apps.nix installs, data/services.nix turns on, data/flatpaks.nix reaches
+# what nixpkgs cannot. This one seeds a file in somebody's project directory,
+# which is a file this repo will never see again -- it gets committed, shared
+# with a team, and read by people who have never heard of nixarchy.
+#
+# That is the whole reason for the bar below.
+#
+# ## The bar: a preset is exactly a set of devenv option lines
+#
+# `lines` is pasted verbatim into the user's devenv.nix. What lands there has
+# to be the same text devenv's own documentation and every forum answer shows,
+# with no nixarchy vocabulary in it at all -- not a helper, not a `let`, not an
+# import of anything we ship. Two things follow from that, and both are the
+# point:
+#
+#   * The user can grow the file from devenv.sh's reference alone. They are not
+#     reading our docs to edit their own project.
+#   * Ecosystem drift is devenv's to absorb. When Node moves, `languages.javascript`
+#     moves with it upstream and this file does not change. A template of
+#     mkShell boilerplate would be ours to keep green forever; that is exactly
+#     the trade #148 rejected plain `nix flake init -t` over.
+#
+# Anything that needs custom Nix does not qualify. That is what devenv's
+# examples repository is for, and `nixarchy dev init` says so on the way out.
+#
+# ## What is checked, and what is not
+#
+# Nothing here validates itself: `lines` is a string, so a typo in an option
+# name is a string with a typo in it and Nix will never say a word. What
+# catches that is `nix run .#devenv-presets`, which scaffolds every preset and
+# evaluates it against a real devenv. Read the header of that package in
+# flake.nix before assuming this file is self-checking -- it is not, on
+# purpose, because the checking half cannot be pure.
+#
+# ## Fields
+#   label   Shown by `nixarchy dev init` with no argument.
+#   lines   The devenv options, written flush left. Verbatim upstream syntax;
+#           see the bar. pkgs/dev-init.nix indents them on the way in -- do not
+#           indent them here, because Nix's '' strings strip the common leading
+#           whitespace and the indentation would not survive to the file.
+#   note    What the user gets and what it costs. Same job as the `note` in
+#           data/services.nix: say the thing they would otherwise find out the
+#           hard way, not what the language is.
+#
+# Option names below were read out of devenv's own src/modules/languages at
+# df5c75a, not from memory -- `languages.javascript.npm.enable` and
+# `languages.python.venv.enable` are both a level deeper than the guess.
+{
+  # react and node are the same three lines under two names, and that is
+  # deliberate rather than an oversight waiting to be deduplicated. The name a
+  # person types is the whole interface here: somebody starting a React app
+  # types `react`, and answering "no such preset, did you mean node?" would be
+  # a worse command for no gain. If the JavaScript lines ever diverge, they
+  # diverge here without a caller changing.
+  react = {
+    label = "React";
+    lines = ''
+      languages.javascript = {
+        enable = true;
+        npm.enable = true;
+      };
+    '';
+    note = "Node and npm, pinned to the project. Vite, Next and every other React toolchain install through npm from here.";
+  };
+
+  node = {
+    label = "Node.js";
+    lines = ''
+      languages.javascript = {
+        enable = true;
+        npm.enable = true;
+      };
+    '';
+    note = "Node and npm and nothing else. The starting point for anything JavaScript that is not React.";
+  };
+
+  # typescript on top of javascript, not instead of it: devenv's typescript
+  # module adds the compiler and the language server and no runtime at all, so
+  # a project with only `languages.typescript.enable` has tsc and no node to
+  # run the output with. Checked against src/modules/languages/typescript.nix.
+  typescript = {
+    label = "TypeScript";
+    lines = ''
+      languages.javascript = {
+        enable = true;
+        npm.enable = true;
+      };
+      languages.typescript.enable = true;
+    '';
+    note = "Node, npm, tsc and the TypeScript language server. The javascript lines come too -- devenv's typescript module is the compiler, not a runtime.";
+  };
+
+  python = {
+    label = "Python";
+    lines = ''
+      languages.python = {
+        enable = true;
+        venv.enable = true;
+      };
+    '';
+    note = "Python with a virtualenv devenv creates and enters for you, so `pip install` lands in the project rather than in your home directory.";
+  };
+
+  go = {
+    label = "Go";
+    lines = ''
+      languages.go.enable = true;
+    '';
+    note = "The Go toolchain plus gopls and delve, which devenv turns on with it.";
+  };
+
+  # No `channel` line. devenv defaults languages.rust.channel to "nixpkgs",
+  # which is the toolchain the project's own nixpkgs already carries -- setting
+  # it to "stable" instead would pull rust-overlay into every Rust project for
+  # a version most people do not need, and it is one documented line for
+  # someone who does.
+  rust = {
+    label = "Rust";
+    lines = ''
+      languages.rust.enable = true;
+    '';
+    note = "cargo, rustc, clippy and rust-analyzer from the project's nixpkgs. Add `languages.rust.channel = \"stable\";` for a rust-overlay toolchain instead.";
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -401,6 +401,95 @@
               (builtins.readFile ./pkgs/doctor.sh);
         };
 
+        # `nix run .#devenv-presets` -- scaffolds every preset in
+        # data/devenv-presets.nix with the real `nixarchy dev init`, then asks a
+        # real devenv to evaluate what it wrote.
+        #
+        # This is the whole safety net under that catalogue. `lines` is a
+        # string, so a preset that names an option devenv renamed is a valid Nix
+        # file and a broken project, and nothing in `nix flake check` would ever
+        # say so. It runs the command rather than reproducing what it does,
+        # because a check that scaffolds its own devenv.nix tests a copy.
+        #
+        # NOT in `checks`, and that is not an oversight. #150 proposed it as one
+        # on the reasoning that a full `devenv shell` needs the network but
+        # evaluation does not. That is wrong, twice over: evaluating a devenv
+        # project fetches the inputs devenv.yaml names
+        # (github:cachix/devenv-nixpkgs/rolling), and devenv's own flake reaches
+        # them through import-from-derivation -- `nix flake show
+        # github:cachix/devenv` fails with `allow-import-from-derivation is
+        # disabled` before it prints anything. A sandboxed derivation has
+        # neither, so `checks.devenv-presets` could not run at all. A workflow
+        # job that has a network does, and build.yml has one.
+        devenv-presets =
+          let
+            pkgs = pkgsFor.${system};
+          in
+          pkgs.writeShellApplication {
+            name = "nixarchy-devenv-presets";
+            runtimeInputs = [
+              pkgs.coreutils
+              # The same devenv the catalogue entry installs: pkgs.devenv is
+              # what modules/services/devenv.nix defaults its `package` to, so
+              # what evaluates here is what a user's machine would run.
+              pkgs.devenv
+              pkgs.gnused
+              (pkgs.callPackage ./pkgs/dev-init.nix { })
+            ];
+            text = ''
+              presets=( ${nixpkgs.lib.concatStringsSep " " (builtins.attrNames (import ./data/devenv-presets.nix))} )
+
+              # Everything under one temp root, HOME included: `devenv allow`
+              # writes a trust database into XDG state, and a check has no
+              # business touching the trust decisions of whoever ran it.
+              root=$(mktemp -d)
+              trap 'rm -rf "$root"' EXIT
+              HOME="$root/home"
+              export HOME
+              mkdir -p "$HOME"
+
+              fail=0
+              for preset in "''${presets[@]}"; do
+                echo "== $preset"
+                dir="$root/$preset"
+                mkdir -p "$dir"
+                cd "$dir"
+
+                if ! nixarchy-dev-init "$preset" > init.log 2>&1; then
+                  echo "   scaffolding failed:"
+                  sed 's/^/   /' init.log
+                  fail=1
+                  continue
+                fi
+
+                # `devenv info` is the cheapest command that evaluates the whole
+                # module set -- it prints the packages the environment would
+                # have, which it cannot know without resolving every option the
+                # preset set. A renamed option dies here.
+                if devenv info > eval.log 2>&1; then
+                  echo "   ok"
+                else
+                  echo "   does not evaluate:"
+                  sed 's/^/   /' eval.log
+                  echo "   the devenv.nix it wrote:"
+                  sed 's/^/   /' devenv.nix
+                  fail=1
+                fi
+              done
+
+              if [ "$fail" -ne 0 ]; then
+                echo
+                echo "A preset in data/devenv-presets.nix no longer evaluates against"
+                echo "devenv. Either an option was renamed upstream -- fix the preset,"
+                echo "the new name is in devenv's src/modules -- or the scaffold this"
+                echo "edits changed shape and pkgs/dev-init.nix has to follow."
+                exit 1
+              fi
+              echo
+              echo "all ''${#presets[@]} presets evaluate"
+            '';
+          };
+
         # A screencast of a real session, plus the frames it was made from.
         # Not a check: it boots a desktop, drives a tour of it and encodes a
         # video, which is minutes of work nobody wants on every push. Build it

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -1601,14 +1601,24 @@ in
             '';
           })
 
+          # `nixarchy dev init <preset>`. Its own file because flake.nix's
+          # devenv-presets check runs THIS command rather than a copy of it --
+          # see pkgs/dev-init.nix.
+          #
+          # Installed unconditionally, unlike devenv itself, which is an opt-in
+          # catalogue entry. The command's first act is to check for devenv and
+          # name the entry that installs it, and that answer is only useful on a
+          # machine that has not enabled it yet.
+          (pkgs.callPackage ../pkgs/dev-init.nix { })
+
           # One name for the commands this repo adds, and a way through to
           # the 431 it vendors.
           #
           # Not a rename of Omarchy. Upstream's commands keep upstream's name,
           # because they are upstream's -- `omarchy theme set` is the same
           # script here as on Arch, and a bug in it is a bug to report there.
-          # What this names is the other half: the six commands nixarchy wrote,
-          # which until now were six binaries on PATH with nothing tying them
+          # What this names is the other half: the commands nixarchy wrote,
+          # which until now were binaries on PATH with nothing tying them
           # together and no way to discover them.
           #
           # Anything this does not own falls through to omarchy unchanged, so
@@ -1626,7 +1636,8 @@ in
               # Routed by hand rather than by scanning a bin/ directory the way
               # upstream's dispatcher does: these commands are separate
               # derivations on PATH, not siblings in one tree, so there is no
-              # directory to scan. Six entries is not a table worth generating.
+              # directory to scan. A handful of entries is not a table worth
+              # generating.
               case "''${1:-}" in
                 search)   shift; exec nixarchy-search "$@" ;;
                 apply)    shift; exec nixarchy-apply "$@" ;;
@@ -1657,6 +1668,11 @@ in
                     remove)  shift 2; exec nixarchy-app-remove "$@" ;;
                   esac
                   ;;
+                dev)
+                  case "''${2:-}" in
+                    init) shift 2; exec nixarchy-dev-init "$@" ;;
+                  esac
+                  ;;
                 ""|--help|-h|help)
                   cat <<'USAGE'
               nixarchy -- the Omarchy desktop, vendored for NixOS.
@@ -1669,6 +1685,7 @@ in
                 nixarchy app disable <id>   Deselect one
                 nixarchy app remove         Pick what to deselect, interactively
                 nixarchy apply              Copy the selection into your flake and rebuild
+                nixarchy dev init <preset>  Scaffold a devenv project here (no argument lists them)
                 nixarchy doctor             What this machine needs to run nixarchy
 
               Everything else is Omarchy's own, and reaches it unchanged:

--- a/pkgs/dev-init.nix
+++ b/pkgs/dev-init.nix
@@ -1,0 +1,186 @@
+# `nixarchy dev init <preset>` -- a fresh folder becomes a working, pinned
+# project environment in one command.
+#
+# A separate file rather than another entry in modules/apps.nix's systemPackages
+# list for one reason: flake.nix's `devenv-presets` runner has to invoke the
+# real command, not a copy of it. A check that scaffolds a devenv.nix its own
+# way proves nothing about the command people actually type.
+#
+# What this does NOT do is reimplement `devenv init`. Upstream's scaffold writes
+# devenv.nix, devenv.yaml and .gitignore, with comments and doc links in it that
+# are worth more than anything generated here would be; when upstream changes
+# that scaffold, this follows for free. All this adds is flipping the preset's
+# lines and calling `devenv allow`.
+{
+  lib,
+  runCommand,
+  writeShellApplication,
+  writeText,
+  coreutils,
+  gnugrep,
+  gnused,
+}:
+let
+  presets = import ../data/devenv-presets.nix;
+
+  # `lines` is written flush left in the catalogue and indented here, because
+  # Nix's '' strings strip the common leading whitespace off every line -- so
+  # indentation written into the data file is indentation that silently does not
+  # survive. It did not, the first time: the block landed at column zero in the
+  # middle of an otherwise tidy scaffold. Two spaces is devenv's own scaffold
+  # indentation, and blank lines stay blank rather than becoming trailing space.
+  indent =
+    text:
+    lib.concatMapStrings (l: if l == "" then "\n" else "  ${l}\n") (
+      lib.splitString "\n" (lib.removeSuffix "\n" text)
+    );
+
+  # One file per preset plus a tab-separated index, rather than the table being
+  # spliced into the script as a case statement. The script then has no
+  # knowledge of the catalogue at all: adding a preset is a change to
+  # data/devenv-presets.nix and nothing else, and the `lines` reach devenv.nix
+  # by `cat`, which cannot mangle quoting the way passing them through a shell
+  # variable could.
+  presetDir = runCommand "nixarchy-devenv-presets" { } (
+    ''
+      mkdir -p $out
+      cp ${
+        writeText "index.tsv" (
+          lib.concatMapStrings (n: "${n}\t${presets.${n}.label}\t${presets.${n}.note}\n") (
+            lib.attrNames presets
+          )
+        )
+      } $out/index.tsv
+    ''
+    + lib.concatMapStrings (n: ''
+      cp ${writeText "${n}.nix" (indent presets.${n}.lines)} $out/${n}.nix
+    '') (lib.attrNames presets)
+  );
+in
+writeShellApplication {
+  name = "nixarchy-dev-init";
+  # devenv is deliberately NOT here. It is an opt-in catalogue entry that
+  # bundles its own Nix, and this command is on every nixarchy machine --
+  # declaring it would put that closure on machines whose owner never asked for
+  # devenv. writeShellApplication PREPENDS runtimeInputs to PATH rather than
+  # replacing it, so the user's own devenv is reachable, and the check below
+  # answers for the case where there is none.
+  runtimeInputs = [
+    coreutils
+    gnugrep
+    gnused
+  ];
+  text = ''
+    presets=${presetDir}
+
+    list() {
+      echo "Presets:"
+      while IFS=$'\t' read -r name label note; do
+        printf '  %-12s %s\n' "$name" "$label"
+        printf '  %-12s   %s\n' "" "$note"
+      done < "$presets/index.tsv"
+      echo
+      echo "  nixarchy dev init <preset>"
+    }
+
+    case "''${1:-}" in
+      ""|-h|--help|help) list; exit 0 ;;
+    esac
+
+    preset="$1"
+    if [ ! -f "$presets/$preset.nix" ]; then
+      echo "nixarchy: no preset '$preset'." >&2
+      list >&2
+      exit 1
+    fi
+
+    if ! command -v devenv >/dev/null 2>&1; then
+      echo "nixarchy: devenv is not installed, and this command is a wrapper" >&2
+      echo "around it -- there is nothing useful to do without it." >&2
+      echo >&2
+      echo "It is in the catalogue as a service:" >&2
+      echo >&2
+      echo "  nixarchy-service-enable devenv && nixarchy apply" >&2
+      echo >&2
+      echo "or, in your own configuration:" >&2
+      echo >&2
+      echo "  programs.nixarchy.services.devenv.enable = true;" >&2
+      exit 1
+    fi
+
+    # A refusal rather than a merge, and the reason is that this command's only
+    # editing move is "flip the preset's lines into the scaffold". Against a
+    # devenv.nix somebody has been working in, there is no scaffold to flip them
+    # into and no honest way to guess where they belong -- so it stops, and the
+    # user pastes two lines they can already read.
+    if [ -e devenv.nix ]; then
+      echo "nixarchy: this directory already has a devenv.nix." >&2
+      echo "This command only scaffolds a new project. To add the preset by hand:" >&2
+      echo >&2
+      sed 's/^/  /' "$presets/$preset.nix" >&2
+      exit 1
+    fi
+
+    devenv init
+
+    # Upstream's scaffold ships one commented language line -- at 2.2.2,
+    # `# languages.rust.enable = true;` under the devenv.sh/languages/ link --
+    # which is exactly where a reader looks for this, so the preset takes its
+    # place. The fallback is not decoration: the placeholder is a comment in
+    # somebody else's template and can be reworded or dropped in any release,
+    # and a scaffold that silently gained no preset would be the worst outcome
+    # here. Matched on the shape rather than on `rust` so a change of example
+    # language does not fall through.
+    placeholder='^[[:space:]]*# languages\.[a-z0-9]+\.enable = true;[[:space:]]*$'
+    if grep -qE "$placeholder" devenv.nix; then
+      # GNU sed: `r` queues the file for after this cycle's output, `d` drops
+      # the line itself, so the block lands where the comment was.
+      sed -i -E "/$placeholder/{
+        r $presets/$preset.nix
+        d
+      }" devenv.nix
+    else
+      # Before the closing brace of the attrset, which is the last line that is
+      # a bare `}` at column zero.
+      close=$(grep -n '^}' devenv.nix | tail -1 | cut -d: -f1)
+      head -n "$((close - 1))" devenv.nix > devenv.nix.new
+      cat "$presets/$preset.nix" >> devenv.nix.new
+      tail -n +"$close" devenv.nix >> devenv.nix.new
+      mv devenv.nix.new devenv.nix
+    fi
+
+    # The consent step. devenv refuses to activate a directory nobody has
+    # allowed, which is correct -- a devenv.nix is code that runs on `cd`. It is
+    # not a prompt here because the user typed the command: they asked for this
+    # directory to have an environment, in this directory, seconds ago.
+    devenv allow
+
+    cat <<EOF
+
+    Scaffolded a $preset project.
+
+      devenv.nix    the environment -- the preset's lines are in it now
+      devenv.yaml   which nixpkgs it draws from
+      .gitignore    devenv's own scratch directories
+
+    Re-enter the directory to activate it:
+
+      cd "$PWD"
+
+    The first activation needs the network: devenv.yaml names
+    github:cachix/devenv-nixpkgs/rolling and those inputs have to be fetched
+    once. It will take a while and then never again.
+
+    That first shell also writes devenv.lock. Commit all four files --
+    devenv.nix, devenv.yaml, devenv.lock and .gitignore. The lock IS the
+    reproducibility: without it committed, this is a project that worked once,
+    on your machine, on a Tuesday.
+
+    Two honest limits. This environment lives in the Nix store but in no system
+    generation, so nixos-rebuild --rollback does not touch it and 'devenv gc'
+    is yours to run. And the options here are devenv's, not nixarchy's: grow the
+    file from https://devenv.sh/reference/options/, and for anything needing
+    real Nix rather than an option, https://github.com/cachix/devenv/tree/main/examples
+    EOF
+  '';
+}


### PR DESCRIPTION
Closes #150. Second child of #148.

## What

`nixarchy dev init <preset>` — a fresh folder becomes a pinned devenv project
in one command. It refuses politely when devenv is not installed (naming the
catalogue entry), runs upstream's `devenv init`, flips the preset's lines into
the scaffold, runs `devenv allow`, and says what to commit and why.

`data/devenv-presets.nix` is the fourth catalogue. Six presets: `react`,
`node`, `typescript`, `python`, `go`, `rust`. The bar for an entry is that it
is **exactly a set of devenv option lines** — the generated `devenv.nix`
carries no nixarchy vocabulary, so the user grows it from devenv.sh's own
reference and ecosystem drift is devenv's to absorb.

```nix
  # https://devenv.sh/languages/
  languages.javascript = {
    enable = true;
    npm.enable = true;
  };
```

`nix run .#devenv-presets` scaffolds every preset with the real command and
asks a real devenv to evaluate the result. build.yml runs it on every PR.

## Two things in #150 that did not hold

**The check cannot be a flake check.** #150 reasoned that `devenv shell` needs
the network but evaluation does not. Evaluating a devenv project fetches the
inputs `devenv.yaml` names *and* reaches them through import-from-derivation —
`nix flake show github:cachix/devenv` fails with `allow-import-from-derivation
is disabled` before it prints anything. A sandboxed derivation has neither, so
`checks.devenv-presets` could not have run at all. It is a workflow job with a
network and `devenv.cachix.org` pulled in, and both the flake and the workflow
say why.

**Option names are a level deeper than the issue's table in two places** —
`languages.javascript.npm.enable` and `languages.python.venv.enable`. Read out
of devenv's `src/modules/languages` at `df5c75a`, not from memory. The rest of
the table was correct.

## Verified

- All six presets evaluate: `nix run .#devenv-presets` → `all 6 presets evaluate`.
- And the check fails when a preset is broken: `npm.enable` → `npm.enabel` gives
  exit 1 and `The option 'languages.javascript.npm.enabel' does not exist` for
  each of the three JavaScript presets, with the generated file printed.
- `nixarchy dev init react` run for real in a scratch directory; `devenv info`
  on the result lists `nodejs-slim-24.19.0`.
- `nix build .#checks.x86_64-linux.options`, `nix fmt -- --ci`, statix, deadnix.

## Not done

The epic's end-to-end VM check (fresh folder → `nixarchy dev init react` →
re-enter → `node --version` answers). Its second half is the first activation,
which fetches `devenv.lock`'s inputs — the same reason the preset check is not
a flake check. Worth a follow-up that either accepts an impure VM or asserts
only the offline half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQtAnMBRvbQqxeyuhs3fee