### PR TITLE
Per-project environments, documented: what devenv promises and what it does not

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | **Plugins** | `omarchy plugin add <url>` works as upstream ships it, and `programs.nixarchy.plugins` pins one in your flake |
 | **Themes** | `omarchy theme install <url>` clones and applies a published theme at runtime |
 | 13 language toolchains | Go, Rust, Node, Bun, Deno, Java, Elixir, Zig, Clojure, Scala, .NET, OCaml, Python — from nixpkgs, not from `mise` |
+| **Per-project environments** | `nixarchy dev init react` scaffolds a [devenv](https://devenv.sh) project that activates on `cd` in bash, zsh and fish — [the page](docs/manual/per-project-environments.md). Off by default |
 | Branded boot splash | Omarchy's Plymouth theme, selected by `boot.plymouth.theme` |
 | **Agent skills** | `nixarchy`, `nixos` and `diagnose-crash` — rewritten for NixOS, not Omarchy's Arch originals |
 | **LocalSend** | the firewall opens 53317 as upstream's `firewall.sh` does — Share ▸ Receive is reachable, not merely listening |
@@ -1551,7 +1552,7 @@ is the shape.
 | --- | --- | --- |
 | [#6](https://github.com/olafkfreund/nixarchy/issues/6) | **bare metal to a desktop** — the installer, the ISO, the release | 18 of 22 done |
 | [#112](https://github.com/olafkfreund/nixarchy/issues/112) | **getting back** — snapshots, backup, restore | not started |
-| [#148](https://github.com/olafkfreund/nixarchy/issues/148) | **per-project developer environments** — devenv, and presets for it | 2 of 4 done |
+| [#148](https://github.com/olafkfreund/nixarchy/issues/148) | **per-project developer environments** — devenv, and presets for it | 3 of 4 done |
 | [#159](https://github.com/olafkfreund/nixarchy/issues/159) | **remote desktop** — reaching the Hyprland session from elsewhere | not started |
 
 **Recently finished:**

--- a/README.md
+++ b/README.md
@@ -1552,7 +1552,7 @@ is the shape.
 | --- | --- | --- |
 | [#6](https://github.com/olafkfreund/nixarchy/issues/6) | **bare metal to a desktop** — the installer, the ISO, the release | 18 of 22 done |
 | [#112](https://github.com/olafkfreund/nixarchy/issues/112) | **getting back** — snapshots, backup, restore | not started |
-| [#148](https://github.com/olafkfreund/nixarchy/issues/148) | **per-project developer environments** — devenv, and presets for it | 3 of 4 done |
+| [#148](https://github.com/olafkfreund/nixarchy/issues/148) | **per-project developer environments** — devenv, and presets for it | 2 of 4 done |
 | [#159](https://github.com/olafkfreund/nixarchy/issues/159) | **remote desktop** — reaching the Hyprland session from elsewhere | not started |
 
 **Recently finished:**

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -25,19 +25,20 @@ defaults:
 # and bury "Getting Started", so the order is stated rather than derived.
 # A page added to manual/ and not listed here will not appear in the nav.
 nav:
-  - { path: /manual/,                      title: Welcome to nixarchy }
-  - { path: /manual/philosophy,            title: The NixOS Philosophy }
-  - { path: /manual/getting-started,       title: Getting Started }
-  - { path: /manual/updating-nixos,        title: Updating NixOS }
-  - { path: /manual/updates,               title: Updates }
-  - { path: /manual/other-packages,        title: Packages }
-  - { path: /manual/dotfiles,              title: Dotfiles }
-  - { path: /manual/making-your-own-theme, title: Making Your Own Theme }
-  - { path: /manual/development-tools,     title: Development Tools }
-  - { path: /manual/ai,                    title: AI }
-  - { path: /manual/gaming,                title: Gaming }
-  - { path: /manual/security,              title: Security }
-  - { path: /manual/system-snapshots,      title: System Snapshots }
-  - { path: /manual/dual-boot-install,     title: Dual Boot Install }
-  - { path: /manual/unattended-installs,   title: Unattended Installs }
-  - { path: /manual/troubleshooting,       title: Troubleshooting }
+  - { path: /manual/,                         title: Welcome to nixarchy }
+  - { path: /manual/philosophy,               title: The NixOS Philosophy }
+  - { path: /manual/getting-started,          title: Getting Started }
+  - { path: /manual/updating-nixos,           title: Updating NixOS }
+  - { path: /manual/updates,                  title: Updates }
+  - { path: /manual/other-packages,           title: Packages }
+  - { path: /manual/dotfiles,                 title: Dotfiles }
+  - { path: /manual/making-your-own-theme,    title: Making Your Own Theme }
+  - { path: /manual/development-tools,        title: Development Tools }
+  - { path: /manual/per-project-environments, title: Per-Project Environments }
+  - { path: /manual/ai,                       title: AI }
+  - { path: /manual/gaming,                   title: Gaming }
+  - { path: /manual/security,                 title: Security }
+  - { path: /manual/system-snapshots,         title: System Snapshots }
+  - { path: /manual/dual-boot-install,        title: Dual Boot Install }
+  - { path: /manual/unattended-installs,      title: Unattended Installs }
+  - { path: /manual/troubleshooting,          title: Troubleshooting }

--- a/docs/manual/development-tools.md
+++ b/docs/manual/development-tools.md
@@ -99,6 +99,20 @@ The global rows in the menu are for the tools you want everywhere — a
 language server for your editor, `go` for one-off scripts. Anything a
 project depends on belongs in that project's devShell.
 
+### Or without writing a flake: devenv
+
+The file above is the plain-Nix answer, and it is the right one when a
+project's environment is a list of packages and an environment variable. When
+it is not — a Postgres to run alongside, processes, git hooks — writing that
+in `mkShell` is a lot of Nix.
+
+`nixarchy dev init react` scaffolds a
+[devenv](https://devenv.sh) project instead: one command, options rather than
+derivations, and an environment that activates on `cd` in bash, zsh and fish
+without direnv. It is off by default and it costs a second lockfile;
+[Per-project environments](per-project-environments) is the whole story,
+including when not to.
+
 ## Docker
 
 Docker and Docker Compose are enabled by `virtualisation.docker.enable`,

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -11,7 +11,8 @@ replaces only what assumed Arch.
 **So this manual only covers what is different.** Of Omarchy's 51 manual pages,
 38 are word-for-word true here and are linked straight through to
 [omarchy.org/manual](https://omarchy.org/manual/). The 13 that are not are
-rewritten below, plus two that Omarchy has no reason to have.
+rewritten below, plus the ones Omarchy has no reason to have — marked
+**nixarchy only** in the table.
 
 That is the same decision the port itself makes. Forking a manual you do not
 change means maintaining a copy that goes stale at every upstream release, and
@@ -48,6 +49,7 @@ the documentation as much as the code.
 | Neovim | same as Omarchy — [read there](https://omarchy.org/manual/neovim/) |
 | **Ai** | **differs on NixOS** — [read here](ai) |
 | **Development tools** | **differs on NixOS** — [read here](development-tools) |
+| **Per-project environments** | **nixarchy only** — [read here](per-project-environments) |
 | Shell tools | same as Omarchy — [read there](https://omarchy.org/manual/shell-tools/) |
 | Shell functions | same as Omarchy — [read there](https://omarchy.org/manual/shell-functions/) |
 | Tuis | same as Omarchy — [read there](https://omarchy.org/manual/tuis/) |

--- a/docs/manual/per-project-environments.md
+++ b/docs/manual/per-project-environments.md
@@ -1,0 +1,182 @@
+---
+title: Per-project environments
+---
+
+# Per-project environments
+
+One folder, one command, and the folder has a working toolchain that appears
+when you `cd` in and is gone when you leave:
+
+```sh
+mkdir hello-react && cd hello-react
+nixarchy dev init react
+```
+
+The next prompt in that directory is inside the environment, and `node
+--version` answers the project's Node rather than the machine's. Nothing was
+installed on the machine: that Node is pinned in a file the project owns, and
+committing that file is how a colleague gets the same one.
+
+This is nixarchy's, not Omarchy's — upstream reaches for `mise use`, which
+[Development tools](development-tools) explains does not fit here. It is also
+not on by default.
+
+## Turning it on
+
+devenv is a row in the services catalogue, off until you pick it:
+
+```sh
+nixarchy-service-enable devenv
+nixarchy apply
+```
+
+or, in your own configuration:
+
+```nix
+programs.nixarchy.services.devenv.enable = true;
+```
+
+**Then open a new shell.** What makes a project activate is a hook in
+`/etc/bashrc`, `/etc/zshrc` or `/etc/fish/config.fish`, and a shell that
+started before the rebuild read the old one. The hook is guarded, so such a
+session stays silent rather than printing `devenv: command not found` at every
+prompt — which also means nothing tells you to log out. `nixarchy doctor` says
+it instead:
+
+```
+devenv is selected but not on this session's PATH
+```
+
+The rebuild also adds `devenv.cachix.org` as a substituter, so the first `cd`
+into a project downloads what Cachix already built rather than compiling a
+toolchain. Decline it with
+`programs.nixarchy.services.devenv.binaryCache = false;` if you would rather
+not trust that cache; the environments still work, they are just built locally.
+
+## What `nixarchy dev init` writes
+
+`nixarchy dev init` with no argument lists the presets — `react`, `node`,
+`typescript`, `python`, `go`, `rust`. With one, it runs devenv's own
+`devenv init`, replaces the commented example language line in the scaffold
+with the preset's options, and runs `devenv allow` for you.
+
+Four files, and all four are yours to commit:
+
+| file | what it is |
+|---|---|
+| `devenv.nix` | the environment. `react` puts `languages.javascript.{enable,npm.enable}` in it |
+| `devenv.yaml` | which nixpkgs it draws from — `github:cachix/devenv-nixpkgs/rolling` |
+| `devenv.lock` | the pins. Written by the **first** activation, not by `init` |
+| `.gitignore` | devenv's scratch directories |
+
+The lock is the reproducibility. Without it committed this is a project that
+worked once, on your machine, on a Tuesday — so the first thing to do after
+`cd`-ing in is commit again.
+
+The first activation needs the network and takes a while: the inputs
+`devenv.yaml` names have to be fetched once. After that it is instant.
+
+`nixarchy dev init` refuses to touch a directory that already has a
+`devenv.nix`; it only scaffolds. Against a file you have been working in it
+prints the preset's two or three lines for you to paste, because there is no
+honest way to guess where in your file they belong.
+
+## What is promised, and what is not
+
+- **Pinned — strongly.** `devenv.lock` names exact revisions. Same lock, same
+  environment, on any machine, next year.
+- **Activated per shell session.** Activation is the hook, so it holds for
+  shells started after the rebuild and not for the one you are sitting in.
+- **Consented per user, per machine.** `devenv.nix` is code that runs when you
+  `cd`, so devenv will not run it until you say so. In a project you cloned
+  rather than scaffolded, the first prompt says:
+
+  ```
+  devenv: /home/you/hello-react is not allowed. Run 'devenv allow' to trust this directory.
+  ```
+
+  `nixarchy dev init` runs `devenv allow` on your behalf because you typed the
+  command in that directory seconds ago. Nobody else's consent carries: the
+  trust database is per-user state that a fresh machine does not have, so a
+  clone there asks again. That is the right kind of imperative — it is a
+  security decision, like `direnv allow`, not software the rebuild forgot.
+- **In the store, but in no generation.** A project environment is not part of
+  any system NixOS built, so `nixos-rebuild --rollback` does not touch it and
+  the boot menu does not carry it. Rolling the machine back to last week leaves
+  every project exactly where it was. The other half of that is that nothing
+  keeps it either: garbage collection reclaims it, and `devenv gc` is yours to
+  run.
+- **Two sets of pins on one machine.** `devenv.yaml` defaults to
+  devenv-nixpkgs, which is a *second* nixpkgs beside your system's, per
+  project, on its own update schedule (`devenv update`). That is the price of a
+  per-project environment, and it is worth knowing before the second nixpkgs is
+  downloaded.
+
+## The global toolchain and the project's
+
+They coexist, and the project wins inside the project:
+
+```sh
+$ node --version
+v18.0.0                     # the one from Install ▸ Development
+$ cd hello-react
+$ node --version
+v24.19.0                    # this project's, from devenv.lock
+```
+
+The environment prepends to `PATH`; leaving the directory takes it back off.
+The global rows in _Install ▸ Development_ are still the right place for
+language servers and one-off scripts — anything a *project* depends on belongs
+in that project.
+
+## Growing past the presets
+
+A preset is exactly a set of devenv option lines, deliberately: what lands in
+your `devenv.nix` is the same text devenv's own documentation and every forum
+answer show, with no nixarchy vocabulary in it. So the reference for editing
+that file is devenv's, not ours:
+
+- [devenv.sh/reference/options](https://devenv.sh/reference/options/) — every
+  option, including `services.postgres.enable`, `processes`, `scripts`,
+  `tasks` and git hooks, which are the things plain dev shells do not have.
+- [devenv's examples](https://github.com/cachix/devenv/tree/main/examples) —
+  for anything that needs real Nix rather than an option.
+
+`devenv update` moves the lock forward when you want it moved. Nothing about
+your project environments changes when the system updates.
+
+## If you already run direnv
+
+devenv ships its own direnvrc, so you do not need `nix-direnv` for this. A
+two-line `.envrc`:
+
+```sh
+eval "$(devenv direnvrc)"
+use devenv
+```
+
+Then `direnv allow`. **Do not run both**: the shell hook and direnv would each
+activate the same project, and the environment you land in depends on which
+went first. Pick one. Take direnv if you already use it for projects that are
+not devenv projects; take the hook if this is your only reason to want one,
+since it is already wired in all three shells.
+
+## When this is the wrong tool
+
+- **For the machine itself.** Editors, browsers, a language server, `go` for
+  one-off scripts — those are the app selection, one line in a file that a
+  second machine built from the same flake also gets. devenv answers a
+  question about a directory.
+- **When you want nixpkgs' contract.** devenv is a layer over Nix maintained
+  by Cachix, and its option names are theirs to change. A `flake.nix` with
+  `pkgs.mkShell` in it — the form
+  [Development tools](development-tools#per-project-environments-nix-develop)
+  shows — is plain Nix all the way down, has no second lockfile, and is the
+  better answer for a project whose environment is a list of packages and an
+  environment variable. devenv earns its layer when you want the services,
+  processes and language modules on top.
+- **When the project already has a flake.** `nix develop` is already doing
+  this job. Adding devenv beside it is two environments to keep agreeing.
+- **When the repo is not yours.** These are four files at the root of somebody
+  else's project. `devenv.local.nix`, or a plain `nix develop` you never
+  commit, keeps the decision to yourself.


### PR DESCRIPTION
Closes #152. Belongs to the #148 epic, which this PR does not close.

The last piece of the devenv epic that anyone reads. `nixarchy dev init react`
shipped in #163 and the only explanation of it was the command's own closing
message.

## The page

`docs/manual/per-project-environments.md`, marked **nixarchy only** in the
index and added to the sidebar nav. A new page rather than a section in
`development-tools.md`: that page rewrites an Omarchy page for NixOS, and
devenv has no upstream counterpart at all. `development-tools.md` gains a
short subsection under its `nix develop` answer pointing here, and says which
of the two to reach for — `mkShell` when the environment is a package list,
devenv when you want the services, processes and language modules on top.

It covers what `nixarchy dev init` writes and that all four files get
committed; that the environment is the project's and not the machine's; the
trust prompt and why `dev init` answers it for you but a clone re-asks; that a
NixOS rollback does not touch a project environment and does not keep it
either; the second nixpkgs `devenv.yaml` pulls in; direnv for people who
already run it; and a closing section on when devenv is the wrong tool.

## Verified, not recalled

Every command and every quoted string was run against a real
`pkgs.devenv` 2.2.2 and a real build of `pkgs/dev-init.nix`:

| ran | got |
|---|---|
| `nixarchy-dev-init` | the six presets |
| `nixarchy-dev-init nope` | the refusal, exit 1 |
| `nixarchy-dev-init react` | the scaffold; `devenv.nix` with the preset's lines where the commented example was |
| `devenv shell -- node --version` | `v24.19.0`, over a `v18` stub earlier on `PATH` |
| `devenv hook-should-activate` (copied, unallowed dir) | `devenv: <path> is not allowed. Run 'devenv allow' to trust this directory.` — quoted verbatim |
| `devenv direnvrc` + its man page | the two-line `.envrc` |

The hook fires from `PROMPT_COMMAND`, not from `cd` — checked by evaluating
one prompt cycle without cd-ing — so the page says "the next prompt in that
directory" rather than repeating the command's "re-enter the directory".

## The Roadmap: untouched, deliberately

**This PR does not edit the Roadmap section at all** — it is byte-identical to
`main`, table and "Recently finished" both.

The issue's done-when asks for the row, on the premise that #152 is the epic's
last child. It is not: #151 is open with PR #165 in flight.

Closing #148 here would be false, and would fail #165 in the other direction —
the check reads live GitHub state, so a CLOSED #148 breaks every branch whose
README still lists it.

Moving the progress cell to `3 of 4 done` would be right only if this PR merges
last. Either order is possible, so that value is wrong half the time, and if
#165 edits the same cell it is a conflict in README.md — the file this PR is
meant to be the only one touching. The epic gets closed and its row moved in a
separate small PR once both of these have landed, which removes the race rather
than picking a side of it.

The check was still simulated **under bash**, three ways, against this branch:

- as it stands → `the roadmap names every open epic and no closed one`, exit 0
- `#148`'s row deleted → `::error::epic #148 is open and not in the README's Roadmap`, exit 1
- a closed epic (`#121`) added to the table → `::error::epic #121 is closed but the Roadmap still lists it as planned`, exit 1

The third case also proves the `for n in $roadmap` loop iterates over all
entries rather than once, which is the zsh false-PASS this was worth checking
for.

## Checks

`nix fmt -- --ci`, `statix`, `deadnix` all clean. No `.nix` files changed.

**`install-check` does not run on this PR**, correctly: its `paths:` denylist
excludes `!docs/**` and `!README.md`, and those are the only paths touched.

## Also in here

- `docs/manual/index.md`: the count of nixarchy-only pages was already
  ambiguous — "plus two" against one row marked as such — and a fourth would
  have made it wronger. Replaced with a claim the table can be checked against.
- `docs/_config.yml`: nav entry, and the hand-aligned block realigned to the
  new longest path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9nDMR5Am8sypxG81iri8W
