### PR TITLE
Roadmap: devenv is done, and there are eleven skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ this repo replaced with one that deliberately refuses. Shipping them unchanged m
 an agent confidently doing imperative things the next rebuild wipes, which is the
 one failure mode that looks like success.
 
-So ten skills ship here instead:
+So eleven skills ship here instead:
 
 | skill | owns |
 |---|---|
@@ -1552,10 +1552,12 @@ is the shape.
 | --- | --- | --- |
 | [#6](https://github.com/olafkfreund/nixarchy/issues/6) | **bare metal to a desktop** — the installer, the ISO, the release | 18 of 22 done |
 | [#112](https://github.com/olafkfreund/nixarchy/issues/112) | **getting back** — snapshots, backup, restore | not started |
-| [#148](https://github.com/olafkfreund/nixarchy/issues/148) | **per-project developer environments** — devenv, and presets for it | 2 of 4 done |
 | [#159](https://github.com/olafkfreund/nixarchy/issues/159) | **remote desktop** — reaching the Hyprland session from elsewhere | not started |
 
 **Recently finished:**
+[per-project developer environments](https://github.com/olafkfreund/nixarchy/issues/148)
+— `nixarchy dev init react` scaffolds a devenv project that activates at the
+next prompt, in bash, zsh and fish. Off unless you select it. Also
 [many machines, one repo](https://github.com/olafkfreund/nixarchy/issues/121)
 — a machine is a directory, a second one is installed from the same
 repository with `nixarchy-install --from`, and they keep themselves current


### PR DESCRIPTION
Two README corrections, both created by the devenv epic finishing.

**The Roadmap row.** #148 closed when its last child merged, leaving `main` in the state the check fails on — a *closed* epic still listed as planned. Verified both directions locally under bash before pushing: open epics `112 159 6`, roadmap `112 159 6`.

**The skill count.** #165 added the eleventh skill and correctly left README alone — it belonged to #167, which had already merged, so the fix had no owner. CI asserts the skill *set* (in `build.yml` and `tests/session.nix`, both updated by #165) but does not read the prose, so nothing caught "So ten skills ship here".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5