### PR TITLE
Free space install, alongside an existing OS (#47)

### DIFF
--- a/.github/workflows/install-check.yml
+++ b/.github/workflows/install-check.yml
@@ -96,7 +96,12 @@ jobs:
     # here noting there was no `if:` guarding pull_request either. There was
     # nothing to guard: pull requests did not reach this file at all. They do
     # now, and the `on:` block above is the only place that decides which.)
-    timeout-minutes: 45
+    #
+    # 90, not 45: this job does two full installs now. The old number was sized
+    # for one, and a timeout is recorded as `cancelled` -- which reads like
+    # somebody pressed a button rather than like the job running out of road,
+    # the exact confusion the top of this file is about.
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v5
@@ -106,6 +111,18 @@ jobs:
       # hour.
       - name: Install onto a blank disk and boot the result
         run: nix build .#checks.x86_64-linux.install --print-build-logs
+
+      # The same machine, and the one check in the repo whose failure means
+      # somebody's other operating system did not survive. Here rather than in
+      # build.yml for exactly the reason at the top of this file: it boots a
+      # VM, installs, and boots the result, and a push to main would cancel it
+      # there.
+      #
+      # After the blank-disk install, not before: if the installer is broken in
+      # some way that has nothing to do with partitioning, checks.install says
+      # so in a tenth of the log.
+      - name: Install into free space and prove the neighbour survived
+        run: nix build .#checks.x86_64-linux.free-space --print-build-logs
 
       - name: Report what it cost
         if: always()

--- a/README.md
+++ b/README.md
@@ -1476,12 +1476,13 @@ someone would miss it:
    own `.desktop` -- came up to a black desktop. That cause was not chased down,
    because the answer did not depend on it and guessing at one would be worse
    than saying so. The guards work; the branch is not somewhere to go.
-2. **The installer takes the whole disk, and there is no Secure Boot and no
-   graphical installer.** Each is a decision rather than a gap. Sharing a disk
-   means partitioning it yourself, which `installer/disk-config.nix` lets you
-   do and the installer will not: a partition picker is the part of an
-   installer most likely to destroy something, and the layout being one
-   readable file is a better answer than a wizard that hides it. Secure Boot
+2. **The installer will not resize a partition, and there is no Secure Boot and
+   no graphical installer.** Each is a decision rather than a gap. It does
+   install into free space beside another operating system -- see
+   [the dual boot page](docs/manual/dual-boot-install.md) -- but the free space
+   has to be free before it starts: a resize is the operation in this area most
+   likely to lose data and it has a much better tool on the Windows side.
+   Secure Boot
    needs signed shims and enrolled keys, which is a distribution-level
    commitment rather than an installer feature. And the installer is a TUI
    because it runs before there is a desktop to draw a GUI with -- Omarchy's

--- a/docs/manual/dual-boot-install.md
+++ b/docs/manual/dual-boot-install.md
@@ -4,36 +4,70 @@ title: Dual boot install
 
 # Dual boot install
 
-There is no nixarchy installer, so there is no dual-boot installer either.
+The nixarchy installer offers two disk modes, the way Omarchy's does:
 
-Omarchy ships an ISO whose installer offers a **Free space install** next to
-Windows, encrypts the partition with LUKS, and then runs `limine-scan` to add
-the other operating systems to its bootloader.
+- **Full disk install** — the disk is nixarchy's, and everything on it is gone.
+- **Free space install** — nixarchy goes into the largest unpartitioned region
+  on the disk, and every partition already there is left exactly as it was.
 
-**nixarchy has the ISO now, but not the free-space install.** Its installer
-formats a whole disk — that and nothing else. Installing alongside Windows is
-[issue #47](https://github.com/olafkfreund/nixarchy/issues/47), and it is the
-one piece of this work whose failure mode is destroying data that is not ours,
-so it is being done carefully rather than quickly. Until it lands, this page
-cannot honestly say more than the following.
+The second screen only appears when it can. On a disk with no partitions there
+is nothing to install beside, so the question is not asked at all.
 
-## What to do instead
+## Before you start
 
-1. **Make room on the Windows side** exactly as upstream describes — Disk
-   Management, *Shrink Volume*, and turn BitLocker off first, since it encrypts
-   the whole drive rather than a partition. That half of
-   [the upstream page](https://omarchy.org/manual/dual-boot-install/) is about
-   Windows, not Omarchy, and applies unchanged.
+**Shrink Windows from inside Windows.** Disk Management, *Shrink Volume*, and
+leave at least 32 GiB unallocated — that is the floor the installer enforces,
+and it is a floor rather than a recommendation: a desktop with a Nix store in
+it is not comfortable below it. That half of
+[the upstream page](https://omarchy.org/manual/dual-boot-install/) is about
+Windows, not Omarchy, and applies unchanged here.
 
-2. **Install NixOS into the free space** by whichever method you prefer. The
-   NixOS installer supports installing alongside an existing operating system;
-   partitioning and bootloader setup for that are covered by the NixOS manual,
-   and this manual does not repeat them.
+**Turn BitLocker off first.** The installer refuses a free-space install on a
+disk BitLocker is holding, and the reason is worth knowing rather than working
+around: nothing nixarchy does would touch the encrypted volume, but the install
+adds an EFI boot entry and changes the boot order, and BitLocker measures the
+boot chain. The next boot of Windows asks for a recovery key. If you have it,
+you lost an afternoon. If you do not — and most people do not — the data is
+gone as surely as if the disk had been formatted.
 
-3. **Add nixarchy as a flake input** to the resulting configuration and
-   rebuild. That is the whole of the nixarchy-specific work, and it is
-   described on [the getting-started page](getting-started).
+**Back up anyway.** This is a partitioning operation on a disk holding somebody
+else's operating system. It is tested — `nix build .#checks.x86_64-linux.free-space`
+installs onto a disk carrying a Windows-shaped ESP and data partition and
+asserts both come out byte-identical — but a tested operation and a safe one
+are different claims, and the second one is not available.
 
-Dual boot is therefore a NixOS question, and the NixOS manual and wiki are the
-right references for it. Once the machine boots into NixOS, nothing about
-adding nixarchy is different for having Windows on the next partition.
+## What it does
+
+1. Finds the largest unpartitioned region with `sgdisk`, and requires 32 GiB.
+2. Cuts two partitions out of it with `sgdisk --new=0:`, where `0` is sgdisk's
+   own *next free partition number* — so a new partition can never be given a
+   number that is already in use.
+3. Formats **only those two**, mounts them and installs, exactly as the
+   whole-disk mode does.
+
+nixarchy gets its own 2 GiB ESP. It does not adopt the ESP Windows is using,
+even when there is one and it would technically work, which is also what
+Omarchy does. An ESP nixarchy created is one it is allowed to write to; an ESP
+somebody else created is not.
+
+## What it does not do
+
+**It does not add Windows to the boot menu.** Omarchy runs `limine-scan` for
+this; nixarchy's bootloader is systemd-boot, which does not scan. Both
+operating systems are installed and bootable, and you choose between them from
+your firmware's boot menu (usually F12, F11 or Esc at power-on). Adding a
+systemd-boot entry for Windows by hand is a few lines in your configuration and
+is a NixOS question rather than a nixarchy one.
+
+**It does not shrink anything.** The free space has to be free before you
+start. The installer will not resize a partition, and that is deliberate: a
+resize is the operation in this whole area most likely to lose data, and it has
+a much better tool on the Windows side.
+
+**It does not describe your partition table.** The `disk-config.nix` in the
+flake it writes addresses two partitions by label — `nixarchy-esp` and
+`nixarchy-root` — and declares no partition table at all. That is what keeps
+disko from ever reaching a partition nixarchy did not create, and the cost is
+that the file cannot rebuild your disk. Running disko against it on a wiped
+disk produces nothing. The file says so at the top; read it before assuming
+otherwise.

--- a/docs/manual/unattended-installs.md
+++ b/docs/manual/unattended-installs.md
@@ -14,6 +14,7 @@ malformed key is named in one pass instead of one per attempt:
 
 ```ini
 device=/dev/vda
+disk_mode=whole             # or `free`; default `whole`
 encrypt=yes
 luks_passphrase=correct horse
 hostname=nixarchy
@@ -26,6 +27,12 @@ keymap=us
 
 It holds a password in clear. That is inherent to installing without being
 asked, and nothing copies it onto the installed machine.
+
+`disk_mode=free` installs into the largest free region on the disk and leaves
+every existing partition alone — see
+[dual boot install](dual-boot-install). If the disk cannot take one, the
+install **stops**. It does not quietly fall back to `whole`, which would erase
+the disk the file asked to preserve.
 
 `<file>` may also be an **`https://` URL**, which is what makes it unattended
 rather than merely unprompted — otherwise somebody had to put the file on the

--- a/flake.nix
+++ b/flake.nix
@@ -296,7 +296,11 @@
             gnugrep
             gawk
             findutils
-            util-linux # lsblk, findmnt
+            util-linux # lsblk, findmnt, blkid, blockdev, partx, wipefs
+            # sgdisk, and only sgdisk: the free-space mode's whole safety
+            # argument rests on `--new=0:` picking the next free partition
+            # number, which is gptfdisk's behaviour and nothing else's.
+            gptfdisk
             git
             mkpasswd
             nixos-install-tools # nixos-install, nixos-generate-config
@@ -884,6 +888,16 @@
         # nothing. See tests/install.nix for why the second machine is not a
         # normal test node.
         install = import ./tests/install.nix {
+          inherit inputs;
+          pkgs = pkgsFor.${system};
+        };
+
+        # The dangerous one. Installs into free space on a disk that already
+        # carries partitions and asserts those partitions are byte-identical
+        # afterwards -- entry and content. See tests/free-space.nix; #47 is
+        # the only item in the epic whose failure mode is destroying data
+        # that is not ours, and this is the gate it sits behind.
+        free-space = import ./tests/free-space.nix {
           inherit inputs;
           pkgs = pkgsFor.${system};
         };

--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -82,6 +82,20 @@ let
   # Found the hard way: an image carrying only the encrypted reference
   # installs an encrypted machine perfectly and dies partway through an
   # unencrypted one.
+  #
+  # NOT here, and known: the free-space mode (#47). Its layout addresses
+  # partitions by partlabel instead of by disko's generated names, so its
+  # fileSystems differ, so its etc, system-units and toplevel differ -- the
+  # same class of difference as encryption on and off, and the same size. It
+  # is not baked because doing so is two more full references on an image that
+  # already has a budget, and the argument for skipping it is that the ISO
+  # carries stdenv and the reference inputDerivations, so the difference is a
+  # local build of a few dozen text derivations rather than a fetch.
+  #
+  # That argument has NOT been tested. If a free-space install from the
+  # offline image ends in the source bootstrap, this list is the place it is
+  # wrong, and checks.free-space -- which seeds the free-mode toplevels the
+  # way this would -- is the shape of the fix.
   referenceConfigs = map (c: c.config) [
     inputs.self.nixosConfigurations.reference
     inputs.self.nixosConfigurations.reference-unencrypted

--- a/installer/disk-config.nix
+++ b/installer/disk-config.nix
@@ -1,16 +1,20 @@
-# The one disk layout the installer offers. Imported by the installed system
-# too, so the layout is declared once and is what `fileSystems` derives from --
-# epic invariant 1 applied to the disk: text in the user's flake, not a side
-# effect of an install script.
+# The disk layouts the installer offers. Imported by the installed system too,
+# so a layout is declared once and is what `fileSystems` derives from -- epic
+# invariant 1 applied to the disk: text in the user's flake, not a side effect
+# of an install script.
 #
-# `device` is the whole disk. Installing beside an existing OS is a second
-# mode with a different shape, tracked as #47; it cannot reuse this GPT block,
-# because disko only clears a partition table on a disk with no signatures and
-# its partition numbers are positional. It reuses the `btrfs` block below,
-# which is the reason that block is a binding rather than written out twice.
+# Two modes, one file, one btrfs layout. `mode` picks between them:
+#
+#   "whole"  the whole disk. `device` is the disk, disko owns the partition
+#            table, and everything that was on it is gone.
+#
+#   "free"   installed into free space beside an existing OS (#47). There is
+#            NO partition table here at all -- see the block below for why
+#            that is the safety property and not an omission.
 {
   device,
   encrypt ? true,
+  mode ? "whole",
 }:
 let
   # Omarchy's layout on Arch is @ @home @log and @pkg for pacman's cache.
@@ -66,51 +70,150 @@ let
       };
     };
   };
-in
-{
-  disko.devices.disk.main = {
-    inherit device;
-    type = "disk";
-    content = {
-      type = "gpt";
-      partitions = {
-        # /boot rather than /boot/efi: it is what boot.loader.systemd-boot
-        # expects with no further options, and what Omarchy does with Limine.
-        # 2G because a NixOS /boot holds every generation's kernel and initrd,
-        # and the usual 512M runs out quietly, mid-rebuild.
-        esp = {
-          size = "2G";
-          type = "EF00";
-          content = {
-            type = "filesystem";
-            format = "vfat";
-            mountpoint = "/boot";
-            mountOptions = [ "umask=0077" ];
+
+  # LUKS, or not, around whatever content is handed in. Both modes ask the
+  # same question and get the same answer, so the block is written once and
+  # the two layouts differ only in what sits above it.
+  luksOr =
+    content:
+    if encrypt then
+      {
+        type = "luks";
+        name = "cryptroot";
+        # Read once, by the disko script, at format time. The installer
+        # writes it and removes it; the installed system never sees this
+        # path -- its initrd prompts for the passphrase instead, and
+        # nothing about this leaks into the closure. Never put it in the
+        # generated flake directory: that becomes /etc/nixos and a git
+        # repository.
+        passwordFile = "/tmp/nixarchy-luks.key";
+        # TRIM through LUKS. Upstream accepts the trade -- it makes the
+        # free-space pattern visible on the device -- and so do we.
+        settings.allowDiscards = true;
+        inherit content;
+      }
+    else
+      content;
+
+  # ---------------------------------------------------------------------------
+  # mode = "whole" -- the disk is ours, all of it.
+  # ---------------------------------------------------------------------------
+  whole = {
+    disko.devices.disk.main = {
+      inherit device;
+      type = "disk";
+      content = {
+        type = "gpt";
+        partitions = {
+          # /boot rather than /boot/efi: it is what boot.loader.systemd-boot
+          # expects with no further options, and what Omarchy does with Limine.
+          # 2G because a NixOS /boot holds every generation's kernel and initrd,
+          # and the usual 512M runs out quietly, mid-rebuild.
+          esp = {
+            size = "2G";
+            type = "EF00";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot";
+              mountOptions = [ "umask=0077" ];
+            };
           };
-        };
-        root = {
-          size = "100%";
-          content =
-            if encrypt then
-              {
-                type = "luks";
-                name = "cryptroot";
-                # Read once, by the disko script, at format time. The installer
-                # writes it and removes it; the installed system never sees this
-                # path -- its initrd prompts for the passphrase instead, and
-                # nothing about this leaks into the closure. Never put it in the
-                # generated flake directory: that becomes /etc/nixos and a git
-                # repository.
-                passwordFile = "/tmp/nixarchy-luks.key";
-                # TRIM through LUKS. Upstream accepts the trade -- it makes the
-                # free-space pattern visible on the device -- and so do we.
-                settings.allowDiscards = true;
-                content = btrfs;
-              }
-            else
-              btrfs;
+          root = {
+            size = "100%";
+            content = luksOr btrfs;
+          };
         };
       };
     };
   };
-}
+
+  # ---------------------------------------------------------------------------
+  # mode = "free" -- somebody else's OS is on this disk and stays on it.
+  #
+  # THIS DESCRIBES NO PARTITION TABLE, AND THAT IS THE POINT.
+  #
+  # The obvious way to write this is a `gpt` block with the existing
+  # partitions declared alongside ours. It is also the way that destroys
+  # data, and the reason is not obvious, so it is written down here:
+  #
+  #   disko's gpt type numbers partitions POSITIONALLY. lib/types/gpt.nix:244
+  #   defaults `_index` to `diskoLib.indexOf ... sortedPartitions 0`, and
+  #   indexOf counts from 1 (lib/default.nix:308, `iter 1 list`). The first
+  #   partition disko declares is partition 1, always.
+  #
+  #   gpt's `_create` (gpt.nix:281) only clears a disk that blkid does not
+  #   recognise, which sounds like the safe behaviour until the fallback at
+  #   gpt.nix:315: when `sgdisk --new=1:...` fails because number 1 is in
+  #   use, it retries WITHOUT --new -- `sgdisk --change-name=1 --typecode=1`
+  #   on the partition that is already there. On a disk holding Windows,
+  #   that relabels and retypes Windows' partition and reports success.
+  #
+  # `_index` is overridable -- `internal` hides an option from the docs, it
+  # does not seal it -- so this is technically avoidable. It would still mean
+  # a data-destroying operation depending on an undocumented internal that
+  # disko may change without notice, so it is not done.
+  #
+  # Instead the partitions are cut by installer/install.sh with
+  # `sgdisk --new=0:`, where 0 is sgdisk's own "next free partition number"
+  # and a collision cannot arise, and this file describes the RESULT. Every
+  # entry below is a disko `disk` whose device is one partition, addressed by
+  # the partlabel install.sh gave it. disk._create is exactly its content's
+  # _create (lib/types/disk.nix), and neither luks._create nor
+  # filesystem._create touches anything but its own `device` -- so nothing in
+  # this file can reach a partition the installer did not create. That is
+  # disko's behaviour, relied on deliberately; the part enforced by our own
+  # code is which partitions exist at all, and that is in install.sh.
+  #
+  # By-partlabel, not by-uuid: the labels are known before the partitions
+  # exist, so this file can be written by the same template as the whole-disk
+  # mode instead of being generated after the fact from whatever UUIDs came
+  # out. The cost is that two nixarchy installs on one disk would collide on
+  # the names; install.sh refuses to start a free-space install when either
+  # label is already taken.
+  #
+  # And the thing somebody will otherwise assume: THIS FILE CANNOT REBUILD
+  # YOUR PARTITION TABLE. It is not a whole-device description. Running
+  # disko against it on a wiped disk produces nothing -- the partitions it
+  # names would not exist. It keeps `fileSystems` and `boot.initrd.luks`
+  # declarative, which is what invariant 1 asks of it, and that is all.
+  #
+  # `device` is unused here, deliberately. The installer still substitutes
+  # the disk it partitioned into the template so the file records which disk
+  # this machine came from; nothing addresses it.
+  # ---------------------------------------------------------------------------
+  free = {
+    disko.devices.disk = {
+      # Ours, cut fresh in the free space -- never the ESP that was already
+      # on the disk. Upstream does not adopt an existing ESP either, even
+      # when a Windows one is present and technically usable, and the reason
+      # is this file: an adopted ESP is a partition we did not create, which
+      # the paragraph above promises never to write to.
+      #
+      # 2G, for the same reason as the whole-disk mode: a NixOS /boot holds
+      # every generation's kernel and initrd.
+      esp = {
+        type = "disk";
+        device = "/dev/disk/by-partlabel/nixarchy-esp";
+        content = {
+          type = "filesystem";
+          format = "vfat";
+          mountpoint = "/boot";
+          mountOptions = [ "umask=0077" ];
+        };
+      };
+
+      root = {
+        type = "disk";
+        device = "/dev/disk/by-partlabel/nixarchy-root";
+        content = luksOr btrfs;
+      };
+    };
+  };
+in
+if mode == "whole" then
+  whole
+else if mode == "free" then
+  free
+else
+  throw "disk-config.nix: mode must be \"whole\" or \"free\", got: ${mode}"

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -106,6 +106,14 @@ from_host_exists=false
 # variable three functions later.
 device=""
 encrypt=""
+# "whole" (the disk is ours) or "free" (installed beside an existing OS, #47).
+# Set by ask_disk_mode or the answers file; the free-space region it applies to
+# lives in free_start/free_end, in sectors, and is measured twice -- once to
+# decide whether to offer the mode, once immediately before cutting.
+disk_mode="whole"
+free_start=""
+free_end=""
+free_why=""
 hostname=""
 username=""
 password_hash=""
@@ -149,6 +157,9 @@ configuration becomes a starting point for yours.
 The answers file is one key=value per line, # for comments, no quoting:
 
   device=/dev/vda           whole disk, not a partition
+  disk_mode=whole           whole or free; default whole. `free` installs into
+                            the largest free region on the disk and leaves
+                            every existing partition alone
   encrypt=yes               yes or no
   luks_passphrase=...       required when encrypt=yes
   hostname=nixarchy
@@ -161,8 +172,15 @@ The answers file is one key=value per line, # for comments, no quoting:
 It holds a password in clear, which is inherent to installing without being
 asked. Nothing copies it onto the installed machine.
 
-Run as root from a NixOS live medium, on a UEFI machine. It formats the disk
-you choose, completely. There is no dual-boot path yet.
+Run as root from a NixOS live medium, on a UEFI machine. By default it formats
+the disk you choose, completely.
+
+The other mode installs into free space beside whatever is already on the disk
+-- see disk_mode above. It is offered only on a GPT disk that already has
+partitions and at least 32 GiB of contiguous free space, and never on a disk
+BitLocker is holding: adding a boot entry to such a machine wakes BitLocker's
+recovery prompt, and a Windows that asks for a key nobody has is worse than an
+install that refused.
 USAGE
 }
 
@@ -448,12 +466,219 @@ ask_device() {
   [ -n "$device" ] || exit 1
 }
 
+# ---------------------------------------------------------------------------
+# Free space, beside an existing OS (#47)
+#
+# The dangerous mode. Everything below runs next to somebody's Windows, so the
+# rules it keeps are worth stating in one place:
+#
+#   Nothing here writes to a partition it did not create. The partitions are
+#   cut with `sgdisk --new=0:`, where 0 is sgdisk's own "next free partition
+#   number" -- a collision is impossible and there is no fallback that edits an
+#   existing entry instead. The layout that formats them addresses only those
+#   two partitions, by partlabel; see installer/disk-config.nix, mode = "free",
+#   for why it describes no partition table at all and what disko would have
+#   done if it did.
+#
+#   The disk is measured twice. Once to decide whether to offer the mode, and
+#   once immediately before cutting, and the two must agree.
+#
+#   Every refusal is a refusal. There is no "install anyway".
+# ---------------------------------------------------------------------------
+
+# Upstream's floor, and it is the whole region rather than what is left after
+# our ESP: 32 GiB is already tight for a desktop with a Nix store in it, and
+# subtracting 2 GiB from a number somebody chose as a minimum makes it not the
+# minimum any more.
+FREE_MIN_GIB=32
+# Same 2 GiB as the whole-disk ESP, for the same reason: a NixOS /boot holds
+# every generation's kernel and initrd.
+FREE_ESP_MIB=2048
+
+# The largest free region on $1, as "start end" in sectors.
+#
+# NOT `sfdisk -F -J`, which #47 proposed and which does not exist: util-linux
+# refuses the combination outright -- "options --list-free and --json cannot be
+# combined" -- so the only machine-readable form left is sfdisk's human table,
+# which is a parse waiting to rot. sgdisk answers the question directly and is
+# the tool that then does the cutting, which is one fewer thing that can
+# disagree: -F is the first ALIGNED sector of the largest free block, -E is its
+# last sector.
+free_region() {
+  local dev=$1 start end
+  start=$(sgdisk -F "$dev" 2>/dev/null) || return 1
+  end=$(sgdisk -E "$dev" 2>/dev/null) || return 1
+  case "$start$end" in
+    "" | *[!0-9]*) return 1 ;;
+  esac
+  # Aligned up to the next 2048-sector boundary. sgdisk -F is documented as
+  # the first ALIGNED sector of the largest free block, and usually is -- but
+  # on a disk with no free block big enough to hold an aligned sector it
+  # answers with the raw first free one (sector 34, on a full GPT disk). That
+  # case is rejected by the size floor rather than by this, and the alignment
+  # is done anyway so that the arithmetic in partition_free_space can state
+  # that its start sectors are aligned and be right about it.
+  start=$(((start + 2047) / 2048 * 2048))
+  [ "$end" -gt "$start" ] || return 1
+  printf '%s %s\n' "$start" "$end"
+}
+
+# Every partition on $1 that BitLocker owns.
+#
+# Two tests, and the second is not redundant. libblkid has recognised BitLocker
+# since 2.31 and reports TYPE="BitLocker", but it wants a well-formed BDE
+# header before it will say so -- a partition carrying the signature and
+# nothing else libblkid recognises comes back with no TYPE at all, which was
+# measured here rather than assumed. That is the right behaviour for
+# identifying a volume and the wrong one for deciding whether to go near it.
+#
+# So the eight bytes at offset 3 are read directly as well. They are what
+# BitLocker writes and what every other tool looks for, and a partition
+# carrying them is not somewhere to install beside whatever libblkid makes of
+# the rest of the header. A read of eight bytes; nothing here opens the device
+# for writing.
+bitlocker_partitions() {
+  local dev=$1 part
+  while read -r part; do
+    [ -n "$part" ] || continue
+    if [ "$(blkid -o value -s TYPE "/dev/$part" 2>/dev/null)" = "BitLocker" ] ||
+      [ "$(dd if="/dev/$part" bs=1 skip=3 count=8 status=none 2>/dev/null)" = "-FVE-FS-" ]; then
+      printf '%s\n' "/dev/$part"
+    fi
+  done < <(lsblk -lno NAME,TYPE "$dev" 2>/dev/null | awk '$2=="part"{print $1}')
+}
+
+# Can $1 take a free-space install? Sets free_start/free_end when it can and
+# free_why when it cannot. Read-only: it opens nothing for writing and changes
+# nothing, which is what makes it safe to call from the question screen.
+free_space_possible() {
+  local dev=$1 region sector_bytes region_bytes locked label
+
+  free_start=""
+  free_end=""
+  free_why=""
+
+  # An MBR disk is not refused because GPT is nicer. sgdisk CONVERTS an MBR
+  # table to GPT the moment it writes one, and a Windows that was booting from
+  # that MBR then does not boot. Nothing here is willing to do that on
+  # somebody's behalf, so a disk without a GPT gets the whole-disk mode or
+  # nothing.
+  # blkid rather than `lsblk -dno PTTYPE`: lsblk reads that column from udev's
+  # properties, which a loop device does not have, so the whole free-space path
+  # was unreachable on exactly the kind of device this is safe to test against.
+  # blkid probes the disk itself and answers the same question.
+  if [ "$(blkid -o value -s PTTYPE "$dev" 2>/dev/null)" != "gpt" ]; then
+    free_why="$dev has no GPT partition table"
+    return 1
+  fi
+
+  # Nothing to install beside. Upstream skips the mode screen entirely here and
+  # so does this: "alongside existing data" with no existing data is a question
+  # with one honest answer, and asking it invites the other one.
+  if [ "$(lsblk -rno TYPE "$dev" 2>/dev/null | grep -c '^part$')" -eq 0 ]; then
+    free_why="$dev has no partitions -- there is nothing to install beside"
+    return 1
+  fi
+
+  # BitLocker. Refused rather than worked around, which #47 asks for and which
+  # is not conservatism: nothing here would touch the encrypted volume, but a
+  # free-space install adds an EFI boot entry and changes the boot order, and
+  # BitLocker measures the boot chain. The next boot of Windows asks for a
+  # recovery key. If the person has it, they lost an afternoon; if they do not
+  # -- and most people do not -- the data is gone as surely as if this had
+  # formatted it.
+  locked=$(bitlocker_partitions "$dev")
+  if [ -n "$locked" ]; then
+    free_why="BitLocker is holding $(echo "$locked" | tr '\n' ' ')on $dev"
+    return 1
+  fi
+
+  # Our own labels, already taken. The layout addresses partitions by
+  # /dev/disk/by-partlabel/nixarchy-{esp,root}, and a second partition with the
+  # same label makes that symlink point at whichever one udev saw last -- which
+  # is to say, at a coin toss. A second nixarchy on one disk needs a way to
+  # name the two apart; until there is one, this refuses.
+  for label in nixarchy-esp nixarchy-root; do
+    if [ -e "/dev/disk/by-partlabel/$label" ]; then
+      free_why="a partition called $label already exists on this machine"
+      return 1
+    fi
+  done
+
+  region=$(free_region "$dev") || {
+    free_why="$dev has no free space outside its partitions"
+    return 1
+  }
+  read -r free_start free_end <<<"$region"
+
+  # Sectors are not always 512 bytes and a 4Kn disk is not exotic. Asking the
+  # kernel costs nothing and getting it wrong is a factor of eight.
+  sector_bytes=$(blockdev --getss "$dev" 2>/dev/null || echo 512)
+  region_bytes=$(((free_end - free_start + 1) * sector_bytes))
+  if [ "$region_bytes" -lt $((FREE_MIN_GIB * 1024 * 1024 * 1024)) ]; then
+    free_why="the largest free region on $dev is under ${FREE_MIN_GIB} GiB"
+    free_start=""
+    free_end=""
+    return 1
+  fi
+
+  return 0
+}
+
+# A region size a person can read, for the screens.
+free_region_human() {
+  local sector_bytes
+  sector_bytes=$(blockdev --getss "$device" 2>/dev/null || echo 512)
+  # iec-i, not iec: sectors are counted in powers of two and "60GB" for
+  # 60 GiB is the kind of small lie that turns into a support question.
+  numfmt --to=iec-i --suffix=B $(((free_end - free_start + 1) * sector_bytes))
+}
+
+# Full disk or free space. Skipped entirely -- not shown greyed out, not shown
+# with one option -- when the disk cannot take a free-space install, which is
+# upstream's shape and is also the only version of this screen that cannot be
+# answered wrongly.
+ask_disk_mode() {
+  if ! free_space_possible "$device"; then
+    disk_mode=whole
+    return 0
+  fi
+
+  ui_screen "There is already something on this disk..."
+  # Piped through ui_indent rather than handed to ui_left, which formats with
+  # %b: a partition LABEL is somebody else's string and %b would interpret a
+  # backslash escape in it.
+  lsblk -no NAME,SIZE,FSTYPE,LABEL "$device" 2>/dev/null | head -12 | ui_indent
+  echo
+
+  local choice
+  choice=$(printf '%s\n' \
+    "Free space install -- keep what is on $device, use the $(free_region_human) free" \
+    "Full disk install -- erase $device and everything on it" |
+    gum choose --height "$(ui_widget_height)" --padding "$(ui_gum_pad)" --header "How should nixarchy use $device?")
+  case $choice in
+    "Free space install"*) disk_mode=free ;;
+    "Full disk install"*) disk_mode=whole ;;
+    # Escape, or a gum that could not draw. Neither is consent to format a
+    # disk with an operating system on it.
+    *) exit 1 ;;
+  esac
+}
+
 # Encryption is on unless the user opts out, matching upstream: the hint is dim
 # and Ctrl+C at the warning is the way out. That is upstream's shape, and it
 # means the safe answer is the one you get by doing nothing.
 ask_encrypt() {
   ui_screen "Ready to install"
-  ui_left "\e[33mEverything on $device will be overwritten. There is no recovery possible.\e[0m"
+  # The warning has to be true. "Everything on $device will be overwritten" is
+  # the correct sentence for a whole-disk install and a lie for a free-space
+  # one, and a person who reads a lie here learns to skip the next warning too.
+  if [ "$disk_mode" = free ]; then
+    ui_left "\e[33m$(free_region_human) of free space on $device will be overwritten.\e[0m"
+    ui_left "\e[33mThe partitions already on $device are not touched.\e[0m"
+  else
+    ui_left "\e[33mEverything on $device will be overwritten. There is no recovery possible.\e[0m"
+  fi
   ui_left "\e[90mPress Ctrl+C for an unencrypted install.\e[0m"
   echo
 
@@ -461,7 +686,9 @@ ask_encrypt() {
   # destructive question should never mean "do it anyway, differently"; and an
   # interrupt is upstream's hidden opt-out, which gum reports as 130.
   local rc=0
-  gum confirm --padding "$(ui_gum_pad)" "Encrypt and install to $device?" || rc=$?
+  local where=$device
+  [ "$disk_mode" = free ] && where="the free space on $device"
+  gum confirm --padding "$(ui_gum_pad)" "Encrypt and install to $where?" || rc=$?
   case $rc in
     0) encrypt=true ;;
     130) encrypt=false ;;
@@ -478,6 +705,11 @@ confirm_summary() {
     printf 'Timezone,%s\n' "$timezone"
     printf 'Keyboard,%s\n' "$keymap"
     printf 'Disk,%s\n' "$device"
+    if [ "$disk_mode" = free ]; then
+      printf 'Disk use,free space only (%s)\n' "$(free_region_human)"
+    else
+      printf 'Disk use,the whole disk -- erased\n'
+    fi
     printf 'Encrypted,%s\n' "$encrypt"
   } | gum table --separator ',' --print --columns "Setting,Value" | ui_indent
   echo
@@ -559,6 +791,7 @@ read_answers() {
     # machine called nixarchy that nobody asked for.
     case $key in
       device) device=$value ;;
+      disk_mode) disk_mode=$value ;;
       encrypt) encrypt=$value ;;
       luks_passphrase) luks_passphrase=$value ;;
       hostname) hostname=$value ;;
@@ -594,6 +827,13 @@ validate_answers() {
   if [ "$from_host_exists" = true ]; then
     local problems=()
     [ -n "$password_hash" ] || problems+=("password: one of password or password_hash is required")
+    # The repository's own disk-config.nix decides the layout, and format_disk
+    # runs that rather than anything chosen here. A disk_mode in the answers
+    # file would be read, ignored, and then acted on by partition_free_space --
+    # cutting partitions the layout about to run knows nothing about. Refused
+    # rather than silently dropped.
+    [ "$disk_mode" = whole ] ||
+      problems+=("disk_mode: --host names a machine the repository already describes; it decides the disk")
     if [ ${#problems[@]} -gt 0 ]; then
       printf 'nixarchy-install: answers: %s\n' "${problems[@]}" >&2
       exit 2
@@ -626,6 +866,19 @@ validate_answers() {
     "" | yes | no) ;;
     *) problems+=("encrypt: must be yes or no, got: $encrypt") ;;
   esac
+
+  # The mode, and then -- for free -- the same test the question screen runs.
+  # An answers file is the consent, not the judgement: `disk_mode=free` against
+  # a disk that cannot take one has to fail here, loudly, rather than fall back
+  # to the whole-disk mode. Falling back would silently erase the very disk the
+  # file asked to preserve, which is the worst failure this script has.
+  case $disk_mode in
+    whole | free) ;;
+    *) problems+=("disk_mode: must be whole or free, got: $disk_mode") ;;
+  esac
+  if [ "$disk_mode" = free ] && [ -n "$device" ] && [ -b "$device" ]; then
+    free_space_possible "$device" || problems+=("disk_mode: free is not possible here: $free_why")
+  fi
   if [ "$encrypt" = yes ] && [ -z "$luks_passphrase" ]; then
     problems+=("luks_passphrase: required when encrypt=yes")
   fi
@@ -655,8 +908,8 @@ validate_answers() {
 
   # The file is the consent; there is no confirmation prompt. The summary is
   # still printed so a test log shows what was about to happen.
-  printf 'hostname=%s username=%s device=%s encrypt=%s timezone=%s keymap=%s\n' \
-    "$hostname" "$username" "$device" "$encrypt" "$timezone" "$keymap"
+  printf 'hostname=%s username=%s device=%s disk_mode=%s encrypt=%s timezone=%s keymap=%s\n' \
+    "$hostname" "$username" "$device" "$disk_mode" "$encrypt" "$timezone" "$keymap"
 
   # The rest of the script speaks true/false; the file speaks yes/no because
   # that is what a person writing one expects.
@@ -680,6 +933,7 @@ substitute_host_files() {
     subst "$f" '@hostname@' "$hostname"
     subst "$f" '@username@' "$username"
     subst "$f" '@device@' "$device"
+    subst "$f" '@diskmode@' "$disk_mode"
     subst "$f" '@timezone@' "$timezone"
     subst "$f" '@keymap@' "$keymap"
     # Quoted in the template because a bare token is not parseable Nix; the
@@ -781,7 +1035,110 @@ write_flake() {
   printf '{ ... }:\n{ }\n' >"$hostdir/hardware-configuration.nix"
 }
 
+# Cut our two partitions out of the free region, and nothing else.
+#
+# Imperative, and deliberately not disko: installer/disk-config.nix explains
+# under mode = "free" what disko's gpt type does to a disk that already has a
+# partition 1, and why no amount of care with its internals makes that the
+# right foundation.
+#
+# The two properties that keep this from eating somebody's Windows:
+#
+#   --new=0:  0 is sgdisk's own "next free partition number". The number
+#             cannot collide, and unlike disko there is no fallback path that
+#             edits an existing entry when the one it wanted is taken.
+#
+#   explicit start and end sectors, from the region measured before anything
+#   was written. `--new=0:0:0` looks tidier and is wrong: sgdisk's 0 start
+#   means "the largest free block", and once the ESP has been cut the largest
+#   free block on the disk may be a completely different hole. That is how a
+#   root partition ends up somewhere nobody looked at.
+partition_free_space() {
+  local dev=$device sector_bytes esp_sectors esp_end root_start root_type
+  local before after esp_dev=/dev/disk/by-partlabel/nixarchy-esp
+  local root_dev=/dev/disk/by-partlabel/nixarchy-root waited
+
+  # Measured a second time, immediately before writing, and it has to agree
+  # with what the question screen saw. Between the two, a USB disk can be
+  # unplugged and another one plugged into the same node -- and then the
+  # sectors somebody consented to give up belong to a different machine.
+  before="$free_start $free_end"
+  free_space_possible "$dev" || {
+    echo "nixarchy-install: $dev can no longer take a free-space install: $free_why" >&2
+    exit 1
+  }
+  after="$free_start $free_end"
+  if [ "$before" != "$after" ]; then
+    echo "nixarchy-install: the free region on $dev moved between the question" >&2
+    echo "  and now ($before -> $after). Nothing was written. Start again." >&2
+    exit 1
+  fi
+
+  sector_bytes=$(blockdev --getss "$dev" 2>/dev/null || echo 512)
+  esp_sectors=$((FREE_ESP_MIB * 1024 * 1024 / sector_bytes))
+  esp_end=$((free_start + esp_sectors - 1))
+  root_start=$((esp_end + 1))
+  # free_start is already 2048-aligned (sgdisk -F says so) and esp_sectors is a
+  # multiple of 2048 at both 512 and 4096 byte sectors, so root_start is
+  # aligned too and sgdisk does not quietly move it somewhere else.
+  if [ "$root_start" -ge "$free_end" ]; then
+    echo "nixarchy-install: the free region is not big enough for an ESP and a root." >&2
+    exit 1
+  fi
+
+  # 8309 is Linux LUKS, 8300 is a Linux filesystem. Cosmetic to the kernel and
+  # not cosmetic to a person reading the disk later with somebody else's tool.
+  root_type=8300
+  [ "$encrypt" = true ] && root_type=8309
+
+  sgdisk --new=0:"$free_start":"$esp_end" \
+    --typecode=0:EF00 --change-name=0:nixarchy-esp "$dev"
+  sgdisk --new=0:"$root_start":"$free_end" \
+    --typecode=0:"$root_type" --change-name=0:nixarchy-root "$dev"
+
+  # sgdisk asks the kernel to re-read the table itself; partx is the fallback
+  # for when it cannot, which is any disk that has a partition mounted.
+  partx -u "$dev" >/dev/null 2>&1 || partx -a "$dev" >/dev/null 2>&1 || true
+
+  # udevadm settle, because the layout addresses these two by
+  # /dev/disk/by-partlabel and those symlinks are udev's work, not the
+  # kernel's. Without the wait the disko script runs against paths that do not
+  # exist yet.
+  waited=0
+  until [ -b "$esp_dev" ] && [ -b "$root_dev" ]; do
+    udevadm settle
+    waited=$((waited + 1))
+    if [ "$waited" -gt 30 ]; then
+      echo "nixarchy-install: $esp_dev and $root_dev never appeared." >&2
+      echo "  The partitions were created; nothing was formatted. Reboot and look." >&2
+      exit 1
+    fi
+    sleep 0.5
+  done
+
+  # The region was free, not blank.
+  #
+  # Whatever used to live in those sectors is still sitting in them, and blkid
+  # will happily report its old filesystem. That matters because disko's
+  # luks._create and filesystem._create BOTH skip when blkid already recognises
+  # the device -- so a stale signature means the format silently does not
+  # happen, and the install proceeds to mount and write over whatever the
+  # previous owner of those sectors left behind.
+  #
+  # Only these two paths, and only after the wait above proved they are the
+  # partitions this function just created. wipefs takes a device, and the two
+  # arguments it gets here are the only two devices in this script that are
+  # ours by construction.
+  wipefs -a "$esp_dev" "$root_dev"
+}
+
 format_disk() {
+  # Before the passphrase file and before the disko script: in free-space mode
+  # the layout the script evaluates addresses partitions that do not exist yet.
+  if [ "$disk_mode" = free ]; then
+    partition_free_space
+  fi
+
   # The passphrase file disko's passwordFile points at. Written with umask 077,
   # removed as soon as the format is done; it never reaches the installed
   # system, whose initrd prompts instead.
@@ -1146,6 +1503,7 @@ main() {
     ask_keymap
     ask_identity
     ask_device
+    ask_disk_mode
     ask_encrypt
     confirm_summary || exit 1
   fi

--- a/installer/template/host/default.nix
+++ b/installer/template/host/default.nix
@@ -21,6 +21,11 @@
     # everywhere the installer writes one. A machine that partitions
     # differently gets its own file here instead.
     (import ../../disk-config.nix {
+      # "whole" or "free". "free" means this machine was installed beside
+      # another operating system: it describes two partitions by label and no
+      # partition table at all, so disko can never rebuild the table from it.
+      # Read the header of ../../disk-config.nix before assuming otherwise.
+      mode = "@diskmode@";
       device = "@device@";
       # Quoted deliberately: the bare token is not valid Nix -- the file would
       # not parse, let alone format -- so the installer substitutes the quotes

--- a/tests/free-space.nix
+++ b/tests/free-space.nix
@@ -1,0 +1,648 @@
+{ inputs, pkgs }:
+# Does a free-space install leave the other operating system alone?
+#
+# checks.install asks whether the installer's output boots. This asks the
+# question that costs somebody their data if the answer is wrong: nixarchy is
+# installed into free space on a disk that already carries partitions, and
+# those partitions have to come out the other side BYTE-IDENTICAL. Not
+# "still present", not "still mountable" -- identical, hashed at the block
+# device.
+#
+# The fixture is shaped like the machine this mode exists for. /dev/vdb gets:
+#
+#   p1  a 128 MiB EFI system partition with EFI/Microsoft/Boot/bootmgfw.efi
+#       in it. It is a real, usable, correctly-typed ESP -- which is exactly
+#       what makes it worth having here. A free-space install must NOT adopt
+#       it, and the assertion that it did not is that the whole partition
+#       hashes the same afterwards: writing a bootloader into it, or even
+#       mounting it read-write, would change the bytes.
+#
+#   p2  256 MiB of random data with a Microsoft-basic-data type code, standing
+#       in for the Windows volume. Raw rather than a filesystem on purpose:
+#       a filesystem's own metadata drifts on mount, and "byte-identical" has
+#       to mean what it says.
+#
+#   ~19 GiB of free space after them, which is where nixarchy goes.
+#
+# What would make this check pass on broken code, and therefore what was
+# verified by hand before trusting it: the partition table is compared entry
+# by entry (sgdisk -i, which prints type GUID, unique GUID, first and last
+# sector, attributes and name) as well as by content hash. Restoring disko's
+# positional numbering in installer/install.sh -- `--new=1:` with the
+# --change-name fallback disko's gpt type uses -- fails this check on p1's
+# entry, which is the failure mode #47 is about.
+#
+# encrypt=no, for the same reason checks.install uses it: an encrypted target
+# stops at a passphrase prompt the driver would have to type through on a
+# screen it cannot reliably read. Which layout LUKS produces is a different
+# question and this is not the check for it.
+let
+  # hyprland does not follow nixpkgs, so its inputs are separate locked entries
+  # and are needed to evaluate the generated flake. Collected rather than
+  # listed: enumerating aquamarine, hyprlang, hyprutils and the rest by hand is
+  # a list that goes stale on the next bump and fails as a network fetch inside
+  # a VM that has no network.
+  collectInputs =
+    flake:
+    [ flake.outPath ] ++ builtins.concatMap collectInputs (builtins.attrValues (flake.inputs or { }));
+
+  inputPaths = pkgs.lib.unique (builtins.concatMap collectInputs (builtins.attrValues inputs));
+
+  reference = inputs.self.nixosConfigurations.reference.config.system.build;
+
+  # A fixed hash, not a plaintext password. `password=` makes the installer
+  # call mkpasswd, which salts randomly -- so the installed toplevel would be a
+  # different store path on every run and could never match anything seeded
+  # here. This is "omarchy", on a disposable VM.
+  #
+  # Generated, never typed. The value that stood here before was written out by
+  # hand and was not the hash of anything: the install completed, the machine
+  # booted, and the greeter rejected the only password the test knew, which
+  # reads as a broken desktop rather than a broken fixture. Regenerate with
+  #
+  #   mkpasswd -m sha-512 -R 100000 -S nixarchytestsalt omarchy
+  #
+  # and check it round-trips before trusting it.
+  passwordHash = "$6$rounds=100000$nixarchytestsalt$zoz9HmOtqvELBidMdICVEOuvNl5LQCo.yhxsVpM6bgkeTdCG9D91zOaGX9Bu/YsQTlWLwuQF1SrOL0DY8Bu/V/";
+
+  # The NixOS test backdoor, as a module the generated flake can import.
+  #
+  # An installed machine has no reason to carry it, and the installer is right
+  # not to write it -- but without it the driver cannot run a single command on
+  # the target: wait_for_unit, succeed and the rest all talk to a root shell on
+  # /dev/hvc0 that only this module provides. The alternative is to type every
+  # assertion into a getty and scrape the console for it, which is a worse test
+  # of the same things.
+  #
+  # So the installer runs untouched and writes what it would write; then this
+  # is added and nixos-install is run a second time, which is a copy rather
+  # than a build because the instrumented system is seeded too. What boots is
+  # the disk the installer produced, plus a serial shell.
+  #
+  # modulesPath, not an absolute store path: the generated flake evaluates in
+  # pure mode, where a path outside its own tree is an error, and modulesPath
+  # points into the nixpkgs the flake already has.
+  instrumentation = {
+    imports = [ "${inputs.nixpkgs}/nixos/modules/testing/test-instrumentation.nix" ];
+  };
+
+  # What nixos-generate-config writes on the target, as a module.
+  #
+  # This is the file the install generates INSIDE the VM, and #12 called it
+  # unknowable from outside -- which is why this check could not pass. It is
+  # not unknowable, it is just late: the machine is qemu, its devices are the
+  # ones the test driver gives it, and the output is the same every run. What
+  # is genuinely variable is one line, the host CPU's KVM module, so both
+  # values are seeded and the install picks whichever it wrote.
+  #
+  # The file's TEXT does not have to match. It is imported as Nix source, not
+  # copied to the store, so only the configuration it produces matters -- and
+  # that is what this reproduces. If qemu's devices ever change, the install
+  # falls back to building the difference, finds no network, and fails here
+  # with the derivation it wanted; update this to match.
+  hardwareConfig = cpuModule: {
+    imports = [ "${inputs.nixpkgs}/nixos/modules/profiles/qemu-guest.nix" ];
+    boot = {
+      initrd.availableKernelModules = [
+        "virtio_pci"
+        "uhci_hcd"
+        "ehci_pci"
+        "ahci"
+        "sr_mod"
+        "virtio_blk"
+      ];
+      initrd.kernelModules = [ ];
+      kernelModules = [ cpuModule ];
+      extraModulePackages = [ ];
+    };
+    nixpkgs.hostPlatform = pkgs.lib.mkDefault pkgs.stdenv.hostPlatform.system;
+  };
+
+  # And the pin installer/install.sh adds underneath it.
+  #
+  # The installer forces both initrd lists to what the medium carries, so the
+  # machine can reuse the initrd already there instead of building a
+  # near-identical one -- see reuse_baked_initrd. That means the system this
+  # test seeds has to carry the same force, or the installed system differs
+  # from the seeded one by exactly an initrd and the install has to build it
+  # with no network. Which is not a subtle failure: it is the source bootstrap,
+  # and it ends by trying to download a patch from salsa.debian.org.
+  #
+  # reference-unencrypted, because this test installs with encrypt=no and LUKS
+  # adds a dozen crypto modules to the other one.
+  initrdPin =
+    let
+      ref = inputs.self.nixosConfigurations.reference-unencrypted.config;
+    in
+    {
+      boot.initrd.availableKernelModules = pkgs.lib.mkForce ref.boot.initrd.availableKernelModules;
+      boot.initrd.kernelModules = pkgs.lib.mkForce ref.boot.initrd.kernelModules;
+    };
+
+  # The exact disko script the generated flake will evaluate to. The reference
+  # host's is for /dev/vda -- its placeholder device -- and this test installs
+  # to /dev/vdb, so they are different derivations and the VM would have to
+  # build one with no network. Seeding it here is what the ISO does for the
+  # whole closure in #15; the test meets the same requirement early.
+  targetSystemFor =
+    {
+      cpuModule,
+      instrumented ? false,
+    }:
+    (inputs.nixpkgs.lib.nixosSystem {
+      # Not `inherit (pkgs) system`: pkgs.system is deprecated in favour of
+      # stdenv.hostPlatform.system, and nixpkgs warns on every evaluation of
+      # this check. Written out rather than inherited because the inherit form
+      # is what hid it -- a grep for `pkgs.system` does not find it.
+      system = pkgs.stdenv.hostPlatform.system;
+      specialArgs = { inherit inputs; };
+      modules = [
+        inputs.self.nixosModules.nixarchy
+        inputs.home-manager.nixosModules.home-manager
+        inputs.disko.nixosModules.disko
+
+        # The machine, as ONE module whose imports are the three files
+        # installer/template/host/default.nix imports -- not as three entries
+        # in this list.
+        #
+        # The shape is load-bearing and was not, before the hosts/ layout. A
+        # module's `imports` and a nixosSystem's `modules` merge in different
+        # orders, so listing these flat gives the same packages in a different
+        # environment.systemPackages ORDER; system-path hashes that order into
+        # chosenOutputs, so it is a different derivation, so the toplevel is,
+        # and the install has to build what it can no longer copy -- offline,
+        # which means stdenv, which means 459 derivations from hex0-seed and a
+        # fetch of a Debian patch that never arrives.
+        #
+        # So this mirrors hosts/<name>/default.nix, and the block below mirrors
+        # the configuration.nix that sits beside it. Keep both in step with
+        # installer/template/host/ -- a mismatch shows up as "cannot build",
+        # which is a clear enough signal.
+        {
+          imports = [
+            (import ../installer/host.nix {
+              hostname = "installed";
+              username = "omarchy";
+            })
+            (import ../installer/disk-config.nix {
+              # The whole point. mode = "free" addresses two partitions by
+              # partlabel and declares no partition table at all, so this is a
+              # different toplevel from the whole-disk reference and has to be
+              # seeded separately or the install builds it with no network.
+              mode = "free";
+              device = "/dev/vdb";
+              encrypt = false;
+            })
+            {
+              time.timeZone = "UTC";
+              console.keyMap = "us";
+              nixpkgs.config.allowUnfree = true;
+              services.displayManager.autoLogin = {
+                enable = false;
+                user = "omarchy";
+              };
+              users.users.omarchy.hashedPassword = passwordHash;
+            }
+          ];
+        }
+        (hardwareConfig cpuModule)
+        initrdPin
+      ]
+      ++ pkgs.lib.optional instrumented instrumentation;
+    }).config.system.build;
+
+  # Every system the target might end up being: two CPU vendors, with and
+  # without the backdoor. They share all but a handful of derivations, so the
+  # four cost barely more than one, and between them they remove the only two
+  # variables this test cannot control.
+  targetSystems =
+    pkgs.lib.concatMap
+      (cpuModule: [
+        (targetSystemFor { inherit cpuModule; })
+        (targetSystemFor {
+          inherit cpuModule;
+          instrumented = true;
+        })
+      ])
+      [
+        "kvm-amd"
+        "kvm-intel"
+      ];
+
+  # The same helper nixpkgs' own boot tests use to pick a qemu binary, rather
+  # than hardcoding qemu-system-x86_64 and losing KVM.
+  qemuCommon = import "${inputs.nixpkgs}/nixos/lib/qemu-common.nix" {
+    inherit (pkgs) lib stdenv;
+  };
+
+  # The code drive only. The VARIABLE drive is added by the test script, as a
+  # WRITABLE COPY, and that is not a detail.
+  #
+  # checks.install attaches ${pkgs.OVMF.variables} with readonly=on, which is
+  # fine when there is one ESP on the disk and wrong here. A firmware with no
+  # writable variable store falls back to keeping its variables in a file
+  # called NvVars in the root of the first FAT partition it finds -- and the
+  # first ESP on this disk is the fixture's, standing in for Windows'. The
+  # post-boot byte-identity assertion caught it: /dev/vdb1 came back changed,
+  # and mounting it showed bootmgfw.efi untouched beside a brand new NvVars,
+  # written by OVMF and not by anything nixarchy installed.
+  #
+  # A machine with working NVRAM is also the honest fixture, so the fix is to
+  # give it one rather than to weaken the assertion. Worth knowing anyway: on
+  # a real machine whose firmware cannot write its own variables, the firmware
+  # will do this to somebody's ESP no matter what any installer does.
+  # Without the disk, which is added at runtime: the driver starts qemu with
+  # cwd set to the TARGET's state directory, so a path relative to the test
+  # root -- vm-state-installer/empty0.qcow2, where the installer's second disk
+  # actually is -- resolves inside vm-state-target/ instead, and qemu exits
+  # before it says anything. The failure is a bare ConnectionResetError on the
+  # QMP socket, which names nothing.
+  targetCommand = pkgs.lib.concatStringsSep " " [
+    (qemuCommon.qemuBinary pkgs.qemu_test)
+    "-cpu max -m 4096 -smp 4"
+    "-drive if=pflash,format=raw,unit=0,readonly=on,file=${pkgs.OVMF.firmware}"
+  ];
+
+  # Copied at runtime, because a store path is read-only and a pflash drive
+  # qemu can write to cannot be one.
+  ovmfVariables = "${pkgs.OVMF.variables}";
+in
+pkgs.testers.runNixOSTest {
+  name = "nixarchy-free-space";
+
+  nodes.installer =
+    { ... }:
+    {
+      imports = [
+        inputs.self.nixosModules.nixarchy
+        inputs.home-manager.nixosModules.home-manager
+      ];
+
+      environment.systemPackages = [
+        inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.install
+        pkgs.git
+        # The fixture's own tools. The installer carries these too, but the
+        # test builds the "existing OS" with them before the installer runs,
+        # and a fixture that depends on the thing under test having the right
+        # runtime inputs would hide a missing one.
+        pkgs.gptfdisk
+        pkgs.dosfstools
+      ];
+
+      nix.settings = {
+        experimental-features = [
+          "nix-command"
+          "flakes"
+        ];
+        # There is no network. Saying so explicitly turns "tried to fetch" into
+        # a clear failure rather than a timeout that reads like flakiness.
+        substituters = pkgs.lib.mkForce [ ];
+
+        # nixos-install builds with --store /mnt and offers the host store as
+        # a substituter (auto?trusted=1). Every path this test seeded was put
+        # there by the test itself and carries no signature, so with
+        # require-sigs on, /mnt refuses all of them -- "cannot add path ...
+        # because it lacks a signature by a trusted key" -- and falls back to
+        # building what it cannot copy. That is not a handful of derivations:
+        # building anything at all offline means building stdenv, so the whole
+        # source bootstrap from stage0-posix appears and the install dies
+        # fetching bash's tarball.
+        #
+        # The store is the test's own output, on a medium the test built. An
+        # offline ISO is in exactly the same position -- its closure is baked
+        # in unsigned -- so #15 and #16 will need this too.
+        require-sigs = false;
+      };
+
+      environment.etc = {
+        # The answers the wizard would have collected. device is the second
+        # disk, which the test script partitions first; /dev/vda is this
+        # node's own root. disk_mode=free is the whole subject of this check,
+        # and install.sh refuses it -- rather than quietly falling back to
+        # erasing the disk -- if the disk cannot take one.
+        "nixarchy/answers".text = ''
+          device=/dev/vdb
+          disk_mode=free
+          encrypt=no
+          hostname=installed
+          username=omarchy
+          password_hash=${passwordHash}
+          timezone=UTC
+          keymap=us
+        '';
+
+        # Copied into the generated flake after the install; see the note on
+        # `instrumentation`. modulesPath rather than an absolute store path,
+        # because the flake it joins evaluates in pure mode.
+        "nixarchy/test-instrumentation.nix".text = ''
+          { modulesPath, ... }:
+          {
+            imports = [ "''${modulesPath}/testing/test-instrumentation.nix" ];
+          }
+        '';
+      };
+
+      # Everything the install will copy or evaluate, already present: the test
+      # meets the offline reality that the ISO phase will have to solve for
+      # real. If something is missing it surfaces as a fetch attempt with no
+      # network, which is a clearer failure than a silent download would be.
+      system.extraDependencies = [
+        reference.toplevel
+        reference.diskoScript
+        (targetSystemFor { cpuModule = "kvm-amd"; }).diskoScript
+        # A build environment, for the little that still has to be built here
+        # rather than copied: disko's script runs on this machine, not the
+        # target. It is deliberately not the answer to "the install wants to
+        # build something" -- when that happens the seeded system has drifted
+        # from the installed one, and the fix is to make them match again, not
+        # to widen this list until the difference can be compiled.
+        #
+        # system.includeBuildDependencies would cover far more and is not
+        # usable: on a desktop this size the evaluation alone passed 3.4 GB
+        # resident with no end in sight.
+        pkgs.stdenv
+        pkgs.stdenvNoCC
+        pkgs.stdenv.cc
+        pkgs.gnumake
+        pkgs.gnutar
+        pkgs.diffutils
+        pkgs.patchelf
+        pkgs.file
+        pkgs.findutils
+        pkgs.gawk
+        pkgs.gnused
+        pkgs.gnugrep
+        pkgs.gzip
+        pkgs.xz
+        pkgs.bash
+        pkgs.bashInteractive
+        pkgs.coreutils
+        pkgs.perl
+        pkgs.python3
+        pkgs.jq
+      ]
+      ++ map (t: t.toplevel) targetSystems
+
+      # And the parts the few per-machine derivations are built FROM.
+      #
+      # The installed machine's hostname is not the reference's, and a systemd
+      # initrd embeds the hostname -- initrd-hostname, initrd-group,
+      # initrd-release. So an initrd has to be built here no matter what is
+      # seeded, and building it needs kmod's dev output, and the toplevel's
+      # own wrapper check needs libcap. Neither is in any runtime closure, so
+      # neither arrives with the systems above, and nix does not degrade over
+      # a missing build input -- it builds it, needs a compiler, has none, and
+      # walks back to the source bootstrap. The install then ends several
+      # minutes later trying to fetch a patch from salsa.debian.org.
+      #
+      # inputDerivation is nixpkgs' own "realise everything this is built
+      # from", which is exactly the question, and it keeps working when the
+      # answer changes. installer/cd.nix carries the same list for the ISO.
+      ++ map (t: t.toplevel.inputDerivation) targetSystems
+      ++ map (t: t.initialRamdisk.inputDerivation) targetSystems
+      ++ map (t: t.etc.inputDerivation) targetSystems
+      ++ [
+        pkgs.kmod
+        pkgs.kmod.dev
+        pkgs.libcap
+        pkgs.nukeReferences
+      ]
+      ++ inputPaths;
+
+      virtualisation = {
+        memorySize = 6144;
+        cores = 4;
+        # The installer refuses to run where /sys/firmware/efi does not exist,
+        # and is right to -- the layout is an ESP with systemd-boot and there
+        # is no BIOS path. A default test node boots through -kernel with no
+        # firmware at all, so the node has to be given some.
+        useEFIBoot = true;
+        # The target, which appears as /dev/vdb. Bigger than checks.install's
+        # because it has to hold the fixture's two partitions AND leave more
+        # than the 32 GiB free region install.sh insists on -- below that the
+        # free-space mode is not offered at all, which would turn this check
+        # into a whole-disk install that passes for the wrong reason.
+        emptyDiskImages = [ 36864 ];
+        # nixos-install copies the whole closure into the target, and the
+        # default 1 GB store overlay is nowhere near enough.
+        diskSize = 32768;
+      };
+    };
+
+  testScript = ''
+    installer.wait_for_unit("multi-user.target")
+
+    # ---- build the machine we are not allowed to break --------------------
+    #
+    # Written here rather than as a prepared image because the assertion is
+    # about bytes, and bytes that this script wrote are bytes nothing else
+    # could have put there.
+    installer.succeed("sgdisk --clear /dev/vdb")
+    installer.succeed(
+        "sgdisk --new=1:2048:+128M --typecode=1:EF00"
+        " --change-name=1:'EFI system partition' /dev/vdb")
+    installer.succeed(
+        "sgdisk --new=2:0:+256M --typecode=2:0700"
+        " --change-name=2:'Basic data partition' /dev/vdb")
+    installer.succeed("partx -u /dev/vdb || partx -a /dev/vdb || true")
+    installer.succeed("udevadm settle")
+
+    # A real ESP with a real Windows bootloader path in it. mkfs, mount, write,
+    # unmount -- and then never touch it again, so that the hash taken in a
+    # moment is the hash of a filesystem nobody has opened since.
+    installer.succeed("mkfs.vfat -n SYSTEM /dev/vdb1")
+    installer.succeed("mkdir -p /win && mount /dev/vdb1 /win")
+    installer.succeed("mkdir -p /win/EFI/Microsoft/Boot")
+    installer.succeed("head -c 65536 /dev/urandom > /win/EFI/Microsoft/Boot/bootmgfw.efi")
+    installer.succeed("umount /win")
+
+    # And the volume itself: raw, so "byte-identical" means byte-identical and
+    # not "the filesystem still mounts".
+    installer.succeed("dd if=/dev/urandom of=/dev/vdb2 bs=1M count=256 conv=fsync")
+
+    installer.succeed("udevadm settle")
+    before_hashes = installer.succeed("sha256sum /dev/vdb1 /dev/vdb2")
+    before_p1 = installer.succeed("sgdisk -i 1 /dev/vdb")
+    before_p2 = installer.succeed("sgdisk -i 2 /dev/vdb")
+    print("the disk this install must not break:")
+    print(installer.succeed("sgdisk -p /dev/vdb"))
+    print(before_hashes)
+
+    # ---- install into what is left ----------------------------------------
+    import os
+    import time
+    import subprocess
+    started = time.time()
+    # execute, not succeed, and then print the log whatever happened: the
+    # dashboard keeps the screen and sends every phase to a file, so a failed
+    # install prints nothing a test can read. Same reasoning as checks.install,
+    # and the same refusal to use `bash -x` -- a passphrase goes through here.
+    rc, out = installer.execute(
+        "nixarchy-install --answers /etc/nixarchy/answers 2>&1", timeout=1800)
+    print(f"driver_seconds={int(time.time() - started)}")
+    print(out)
+    print("=============== /var/log/nixarchy-install.log ===============")
+    print(installer.execute("cat /var/log/nixarchy-install.log 2>&1")[1])
+    print("============================================================")
+    assert rc == 0, f"nixarchy-install exited {rc}; the log above says why"
+
+    print("the disk afterwards:")
+    print(installer.succeed("sgdisk -p /dev/vdb"))
+
+    # ---- THE ASSERTION ----------------------------------------------------
+    #
+    # Content first, because it is the one that matters. sha256sum reads the
+    # block devices, not a mounted view of them, so a single changed byte
+    # anywhere in either partition fails this -- including a filesystem's own
+    # "last mounted" bookkeeping, which is what makes it also the proof that
+    # the existing ESP was never adopted.
+    after_hashes = installer.succeed("sha256sum /dev/vdb1 /dev/vdb2")
+    assert after_hashes == before_hashes, (
+        "a partition this install did not create has changed.\n"
+        f"before:\n{before_hashes}\nafter:\n{after_hashes}")
+
+    # And the table entries, which a content hash cannot see: a partition
+    # relabelled or retyped in place holds the same bytes. This is the exact
+    # damage disko's gpt type does when its positional partition 1 collides
+    # with an existing one -- see installer/disk-config.nix, mode = "free".
+    after_p1 = installer.succeed("sgdisk -i 1 /dev/vdb")
+    after_p2 = installer.succeed("sgdisk -i 2 /dev/vdb")
+    assert after_p1 == before_p1, (
+        f"partition 1's table entry changed.\nbefore:\n{before_p1}\nafter:\n{after_p1}")
+    assert after_p2 == before_p2, (
+        f"partition 2's table entry changed.\nbefore:\n{before_p2}\nafter:\n{after_p2}")
+    print("both pre-existing partitions are byte-identical, entry and content")
+
+    # ---- and nixarchy is where it should be -------------------------------
+    #
+    # The other half of the claim: the partitions survived AND the install
+    # actually happened. Either one alone passes for the wrong reason -- an
+    # installer that did nothing at all would sail through the block above.
+    table = installer.succeed("sgdisk -p /dev/vdb")
+    assert "nixarchy-esp" in table and "nixarchy-root" in table, table
+    assert installer.succeed(
+        "findmnt -no SOURCE /mnt/boot").strip() == "/dev/vdb3", (
+        "/mnt/boot is not the ESP this install created")
+    assert installer.succeed("findmnt -no SOURCE /mnt").strip().startswith("/dev/vdb4"), (
+        "/mnt is not the root this install created")
+    installer.succeed("test -f /mnt/boot/EFI/BOOT/BOOTX64.EFI")
+    installer.succeed("test -d /mnt/boot/EFI/systemd")
+    # The existing ESP is still Windows'. Nothing of ours is in it -- checked
+    # as well as hashed, because a reader should not have to reason from a
+    # hash to see what the rule is.
+    installer.succeed("mkdir -p /win && mount -o ro /dev/vdb1 /win")
+    installer.succeed("test -f /win/EFI/Microsoft/Boot/bootmgfw.efi")
+    installer.fail("test -e /win/EFI/systemd")
+    installer.fail("test -e /win/loader")
+    installer.succeed("umount /win")
+    print("nixarchy is on its own new ESP, and Windows' is untouched")
+
+    # ---- no gpt type in the generated layout ------------------------------
+    #
+    # #47's other done-when, asserted rather than reviewed: if a `gpt` block
+    # ever appears in the free-space layout, the path that relabels somebody
+    # else's partition has been reintroduced. Evaluated from the file the
+    # installer actually wrote into the user's flake, with the arguments the
+    # generated host passes it.
+    layout = installer.succeed(
+        "nix --extra-experimental-features 'nix-command flakes' eval --impure --raw"
+        " --expr 'builtins.toJSON (import /mnt/etc/nixos/disk-config.nix"
+        " { mode = \"free\"; device = \"/dev/vdb\"; encrypt = false; })'")
+    assert '"gpt"' not in layout, f"the free-space layout declares a gpt type: {layout}"
+    assert "by-partlabel/nixarchy-root" in layout, layout
+    print("the generated layout declares no partition table")
+    installer.succeed(
+        "grep -q 'mode = \"free\"' /mnt/etc/nixos/hosts/installed/default.nix")
+
+    # ---- make the result observable ---------------------------------------
+    # Identical to checks.install, and for the same reason: an installed
+    # machine has no serial root shell and the driver cannot assert anything on
+    # one without it. See tests/install.nix's note on `instrumentation`.
+    installer.succeed(
+        "cp /etc/nixarchy/test-instrumentation.nix /mnt/etc/nixos/hosts/installed/")
+    installer.succeed(
+        "sed -i 's|./hardware-configuration.nix|./hardware-configuration.nix\\n"
+        "    ./test-instrumentation.nix|'"
+        " /mnt/etc/nixos/hosts/installed/configuration.nix")
+    installer.succeed("git -C /mnt/etc/nixos add -A")
+    print(installer.succeed(
+        "nixos-install --root /mnt --flake /mnt/etc/nixos#installed"
+        " --no-root-password"
+        " --option extra-experimental-features 'nix-command flakes'"
+        " --option always-allow-substitutes true 2>&1 | tail -20",
+        timeout=1800))
+
+    installer.shutdown()
+
+    # ---- boot it ----------------------------------------------------------
+    #
+    # On the bootloader the installer wrote, from the ESP it created, with two
+    # ESPs on the disk. The firmware gets no boot variables -- OVMF's are
+    # attached read-only -- so it falls back to scanning for
+    # EFI/BOOT/BOOTX64.EFI, and the only ESP that has one is ours. That is the
+    # honest version of the case: a machine whose NVRAM entry was lost still
+    # has to come up.
+    disk = os.path.abspath("vm-state-installer/empty0.qcow2")
+    assert os.path.exists(disk), f"the installer's target disk is not at {disk}"
+    print(subprocess.run(["ls", "vm-state-installer"], capture_output=True, text=True).stdout)
+    import shutil
+    variables = os.path.abspath("OVMF_VARS.fd")
+    shutil.copyfile("${ovmfVariables}", variables)
+    os.chmod(variables, 0o644)
+    target = create_machine(
+        "${targetCommand}"
+        + f" -drive if=pflash,format=raw,unit=1,file={variables}"
+        + f" -drive file={disk},if=virtio,werror=report",
+        name="target")
+    target.start()
+    target.wait_for_unit("multi-user.target")
+    print("a free-space install boots on its own bootloader")
+
+    # The neighbour is still there, seen from the installed machine this time.
+    after_boot = target.succeed("sha256sum /dev/vda1 /dev/vda2").replace("/dev/vda", "/dev/vdb")
+    if after_boot != before_hashes:
+        # "the bytes differ" is not a diagnosis, and the answer is always the
+        # same two questions: who mounted it, and what appeared in it. Both
+        # asked here so a failure arrives with its own explanation. Read-only,
+        # and measured: a mount and unmount of a vfat with no writes does not
+        # change a byte, so this cannot be what broke the comparison.
+        print(target.succeed("findmnt --raw -no SOURCE,TARGET,OPTIONS || true"))
+        target.succeed("mkdir -p /win && mount -o ro /dev/vda1 /win")
+        print(target.succeed("find /win | head -40"))
+        target.succeed("umount /win")
+    assert after_boot == before_hashes, (
+        "booting the installed machine changed a partition it does not own.\n"
+        f"before:\n{before_hashes}\nafter:\n{after_boot}")
+    # And nixarchy did not quietly mount it. A dual boot where one side
+    # automounts the other's ESP read-write is a slower version of the same
+    # accident.
+    target.fail("findmnt -no TARGET /dev/vda1")
+    target.fail("findmnt -no TARGET /dev/vda2")
+    print("the other OS survived the boot too, and is not mounted")
+
+    # ---- Invariant 1 ------------------------------------------------------
+    # A rebuild straight after install builds nothing. Same assertion as
+    # checks.install and the same reasoning: if the flake evaluates to the
+    # store path that is running, there is by definition nothing to build.
+    # Repeated here because this mode has a different layout, and a layout is
+    # exactly the sort of thing that ends up describing a machine other than
+    # the one it produced.
+    before_sys = target.succeed("readlink -f /run/current-system").strip()
+    target.succeed("cd /etc/nixos && nixos-rebuild build --flake .#installed 2>&1 | tail -20")
+    built = target.succeed("readlink -f /etc/nixos/result").strip()
+    if built != before_sys:
+        print(target.succeed(
+            "cd /etc/nixos && nix build --dry-run "
+            ".#nixosConfigurations.installed.config.system.build.toplevel 2>&1 || true"))
+    assert built == before_sys, (
+        f"a rebuild of the generated flake evaluates to {built}, not the "
+        f"installed {before_sys}: the free-space layout does not describe the "
+        "machine it produced (Invariant 1).")
+    print("a rebuild straight after a free-space install builds nothing")
+
+    # Or this check never finishes: a machine from create_machine is not reaped
+    # for us the way a declared node is, and the derivation sits with a live
+    # qemu until the timeout. See tests/install.nix, which paid for this once.
+    target.shutdown()
+  '';
+}


### PR DESCRIPTION
Closes #47.

A second disk mode: install into free space beside an existing operating
system, leaving every partition already on the disk exactly as it was.

## Not through disko's `gpt` type

The issue's warning was verified against disko master and is written into
`installer/disk-config.nix` so it does not have to be rediscovered. A
partition's number in disko's gpt type is positional (`lib/types/gpt.nix:244`;
`diskoLib.indexOf` counts from 1), so the first partition disko declares is
partition 1, always. When `sgdisk --new=1:` then fails because number 1 belongs
to Windows, `_create`'s fallback runs `sgdisk --change-name=1 --typecode=1` on
the partition that is already there — it relabels and retypes Windows'
partition and reports success.

So `install.sh` cuts the partitions itself with `sgdisk --new=0:`, where `0` is
sgdisk's own next-free-number and a collision cannot arise, and
`disk-config.nix` gains `mode = "free"`, which describes the **result**: two
disko `disk` entries addressed by partlabel, no `gpt` block, no partition table
at all. `disk._create` is exactly its content's `_create`, and neither
`luks._create` nor `filesystem._create` touches anything but its own `device`.
The file's header states that it therefore cannot rebuild anybody's partition
table.

nixarchy gets its own 2 GiB ESP. It never adopts the one already there, which
is what upstream does and what the "we do not write to partitions we did not
create" rule requires.

## Refusals

No GPT (sgdisk would convert an MBR and Windows would stop booting) · no
partitions (the screen is skipped entirely) · under 32 GiB free · a partition
already called `nixarchy-esp`/`nixarchy-root` · BitLocker. In answers-file mode
each is a hard stop — falling back to `whole` would erase the disk the file
asked to preserve.

Incidentally, `sfdisk -F -J`, which the issue proposed, does not exist:
util-linux refuses the combination. `sgdisk -F`/`-E` answer directly.

## Verification

`checks.install` and `checks.free-space` were both **run by hand on this
commit** (they do not run on PRs, #144):

```
/nix/store/r7sfs5d39cdp0ilakfxdibq6dm4qkj6v-vm-test-run-nixarchy-free-space
/nix/store/2bx7nsim0p12fzfib4p53r3676p8rbvp-vm-test-run-nixarchy-install
```

`checks.free-space` builds a disk carrying a real ESP with `bootmgfw.efi` in it
and a raw Windows-shaped data partition, installs into the free space after
them, and asserts both come out **byte-identical** — content hashed at the
block device, and table entries compared with `sgdisk -i`, because a partition
relabelled in place holds the same bytes. It then boots the result on the
bootloader the installer wrote, with two ESPs on the disk, and re-checks the
neighbour and Invariant 1.

**Proved to fail when the protection is removed.** A variant that adopts the
existing ESP instead of creating one dies on
`AssertionError: a partition this install did not create has changed`.

The check also caught something real on the way: given a *read-only* OVMF
variable store, the firmware writes its variables into a file called `NvVars`
in the first FAT partition it can find — here, the fixture's Windows ESP.
Nothing nixarchy installed did that; the target now gets a writable copy.

## Known boundary

The offline ISO does not bake the free-space references, so a free-space
install from it has to build the few dozen text derivations that differ.
`installer/cd.nix` says so at the place it would be fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
