### PR TITLE
Nixarchy no longer offers to publish a configuration it did not write

### DIFF
--- a/installer/host.nix
+++ b/installer/host.nix
@@ -28,6 +28,15 @@
     # their devices. The module cannot guess who logs in, so it is told.
     user = username;
 
+    # "Nixarchy wrote this machine." This file is imported only by a
+    # hosts/<name>/default.nix the installer generated, so a configuration that
+    # evaluates it is one nixarchy shaped -- which is what the armed commands
+    # (nixarchy-config-repo and the post-boot nudge that offers it) need to know
+    # before they commit, push or rewrite anything. Surfaced to them as
+    # /etc/nixarchy/managed; see modules/nixos.nix for why this and not
+    # .nixarchy-url, which `--from` copies onto machines nixarchy never touched.
+    installerManaged = true;
+
     # Where nixarchy-apply copies the app selection before rebuilding. Stated
     # even though modules/apps.nix defaults to the same path: on an installed
     # machine this is the installer's decision, not a default it could later

--- a/installer/mkFlake.nix
+++ b/installer/mkFlake.nix
@@ -97,6 +97,13 @@ runCommand "nixarchy-flake-template"
     ' ${../flake.lock} > $out/flake.lock
 
     # So the installer does not have to recompute what this already knows.
+    #
+    # Provenance of the REPOSITORY, and nothing more. It is tracked by the
+    # `git add -A` install.sh does, so it is committed, pushed, and cloned onto
+    # every machine enrolled from this repo with `--from` -- machines this
+    # installer never touched. "Did nixarchy write this machine" is a different
+    # question and is answered elsewhere: programs.nixarchy.installerManaged,
+    # via installer/host.nix. Nothing should gate on this file.
     printf '%s\n' "$url" > $out/.nixarchy-url
 
     sed -i "s|@nixarchy_url@|$url|g" $out/flake.nix

--- a/modules/home.nix
+++ b/modules/home.nix
@@ -790,14 +790,20 @@ in
     # Same extension point, on the other hook Omarchy already runs:
     # default/hypr/autostart.lua ends its startup with `omarchy-hook post-boot`.
     #
-    # A notification rather than a window. The installer leaves /etc/nixos as a
-    # repository with one staged, never-committed tree -- so there is something
-    # real to say -- but a terminal that seizes the screen on a first-ever boot
-    # arrives before the user has signed in to anything, which makes the one
-    # answer they can give "dismiss". The nudge is a notification they can act
-    # on when they are ready, and the script's own --check decides whether
-    # there is any point showing it: already committed and pushed, no agent
-    # chosen yet, or already answered once, and it stays quiet.
+    # A notification rather than a window. On a machine the installer built,
+    # /etc/nixos is a repository with one staged, never-committed tree -- so
+    # there is something real to say -- but a terminal that seizes the screen on
+    # a first-ever boot arrives before the user has signed in to anything, which
+    # makes the one answer they can give "dismiss". The nudge is a notification
+    # they can act on when they are ready, and the script's own --check decides
+    # whether there is any point showing it: already committed and pushed, no
+    # agent chosen yet, or already answered once, and it stays quiet.
+    #
+    # It stays quiet for one more reason now, and it is the important one. This
+    # module reaches every machine that imports it, including one where somebody
+    # added nixarchy to a configuration of their own -- and on that machine
+    # /etc/nixos is theirs. --check asks /etc/nixarchy/managed before anything
+    # else and answers "no nudge", so the hook exits 0 having said nothing.
     xdg.configFile."omarchy/hooks/post-boot.d/config-repo" = {
       executable = true;
       text = ''

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -77,6 +77,40 @@ in
   options.programs.nixarchy = {
     enable = lib.mkEnableOption "Nixarchy, the Omarchy desktop vendored for NixOS";
 
+    # "Nixarchy wrote this machine", as a property of the configuration rather
+    # than of the install event.
+    #
+    # Set in exactly one place -- installer/host.nix, which is imported only by
+    # a hosts/<name>/default.nix the installer generated. That is what makes a
+    # machine nixarchy-shaped: snapper, nh, the registry pin, the seeded user.
+    # So the question "did nixarchy build this?" is answered by whether that
+    # module is in the evaluation, and re-answered at every rebuild.
+    #
+    # Not /etc/nixos/.nixarchy-url, which used to look like the same signal and
+    # is not one any more. `git add -A` tracks it, so it is committed, pushed,
+    # and cloned onto every machine enrolled with `nixarchy install --from` --
+    # including a machine the installer never touched. And an admin-authored
+    # repo of the shape `--from` accepts carries no such file while being a
+    # perfectly good nixarchy install. Presence stopped meaning "here", absence
+    # stopped meaning "hands off". It survives as provenance of the *repo*.
+    #
+    # Not a heuristic either. Sniffing flake.lock's root inputs or testing for
+    # hosts/$(hostname) reads state the user is invited to edit, and would one
+    # day refuse a machine to its own owner.
+    installerManaged = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      internal = true;
+      description = ''
+        Whether this configuration descends from the host module the Nixarchy
+        installer generates. Set by installer/host.nix and by nothing else.
+
+        Surfaced to shell tools as /etc/nixarchy/managed, which is the single
+        predicate every armed command gates on: nixarchy commits, pushes and
+        rewrites configuration only on a machine it wrote.
+      '';
+    };
+
     package = lib.mkOption {
       type = lib.types.package;
       # Built from *your* nixpkgs through this flake's overlay, not from
@@ -732,6 +766,33 @@ in
     # login and never rewritten, so it cannot name a store path: this one is
     # regenerated with the system and always points at the current package.
     environment.etc."omarchy/xcompose".source = "${cfg.package}/share/omarchy/default/xcompose";
+
+    # The ownership marker, for the shell tools that cannot ask the module
+    # system anything.
+    #
+    # Declarative on purpose: it is in the closure, it is rewritten by every
+    # rebuild, and a machine that stops descending from installer/host.nix
+    # loses it in the same switch that made that true. A file the installer
+    # wrote once could not say that -- it would survive being wrong, and a
+    # `--from` rebuild that never created it would leave the machine looking
+    # unmanaged for the rest of its life.
+    #
+    # The contents are for the person who finds the file and wonders. Nothing
+    # reads them, and nothing should start: the predicate is the file's
+    # existence, which is the only part that is cheap to get right in every
+    # shell script that needs it.
+    environment.etc."nixarchy/managed" = lib.mkIf cfg.installerManaged {
+      text = ''
+        This machine's configuration descends from the host module the Nixarchy
+        installer generates (installer/host.nix), so nixarchy commands that
+        commit, push or rewrite configuration will act on it.
+
+        Written declaratively by programs.nixarchy.installerManaged and renewed
+        by every rebuild. Deleting it changes nothing until the next switch.
+
+        nixarchy ${cfg.package.version}
+      '';
+    };
 
     # glib looks for compiled schemas in $XDG_DATA_DIRS/glib-2.0/schemas, but
     # nixpkgs' glib setup hook relocates them to

--- a/pkgs/omarchy/nix-bin/nixarchy-config-repo
+++ b/pkgs/omarchy/nix-bin/nixarchy-config-repo
@@ -16,6 +16,9 @@
 # Everything here is idempotent and re-runnable. Each step looks at what is
 # already true and skips itself, so a user who has done half of this by hand
 # gets the other half rather than an argument.
+#
+# And all of it is behind one question, asked first: did nixarchy write this
+# machine's configuration? See is_managed below.
 
 set -uo pipefail
 
@@ -61,6 +64,24 @@ wcommit() {
        -c "user.email=$(command git config --global user.email)" \
        commit -qm "$1"
 }
+
+# ---------------------------------------------------------------------------
+# Ownership
+# ---------------------------------------------------------------------------
+#
+# The one question that comes before every other one here: did nixarchy write
+# this machine's configuration?
+#
+# /etc/nixarchy/managed is written declaratively by
+# programs.nixarchy.installerManaged, which installer/host.nix sets and nothing
+# else does -- see modules/nixos.nix for why that module, and not the install
+# event or /etc/nixos/.nixarchy-url, is what the question means.
+#
+# Somebody who imported nixosModules.nixarchy into a configuration of their own
+# has a /etc/nixos that is theirs. Committing it, choosing its visibility and
+# pushing it to a host they have not picked is not a favour.
+MANAGED_MARKER=/etc/nixarchy/managed
+is_managed() { [[ -e $MANAGED_MARKER ]]; }
 
 # ---------------------------------------------------------------------------
 # State
@@ -113,6 +134,11 @@ agent_ready() {
 
 # --check: should the post-boot hook nudge? Silent; the exit code is the answer.
 if [[ $check_only == true ]]; then
+  # Not our machine, not our nudge. A Mode A user -- somebody who imported
+  # nixosModules.nixarchy into a configuration of their own -- must never see
+  # this at all, so it is the first question and not a late one.
+  is_managed || exit 1
+
   omarchy-done check "$DONE_MARKER" && exit 1
 
   # Nothing left to do -- mark it done so this never asks again. A machine that
@@ -124,6 +150,31 @@ if [[ $check_only == true ]]; then
 
   agent_ready || exit 1
   exit 0
+fi
+
+# The same question, asked of a person rather than of a hook -- and answered
+# out loud, because somebody who typed this deserves to know why it declined
+# and where to go instead.
+#
+# --force does not lift this. It exists to re-run a setup that was marked done;
+# it is not a way to tell nixarchy that a configuration it did not write is
+# nonetheless its to publish.
+if ! is_managed; then
+  echo -e "\n\033[1;31m✗\033[0m This machine's configuration is not one Nixarchy wrote." >&2
+  echo >&2
+  echo "  $FLAKE belongs to whoever built it." >&2
+  echo "  Nixarchy is here as a module somebody imported, not as the thing that" >&2
+  echo "  shaped this machine -- so committing that configuration, choosing" >&2
+  echo "  whether it is public, and pushing it to a host you have not picked" >&2
+  echo "  are not decisions it gets to make." >&2
+  echo >&2
+  echo "  Your agent has the same steps as a skill you can drive yourself:" >&2
+  echo -e "  ask it about \033[1mnixos-config-repo\033[0m -- git setup, .gitignore," >&2
+  echo "  a first commit, a remote, and CI for the flake." >&2
+  echo >&2
+  echo "  (A machine the Nixarchy installer built carries $MANAGED_MARKER," >&2
+  echo "  which this one does not.)" >&2
+  exit 1
 fi
 
 if [[ $force == false ]] && omarchy-done check "$DONE_MARKER"; then

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -348,6 +348,24 @@ let
   dockerGroups =
     (configBeside { programs.nixarchy.user = "someone"; }).users.users.someone.extraGroups;
 
+  # ---- "nixarchy wrote this machine", both ways -------------------------
+  #
+  # The armed commands -- nixarchy-config-repo, and the post-boot hook that
+  # offers it -- commit a configuration, choose whether it is public and push
+  # it somewhere. On a machine nixarchy built that is the whole point. On a
+  # machine where somebody imported nixosModules.nixarchy into a configuration
+  # of their own, it is nixarchy publishing a repository it does not own.
+  #
+  # The predicate is /etc/nixarchy/managed, written only where
+  # programs.nixarchy.installerManaged is set, which is only in
+  # installer/host.nix. So the off case is a plain nixosSystem importing the
+  # module -- Mode A, exactly the machine that must not get it -- and the on
+  # case is the reference host, which imports that file.
+  #
+  # The off case is the one that breaks quietly: a marker that arrives for
+  # everybody makes every gate below it read as passing, and nothing says so.
+  managedModeA = (configWith { }).environment.etc ? "nixarchy/managed";
+
   # ---- enabling a custom remote must not remove Flathub ----
   #
   # nix-flatpak's `remotes` defaults to a list holding only Flathub, and it is
@@ -492,6 +510,7 @@ pkgs.runCommand "nixarchy-options"
     ollamaPort = builtins.toString ollamaBeside.services.ollama.port;
     ollamaEndpoint = ollamaBeside.programs.nixarchy.localAi.resolved.endpoint;
     dockerGroups = pkgs.lib.concatStringsSep " " dockerGroups;
+    managedModeA = pkgs.lib.boolToString managedModeA;
     devenvOffPackage = pkgs.lib.boolToString (hasDevenv devenvOff);
     devenvOffBash = pkgs.lib.boolToString (hookIn devenvOff.programs.bash.interactiveShellInit);
     devenvOffZsh = pkgs.lib.boolToString (hookIn devenvOff.programs.zsh.interactiveShellInit);
@@ -593,6 +612,81 @@ pkgs.runCommand "nixarchy-options"
                echo "groups: $dockerGroups" >&2
                exit 1 ;;
           esac
+
+          # ---- nixarchy only commits a configuration it wrote --------------
+          #
+          # Three assertions, and the first is the one that matters. A Mode A
+          # machine -- somebody's own configuration, with nixosModules.nixarchy
+          # imported into it -- must not carry the marker, because everything
+          # downstream reads its presence as permission to commit and push
+          # /etc/nixos to a remote of nixarchy's choosing.
+          [ "$managedModeA" = "false" ] || {
+            echo "importing nixosModules.nixarchy wrote /etc/nixarchy/managed." >&2
+            echo "  That file means 'nixarchy wrote this machine', and it is what" >&2
+            echo "  nixarchy-config-repo and the post-boot nudge gate on. On a" >&2
+            echo "  configuration somebody else wrote, it makes nixarchy offer to" >&2
+            echo "  commit and push a repository that is not its to publish." >&2
+            echo "  Only installer/host.nix may set programs.nixarchy.installerManaged." >&2
+            exit 1
+          }
+
+          # And the other way: the reference host imports installer/host.nix,
+          # so it must. A gate nothing ever passes is a command nobody can run.
+          test -e "$vm/etc/nixarchy/managed" || {
+            echo "the installed reference host has no /etc/nixarchy/managed" >&2
+            echo "  installer/host.nix sets programs.nixarchy.installerManaged;" >&2
+            echo "  without the file every armed command refuses the machines" >&2
+            echo "  nixarchy itself built." >&2
+            exit 1
+          }
+          echo "the ownership marker reaches the installed host and no one else"
+
+          # The coupling, which neither of the above can see: the marker could
+          # be perfect and the command could still never look at it. Both the
+          # refusal and the --check the post-boot hook calls are in this one
+          # script, so this is where a missing gate would show.
+          #
+          # Comments stripped first. The path is named in the prose above the
+          # gate as well as in the gate, and a check that a file mentions
+          # something in a comment is not a check.
+          grep -v '^[[:space:]]*#' "$vm/sw/bin/nixarchy-config-repo" \
+            | grep -q '/etc/nixarchy/managed' || {
+            echo "nixarchy-config-repo does not consult /etc/nixarchy/managed" >&2
+            echo "  Its only gate would then be consent, not ownership." >&2
+            exit 1
+          }
+
+          # Run it. The build sandbox has no /etc/nixarchy/managed, which makes
+          # it exactly the unowned machine, and the refusal has to be an exit
+          # code as well as a paragraph -- the post-boot hook reads --check's
+          # status and nothing else.
+          if "$vm/sw/bin/nixarchy-config-repo" >refusal 2>&1; then
+            echo "nixarchy-config-repo succeeded on a machine nixarchy did not write:" >&2
+            cat refusal >&2
+            exit 1
+          fi
+          grep -qi "not one Nixarchy wrote" refusal || {
+            echo "the refusal does not say why it refused:" >&2
+            cat refusal >&2
+            exit 1
+          }
+          grep -q "nixos-config-repo" refusal || {
+            echo "the refusal names no way for the user to do it themselves" >&2
+            cat refusal >&2
+            exit 1
+          }
+          if "$vm/sw/bin/nixarchy-config-repo" --check >check 2>&1; then
+            echo "--check asked for a nudge on a machine nixarchy did not write" >&2
+            cat check >&2
+            exit 1
+          fi
+          test ! -s check || {
+            echo "--check is documented as printing nothing; it printed:" >&2
+            cat check >&2
+            exit 1
+          }
+          echo "on an unowned machine it refuses, says why, and nudges nobody"
+
           # ---- devenv: nothing at all until it is asked for ---------------
           for pair in "package:$devenvOffPackage" "bash hook:$devenvOffBash" \
             "zsh hook:$devenvOffZsh" "fish hook:$devenvOffFish" \

--- a/tests/session.nix
+++ b/tests/session.nix
@@ -362,7 +362,7 @@ pkgs.testers.runNixOSTest {
         machine.fail(f"test -e /home/omarchy/{home}/omarchy")
     print("agent skills linked into all four agent homes, under the new names")
 
-    # The config-repo nudge, and the two ways it is supposed to stay silent.
+    # The config-repo nudge, and the three ways it is supposed to stay silent.
     #
     # The hook is the whole delivery mechanism: default/hypr/autostart.lua ends
     # startup with `omarchy-hook post-boot`, which runs everything in this
@@ -377,6 +377,32 @@ pkgs.testers.runNixOSTest {
     machine.succeed(
         "grep -q 'nixarchy-config-repo --check || exit 0' "
         "/home/omarchy/.config/omarchy/hooks/post-boot.d/config-repo")
+
+    # Silence, gate zero: nixarchy did not write this machine.
+    #
+    # This VM imports nixosModules.nixarchy into a configuration of its own and
+    # never touches installer/host.nix -- it IS a Mode A machine, which makes it
+    # the right place to assert this and the reason the two gates below had to
+    # be rearranged. The ownership question is asked before either of them, so
+    # without the fixture further down they would both have gone on passing
+    # while testing nothing at all.
+    machine.fail("test -e /etc/nixarchy/managed")
+    machine.fail("su - omarchy -c 'nixarchy-config-repo --check'")
+    refusal = machine.fail("su - omarchy -c 'nixarchy-config-repo' 2>&1")
+    assert "not one Nixarchy wrote" in refusal, (
+        "the command did not refuse a configuration nixarchy does not own; "
+        f"it said: {refusal}")
+    assert "nixos-config-repo" in refusal, (
+        "the refusal names no way for the user to do it themselves")
+    print("config-repo refuses, and nudges nobody, on a machine nixarchy did not write")
+
+    # And now the fixture that makes the rest of this block reachable: the
+    # marker as a real machine would carry it. Written by hand rather than by
+    # setting programs.nixarchy.installerManaged, because this VM has to stay a
+    # Mode A machine for the assertions above -- and because installer/host.nix
+    # is the only configuration allowed to set that option, which is itself
+    # asserted in tests/options.nix.
+    machine.succeed("mkdir -p /etc/nixarchy && touch /etc/nixarchy/managed")
 
     # Silence, gate one: no default agent. Omarchy deliberately ships without
     # one, so this is the state of every machine whose owner has not finished


### PR DESCRIPTION
Closes #168.

`modules/home.nix` ships a `post-boot.d/config-repo` hook to **every** machine that imports the Home Manager module, and it had no ownership gate. On a machine where somebody imported `nixosModules.nixarchy` into a configuration of their own and keeps that flake at `/etc/nixos` — the most common place — the nudge fired, and `nixarchy-config-repo` would go on to commit that configuration, decide whether it was public, and push it to a host nixarchy chose. Its only gate was consent. The README says the project refuses to touch such a configuration; it did not.

Demonstrated on a fixture Mode A machine (nixarchy imported as a module, an agent signed in, `/etc/nixos` a git repo with no commits and no remote):

```
BEFORE (main):  nixarchy-config-repo --check  → exit 0   the hook fires the nudge
AFTER:          nixarchy-config-repo --check  → exit 1   silent
AFTER, typed by hand:
  ✗ This machine's configuration is not one Nixarchy wrote.
    …belongs to whoever built it. Nixarchy is here as a module somebody
    imported, not as the thing that shaped this machine …
    ask it about nixos-config-repo -- git setup, .gitignore, a first commit,
    a remote, and CI for the flake.
  exit 1
```

## The predicate

"Nixarchy wrote this machine" is a property of the **configuration**, not of the install event: *this machine's evaluated configuration descends from `installer/host.nix`*. That module is imported only by a `hosts/<name>/default.nix` the installer generated, and it is what makes a machine nixarchy-shaped — snapper, nh, the registry pin, the seeded user. It survives `install --from`, fleets, renames and repo surgery, because it is re-derived at every rebuild.

- `programs.nixarchy.installerManaged` (internal, default `false`), set by `installer/host.nix` and nothing else.
- Surfaced through `environment.etc` as `/etc/nixarchy/managed`. Declarative on purpose: in the closure, rewritten by every rebuild, and lost in the same switch that stops the configuration descending from that module. A file the installer wrote once could not say that — it would survive being wrong, and a `--from` rebuild would never create it.
- One shell predicate, `test -e /etc/nixarchy/managed`, asked by `--check` before anything else and by the interactive path before anything else.

`/etc/nixos/.nixarchy-url` is **not** that test and is demoted in comment to what it now is: provenance of the *repo*. `git add -A` tracks it, so it is committed, pushed and cloned by `--from` onto machines the installer never shaped — while an admin-authored `hosts/`-shaped repo carries none. No heuristics either: no sniffing `flake.lock`'s root inputs, no `hosts/$(hostname)` test. Both read state the user is invited to edit and would one day refuse a machine to its owner.

## Checks

`tests/options.nix` asserts it both ways and asserts that the command acts on it:

```
the ownership marker reaches the installed host and no one else
on an unowned machine it refuses, says why, and nudges nobody
```

- a Mode A `nixosSystem` must not carry the marker;
- the reference host (which imports `installer/host.nix`) must;
- the script, **run inside the build sandbox** — which is exactly an unowned machine — must exit non-zero, say why, name the `nixos-config-repo` skill, and leave `--check` silent and non-zero.

Each was confirmed to fail when the thing it checks is broken, by breaking it:

| broken | what the check said |
|---|---|
| `installerManaged` default flipped to `true` | `importing nixosModules.nixarchy wrote /etc/nixarchy/managed.` |
| the line removed from `installer/host.nix` | `the installed reference host has no /etc/nixarchy/managed` |
| the gate removed from the script | `the refusal does not say why it refused:` … |

`nix fmt -- --ci`, `statix`, `deadnix` clean.

## Not in this PR

- Gating snapper: `installer/host.nix` already reaches only installer-generated flakes by construction, and a runtime gate would re-check what the module system guarantees.
- Recording *which* host directory the marker came from. Nothing reads it yet.
- The drift half of #112 — that is #169, stacked on this branch.
