### PR TITLE
hypr-rdp: the RDP daemon, pinned to v0.1.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -111,6 +111,27 @@
         "type": "github"
       }
     },
+    "hypr-rdp": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787094885,
+        "narHash": "sha256-yrC8fITJofWJ2wpZMiaX06UVCMFI4GRg9pGyaTdosHg=",
+        "owner": "MuNeNiCK",
+        "repo": "hypr-rdp",
+        "rev": "cf3fbd82e2176070c0860bd53eb87d0b098decd4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "MuNeNiCK",
+        "ref": "v0.1.5",
+        "repo": "hypr-rdp",
+        "type": "github"
+      }
+    },
     "hyprcursor": {
       "inputs": {
         "hyprlang": [
@@ -522,6 +543,7 @@
       "inputs": {
         "disko": "disko",
         "home-manager": "home-manager",
+        "hypr-rdp": "hypr-rdp",
         "hyprland": "hyprland",
         "nix-flatpak": "nix-flatpak",
         "nixpkgs": "nixpkgs_2",

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,42 @@
       url = "github:0xc000022070/zen-browser-flake";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    # The RDP server behind the remote-desktop feature (#159). Not in nixpkgs
+    # -- nothing under that name as of 2026-09 -- and the two RDP servers that
+    # are there cannot serve Hyprland: krdp needs the
+    # org.freedesktop.portal.RemoteDesktop interface, which
+    # xdg-desktop-portal-hyprland 1.4.1 does not advertise, and xrdp only
+    # reaches Wayland through a wayvnc chain built from an unreleased commit.
+    # So nixarchy carries the package until nixpkgs does.
+    #
+    # The cost, stated rather than hidden: a flake input lands in EVERY user's
+    # lock, including the Mode A machine that will never enable RDP. It is one
+    # more ref `nix flake update` can move and one more repository that has to
+    # keep existing. That is paid because the thing it buys -- reaching this
+    # desktop from a Windows machine with nothing installed on it -- has no
+    # other implementation at all, at any price. See the alternatives survey
+    # on #159; every other route is closed, not merely worse.
+    #
+    # What this project is taking on: v0.1.5, six months old, one primary
+    # author. The protocol stack is not theirs -- it is IronRDP, Devolutions'
+    # maintained Rust implementation -- so what this author owns is the
+    # Hyprland glue: capture, input, audio, clipboard. That is a real
+    # dependency on a small project, and a bad rebuild here breaks the machine
+    # you are remote to, from where you cannot fix it. Hence a tag. Never a
+    # branch, and bump it deliberately.
+    #
+    # The input has a named exit: when hypr-rdp lands in nixpkgs, delete this
+    # and point the module at pkgs.hypr-rdp.
+    #
+    # `follows` is right here and wrong for hyprland above -- upstream's
+    # pkg/nix/package.nix is a plain rustPlatform.buildRustPackage whose
+    # cargoHash does not depend on which nixpkgs supplies ffmpeg, and they
+    # publish no binary cache to forfeit by overriding it.
+    hypr-rdp = {
+      url = "github:MuNeNiCK/hypr-rdp/v0.1.5";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -182,6 +218,19 @@
         omarchy-nvim-config = final.callPackage ./pkgs/omarchy-nvim {
           inherit omarchyVersion;
         };
+
+        # The RDP daemon, re-exported from its own flake so the module that
+        # will run it (#156) can say `pkgs.hypr-rdp` and never mention an
+        # input. Built by upstream's pkg/nix/package.nix against OUR nixpkgs,
+        # through the `follows` on the input.
+        #
+        # This indirection is what makes the input's exit cheap: when nixpkgs
+        # carries hypr-rdp, delete the input and this attribute, and every
+        # `pkgs.hypr-rdp` in the tree keeps resolving -- to nixpkgs' own.
+        #
+        # Lazy, so a machine that never enables RDP never builds it. Being in
+        # the overlay is not being on the system.
+        hypr-rdp = inputs.hypr-rdp.packages.${final.stdenv.hostPlatform.system}.hypr-rdp;
 
         omarchy = final.callPackage ./pkgs/omarchy {
           src = omarchy;


### PR DESCRIPTION
Closes #154. Part of #159.

Pins hypr-rdp as a flake input and re-exports it into the overlay as
`pkgs.hypr-rdp`. No module — that is #156.

## What is pinned

`github:MuNeNiCK/hypr-rdp/v0.1.5`, locked to commit `cf3fbd8`. v0.1.5 is the
newest tag (2026-08-18). A tag, never a branch: a pre-1.0 daemon on a moving
ref is how a rebuild breaks remote access to a machine you are remote to.

`nix flake metadata`:

```
├───hypr-rdp: github:MuNeNiCK/hypr-rdp/cf3fbd82e2176070c0860bd53eb87d0b098decd4 (2026-08-18)
│   └───nixpkgs follows input 'nixpkgs'
```

## `follows` works, verified by building

#154 asked whether upstream's `package.nix` survives having our nixpkgs
swapped in. It does — the vendor step is where a stale `cargoHash` would
fail, and the build completes:

```
building '/nix/store/2ljjgw0xl1936gqjggvh6l8lv9kb3lar-hypr-rdp-0.1.5-vendor.drv'...
building '/nix/store/s7anxl89fmd7lzx4fmk59hw08q1rsk1i-hypr-rdp-0.1.5.drv'...
/nix/store/0wqasdhgx69m0zc1bnwlkrky93mxarj5-hypr-rdp-0.1.5
```

So the `follows` stays, and the flake carries one nixpkgs rather than two.
This is the opposite call to hyprland's, for the reason flake.nix already
documents there: hyprwm publish a binary cache to forfeit, and these authors
do not.

## Consumed through the overlay, which is what makes the exit cheap

`pkgs.hypr-rdp`, alongside `omarchy`, rather than under `nixarchy-apps` —
this is a daemon, not a menu entry, and `nixarchy-apps` is what the doctor
and the Install menu enumerate.

The indirection is the point. When hypr-rdp lands in nixpkgs, delete the
input and the overlay line and every `pkgs.hypr-rdp` in the tree keeps
resolving, to nixpkgs' own. The input is scaffolding with a named exit.

The attribute is lazy, so a machine that never enables RDP never builds it.

## Mode A is unaffected, byte for byte

Not argued — measured. The toplevel derivation of a machine that imports
`nixosModules.nixarchy`, enables it, and enables nothing optional:

```
main    /nix/store/p6x5jis4crld4bdxy5g5mvcnflnqq0ai-nixos-system-nixos-...drv
branch  /nix/store/p6x5jis4crld4bdxy5g5mvcnflnqq0ai-nixos-system-nixos-...drv
```

Identical. Being in the overlay is not being on the system.

## What this project is taking on, stated

A new flake input lands in **every** user's lock, Mode A included — one more
ref `nix flake update` can move, one more repository that has to keep
existing. v0.1.5 is six months old with one primary author.

It is worth it because the protocol stack is not the author's own: hypr-rdp
is built on IronRDP, Devolutions' maintained Rust RDP implementation, so what
this project depends on that author for is the Hyprland glue — capture,
input, audio, clipboard. And because the alternatives survey on #159 found no
other route open: portal-based servers need
`org.freedesktop.portal.RemoteDesktop`, which xdg-desktop-portal-hyprland
1.4.1 does not advertise; xrdp reaches Wayland only through a wayvnc chain
built from an unreleased commit; wayvnc no longer supports Hyprland; and
Lamco is Business Source Licensed. The reasoning is recorded in the comment
in flake.nix, not only here.

## Checks

- `nix build .#checks.x86_64-linux.options` passes.
- `nix fmt -- --ci`, `statix check`, `deadnix --fail` all clean.
- `checks.install` runs in CI (`flake.nix` is in its path filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhToUKGVGwy61MeZudCsFu
