### PR TITLE
The install check reports on every pull request, so it can be required

### DIFF
--- a/.github/workflows/install-check.yml
+++ b/.github/workflows/install-check.yml
@@ -16,7 +16,7 @@ name: install check
 # (Pull requests are the one place where cancelling is right; see the
 # concurrency block below.)
 
-# It also runs on pull requests, and the filter below is a denylist on purpose.
+# It also runs on pull requests, and the filter is a denylist on purpose.
 #
 # For most of this repo's life it did not. It ran on main and nightly, so the
 # first real gate on "does an install still work" was main itself, and every PR
@@ -39,25 +39,30 @@ name: install check
 # filter because it still reads like coverage. That is the same failure this
 # whole file is about, one level down.
 #
-# So: `**` first, and then the handful of paths that provably cannot change
-# what an install produces. A new top-level directory is covered on the day it
-# appears, and dropping something out of coverage takes a deliberate line here.
-# .github/** is excluded because no workflow file can break an install -- with
-# this one re-included on the next line, since a change to how the gate runs
-# should be tested by the gate running.
+# So: everything is relevant, and then the handful of paths that provably
+# cannot change what an install produces are subtracted. A new top-level
+# directory is covered on the day it appears, and dropping something out of
+# coverage takes a deliberate line in the `gate` job below. .github/** is
+# excluded because no workflow file can break an install -- with this one
+# re-included, since a change to how the gate runs should be tested by the gate
+# running.
+#
+# That list used to live in `on: pull_request: paths:`, and #183 is why it does
+# not any more. A workflow filtered out at the `on:` level does not report a
+# skipped check; it reports NOTHING AT ALL. Measured, on #167 (docs-only): its
+# check-runs are `devenv-presets, lint, omarchy, system` and there is no
+# `install` entry of any kind. GitHub cannot express "required if it ran", so
+# requiring an absent context waits for a report that will never arrive, and a
+# docs-only PR is unmergeable forever.
+#
+# The denylist is therefore read one level in, by the `gate` job, and `install`
+# runs on every pull request and exits 0 when there is nothing to do. Then the
+# context always exists and can safely be a required check.
 
 on:
   push:
     branches: [main]
   pull_request:
-    paths:
-      - '**'
-      - '!docs/**'
-      - '!README.md'
-      - '!.envrc'
-      - '!.gitignore'
-      - '!.github/**'
-      - '.github/workflows/install-check.yml'
   workflow_dispatch:
 
 concurrency:
@@ -80,22 +85,97 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # The denylist, moved inside the workflow. Cheap, hosted, and deliberately
+  # not the required context: it decides, `install` reports.
+  gate:
+    name: gate
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+      runner: ${{ steps.filter.outputs.runner }}
+    steps:
+      - name: Decide whether this change can affect an install
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Anything that is not a pull request is not filtered. main and
+          # workflow_dispatch always ran the real thing and still do.
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            relevant=true
+          else
+            # The API, not `git diff`: actions/checkout gives this job a single
+            # commit by default, so a diff against the base needs a deepened
+            # fetch whose depth is a guess. The PR's file list is the same
+            # answer without one, and without a checkout at all.
+            files=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/files" \
+              --paginate --jq '.[].filename')
+
+            # Order matters and this loop is where it is expressed: the
+            # re-include is tested before the exclusions, so a change to this
+            # very file is relevant even though it lives under .github/.
+            # `case` globs are not path-aware -- `*` crosses `/` -- which is
+            # what makes `docs/*` and `.github/*` cover nested files.
+            relevant=false
+            while IFS= read -r f; do
+              [ -n "$f" ] || continue
+              case "$f" in
+                .github/workflows/install-check.yml) relevant=true; break ;;
+                # Provably cannot change what an install produces.
+                docs/*|README.md|AGENTS.md|CONTRIBUTING.md|.envrc|.gitignore|.github/*)
+                  continue ;;
+                *) relevant=true; break ;;
+              esac
+            done <<EOF
+          $files
+          EOF
+          fi
+
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+
+          # And which machine `install` should ask for. A run with nothing to
+          # do must not queue for the one self-hosted box -- seven concurrent
+          # PRs queue there for about three hours, and a docs PR waiting in
+          # that line for a check it is not going to run is the old bug wearing
+          # a different hat.
+          if [ "$relevant" = true ]; then
+            echo 'runner=["self-hosted","nixos","kvm","big"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'runner=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "relevant=$relevant" >> "$GITHUB_STEP_SUMMARY"
+
   install:
     name: install
+    needs: gate
+
+    # No `if:` on this job, and that is the whole fix -- measured, not assumed.
+    # A probe run with three jobs reported: a job skipped by a job-level `if:`
+    # appears as a check-run with conclusion `skipped`, and `skipped` is not
+    # `success`, so requiring it blocks the merge just as an absent context
+    # does. The same job with the `if:` moved onto its steps reported
+    # `success`. So the steps below carry the condition and the job always
+    # completes green.
+    #
     # p510: 40 cores, 94 GB, /dev/kvm, and a pool with room for the images.
     # This job boots a VM, installs a desktop onto a blank disk, boots the
     # result on its own bootloader and asserts a rebuild builds nothing. None
     # of that fits on a hosted runner -- fourteen gigabytes of disk and no KVM
     # worth the name -- and it is the only check that exercises the artefact a
-    # person actually receives.
-    runs-on: [self-hosted, nixos, kvm, big]
+    # person actually receives. When there is nothing to do it asks for a
+    # hosted runner instead, which is what the fromJSON is for: `runs-on`
+    # takes an expression, but a label LIST has to arrive as JSON.
+    runs-on: ${{ fromJSON(needs.gate.outputs.runner) }}
 
     # No job-level concurrency: the `concurrency:` at the top of this file
     # already says it, and saying it twice is how the first version came to
-    # look protected while being cancelled every time. (There used to be a line
-    # here noting there was no `if:` guarding pull_request either. There was
-    # nothing to guard: pull requests did not reach this file at all. They do
-    # now, and the `on:` block above is the only place that decides which.)
+    # look protected while being cancelled every time.
     #
     # 90, not 45: this job does two full installs now. The old number was sized
     # for one, and a timeout is recorded as `cancelled` -- which reads like
@@ -104,12 +184,20 @@ jobs:
     timeout-minutes: 90
 
     steps:
+      - name: Nothing here can affect an install
+        if: needs.gate.outputs.relevant != 'true'
+        run: |
+          echo "Only paths the gate excludes changed; not building." \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/checkout@v5
+        if: needs.gate.outputs.relevant == 'true'
 
       # No installer action, no cachix. The runner is a NixOS machine with a
       # warm store, which is most of why this is ten minutes rather than an
       # hour.
       - name: Install onto a blank disk and boot the result
+        if: needs.gate.outputs.relevant == 'true'
         run: nix build .#checks.x86_64-linux.install --print-build-logs
 
       # The same machine, and the one check in the repo whose failure means
@@ -122,10 +210,11 @@ jobs:
       # some way that has nothing to do with partitioning, checks.install says
       # so in a tenth of the log.
       - name: Install into free space and prove the neighbour survived
+        if: needs.gate.outputs.relevant == 'true'
         run: nix build .#checks.x86_64-linux.free-space --print-build-logs
 
       - name: Report what it cost
-        if: always()
+        if: always() && needs.gate.outputs.relevant == 'true'
         run: |
           # The installer's own figure, not the driver's, and the same one the
           # finish screen shows. checks.install already fails above a budget;


### PR DESCRIPTION
Fixes #183.

## What this changes, and why

`checks.install` was filtered at the `on: pull_request: paths:` level. A workflow
filtered out there does not report a skipped check — it reports **nothing at all**.
GitHub cannot express "required if it ran", so adding `install` to the required
contexts would make every docs-only PR wait forever for a report that never
arrives: unmergeable, permanently.

The denylist moves one level in. `on: pull_request:` is now unfiltered; a cheap
hosted `gate` job reads the PR's file list and decides; the `install` job runs on
**every** pull request and exits 0 when there is nothing to do. Same denylist,
same #162 argument for a denylist over an allowlist, read in a different place.
Per the comment on #183 it also now excludes `AGENTS.md` and `CONTRIBUTING.md`
(`CODEOWNERS` already fell under `.github/**`).

Two details worth the reviewer's eye:

- **The condition is on the steps, not the job.** A job-level `if:` would be the
  obvious shape and it reintroduces the bug — see the measurement below.
- **`runs-on` is computed.** A run with nothing to do must not queue for the one
  self-hosted box; seven concurrent PRs queue there for ~3h, and a docs PR sitting
  in that line for a check it will not run is the old bug wearing a different hat.
  So the gate emits a JSON label list and `install` takes `ubuntu-latest` when
  irrelevant, `[self-hosted, nixos, kvm, big]` when relevant.

## How I proved the check fails

Three separate claims, three separate measurements. None of this is from memory.

### 1. The bug is real: a path-filtered check is *absent*, not skipped

`#167` is docs-only, on the current `main`:

```
$ gh api repos/olafkfreund/nixarchy/commits/16135532e9957e089b05e2e77d670ed9958dfe5f/check-runs \
    --jq '.check_runs[] | "\(.name)\t\(.status)\t\(.conclusion)"' | sort
devenv-presets	completed	success
lint		completed	success
omarchy		completed	failure
system		completed	success
```

No `install` row of any kind. Required-but-absent is the deadlock.

### 2. The obvious alternative shape reintroduces it

I did not want to reason about how a skipped job reports, so I pushed a throwaway
branch (`probe/check-run-reporting`, commit `4e894c4`) with three jobs: a gate, a
job skipped by a **job-level `if:`**, and a job that always runs with the `if:` on
its **steps** and a `fromJSON` `runs-on`.

```
$ gh api repos/olafkfreund/nixarchy/commits/4e894c45a6fdb199581c14acc4677d4de5c4ed6d/check-runs \
    --jq '.check_runs[] | "\(.name)\t\(.status)\t\(.conclusion)"' | sort
gate			completed	success
probe-job-level-if	completed	skipped
probe-steps-conditional	completed	success
```

So a `needs:`-gated skipped job *does* report — as `skipped`, which is not
`success`, so requiring it blocks the merge exactly as an absent context does.
Only the steps-conditional shape reports `success`. That measurement also
confirms `runs-on: ${{ fromJSON(...) }}` is accepted.

Worth stating flatly, because the intuitive model is wrong in a way that yields
the same symptom by a different mechanism: **absent and `skipped` are not the same
thing.** A workflow filtered out at `on:`/`paths:` emits no context at all; a job
skipped by a job-level `if:` emits one with conclusion `skipped`. Both block a
required check, for different reasons, and they would be fixed differently. I went
into this expecting a skipped job to report nothing, and the probe says otherwise —
which is the whole reason to run a probe rather than trust the expectation. Anyone
changing this workflow later should re-measure rather than re-derive.

(The one link I have **not** tested directly is that branch protection rejects
`skipped`; changing protection is the maintainer's call. It does not matter for
the choice made here — `success` is unambiguously safe either way.)

### 3. The gate logic itself, broken and restored

`tests/` has no home for a workflow step, so I ran the step **extracted verbatim
from the YAML** (`yq -r '.jobs.gate.steps[0].run'`) against a table of file sets
with `gh` stubbed, under bash. Broken first — the re-include moved *after* the
`.github/*` exclusion, the exact ordering trap the issue comment warns about:

```
PASS  README.md only                                       relevant=false
PASS  docs/, nested                                        relevant=false
PASS  AGENTS.md (added by #183 comment)                    relevant=false
PASS  CONTRIBUTING.md (added by #183)                      relevant=false
PASS  .envrc / .gitignore                                  relevant=false
PASS  another workflow                                     relevant=false
PASS  CODEOWNERS (lives under .github/)                    relevant=false
PASS  no files at all                                      relevant=false
FAIL  the gate itself is re-included                       want=true got=false
FAIL  re-include wins from any position                    want=true got=false
PASS  installer/                                           relevant=true
PASS  flake.nix                                            relevant=true
PASS  docs plus one real file                              relevant=true
PASS  a top-level dir nobody has added yet                 relevant=true
PASS  push to main is never filtered                       relevant=true

FAILURES
harness exit=1
```

Restored, the same harness prints `ALL PASS` / `harness exit=0`.

### 4. End to end, on real PRs

- **Filtered path → real run.** *This* PR touches only
  `.github/workflows/install-check.yml`, which the denylist deliberately
  re-includes, so `install` takes the self-hosted runner and does the full
  ~25 minute install + free-space install. Result linked below.
- **Non-filtered path → reports green without building.** Proved on #188, a probe
  stacked on this branch and now **closed unmerged** — it could not be left open,
  because `delete_branch_on_merge` would have deleted this PR's branch out from
  under it and auto-closed it beyond recovery (#102 and #178 went that way). Its
  runs are transcribed verbatim in the comment below: `README.md` alone, and
  `README.md` + `AGENTS.md`, both `install completed/success` in three seconds on
  `ubuntu-latest` with every expensive step skipped. The second run is there
  because `AGENTS.md` is a *new* exclusion in this PR and the plain docs case
  would have passed with or without it.

## Checks run locally

- `actionlint .github/workflows/install-check.yml` — clean
- `bash -n` on the extracted gate step — clean
- the gate table above, under bash
- no `.nix` files touched, so no flake check is implicated; `install` and
  `free-space` are still named by a workflow matching `^  pull_request:`, which is
  what build.yml's coverage guard greps for

- [x] `nix fmt` / statix / deadnix are clean (no Nix changed)
- [x] New files are `git add`ed (no new files)
- [x] If this adds an option: n/a
- [x] If this adds a `checks.*` entry: n/a — no new check; this **is** a CI-gate
      change and needs maintainer sign-off per AGENTS.md §9

## For the maintainer

Once this is merged and the two runs below are green, `install` is safe to add to
the required contexts on `main`. I have not touched branch protection.

