### PR TITLE
[verification for #187] docs-only PR: install must report, not vanish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,3 +190,5 @@ Do not retry-until-green. A flaky pass is a bug report you deleted.
 
 When in doubt, the cost asymmetry decides: a question costs a minute; an
 unwanted force-push or a misrouted issue costs a human an evening.
+
+<!-- #183: proving the AGENTS.md exclusion end-to-end, not just in the harness. -->

--- a/README.md
+++ b/README.md
@@ -1611,3 +1611,5 @@ been seen working.
 ## License
 
 Packaging is MIT. Vendored Omarchy is MIT, © Basecamp.
+
+<!-- #183: proving the install check reports on a docs-only PR. -->


### PR DESCRIPTION
Not for merge — evidence for #187 / #183.

Touches **only** `README.md`, which the denylist excludes. Against the workflow on the base branch (`fix/install-check-required`), the `install` context must **exist and be green**, having built nothing, on `ubuntu-latest`.

The counterfactual is #167 on today's `main`: docs-only, and `install` is absent from its check-runs entirely.

Close and delete this branch when #187 lands. **Do not delete the base branch** `fix/install-check-required` while this is open.