### PR TITLE
The contributor process, written down: CONTRIBUTING, AGENTS, templates, CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Review routing, and the precondition for required-review branch protection
+# if that is ever turned on. One maintainer today, so one line; the day a
+# second person owns a directory, that directory gets a line of its own.
+* @olafkfreund

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,42 @@
+name: Bug report
+description: Something specific to NixOS is broken — the Nix store, a rebuild, nixarchy-apply, a replaced command, a path that assumes /usr.
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: >
+        First: **would this happen on Arch?** If yes, it is Omarchy's bug and
+        belongs at basecamp/omarchy — the links on the previous page route it.
+        A quick test that settles most cases: `head -20 "$(which
+        omarchy-<command>)"` — nixarchy's replacements carry a header saying
+        what they replace and why. When genuinely unsure, file here; routing
+        it onward with the NixOS detail attached is cheaper than the reverse.
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened, and what you expected
+      description: Steps to reproduce beat description. A screenshot or short recording often beats both.
+    validations:
+      required: true
+  - type: textarea
+    id: versions
+    attributes:
+      label: Versions
+      description: >
+        These identify exactly what was built, and they are the first thing
+        anyone will ask for.
+      placeholder: |
+        omarchy version
+        nixos-version
+        nix flake metadata "${NIXARCHY_FLAKE:-/etc/nixos}"   # the locked nixarchy and nixpkgs revisions
+    validations:
+      required: true
+  - type: textarea
+    id: search
+    attributes:
+      label: Existing issues checked
+      description: >
+        Search both trackers, including closed issues — a closed-as-fixed
+        match that still reproduces is a regression, which is worth far more
+        than a duplicate.
+      placeholder: "gh search issues --repo olafkfreund/nixarchy \"…\""

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+# Routing before filing: two projects share this desktop, and a report in the
+# wrong tracker asks people to debug a distribution they do not run. The full
+# rules are in pkgs/omarchy/skills/nixarchy/contributing.md.
+blank_issues_enabled: true
+contact_links:
+  - name: A bug that would also happen on Arch
+    url: https://github.com/basecamp/omarchy/issues
+    about: >
+      The shell, themes, Hyprland config, menus, and every omarchy-* command
+      nixarchy does not replace are upstream's. If it would break on stock
+      Omarchy too, report it there — ideally reproduced there first.
+  - name: An Omarchy feature idea
+    url: https://github.com/basecamp/omarchy/discussions/categories/suggestions
+    about: Feature suggestions for the desktop itself go to upstream's discussions.
+  - name: Omarchy support / "is this a bug?"
+    url: https://omarchy.org/discord
+    about: Questions about the desktop are answered fastest on the Omarchy Discord.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!-- The subject-line rule: a single-commit branch is squashed using the
+     COMMIT subject, not the PR title. If your branch has one commit, its
+     subject is what lands on main — amend away any `wip:` before marking
+     this ready. -->
+
+## What this changes, and why
+
+<!-- One paragraph. If it fixes a bug: what broke, and would it also break on
+     Arch? If yes, it belongs at basecamp/omarchy, not here — see
+     CONTRIBUTING.md. -->
+
+## How I proved the check fails
+
+<!-- The verification contract (AGENTS.md §1): break the thing, run the
+     check, paste the RED output here, then show it green with the fix.
+     A check that has never been seen failing has never been seen working.
+
+     If this PR genuinely needs no check (docs, comments), say so instead. -->
+
+```
+(failing output here)
+```
+
+## Checks run locally
+
+<!-- Which `nix build .#checks.x86_64-linux.<name>` you ran, by name.
+     `checks.install` costs ~25 min on the one runner — you don't need to
+     have run it locally, but say what you did run. -->
+
+- [ ] `nix fmt` / statix / deadnix are clean
+- [ ] New files are `git add`ed (a flake cannot see untracked files)
+- [ ] If this adds an option: `tests/options.nix` covers both states
+- [ ] If this adds a `checks.*` entry: a PR-triggered workflow builds it
+      (CI enforces this; the workflow edit needs maintainer sign-off)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,192 @@
+# Working in this repository as an AI agent
+
+You are capable and you have no memory of this project. Both of those are why
+this file exists: every rule below is here because an agent — sometimes seven
+of them in one day — got it wrong in a specific, repeatable way. The rules are
+in priority order. The reason is attached to each one, because a rule without
+a reason gets rationalised away the moment it is inconvenient.
+
+`CONTRIBUTING.md` covers the human-facing process (forking, PR conventions,
+review). This file covers what goes wrong at the keyboard.
+
+## 1. Prove your check fails
+
+This is the most important rule in the file.
+
+A check was written for #133, added to the test suite, and passed. Later the
+bug it existed to catch was fully reintroduced — and the check **passed
+again**. It was measuring something that could not vary with the bug. Every
+minute spent on it had bought negative value: it read like coverage and
+covered nothing.
+
+The contract, for any check, assertion, or verification loop you write:
+
+1. Break the thing the check is about — revert the fix, reintroduce the bug.
+2. Run the check. Watch it fail. Capture that output.
+3. Restore the fix. Watch it pass.
+4. Put the failing output in the PR.
+
+If you cannot make the check fail, you have not written a check; you have
+written a green light. `installer/vm.nix` describes a harness that reported
+success on failure as "worse than no harness", and that judgement generalises.
+
+Two mechanical traps that produced fake green results here, live:
+
+- **Pipelines report the last command's status.** `nix build ... | tail -20`
+  exits with *tail's* status. A "0" after that pipe means tail worked. Use
+  `set -o pipefail`, or don't pipe the command whose status you need.
+- **Verify under bash, because CI runs bash.** A verification loop here
+  reported PASS for both the working and the broken case because it ran in
+  zsh, and zsh does not word-split unquoted expansions — `for c in $names`
+  iterated once, over the whole string. Interactive shells on the machines
+  this repo is developed on are zsh. Put `#!/usr/bin/env bash` on the script
+  and run it as a script, not by pasting into your shell.
+
+## 2. A check that nothing runs is worse than no check
+
+`checks.installer-ui` was written, wired into `checks` in `flake.nix`, and
+named by **no workflow**. The PR adding it went green without the check ever
+executing. There is now a CI step (`build.yml`, "Every check is run by some
+workflow, on pull requests", from #164/#166) that fails if any entry in
+`checks` is not built by a workflow that triggers on pull requests.
+
+So: adding a `checks.<name>` entry means also naming
+`nix build .#checks.x86_64-linux.<name>` in a workflow that runs on
+`pull_request` — and that workflow edit is a CI-gate change, which needs a
+human (see §9). Raise it in the PR rather than wiring it yourself.
+
+## 3. Git and flake mechanics that bite
+
+- **A flake in a worktree sees only tracked or staged files.** A new file you
+  have not `git add`ed fails evaluation with `path '…' does not exist` — not
+  "untracked", *does not exist*. This cost three separate debugging sessions
+  in one day. If a path you can `ls` "does not exist" to Nix, run `git add`
+  before doubting anything else.
+- **`installer/mkFlake.nix` requires a committed tree.** `git add` is not
+  enough — it reads `self.rev`, which a dirty tree does not have, and throws:
+  `flake-template: build from a committed tree; the generated flake pins
+  nixarchy by commit`. Commit (the subject can be temporary; see §6) before
+  building anything that pulls it in, which includes the installer checks.
+- **Work in a worktree under `/mnt/data/vmtest/`, never `/tmp`.** `/tmp` is a
+  32 GB tmpfs. A VM disk image or an ISO build there is competing with the
+  machine's RAM, and loses quietly.
+
+## 4. How to run the checks, and what each one costs
+
+Checks are built one at a time by name — `nix flake check` is not how this
+repo works:
+
+```sh
+nix develop                                     # nixd, statix, deadnix, qemu, gh
+nix fmt                                         # CI runs `nix fmt -- --ci`
+nix run nixpkgs#statix -- check .
+nix run nixpkgs#deadnix -- --fail .
+nix build .#checks.x86_64-linux.<name> --print-build-logs
+```
+
+Know the price before you pay it, and pick the cheapest check that can answer
+your question:
+
+| check | what it proves | cost |
+|---|---|---|
+| `options` | every option asserted in both states | cheap — evaluation only |
+| `omarchy` (package) | the vendored tree assembles | minutes |
+| `installer-ui`, `installer-wizard` | the installer's screens and questions | minutes |
+| `session`, `coexist`, `integration`, `plugin` | booted VMs | ~10–20 min each |
+| `install` | full install onto a blank disk, reboot, rebuild-builds-nothing | **~25 min, one self-hosted runner** |
+
+`checks.install` gates every pull request and there is exactly one machine
+that can run it. Seven concurrent PRs queue for about three hours. Every push
+to your branch cancels and restarts your own run (that is deliberate — a PR
+only needs an answer about its current head), but the queue is shared:
+batching your pushes is a courtesy to everyone else's merge latency.
+
+## 5. Code rules the repo has already written down
+
+Do not restate these in new comments; read them where they live, because the
+files carry the full reasoning and the failure history.
+
+- **Module priorities:** the header of `modules/services/default.nix`.
+  `lib.mkDefault` on scalars; **plain assignment** on lists and attrsets
+  (mkDefault on a merging type silently drops the whole contribution the
+  moment the user adds an element — reproduced live, not hypothetical);
+  `mkForce` never.
+- **Mode A is real.** Someone importing `nixosModules.nixarchy` into a
+  configuration they already run must be untouched by anything opt-in.
+  `tests/options.nix` asserts every option in both states for this reason —
+  the off state is the one a refactor breaks quietly. (#180, open at the time
+  of writing, adds `programs.nixarchy.installerManaged` to mark the other
+  mode; check whether it has merged before referring to it.)
+- **Comments explain WHY, and record what was tried and what went wrong.**
+  `installer/cd.nix`, `modules/flatpaks.nix` and `installer/vm.nix` are the
+  register. A comment that narrates what the next line does is noise; a
+  comment that says which approach failed and why saves the next agent from
+  re-failing it.
+- **`writeShellApplication` builds a strict PATH from `runtimeInputs`.** A
+  command your script calls and does not declare is a runtime failure that no
+  build catches.
+
+## 6. Commits and pull requests
+
+- The final commit subject is a full sentence describing the change — read
+  `git log --oneline -10` for the register. No `conventional-commits`
+  prefixes.
+- **Do not leave `wip:` on the last commit of a single-commit branch.** The
+  repository squashes using the commit subject when the branch has one
+  commit, and two `wip:` subjects are on `main` today because of it. Before
+  marking a PR ready: `git commit --amend` (or squash locally) so the subject
+  is the real one.
+- Fill in the PR template, including the section that asks for your check's
+  failing output. That section is §1 in form-field shape.
+
+## 7. Territory, and the failure no single PR can see
+
+When several agents work this repo at once, each PR should name the files it
+touches, and stay inside them. But the sharper lesson is this: two PRs, each
+green against a `main` that lacked the other, **broke `main`** (#137 + #141)
+— one moved a file, the other read it from the old place. No per-PR check can
+catch that; green CI on your branch is a statement about a `main` that may no
+longer exist.
+
+So: after anything merges to `main`, rebase before merging your own work, and
+let the checks run again on the rebased head. "It was green an hour ago" is
+not the same claim as "it is green against what `main` is now".
+
+## 8. When a check fails for reasons unrelated to your change
+
+First establish that it *is* unrelated: is `main` red too? One standing trap —
+opening an issue with the `epic` label without adding a row to README's
+Roadmap table fails CI **on every subsequent PR**, related or not (four times
+in one day: #105, #148, #159, #174; the guard is the "roadmap still matches
+the open epics" step in `build.yml`, and it fails the other way when an epic
+closes and the row remains).
+
+If the failure is unrelated: do not "fix" it inside your PR — that is scope
+the reviewer did not ask for and a second thing to review. Say in the PR what
+failed and why you believe it is unrelated, link the run, and if the cause is
+a repo-wide state (like a roadmap row), flag it to a human rather than
+editing README from a PR about something else.
+
+Do not retry-until-green. A flaky pass is a bug report you deleted.
+
+## 9. What not to do without asking a human
+
+- **Destructive git**: `push --force` to any shared branch, deleting branches
+  you did not create, rewriting published history, `git reset --hard` on work
+  that is not yours.
+- **Changing CI gates**: workflow triggers, required checks, the check
+  coverage guard, timeouts on the install job. These are the repo's immune
+  system; a PR may *propose* a change with reasoning, a human merges it.
+- **Repository settings**: anything under `gh api` that mutates the repo —
+  labels, protection, merge settings.
+- **Posting to other people's repositories.** Upstream is
+  `basecamp/omarchy`, and the routing rules in
+  `pkgs/omarchy/skills/nixarchy/contributing.md` apply to you exactly as to a
+  human: never file anywhere unprompted, and a fix to how Omarchy itself
+  behaves belongs upstream, not patched here — a patch carried here is
+  re-applied at every source bump; a fix landed upstream arrives for free.
+- **The `epic` label** — applying or removing it has CI consequences (§8)
+  that outlive your session.
+
+When in doubt, the cost asymmetry decides: a question costs a minute; an
+unwanted force-push or a misrouted issue costs a human an evening.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to nixarchy
+
+Two documents come before this one:
+
+- **Reporting a bug** is routed, not just filed — there are two projects here
+  and sending a report to the wrong one wastes everybody's time. The routing
+  rules live in
+  [`pkgs/omarchy/skills/nixarchy/contributing.md`](pkgs/omarchy/skills/nixarchy/contributing.md),
+  which is also what the AI agents on an installed machine follow. The short
+  version: *would this happen on Arch?* Yes → Omarchy's. No → nixarchy's.
+  Unsure → file it here.
+- **If you bring an AI coding agent** — most contributors do — point it at
+  [`AGENTS.md`](AGENTS.md) before it touches anything. It is a list of the
+  ways agents have actually broken things in this repo, with the reasons
+  attached. Most of it is worth a human's read too.
+
+What follows is the code-contribution process itself.
+
+## The one rule that outranks the others
+
+A change to how *Omarchy* behaves belongs upstream at
+[basecamp/omarchy](https://github.com/basecamp/omarchy), not here. Nixarchy
+tracks Omarchy releases as a source bump; a fix landed upstream arrives here
+for free, while a patch carried here has to be re-applied at every bump. If
+your fix would also fix Arch, it is not a nixarchy PR.
+
+## Setting up
+
+```sh
+gh repo fork olafkfreund/nixarchy --clone
+cd nixarchy
+nix develop            # nixd, statix, deadnix, qemu, gh
+```
+
+Two mechanics worth knowing before your first confusing error:
+
+- A flake sees only **tracked or staged** files. A new file you have not
+  `git add`ed fails evaluation with `path '…' does not exist`.
+- The installer checks require a **committed** tree — `installer/mkFlake.nix`
+  pins the generated flake by commit and throws otherwise. The commit can be
+  temporary; the final subject is what matters (see below).
+
+## Before pushing
+
+```sh
+nix fmt                                          # CI runs `nix fmt -- --ci`
+nix run nixpkgs#statix -- check .
+nix run nixpkgs#deadnix -- --fail .
+nix build .#omarchy                              # the vendored tree assembles
+```
+
+Then build the check nearest your change, by name — `nix flake check` is not
+how this repo runs its suite:
+
+```sh
+nix build .#checks.x86_64-linux.<name> --print-build-logs
+```
+
+`AGENTS.md` §4 has the full table of checks and what each costs. The one
+number to know: **`checks.install` gates every PR, takes ~25 minutes, and
+runs on a single self-hosted machine.** Concurrent PRs queue behind each
+other, so batch your pushes — every push restarts your own run and lengthens
+everyone else's wait.
+
+## What a change needs to bring with it
+
+**A check that provably fails without the change.** This repo has shipped
+checks that passed with the bug they were written for fully reintroduced, and
+the README's "What running it on real hardware found" section records three
+more that were structurally incapable of failing. So the standard is: break
+the thing, show the check going red, fix it, show it going green, and put the
+red output in the PR. A check that cannot fail is worse than no check,
+because it reads like coverage.
+
+**Comments that explain why**, including what was tried and did not work.
+`installer/cd.nix` and `modules/flatpaks.nix` are the register. And read the
+header of `modules/services/default.nix` before setting any NixOS option from
+a module — the priority rules there (`mkDefault` on scalars, plain assignment
+on lists and attrsets, `mkForce` never) exist because getting them wrong
+silently discards user configuration.
+
+**Both states, if it adds an option.** `tests/options.nix` asserts every
+option on and off, because the off state is the half nobody exercises and
+exactly what a refactor breaks quietly. Someone importing this module into a
+machine they already run must be untouched by anything they did not opt into.
+
+## Commits and PRs
+
+- The subject is a full sentence describing the change — `git log --oneline`
+  shows the register. No conventional-commit prefixes.
+- A single-commit branch is squashed using the **commit** subject, so do not
+  leave `wip:` on it; amend before marking the PR ready.
+- Fill in the PR template. Its questions are this document in form shape.
+- After something else merges to `main`, rebase and let CI run again. Two
+  PRs, each green against a `main` that lacked the other, have broken `main`
+  here; green-an-hour-ago is not green-against-now.
+
+## Issues, epics, and the roadmap
+
+Bug reports follow the routing doc linked at the top. One label carries
+machinery: an issue labelled `epic` must have a row in README's Roadmap
+table, and CI fails **every** PR until the two agree — in both directions,
+opening and closing. Leave that label to the maintainer.
+
+## Scope of the project
+
+Read "What is deliberately not planned" at the bottom of the README before
+proposing something in that territory. The reasoning there is the answer to
+the proposal, and it was expensive to earn.

--- a/README.md
+++ b/README.md
@@ -1591,6 +1591,21 @@ there rather than warning about it.
 authoritative list; this table is the summary and CI keeps it honest — an epic
 opened or closed without touching this section fails the build.
 
+## Contributing
+
+Contributions are welcome, and the process is written down rather than
+assumed. [`CONTRIBUTING.md`](CONTRIBUTING.md) is the way in for people;
+[`AGENTS.md`](AGENTS.md) is the way in for the AI agent most people bring
+with them — a priority-ordered list of the mistakes that have actually
+happened here, with the reasons attached. Bug reports are routed before they
+are filed, because two projects share this desktop:
+[the routing rules](pkgs/omarchy/skills/nixarchy/contributing.md) are the
+same ones the agents on an installed machine follow.
+
+The short version of the whole process: a fix that would also fix Arch
+belongs upstream, and a check that has never been seen failing has never
+been seen working.
+
 ## License
 
 Packaging is MIT. Vendored Omarchy is MIT, © Basecamp.


### PR DESCRIPTION
## What this changes, and why

The first outside contributor has arrived (#47, Nicolas25vlad) and the repo has no written process — for people or for the AI agents most people bring. This PR adds it, built from what actually went wrong here on 2026-09-01 rather than from generic advice:

- **`AGENTS.md`** — for AI coding agents. Priority-ordered by the mistakes that actually happened, each rule with its reason attached: the verification contract (a check for #133 passed with its bug fully reintroduced; `checks.installer-ui` was run by nothing and went green), verify under bash (zsh's non-splitting `for c in $names` produced PASS for working and broken alike), pipelines report the last command's status, worktree flakes see only tracked files, `mkFlake.nix` wants a committed tree, never `/tmp` (32 GB tmpfs), check costs (`checks.install`: ~25 min, one runner), the module priority rules by reference to `modules/services/default.nix`, territory and the #137+#141 two-green-PRs failure, the epic↔Roadmap CI guard, and what needs a human.
- **`CONTRIBUTING.md`** — for people. Cross-references `pkgs/omarchy/skills/nixarchy/contributing.md` for bug routing instead of duplicating it; setup, the pre-push commands, the verification contract, commit/PR conventions, the upstream-first rule.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — asks for the failing check output, warns about the single-commit squash subject.
- **`.github/ISSUE_TEMPLATE/`** — `config.yml` routes Arch-reproducible bugs, feature ideas and support to upstream; `bug.yml` asks the routing question and for the locked revisions.
- **`.github/CODEOWNERS`** — `* @olafkfreund`; routing today, precondition for required review if ever wanted.
- **`README.md`** — a short Contributing section before License, pointing at the three documents.

Note: PR #180 (`programs.nixarchy.installerManaged`) is still open, so `AGENTS.md` describes it as pending, not merged. Worth a one-line update when it lands.

## How I proved the check fails

Documentation only — no check added, none applicable. Every factual claim was verified against the tree: the coverage-guard step and roadmap guard in `build.yml`, the throw message in `installer/mkFlake.nix:23`, the priority rules in `modules/services/default.nix`, both-states testing in `tests/options.nix`, the checks→workflow mapping across all four workflows.

## Repo settings — recommendations, not changes

Two of yesterday's problems were settings, not discipline. In rough priority order:

1. **`squash_merge_commit_title: PR_TITLE`** (from `COMMIT_OR_PR_TITLE`). This is what put two `wip:` subjects on `main`: a single-commit branch squashes with the *commit* subject. The PR title is the artifact that was actually reviewed. Also set **`squash_merge_commit_message: PR_BODY`** — `COMMIT_MESSAGES` concatenates every wip commit message into the landed commit. The template's amend-your-subject warning stays useful either way (the commit subject is still what `git log` on the branch shows), but the setting removes the failure rather than documenting it.

2. **Branch protection on `main`**: require a pull request, require status checks, no force pushes. A PR merged with a check still pending — that is exactly what an unprotected `main` permits. Required checks: `lint`, `omarchy`, `system`, and `install`. On requiring `install` despite its cost: it already runs on every PR, so requiring it does not add compute — it only removes the ability to merge before it answers, which is the failure that happened. The real cost is merge latency (~25 min minimum, hours when the single runner is queued). If that becomes intolerable, the honest relaxation is to drop `install` from the *required* set while it keeps running, and accept that the nightly is then the first hard gate — but I would start strict and relax with evidence.

3. **"Require branches to be up to date before merging" (strict checks) — yes, with eyes open.** A merge queue is the clean answer to the #137+#141 class (two PRs each green against a `main` lacking the other), and it is **not available here**: GitHub merge queues require an organization-owned repo, and this one is user-owned. Strict checks are the available substitute: after anything merges, every other PR must rebase and re-run, which re-buys the 25-minute install per PR per merge. With ~7 concurrent PRs that is real money in queue time — but it is also the only mechanism on offer that makes "green" mean "green against current main". Alternative: move the repo into an org and get a real merge queue; that is a bigger decision than a settings toggle and only you can weigh it.

4. **`delete_branch_on_merge: true`.** Cheap, reversible (restorable from the PR page), and seven agents a day generate branch litter fast.

5. **Merge methods: squash only** (disable merge commits and rebase merges). All recent history is already squash-shaped (`(#N)` suffixes); leaving three methods enabled just means one misclick produces a merge commit or an unsquashed wip chain on `main`.

6. **CODEOWNERS / required review / restrict who can merge: file the CODEOWNERS (this PR does), turn nothing else on yet.** With one maintainer, "require review from code owners" blocks your own PRs — you cannot approve yourself — and ends up bypassed-by-admin routinely, which trains everyone that the gate is decorative. Outside contributors already cannot merge without write access, so restriction adds nothing today. Revisit both the day a second person has write access.

Where I am unsure: the required-`install` and strict-checks combination is the maximal-safety, maximal-latency corner, and with one self-hosted runner it may make a busy day genuinely painful. The settings are independent; if one has to give, relax strictness (recommendation 3) before un-requiring the install check (recommendation 2), because 3 defends against the rarer failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWz7pokWB96qmsUYucKQzG
