### PR TITLE
The doctor names a tmpfs /tmp too small for the closure, which nix reports as a full disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,8 +934,8 @@ nix run github:olafkfreund/nixarchy#doctor
 It reads the running system and prints the configuration that machine needs --
 before nixarchy is an input anywhere. It changes nothing.
 
-Two of the things it reports are worth knowing about in advance, because both
-fail *silently* rather than loudly:
+Three of the things it reports are worth knowing about in advance, because
+each fails *silently*, or misleadingly, rather than loudly:
 
 **Your session may be running an older build than the one installed.**
 `OMARCHY_PATH` and `PATH` are set at login and keep pointing at whichever store
@@ -953,6 +953,15 @@ Manager produces, and the right way to declare it -- `xdg-settings` fails on the
 read-only file and *still exits 0*. `omarchy-default-browser`'s `|| exit 1` never
 fires. Nothing is broken and nothing says so, which is the only reason it is
 worth a section: the fix lives in a file the menu cannot reach.
+
+**A tmpfs `/tmp` smaller than 64 GiB will fail a rebuild as a full disk.** Nix
+builds in `$TMPDIR`. When that is a tmpfs it is RAM, not the filesystem `df`
+reports on, and a desktop rebuild unpacking several large sources at once
+(`cef-binary` alone is ~1.9 GiB unpacked) can exhaust it. What you get is `No
+space left on device` and nix's own hint to check free disk space -- on a
+machine with hundreds of gigabytes free. Nothing in the error names tmpfs, RAM
+or `$TMPDIR`. The doctor names the size and both remedies, and sets neither:
+`boot.tmp.*` is your machine's memory policy.
 
 Then, in order:
 

--- a/pkgs/doctor.sh
+++ b/pkgs/doctor.sh
@@ -255,6 +255,115 @@ if [ -d /etc/snapper/configs ] && [ -n "$(ls -A /etc/snapper/configs 2>/dev/null
   say ""
 fi
 
+# ---- $TMPDIR on a tmpfs too small for what nix unpacks into it -----------
+# Nix builds in $TMPDIR. When that is a tmpfs it is RAM, and running out of it
+# surfaces as ENOSPC -- which sends you to `df /`, which reports the disk, which
+# is fine. Observed on a 251 GiB machine with a 32 GiB /tmp: cef-binary,
+# ctranslate2, aerion and gnome-initial-setup all died with "No space left on
+# device" while / had 289 GiB free, and nix's own hint ("build failure may have
+# been caused by lack of free disk space") closed off the only line of enquiry
+# it offered. Nothing in the output says tmpfs, RAM, /tmp or $TMPDIR.
+#
+# nixarchy sets nothing about /tmp and must not: boot.tmp.* is the machine's
+# memory policy, the same reasoning that keeps the bootloader untouched. An
+# installer-built machine has boot.tmp.useTmpfs = false -- the nixpkgs default
+# -- and never sees this. So this names it and stops.
+#
+# /proc/self/mountinfo rather than findmnt, for the same reason mounted_btrfs
+# reads it: util-linux is not in this script's runtimeInputs. It also answers
+# the question the option cannot -- boot.tmp.useTmpfs is not the only way /tmp
+# becomes a tmpfs, and what is mounted is what nix will write into.
+tmp_dir=${TMPDIR:-/tmp}
+
+# The mount a path is on is the longest mountpoint that prefixes it. mountinfo's
+# optional fields are variable in number and end at a lone "-", so fstype and
+# super options are only addressable relative to that separator.
+read -r tmp_fstype tmp_opts <<<"$(
+  awk -v target="$tmp_dir" '
+    {
+      sep = 0
+      for (i = 7; i <= NF; i++) if ($i == "-") { sep = i; break }
+      if (!sep) next
+      mp = $5
+      pfx = (mp == "/") ? "/" : mp "/"
+      if (index(target "/", pfx) == 1 && length(mp) >= length(best)) {
+        best = mp; fstype = $(sep + 1); opts = $(sep + 3)
+      }
+    }
+    END { print fstype, opts }
+  ' /proc/self/mountinfo
+)"
+
+if [ "$tmp_fstype" = tmpfs ]; then
+  mem_kb=$(awk '/^MemTotal:/ { print $2 }' /proc/meminfo)
+  # A tmpfs mounted with no size= is half of RAM and prints no size= at all,
+  # so an empty match here is a real answer rather than a parse failure.
+  tmp_kb=$(sed -n 's/.*size=\([0-9]*\)k.*/\1/p' <<<"$tmp_opts")
+  [ -n "$tmp_kb" ] || tmp_kb=$((mem_kb / 2))
+
+  # 64 GiB, and the gap it sits in is where the number comes from: 32 GiB is
+  # the size that demonstrably failed on a desktop rebuild with parallel
+  # unpacks, 128 GiB is the size that fixed the same rebuild, and 64 is the
+  # only power of two between them. Anything at or below the known-bad size has
+  # to fire; a machine already set generously has to stay quiet, or this
+  # becomes a warning people learn to scroll past.
+  #
+  # The threshold is deliberately not "any tmpfs /tmp". A tmpfs /tmp is a
+  # normal NixOS choice and on its own predicts nothing.
+  # Half of RAM, rounded up to the next power of two. `tmpfsSize = "125G"`
+  # reads like a measurement someone took, and it is not one: tmpfs allocates
+  # lazily, so this is a ceiling and overshooting half of RAM costs nothing
+  # until something fills it. Rounding up rather than down is also what
+  # reproduces the value that actually fixed the machine this came from --
+  # 251 GiB of RAM, and 128G.
+  want_gib=64
+  while [ $((want_gib * 1048576)) -lt $((mem_kb / 2)) ]; do
+    want_gib=$((want_gib * 2))
+  done
+
+  if [ "$tmp_kb" -lt 67108864 ]; then
+    say "${bold}Build space${off}"
+    finding "$tmp_dir is a $(awk -v k="$tmp_kb" 'BEGIN { printf (k < 10485760 ? "%.1f" : "%.0f"), k / 1048576 }') GiB tmpfs" "$warn" ""
+    say "     Nix builds in \$TMPDIR, and here that is ${bold}RAM${off} -- not the filesystem"
+    say "     ${dim}df${off} reports on. A desktop rebuild unpacks several large sources at"
+    say "     once (cef-binary alone is ~1.9 GiB unpacked) and ${dim}max-jobs = auto${off} runs"
+    say "     a dozen of them concurrently. This has failed as ${dim}No space left on"
+    say "     ${dim}device${off} on a machine with 289 GiB free on its root disk, with"
+    say "     nothing in the error naming tmpfs, RAM or \$TMPDIR."
+    say ""
+    if [ $((mem_kb / 2)) -ge 67108864 ]; then
+      say "     Now, without a reboot -- tmpfs allocates lazily, so a bigger size is"
+      say "     a ceiling and not a reservation:"
+      say ""
+      say "       ${dim}sudo mount -o remount,size=${want_gib}G $tmp_dir${off}"
+      say ""
+      say "     Then one of these, in your own configuration:"
+      say ""
+      say "       ${dim}boot.tmp.tmpfsSize = \"${want_gib}G\";${off}"
+      say "       ${dim}boot.tmp.useTmpfs = false;${off}   # /tmp on disk, the nixpkgs default"
+      say ""
+      say "     Either needs a ${bold}reboot${off}: a switch does not remount $tmp_dir."
+    else
+      say "     Half this machine's RAM is only $((mem_kb / 2097152)) GiB, so there is no ceiling"
+      say "     worth raising to. Put it on disk instead:"
+      say ""
+      say "       ${dim}boot.tmp.useTmpfs = false;${off}   # the nixpkgs default"
+      say ""
+      say "     That needs a ${bold}reboot${off}: a switch does not remount $tmp_dir."
+    fi
+    say ""
+    say "     Exporting TMPDIR before the rebuild does ${bold}not${off} move the build --"
+    say "     nixos-rebuild and nh hand the work to nix-daemon, which has its own"
+    say "     environment. The daemon-level version of that is:"
+    say ""
+    say "       ${dim}systemd.services.nix-daemon.environment.TMPDIR = \"/var/tmp\";${off}"
+    say ""
+    say "     ${dim}nixarchy sets none of this. It is your machine's memory policy.${off}"
+    notes+=("$tmp_dir is a tmpfs, so nix builds into RAM rather than the disk df reports on. It is sized below what a desktop closure needs when max-jobs runs large unpacks in parallel, and the failure mode is ENOSPC on a machine with hundreds of gigabytes free -- an error that names neither tmpfs nor \$TMPDIR. Raise boot.tmp.tmpfsSize, or set boot.tmp.useTmpfs = false; both need a reboot, and nixarchy will not choose for you.")
+    say ""
+  fi
+fi
+
 # ---- the default browser, and whether the menu can change it -------------
 # Setup > Default browser runs omarchy-default-browser, which ends in
 #

--- a/tests/session.nix
+++ b/tests/session.nix
@@ -1079,6 +1079,48 @@ pkgs.testers.runNixOSTest {
     assert "displayManager = false" not in report, (
         "the doctor told an SDDM machine to turn SDDM off")
 
+    # ---- $TMPDIR on a tmpfs (#186) ---------------------------------------
+    # Asserted in both directions from inside the VM, because the value of
+    # this finding is entirely in when it stays quiet. A doctor that warns on
+    # every machine is one nobody reads, and a check only ever run against the
+    # quiet case is how the #133 check stayed green through the bug it existed
+    # to catch. TMPDIR is set explicitly rather than trusting whatever this
+    # VM's /tmp happens to be, so both cases are the same on every runner.
+    print(machine.succeed("cat /proc/self/mountinfo | grep ' /tmp '  || true"))
+
+    on_disk = machine.succeed(
+        user % "TMPDIR=/var/tmp ${doctor}/bin/nixarchy-doctor 2>&1 || true")
+    assert "Build space" not in on_disk, (
+        "the doctor raised the tmpfs finding for a $TMPDIR on the root disk")
+
+    # 8 GiB is under the 64 GiB threshold and over what this VM has, which is
+    # fine: tmpfs allocates lazily, so the ceiling is declarable on a machine
+    # that could never fill it -- the same property that makes raising it the
+    # cheap remedy.
+    machine.succeed("mkdir -p /smalltmp && mount -t tmpfs -o size=8G tmpfs /smalltmp")
+    on_tmpfs = machine.succeed(
+        user % "TMPDIR=/smalltmp ${doctor}/bin/nixarchy-doctor 2>&1 || true")
+    machine.succeed("umount /smalltmp")
+    print(on_tmpfs)
+
+    # The size, because "low disk space" is the message that sent someone to
+    # df and cost them the afternoon; and a remedy, because naming a problem
+    # without one is the same failure in a different font.
+    assert "8.0 GiB tmpfs" in on_tmpfs, on_tmpfs
+    assert "boot.tmp.useTmpfs = false" in on_tmpfs, on_tmpfs
+
+    # And it must not offer to set it for them: boot.tmp.* is the machine's
+    # memory policy, which nixarchy leaves alone for the same reason it leaves
+    # the bootloader alone. The paste block stays clean.
+    # Bounded at "Worth knowing", which is prose *about* boot.tmp and is
+    # supposed to mention it. Without that bound this assertion fired on the
+    # note rather than the snippet -- a check failing for the wrong reason,
+    # which is only marginally better than one passing for the wrong reason.
+    snippet_block = on_tmpfs.split(
+        "Add this to your configuration")[1].split("Worth knowing")[0]
+    assert "boot.tmp" not in snippet_block, (
+        "the doctor put boot.tmp into the snippet it tells people to paste")
+
     # ---- the Omarchy session entry ---------------------------------------
     # What lets nixarchy sit beside an existing Hyprland: a session of its own
     # that names Omarchy's hyprland.lua with --config, rather than needing to


### PR DESCRIPTION
Closes #186.

## What this changes, and why

`nix` builds in `$TMPDIR`. When that is a tmpfs, it is RAM — and running out of
it surfaces as `No space left on device` plus nix's own hint to check free disk
space, which sends you to `df /`, which reports the disk, which is fine. On the
p620 that cost an afternoon: a 32 GiB `/tmp`, `max-jobs = auto`, a dozen large
unpacks in flight, four packages dead with ENOSPC and 289 GiB free on the root
disk. Nothing in the output names tmpfs, RAM, `/tmp` or `$TMPDIR`.

`pkgs/doctor.sh` gains a **Build space** finding that says the three things the
error does not: that nix builds in `$TMPDIR`, that here that is RAM rather than
the filesystem `df` reports on, and the remedies. It sets nothing — `boot.tmp.*`
is the machine's memory policy, the same reasoning that leaves the bootloader
alone — and `boot.tmp` never enters the snippet the doctor tells people to
paste (asserted).

**Detection** reads `/proc/self/mountinfo`, not `boot.tmp.useTmpfs`: systemd or
the user's own `fileSystems` entry can make `/tmp` a tmpfs too, and what is
mounted is what nix writes into. It uses the same reader as the #171
`mounted_btrfs` helper and for the same reason — util-linux is not in the
doctor's `runtimeInputs`, so `findmnt` does not exist here. It resolves
`${TMPDIR:-/tmp}` to the longest mountpoint that prefixes it, so a `$TMPDIR`
somewhere other than `/tmp` is judged on the mount it is actually on.

**The threshold is 64 GiB**, and the gap it sits in is where the number comes
from: 32 GiB is the size that demonstrably failed on a desktop rebuild with
parallel unpacks, 128 GiB is the size that fixed the same rebuild, and 64 is the
only power of two between them. Anything at or below the known-bad size has to
fire; a machine already set generously has to stay quiet. It deliberately does
*not* warn on "any tmpfs `/tmp`" — that is a normal NixOS choice and on its own
predicts nothing, and a doctor that always warns is a doctor nobody reads.

The suggested ceiling is half of RAM rounded **up** to the next power of two,
which on the 251 GiB machine this came from reproduces the value that actually
fixed it (`128G`). On a machine whose RAM cannot back 64 GiB there is no ceiling
worth raising to, so that branch offers only `boot.tmp.useTmpfs = false`.

Two things the finding gets right that the issue's own summary did not:
`nixos-rebuild` and `nh` hand the work to `nix-daemon`, so **exporting `TMPDIR`
in your shell does not move the build** — the daemon-level form is given
instead; and both declarative remedies need a **reboot**, because a `switch`
does not remount `/tmp`. The `mount -o remount` line is offered first for that
reason.

### What a user sees

```
Build space
  /mnt/data/vmtest/smalltmp is a 8.0 GiB tmpfs
     Nix builds in $TMPDIR, and here that is RAM -- not the filesystem
     df reports on. A desktop rebuild unpacks several large sources at
     once (cef-binary alone is ~1.9 GiB unpacked) and max-jobs = auto runs
     a dozen of them concurrently. This has failed as No space left on
     device on a machine with 289 GiB free on its root disk, with
     nothing in the error naming tmpfs, RAM or $TMPDIR.

     Now, without a reboot -- tmpfs allocates lazily, so a bigger size is
     a ceiling and not a reservation:

       sudo mount -o remount,size=128G /mnt/data/vmtest/smalltmp

     Then one of these, in your own configuration:

       boot.tmp.tmpfsSize = "128G";
       boot.tmp.useTmpfs = false;   # /tmp on disk, the nixpkgs default

     Either needs a reboot: a switch does not remount /mnt/data/vmtest/smalltmp.

     Exporting TMPDIR before the rebuild does not move the build --
     nixos-rebuild and nh hand the work to nix-daemon, which has its own
     environment. The daemon-level version of that is:

       systemd.services.nix-daemon.environment.TMPDIR = "/var/tmp";

     nixarchy sets none of this. It is your machine's memory policy.
```

plus a line under **Worth knowing**, and nothing at all on a machine whose
`$TMPDIR` is on disk.

## How I proved the check fails

Verified against **real mounts**, not reasoning: an 8 GiB tmpfs, this machine's
own 128 GiB tmpfs `/tmp`, a **4 GiB ext4 loopback**, and a multi-terabyte ext4.
The small ext4 is there on purpose — it is the case that separates this finding
from the naive "low free space" version, which fires on it.

```
== mounts under test ==
/mnt/data/vmtest/smalltmp        tmpfs    rw,size=8388608k
/tmp                             tmpfs    rw,size=134217728k
/mnt/data/vmtest/smalldisk       ext4     rw
/mnt/data                        ext4     rw
```

Four breaks, each red:

```
### BREAK A -- threshold can never fire
--- small tmpfs (8 GiB)     expect=fire  got=quiet  FAIL
--- big tmpfs   (128 GiB)   expect=quiet got=quiet  PASS
--- small disk  (4 GiB)     expect=quiet got=quiet  PASS
--- big disk    (ext4)      expect=quiet got=quiet  PASS
OVERALL: FAIL

### BREAK B -- size read from the wrong mountinfo field (source, not super options)
--- small tmpfs (8 GiB)     expect=fire  got=quiet  FAIL
--- big tmpfs   (128 GiB)   expect=quiet got=quiet  PASS
--- small disk  (4 GiB)     expect=quiet got=quiet  PASS
--- big disk    (ext4)      expect=quiet got=quiet  PASS
OVERALL: FAIL

### BREAK C -- threshold raised until every tmpfs warns (the cry-wolf version)
--- small tmpfs (8 GiB)     expect=fire  got=fire   PASS
--- big tmpfs   (128 GiB)   expect=quiet got=fire   FAIL
--- small disk  (4 GiB)     expect=quiet got=quiet  PASS
--- big disk    (ext4)      expect=quiet got=quiet  PASS
OVERALL: FAIL

### BREAK D -- the naive check: free space, on whatever filesystem it is
--- small tmpfs (8 GiB)     expect=fire  got=fire   PASS
--- big tmpfs   (128 GiB)   expect=quiet got=quiet  PASS
--- small disk  (4 GiB)     expect=quiet got=fire   FAIL
--- big disk    (ext4)      expect=quiet got=quiet  PASS
OVERALL: FAIL

### RESTORED
--- small tmpfs (8 GiB)     expect=fire  got=fire   PASS
--- big tmpfs   (128 GiB)   expect=quiet got=quiet  PASS
--- small disk  (4 GiB)     expect=quiet got=quiet  PASS
--- big disk    (ext4)      expect=quiet got=quiet  PASS
OVERALL: PASS
```

A first attempt at Break B *passed on broken code* — AGENTS.md §1 happening
live. Dropping the tmpfs gate left the "no `size=` means half of RAM" fallback
to rescue the ext4 case, so the case could not vary with the bug. That is why
the small ext4 loopback and Break D exist: they are the pair that actually
discriminates. The loop runs under `#!/usr/bin/env bash` as a script, per §1.

`tests/session.nix` carries the same both-ways assertion into CI: the report
must be silent for a `$TMPDIR` on the root disk, and on a tmpfs mounted at
8 GiB inside the VM it must name the size and a remedy — and must not put
`boot.tmp` into the paste block. That last one **failed on its first run**,
which is how I know it is wired to something:

```
> AssertionError: the doctor put boot.tmp into the snippet it tells people to paste
```

The snippet split was unbounded and swallowed the "Worth knowing" note, which
is prose *about* `boot.tmp` and is supposed to mention it. Bounded at
"Worth knowing", it is green. The VM also exercises the low-RAM branch, since a
test VM has 4 GiB:

```
Build space
  /smalltmp is a 8.0 GiB tmpfs
     ...
     Half this machine's RAM is only 2 GiB, so there is no ceiling
     worth raising to. Put it on disk instead:

       boot.tmp.useTmpfs = false;   # the nixpkgs default
```

## Checks run locally

- `nix build .#checks.x86_64-linux.options` — green
- `nix build .#checks.x86_64-linux.session` — green (this PR edits `tests/session.nix`)
- `nix fmt -- --ci`, `statix check`, `deadnix --fail` — all clean

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (no new files; `pkgs/doctor.sh` is tracked)
- [x] If this adds an option: n/a — this adds no option
- [x] If this adds a `checks.*` entry: n/a — no new `checks.*` entry, so no
      workflow edit is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpJ1uSSA3PyghfQPU6WH3A
