### PR TITLE
A configured snapper with nowhere to write now says so

### DIFF
--- a/docs/manual/system-snapshots.md
+++ b/docs/manual/system-snapshots.md
@@ -9,9 +9,12 @@ into one from the Limine menu to undo a bad update. **None of that machinery
 exists here, and none of it is missing.** NixOS keeps every previous system on
 disk as a *generation*, and generations do everything the snapshot did.
 
-`omarchy-snapshot` still exists in the tree, but it checks for snapper and
-exits 127 when it is not there, which is always. `omarchy update` treats that
-exit code as "no snapshot available" and carries on.
+What generations do *not* cover is `/home` and the mutable state under
+`/var/lib` — so on a machine the nixarchy installer built, snapper covers
+exactly that half. See [snapshots of your home directory](#snapshots-of-your-home-directory)
+below. On a machine that imported the nixarchy module into a configuration of
+its own, there is no snapper at all: nixarchy does not take snapshots of a disk
+it did not lay out, and `omarchy snapshot` says so.
 
 ## What a generation is
 
@@ -88,6 +91,74 @@ sudo nixos-rebuild test --flake <flake>   # activates now, boot default untouche
 `boot` is the one for anything that could cost you the screen; the previous
 generation stays one menu entry away. See
 [updating NixOS](updating-nixos.md).
+
+## Snapshots of your home directory
+
+The installer lays the disk out with two subvolumes that exist only to hold
+snapshots — `@snapshots` mounted at `/.snapshots`, and `@home-snapshots` at
+`/home/.snapshots` — and configures snapper against them: an hourly timeline of
+`/home`, and one snapshot of `/` at every boot.
+
+```sh
+omarchy snapshot          # what exists
+omarchy snapshot create "before I broke it"
+omarchy snapshot restore  # pick one, and copy files back out of it
+```
+
+`restore` copies rather than swapping the subvolume. Upstream swaps, which
+replaces the whole of `/home` in one step — including everything written since
+the snapshot — and cannot be done while the subvolume is mounted and in use.
+Somebody reaching for restore has usually broken one config file, so what this
+prints is the path the snapshot is readable at, plus `snapper status` to see
+what changed. Nothing is written on your behalf.
+
+Snapshots live on the same disk as the thing they snapshot. They are an undo
+button, not a backup: they do not survive the disk failing.
+
+### If your machine was installed before those subvolumes existed
+
+They were added in [#114](https://github.com/olafkfreund/nixarchy/pull/114).
+A machine installed before it has snapper — its next rebuild pulls the current
+`installer/host.nix` — and nowhere for snapper to write, because `disk-config.nix`
+is a copy made in *your* repo at install time and disko only ever ran once.
+NixOS' snapper module does not create `.snapshots` itself
+([nixpkgs#34595](https://github.com/NixOS/nixpkgs/issues/34595)), so the timers
+fire and nothing is ever snapshotted.
+
+`omarchy snapshot` refuses on such a machine rather than letting it look like it
+worked, and `nix run github:olafkfreund/nixarchy#doctor` names it too. Both print
+this fix. It is done once, by hand, because creating btrfs subvolumes on a
+running machine from an activation script is exactly the kind of thing a rebuild
+should never do.
+
+First create them, at the top level of the filesystem beside `@` and `@home` —
+not inside the running root, which is a different place with the same name:
+
+```sh
+sudo mount -o subvol=/ /dev/mapper/cryptroot /mnt   # your root device; `findmnt -no SOURCE /` names it
+sudo btrfs subvolume create /mnt/@snapshots
+sudo btrfs subvolume create /mnt/@home-snapshots
+sudo umount /mnt
+```
+
+Then declare them in your own `/etc/nixos/disk-config.nix`, inside the
+`subvolumes` block:
+
+```nix
+"@snapshots" = {
+  mountpoint = "/.snapshots";
+  mountOptions = [ "noatime" ];
+};
+"@home-snapshots" = {
+  mountpoint = "/home/.snapshots";
+  mountOptions = [ "noatime" ];
+};
+```
+
+and rebuild — `nh os switch` — which is what writes the mount units. That order
+matters: a mount unit for a subvolume that does not exist yet fails at boot.
+The declaration is what makes it survive a reinstall; the two commands alone
+would be undone by the next one.
 
 ## The one command that deletes the safety net
 

--- a/pkgs/doctor.sh
+++ b/pkgs/doctor.sh
@@ -192,6 +192,69 @@ if [ -n "${OMARCHY_PATH:-}" ] && [ -e "$sw/bin/omarchy" ]; then
   say ""
 fi
 
+# ---- snapper configured against a layout that cannot hold a snapshot -----
+# Only ever true on a machine the nixarchy installer built: services.snapper is
+# set in installer/host.nix, which nothing but a generated flake imports. Such
+# a machine pulls the current host.nix at its next rebuild -- but its
+# disk-config.nix is a verbatim copy in its own repo, made at install time, and
+# a copy made before @snapshots existed does not grow one. disko runs once.
+#
+# So snapper is configured, its timers fire, and nothing is snapshotted: the
+# NixOS module does not create the `.snapshots` directories itself
+# (nixpkgs#34595, PR #368449 unmerged). The owner has a safety net in the menu
+# and none on the disk, which is worse than having neither, and they find out
+# at the moment they reach for it.
+#
+# Read from /proc/self/mountinfo rather than findmnt: this script's runtime
+# inputs are systemd, sed, grep, awk and coreutils, and util-linux is not among
+# them.
+mounted_btrfs() {
+  awk -v target="$1" '
+    { for (i = 7; i <= NF; i++) if ($i == "-") { if ($5 == target && $(i + 1) == "btrfs") found = 1 } }
+    END { exit !found }
+  ' /proc/self/mountinfo
+}
+
+# Keyed on the snapper configs installer/host.nix declares, so this stays
+# silent on every machine that has no snapper -- which is every machine reading
+# this report to decide whether to adopt nixarchy.
+if [ -d /etc/snapper/configs ] && [ -n "$(ls -A /etc/snapper/configs 2>/dev/null)" ]; then
+  declare -a no_snapshots=()
+  [ ! -e /etc/snapper/configs/root ] || mounted_btrfs /.snapshots || no_snapshots+=(/.snapshots)
+  [ ! -e /etc/snapper/configs/home ] || mounted_btrfs /home/.snapshots || no_snapshots+=(/home/.snapshots)
+
+  say "${bold}Snapshots${off}"
+  if [ ${#no_snapshots[@]} -gt 0 ]; then
+    finding "snapper is configured and snapshotting nothing" "$warn" ""
+    say "     ${dim}not a mounted subvolume: ${no_snapshots[*]}${off}"
+    say "     Snapper writes into those and cannot create them. This machine was"
+    say "     installed before the disk layout declared them, so the timers have"
+    say "     been running against a layout with nowhere to put a snapshot."
+    say "     Nothing is lost -- but nothing was kept. The fix, in this order:"
+    say ""
+    root_source=$(awk '$5 == "/" { for (i = 7; i <= NF; i++) if ($i == "-") { print $(i + 2); exit } }' /proc/self/mountinfo)
+    say "       ${dim}sudo mount -o subvol=/ ${root_source:-<your root device>} /mnt${off}"
+    say "       ${dim}sudo btrfs subvolume create /mnt/@snapshots${off}"
+    say "       ${dim}sudo btrfs subvolume create /mnt/@home-snapshots${off}"
+    say "       ${dim}sudo umount /mnt${off}"
+    say ""
+    say "     Then declare them in ${bold}/etc/nixos/disk-config.nix${off} -- your copy, which"
+    say "     nothing but you maintains -- inside its ${dim}subvolumes${off} block:"
+    say ""
+    say "       ${dim}\"@snapshots\" = { mountpoint = \"/.snapshots\"; mountOptions = [ \"noatime\" ]; };${off}"
+    say "       ${dim}\"@home-snapshots\" = { mountpoint = \"/home/.snapshots\"; mountOptions = [ \"noatime\" ]; };${off}"
+    say ""
+    say "     and rebuild -- ${dim}nh os switch${off} -- which is what mounts them. That"
+    say "     order matters: a mount unit for a subvolume that does not exist"
+    say "     fails at boot. ${dim}omarchy snapshot${off} prints the same fix and refuses"
+    say "     to pretend until it is done."
+    notes+=("snapper is configured on this machine but ${no_snapshots[*]} is not a mounted btrfs subvolume, so every snapshot it has 'taken' went nowhere. The subvolumes are created by hand once -- disko ran at install time only -- and declared in your own disk-config.nix so the next reinstall keeps them.")
+  else
+    finding "snapper has its subvolumes" "$ok" "/home is being snapshotted"
+  fi
+  say ""
+fi
+
 # ---- the default browser, and whether the menu can change it -------------
 # Setup > Default browser runs omarchy-default-browser, which ends in
 #

--- a/pkgs/omarchy/nix-bin/omarchy-snapshot
+++ b/pkgs/omarchy/nix-bin/omarchy-snapshot
@@ -60,6 +60,84 @@ if ! command -v snapper >/dev/null 2>&1; then
   exit 1
 fi
 
+# Configured is not the same as working. NixOS' snapper module does not create
+# the `.snapshots` directories snapper writes into -- nixpkgs#34595, with PR
+# #368449 still unmerged -- so on a machine whose disk layout predates them,
+# snapper is configured, the timers fire, and nothing is ever snapshotted.
+# `installer/disk-config.nix` declares @snapshots and @home-snapshots for
+# machines installed since; a machine installed before it has that file as a
+# verbatim copy in its own repo, and disko only ever ran at install time.
+#
+# The failure mode this exists for is not an error. It is the absence of one:
+# somebody sees `trigger.snapshot` in the menu, believes they have an undo,
+# and finds out they never did at the moment they reach for it. So every
+# subcommand refuses here rather than letting snapper succeed into a plain
+# directory that no `list` will ever show anything from.
+mounted_subvolume() { findmnt -t btrfs -no TARGET "$1" >/dev/null 2>&1; }
+
+require_snapshot_subvolumes() {
+  local missing=()
+  [ ! -e /etc/snapper/configs/root ] || mounted_subvolume /.snapshots ||
+    missing+=(/.snapshots)
+  [ ! -e /etc/snapper/configs/home ] || mounted_subvolume /home/.snapshots ||
+    missing+=(/home/.snapshots)
+  [ ${#missing[@]} -gt 0 ] || return 0
+
+  # The device as it is actually mounted, so the mount command below is this
+  # machine's rather than an example: findmnt reports the source of / as
+  # /dev/mapper/cryptroot[/@], and the bracket is the subvolume, not the
+  # device.
+  local device
+  device=$(findmnt -no SOURCE / 2>/dev/null | sed 's/\[.*\]//')
+
+  red "snapper is configured here and has nowhere to write."
+  echo
+  echo "  Missing, and snapshots cannot exist without them:"
+  printf '    %s\n' "${missing[@]}"
+  echo
+  echo "  These are btrfs subvolumes the disk layout declares. This machine was"
+  echo "  installed before it declared them, so snapper has been running against"
+  echo "  a layout that has nowhere to put a snapshot. Nothing you did caused"
+  echo "  this and nothing has been lost -- but nothing has been kept either."
+  echo
+  bold "  1. Create the subvolumes"
+  echo
+  echo "     They go at the top level of the filesystem, beside @ and @home --"
+  echo "     not inside the running root, which is a different thing with the"
+  echo "     same name. Mount the top level to reach it:"
+  echo
+  dim "       sudo mount -o subvol=/ ${device:-<your root device>} /mnt"
+  dim "       sudo btrfs subvolume create /mnt/@snapshots"
+  dim "       sudo btrfs subvolume create /mnt/@home-snapshots"
+  dim "       sudo umount /mnt"
+  echo
+  bold "  2. Declare them, in your own disk-config.nix"
+  echo
+  echo "     /etc/nixos/disk-config.nix, which is yours -- the installer copied"
+  echo "     it there once and nothing has maintained it since. Inside the"
+  echo "     \`subvolumes\` block, beside \"@home\":"
+  echo
+  dim '       "@snapshots" = {'
+  dim '         mountpoint = "/.snapshots";'
+  dim '         mountOptions = [ "noatime" ];'
+  dim '       };'
+  dim '       "@home-snapshots" = {'
+  dim '         mountpoint = "/home/.snapshots";'
+  dim '         mountOptions = [ "noatime" ];'
+  dim '       };'
+  echo
+  bold "  3. Rebuild, which is what mounts them"
+  echo
+  dim "       nh os switch"
+  echo
+  echo "     In that order: the rebuild writes mount units, and a mount unit"
+  echo "     for a subvolume that does not exist yet fails at boot."
+  echo
+  dim "  Nothing has been changed by running this. Step 1 is the only command"
+  dim "  here that touches the disk, and it creates two empty subvolumes."
+  exit 1
+}
+
 case "${1:-list}" in
   -h | --help)
     usage
@@ -67,6 +145,7 @@ case "${1:-list}" in
     ;;
 
   create)
+    require_snapshot_subvolumes
     desc="${2:-manual}"
     snapper --config home create --description "$desc" --cleanup-algorithm number
     bold "Snapshotted /home."
@@ -74,6 +153,7 @@ case "${1:-list}" in
     ;;
 
   list)
+    require_snapshot_subvolumes
     bold "/home"
     snapper --config home list 2>/dev/null || dim "  (none yet)"
     echo
@@ -82,6 +162,7 @@ case "${1:-list}" in
     ;;
 
   restore)
+    require_snapshot_subvolumes
     # Copying files out, not swapping the subvolume.
     #
     # Swapping is what upstream does and it is the wrong default here: it

--- a/tests/session.nix
+++ b/tests/session.nix
@@ -1018,6 +1018,14 @@ pkgs.testers.runNixOSTest {
     # And it has to end with something to paste, not just a diagnosis.
     assert "programs.nixarchy.enable = true;" in report, report
 
+    # And it says nothing about snapshots here. The #171 check keys on
+    # /etc/snapper/configs, which only a machine the installer built has -- so
+    # on every other machine, including this one and every machine reading the
+    # report to decide whether to adopt nixarchy, the section is absent rather
+    # than reporting a missing subvolume nobody was promised.
+    assert "Snapshots" not in report, (
+        "the doctor raised a snapshot finding on a machine with no snapper")
+
     # A machine already greeting with SDDM does not need displayManager=false;
     # advising it would be wrong.
     assert "displayManager = false" not in report, (


### PR DESCRIPTION
Fixes #171. Part of #112.

## The lie

A machine installed before #114 pulls the current `installer/host.nix` at its next rebuild and gets snapper configured. Its `disk-config.nix` is a verbatim copy made in *its own* repo at install time, and disko only ever ran once — so `@snapshots` and `@home-snapshots` do not exist. NixOS' snapper module does not create `.snapshots` itself ([nixpkgs#34595](https://github.com/NixOS/nixpkgs/issues/34595), PR #368449 unmerged), so the timers fire and nothing is ever snapshotted.

Checked against real snapper on a real pre-#114 btrfs layout rather than assumed. `create` fails with an internal log line:

```
Snapshot.cc(initialize):425 reading failed
IO error (open failed path:/home/.snapshots errno:2 (No such file or directory)).
create exit=1
```

and `list` — the one the owner actually looks at — **exits 0** and prints a table:

```
# │ Type   │ ... │ Description │
──┼────────┼─────┼─────────────┼
0 │ single │     │ current     │
list exit=0
```

That is the shape of a working snapshot system with nothing in it yet. The timeline timer's failure goes to the journal, where nobody watches. So the owner sees `trigger.snapshot` in the menu, sees a plausible list, and finds out they never had an undo at the moment they reach for it.

## What this adds

**A preflight in `omarchy-snapshot`.** `create`, `list` and `restore` each refuse while `/.snapshots` or `/home/.snapshots` is not a mounted btrfs subvolume — gated on the matching snapper config existing, so it is invisible on a correct machine and silent on one with no snapper. Requiring a *mounted subvolume* rather than a directory also catches the worse case: a plain `/home/.snapshots` directory that snapper would happily succeed into, nested inside the subvolume it is meant to snapshot.

It prints the whole fix, in the order that works:

1. the two `btrfs subvolume create` commands, against the **top level** of the filesystem — the subvolumes go beside `@` and `@home`, not inside the running root, which is a different place with the same name. The root device is read from `findmnt -no SOURCE /` with the subvolume bracket stripped, so the mount command is this machine's rather than an example.
2. the block to paste into their own `/etc/nixos/disk-config.nix`, which is what makes it survive a reinstall.
3. `nh os switch`, which writes the mount units — last, because a mount unit for a subvolume that does not exist fails at boot.

**A finding in the doctor**, keyed on `/etc/snapper/configs` so it stays silent on every machine that has no snapper — which is every machine reading that report to decide whether to adopt nixarchy. It reads `/proc/self/mountinfo` rather than `findmnt`: util-linux is not among the doctor's runtime inputs.

**`docs/manual/system-snapshots.md`** said `omarchy-snapshot` "checks for snapper and exits 127 when it is not there, which is always". That has been untrue since #114. It now documents the half generations do not cover, and carries the same fix.

## Deliberately not built

No activation script creating subvolumes. #114 rejected it and the reasoning holds: disk surgery from a rebuild is a new failure mode on every machine to fix an old one on a few, and it is the opposite of "a rebuild is safe to run". Nothing here writes anything.

The boot-time notification the issue offers as an optional half is also not here — it needs `modules/home.nix`, and the issue itself says to drop it if the affected population is near zero. The preflight fires the first time anyone touches snapshots, which is the moment that matters.

## Verified

Both states constructed for real — a loopback btrfs filesystem with `@` and `@home` and no snapshot subvolumes, entered through a chroot so `/proc/self/mountinfo` reports the paths the checks actually read.

**Broken:**

```
Snapshots
  snapper is configured and snapshotting nothing
     not a mounted subvolume: /.snapshots /home/.snapshots
       sudo mount -o subvol=/ /dev/loop3 /mnt
       ...
```

```
snapper is configured here and has nowhere to write.
  Missing, and snapshots cannot exist without them:
    /.snapshots
    /home/.snapshots
  ...
exit=1
```

**Then the printed fix was followed verbatim** — `mount -o subvol=/`, the two `btrfs subvolume create`s, `umount`, then the mounts a rebuild's units would make. After it, with real snapper 0.13.1:

```
snapper -c home create -d "before I broke it"   →  exit 0
0 │ single │       │                              │ current
1 │ single │       │ Wed 02 Sep 2026 16:39:35 UTC │ before I broke it
```

which is the issue's Done-when. The doctor goes back to one green line, `omarchy snapshot list` works and exits 0, and the note disappears from "Worth knowing".

`nix build .#checks.x86_64-linux.options` and `.session` both pass. `nix fmt -- --ci`, statix, deadnix and shellcheck are clean. `tests/session.nix` gained one assertion: the doctor raises no snapshot finding on a machine with no snapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiGDdsRYdBgTFmZwUSaf4x