### PR TITLE
Secrets: adopt sops-nix, because the password must go inside the file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,8 +548,30 @@
         "nix-flatpak": "nix-flatpak",
         "nixpkgs": "nixpkgs_2",
         "omarchy": "omarchy",
+        "sops-nix": "sops-nix",
         "systems": "systems_2",
         "zen-browser": "zen-browser"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786629091,
+        "narHash": "sha256-gkig4nPi1CWc4Z50GBsjE4ygSE7hMpl/TwID2an2Cck=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "a8627b21b9107c5711c96b84f32a9a4b3d45295f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "a8627b21b9107c5711c96b84f32a9a4b3d45295f",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -116,6 +116,52 @@
       url = "github:MuNeNiCK/hypr-rdp/v0.1.5";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    # Declarative secrets, adopted for one concrete reason rather than as a
+    # general capability. #121 deliberately did not take a secrets mechanism
+    # ("a separate decision with a key-management story attached"), and #122
+    # got away without one because `hashedPasswordFile` is consumed by NixOS
+    # itself, so the cleartext could live outside git and be pointed at.
+    #
+    # hypr-rdp removes that dodge. It reads its password from exactly two
+    # places -- an inline string in config.toml, or `-p` on the command line,
+    # which is world-readable in /proc/*/cmdline. Verified against v0.1.5:
+    # src/config.rs resolves `args.password.or(config.password)` and nothing
+    # else, there is no `password_file`, and clap reads no environment
+    # variable for it. So the secret has to end up INSIDE a config file, and
+    # something has to put it there at runtime from material safe to commit.
+    #
+    # That requirement is what picks sops-nix over agenix. agenix delivers
+    # files of raw secrets and has no templating, so composing one into a TOML
+    # would mean a hand-rolled per-service ExecStartPre shim -- the exact hack
+    # this is meant to avoid. `sops.templates` is that shim, upstreamed, with
+    # the mode and owner declared. Everything else between the two is taste.
+    #
+    # Pinned to a COMMIT because sops-nix publishes no release tags at all --
+    # its only tag, `assets`, is from 2021 and is not a release. master is the
+    # release channel. This is the same call flake.nix already makes for
+    # hyprland above: a commit is exactly as reproducible as a tag. Bump it
+    # deliberately; never track a branch.
+    #
+    # What this costs a user's lock: ONE node. sops-nix declares exactly one
+    # input, nixpkgs, which follows ours, so nothing transitive arrives. (Its
+    # dev inputs live in a private flake under dev/ that consumers never see.)
+    # Its nixConfig asks for cache.thalheim.io, which does NOT apply to us --
+    # nixConfig is honoured only from the flake you invoke, not from inputs --
+    # so no substituter and no trust is granted by taking this.
+    #
+    # Inert on import, which is what makes it safe for Mode A: both halves of
+    # the upstream module are gated, `lib.mkIf (cfg.secrets != { })` and
+    # `lib.mkIf (config.sops.templates != { })`. A machine that defines
+    # neither gets no unit, no activation script and no package. nixarchy sets
+    # no sops scalar of its own -- `sops.age.sshKeyPaths` already defaults to
+    # the ed25519 keys from services.openssh.hostKeys upstream -- so the
+    # mkDefault rule in modules/services/default.nix never even arises here.
+    # tests/options.nix asserts the inertness rather than trusting this note.
+    sops-nix = {
+      url = "github:Mic92/sops-nix/a8627b21b9107c5711c96b84f32a9a4b3d45295f";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -72,6 +72,15 @@ in
     ./services
     ./flatpaks.nix
     inputs.nix-flatpak.nixosModules.nix-flatpak
+
+    # Declarative secrets, for the bundled services that need one. Imported
+    # unconditionally and INERT: upstream gates its whole config on
+    # `sops.secrets != {}` and `sops.templates != {}`, so a machine that
+    # declares neither -- every Mode A machine, and every machine today --
+    # gains no unit, no activation script and no package from this line.
+    # nixarchy sets no sops option of its own; the host-key identity is
+    # already upstream's default. tests/options.nix asserts both halves.
+    inputs.sops-nix.nixosModules.sops
   ];
 
   options.programs.nixarchy = {

--- a/modules/secrets.md
+++ b/modules/secrets.md
@@ -1,0 +1,106 @@
+# Secrets, and the convention a bundled service follows
+
+This is the contributor-facing note. The copy-pasteable user instructions
+belong in `docs/manual/`, which is not this file.
+
+nixarchy carries a declarative secrets mechanism — sops-nix, imported by
+`modules/nixos.nix` — and it is deliberately the smallest thing that works.
+It exists so the services nixarchy *bundles* can consume a secret. It is not
+a user-facing secrets product and there is no wizard.
+
+## Why there is one at all
+
+There was not one for a long time, on purpose. #121 declined to adopt
+declarative secrets, calling it "a separate decision with a key-management
+story attached". #122 then got away without one because
+`users.users.<name>.hashedPasswordFile` is consumed by NixOS itself, so the
+cleartext could sit outside git and be pointed at.
+
+hypr-rdp (#154) removes that dodge, and it is worth being precise about how,
+because the precision is what chooses the tool. Verified against v0.1.5:
+
+- `src/config.rs` resolves the password as `args.password.or(config.password)`
+  and from nowhere else.
+- `-p/--password` is therefore a command-line argument, which is readable by
+  every process on the machine via `/proc/*/cmdline`.
+- The only other source is `password = "..."` inline in `config.toml`.
+- There is no `password_file` option, and clap reads no environment variable
+  for it. (The only environment variables the binary reads at all are VA-API
+  and AVC444 debug knobs, `HOME`, `HYPRLAND_INSTANCE_SIGNATURE` and
+  `XDG_RUNTIME_DIR`.)
+
+So the secret has to end up **inside a config file**, not beside it, and
+something has to put it there at runtime from material that is safe to commit.
+
+That is what picks sops-nix over agenix. agenix delivers files containing raw
+secrets and has no templating, so composing one into a TOML would need a
+hand-rolled `ExecStartPre` shim per service — the exact hack this mechanism
+exists to avoid. `sops.templates` is that shim, upstreamed, with owner and
+mode declared. Everything else between the two is close enough to be taste.
+
+## The convention
+
+One policy file at the repository root, one encrypted file per host:
+
+```
+.sops.yaml                      creation rules: which recipients get which file
+hosts/<name>/secrets.yaml       that host's secrets, encrypted
+```
+
+The layout matches the one #121 established for generated config repos. The
+recipient is the host's own **SSH host key**: sops-nix converts
+`/etc/ssh/ssh_host_ed25519_key` to an age identity itself, and
+`sops.age.sshKeyPaths` already defaults to the ed25519 keys from
+`services.openssh.hostKeys`. nixarchy sets no sops option of its own, and
+should keep it that way — there is no separate keypair for anyone to mint,
+shepherd or lose.
+
+## The ordering constraint, which is real
+
+A machine's SSH host key is generated on **first boot**, so a secret cannot be
+encrypted to a machine that does not exist yet. An ISO install therefore
+always has one rebuild in which the secret is not yet available. Two things
+follow, and both have been checked rather than assumed:
+
+**Without sshd there is no key at all.** `services.openssh` is a
+`kind = "plain"` entry in `data/services.nix` — the user opts into it — so on
+a default nixarchy machine `sops.age.sshKeyPaths` evaluates to `[]`. Declaring
+a secret in that state fails the rebuild at evaluation time, with upstream's
+own message:
+
+```
+No key source configured for sops. Either set services.openssh.enable
+or set sops.age.keyFile or sops.gnupg.home
+```
+
+That is a good failure: it is loud, it is early, and nothing starts. With
+`services.openssh.enable = true`, `sops.age.sshKeyPaths` becomes
+`[/etc/ssh/ssh_host_ed25519_key]` and no assertion fires.
+
+**A module that consumes a secret must assert, because the daemon will not.**
+This matters more than it looks for hypr-rdp specifically. Given an empty
+password it does *not* refuse to start — `src/config.rs` logs
+
+```
+No credentials set (-u/-p). Use -u <user> -p <pass> to require authentication.
+```
+
+and then serves the session **unauthenticated**. It fails open. So the module
+in `modules/services/` is the only thing standing between a missing secret and
+an RDP daemon with no password, and it must assert with a message naming the
+three commands (read the host pubkey → add it to `.sops.yaml` → `sops edit`)
+rather than let a rebuild succeed into that state. Never make the service
+start passwordless as a convenience for the first-boot case.
+
+## What a machine that never uses this pays
+
+Nothing, and `tests/options.nix` asserts it rather than trusting the claim.
+sops-nix gates both halves of its module on `sops.secrets != { }` and
+`sops.templates != { }`, so a machine that declares neither gets no systemd
+unit, no activation script and no package. The toplevel derivation of a Mode A
+machine is byte-for-byte identical with and without the import.
+
+The lock cost is one node: sops-nix declares exactly one input, `nixpkgs`,
+which follows ours. Its `nixConfig` asks for `cache.thalheim.io`, which does
+not apply to us — `nixConfig` is honoured only from the flake you invoke, not
+from its inputs — so taking this input grants no substituter and no trust.

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -161,6 +161,14 @@ let
         builtins.any (r: pkgs.lib.hasInfix "chromium/policies" r)
           (configWith { browserThemeUser = null; }).systemd.tmpfiles.rules;
     };
+
+    # sops-nix is imported by every nixarchy machine and must do nothing
+    # until a secret is declared. See sopsOff/sopsOn below for why this is
+    # asserted rather than assumed.
+    sops = {
+      on = hasSops sopsOn;
+      off = hasSops sopsOff;
+    };
   };
 
   # Every Install row upstream offers, checked against what the selection
@@ -303,6 +311,42 @@ let
   hasDevenv = cfg: builtins.any (p: (p.pname or "") == "devenv") cfg.environment.systemPackages;
   hasCache = cfg: builtins.elem "https://devenv.cachix.org" cfg.nix.settings.substituters;
   hookIn = text: pkgs.lib.hasInfix "devenv hook" text;
+
+  # ---- sops-nix, imported by everyone and doing nothing --------------
+  #
+  # #155 adopted a declarative secrets mechanism for one concrete reason:
+  # hypr-rdp reads its password only from an inline string in its TOML or
+  # from `-p`, so something has to render a config file at runtime. That
+  # decision put an upstream module into EVERY nixarchy machine, including
+  # every Mode A machine that will never declare a secret -- so what has to
+  # be asserted is that the module is inert, not that it works.
+  #
+  # Inertness here is upstream's promise, not ours: sops-nix gates both
+  # halves of its config on `sops.secrets != {}` and `sops.templates != {}`.
+  # A promise made by someone else's module is exactly the kind a version
+  # bump can withdraw quietly, and the failure would be silent -- an
+  # activation script and a systemd unit appearing on machines that never
+  # asked for secrets. Nothing else in this repo would notice.
+  sopsOff = configWith { };
+
+  # The other half, so that the case above measures inertness rather than an
+  # import that never worked. validateSopsFiles is off because there is no
+  # encrypted file here to validate, and a key source is named so this reads
+  # as a machine someone actually configured.
+  sopsOn = configBeside {
+    sops = {
+      validateSopsFiles = false;
+      age.keyFile = "/var/lib/sops-nix/key.txt";
+      defaultSopsFile = ./options.nix;
+      secrets.a-secret = { };
+    };
+  };
+
+  # Which of the two activation paths upstream picks depends on whether the
+  # machine uses systemd-sysusers or userborn, so asking for one of them by
+  # name would assert the wrong thing on the other kind of machine.
+  hasSops =
+    cfg: (cfg.systemd.services ? sops-install-secrets) || (cfg.system.activationScripts ? setupSecrets);
 
   # ---- a bundled service yields to a user who already configured it ----
   #
@@ -511,6 +555,11 @@ pkgs.runCommand "nixarchy-options"
     devenvOnOmarchyChain = pkgs.lib.boolToString (
       pkgs.lib.hasInfix "default/bash/rc" devenvOn.programs.bash.interactiveShellInit
     );
+    sopsOffUnit = pkgs.lib.boolToString (sopsOff.systemd.services ? sops-install-secrets);
+    sopsOffActivation = pkgs.lib.boolToString (sopsOff.system.activationScripts ? setupSecrets);
+    sopsOffSecrets = pkgs.lib.boolToString (sopsOff.sops.secrets == { });
+    sopsOffTemplates = pkgs.lib.boolToString (sopsOff.sops.templates == { });
+    sopsOnActive = pkgs.lib.boolToString (hasSops sopsOn);
     devenvNoCacheCache = pkgs.lib.boolToString (hasCache devenvNoCache);
     devenvNoCachePackage = pkgs.lib.boolToString (hasDevenv devenvNoCache);
     serviceCount = builtins.toString (builtins.length (builtins.attrNames services));
@@ -637,6 +686,29 @@ pkgs.runCommand "nixarchy-options"
             exit 1
           }
           echo "devenv respects binaryCaches = false and still installs"
+
+          # ---- sops-nix: imported by everyone, inert until asked --------
+          for pair in "systemd unit:$sopsOffUnit" "activation script:$sopsOffActivation"; do
+            if [ "''${pair#*:}" != "false" ]; then
+              echo "no secret is declared, yet sops-nix put a ''${pair%%:*} on the machine." >&2
+              echo "Importing the module must cost a Mode A machine nothing. If an" >&2
+              echo "upstream bump stopped gating on sops.secrets/sops.templates, this" >&2
+              echo "is where that shows up -- do not fix it by removing the check." >&2
+              exit 1
+            fi
+          done
+          [ "$sopsOffSecrets" = "true" ] && [ "$sopsOffTemplates" = "true" ] || {
+            echo "nixarchy declared a sops secret or template of its own." >&2
+            echo "It must declare neither: the mechanism exists for the modules" >&2
+            echo "that opt into it, not for every machine that imports nixarchy." >&2
+            exit 1
+          }
+          [ "$sopsOnActive" = "true" ] || {
+            echo "declaring a sops secret produced no activation path at all," >&2
+            echo "so the inertness checked above is an import that never worked." >&2
+            exit 1
+          }
+          echo "sops-nix is imported, declares nothing, and works when asked"
 
           echo "every option adds what it should and removes it again"
 


### PR DESCRIPTION
Closes #155. Part of #159. **Based on #177** — review that first; this branch
contains its commit.

Adds the `sops-nix` input, imports it into `nixosModules.nixarchy` inert, and
records the convention. No module and no secret is declared — that is #156.

## The deciding fact, checked in upstream's source

#155 rests on a claim about hypr-rdp, so I verified it against v0.1.5 rather
than taking it. It holds, and the claim is exact:

- `src/config.rs:188` resolves the password as
  `args.password.or(config.password).unwrap_or_default()` — two sources, no
  third.
- `-p/--password` is a plain clap argument, so it is readable by every
  process on the machine through `/proc/*/cmdline`.
- The only other source is `password = "..."` inline in `config.toml`.
- There is **no** `password_file`, and clap reads **no** environment variable
  for it. The only environment variables the binary reads at all are VA-API
  and AVC444 debug knobs, `HOME`, `HYPRLAND_INSTANCE_SIGNATURE` and
  `XDG_RUNTIME_DIR`.

Confirmed against the built binary too:

```
  -u, --username <USERNAME>   Username for RDP authentication
  -p, --password <PASSWORD>   Password for RDP authentication
      --config <CONFIG>       Path to config file [default: ~/.config/hypr-rdp/config.toml]
```

So the secret must end up **inside a config file**, not beside it. agenix has
no templating and would need a hand-rolled per-service `ExecStartPre` shim —
the exact hack this is meant to avoid. `sops.templates` is that shim,
upstreamed. That is the whole argument; everything else between the two is
taste.

## Pinned to a commit, because there is no tag

sops-nix publishes **no release tags at all** — its only tag, `assets`, is
from 2021 and is not a release. master is its release channel. So this pins
commit `a8627b2` (2026-08-13), chosen over today's tip for three weeks of
soak; it already includes the most recent `golang.org/x/crypto` bump, and the
delta since is a gRPC dependabot bump.

A commit is exactly as reproducible as a tag. This is the same call flake.nix
already documents for hyprland.

## What it costs a user's lock: one node

```
• Added input 'sops-nix':
    'github:Mic92/sops-nix/a8627b21b9107c5711c96b84f32a9a4b3d45295f' (2026-08-13)
• Added input 'sops-nix/nixpkgs':
    follows 'nixpkgs'
```

sops-nix declares exactly one input, `nixpkgs`, which follows ours. Nothing
transitive arrives — its dev inputs live in a private flake under `dev/` that
consumers never see.

Its `nixConfig` names `cache.thalheim.io`, which does **not** apply to us:
`nixConfig` is honoured only from the flake you invoke, never from an input.
Taking this grants no substituter and no trust. Worth stating explicitly in a
repo that already treats a substituter as trust granted without a conflict to
warn anyone.

## Inert, and asserted rather than claimed

nixarchy sets **no sops option at all**. `sops.age.sshKeyPaths` already
defaults upstream to the ed25519 keys from `services.openssh.hostKeys`, so
the host-key identity comes for free and the `mkDefault` rule in
`modules/services/default.nix` never even arises.

Mode A toplevel derivation, measured:

```
main                  p6x5jis4crld4bdxy5g5mvcnflnqq0ai-nixos-system-nixos-...drv
#177 (hypr-rdp)       p6x5jis4crld4bdxy5g5mvcnflnqq0ai-nixos-system-nixos-...drv
this branch           p6x5jis4crld4bdxy5g5mvcnflnqq0ai-nixos-system-nixos-...drv
```

Byte for byte identical across both changes. And on a Mode A machine:
`sopsUnit=false`, `setupSecrets=false`, `secrets={}`, `templates={}`,
no package.

`tests/options.nix` now asserts this, because the gating is *upstream's*
promise — `mkIf (cfg.secrets != {})` and `mkIf (config.sops.templates != {})`
— and a version bump could withdraw it silently, on machines that never asked
for secrets, with nothing else in the repo noticing.

### Both failure paths proven

Deliberately breaking it, as asked:

**nixarchy declares a secret** — the on/off guard catches it:

```
>   sops: on=1 off=1
> these options do not take effect both ways: sops
> an option that cannot be turned off is not an option.
```

**nixarchy declares only a template** — a case the on/off guard does *not*
catch, because a template alone produces no activation path, so the specific
assertion is what fires:

```
> nixarchy declared a sops secret or template of its own.
> It must declare neither: the mechanism exists for the modules
> that opt into it, not for every machine that imports nixarchy.
```

Restored, and `checks.options` is green again.

## What happens on a machine whose secret is not encrypted yet

Two findings for #156, both checked by evaluation, both recorded in
`modules/secrets.md`.

**A default machine has no host key at all.** `services.openssh` is a
`kind = "plain"` catalogue entry the user opts into — nixarchy never enables
sshd. So `sops.age.sshKeyPaths` evaluates to `[]`, and declaring a secret in
that state fails the rebuild **at evaluation**, with upstream's own message:

```
noKey.sshKeyPaths=[]
noKey.failures=No key source configured for sops. Either set
services.openssh.enable or set sops.age.keyFile or sops.gnupg.home
```

That is the good outcome: loud, early, nothing starts. With
`services.openssh.enable = true` it becomes
`[/etc/ssh/ssh_host_ed25519_key]` and no assertion fires — zero ceremony,
as #155 hoped, but conditional on sshd in a way the issue did not state.

**hypr-rdp does not fail closed, and this is the important one.** #155 and the
brief both assume the risk is a daemon starting passwordless. It is worse
than assumed: given an empty password hypr-rdp does not refuse to start. It
logs

```
No credentials set (-u/-p). Use -u <user> -p <pass> to require authentication.
```

and then **serves the session unauthenticated**. Upstream enforces nothing.

So the module assertion in #156 is not a nicety — it is the only thing
between a missing secret and an open RDP daemon, and it must never be relaxed
to let a first boot succeed. `modules/secrets.md` says so where the next
implementer will read it.

## The convention

Recorded in `modules/secrets.md` — deliberately **not** under `docs/manual/`
(another agent's territory) and not at `docs/` root, where `_config.yml` says
"only the manual is a site" and a stray page would become an orphan.

```
.sops.yaml                   creation rules: which recipients get which file
hosts/<name>/secrets.yaml    that host's secrets, encrypted
```

Matching the #121 layout, host SSH key as recipient.

## Checks

- `nix build .#checks.x86_64-linux.options` passes.
- `nix fmt -- --ci`, `statix check`, `deadnix --fail` all clean.
- `nix flake check --no-build` fails identically on `main` and on this branch
  (unfree `grok-bot`, an ambient-config issue, same line, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhToUKGVGwy61MeZudCsFu
