### PR TITLE
Roadmap: #6 and #112 are done, and #159 is not 'not started'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1561,11 +1561,19 @@ is the shape.
 
 | epic | what it is for | |
 | --- | --- | --- |
-| [#6](https://github.com/olafkfreund/nixarchy/issues/6) | **bare metal to a desktop** — the installer, the ISO, the release | 18 of 22 done |
-| [#112](https://github.com/olafkfreund/nixarchy/issues/112) | **getting back** — snapshots, backup, restore | not started |
-| [#159](https://github.com/olafkfreund/nixarchy/issues/159) | **remote desktop** — reaching the Hyprland session from elsewhere | not started |
+| [#159](https://github.com/olafkfreund/nixarchy/issues/159) | **remote desktop** — reaching the Hyprland session from elsewhere | 3 of 5 done |
 
 **Recently finished:**
+[bare metal to a desktop](https://github.com/olafkfreund/nixarchy/issues/6)
+— all 22 of it: disko layout, generated flake, interactive and unattended
+install, a bootable ISO that autostarts it, release automation, free-space
+install alongside an existing OS, and a boot splash that is ours on both the
+live image and the installed machine. Also
+[getting back](https://github.com/olafkfreund/nixarchy/issues/112)
+— an ownership marker that makes every destructive action refuse on a machine
+nixarchy did not write, config-repo drift surfaced rather than left to rot, an
+allowlisted `$HOME` backup, and a factory baseline taken at install time that a
+reset has something to return to. Also
 [per-project developer environments](https://github.com/olafkfreund/nixarchy/issues/148)
 — `nixarchy dev init react` scaffolds a devenv project that activates at the
 next prompt, in bash, zsh and fish. Off unless you select it. Also


### PR DESCRIPTION
`main` is currently in the state its own guard rejects: #6 and #112 are closed and still listed as planned, so every PR fails `build` until this lands.

## Why it could not be one PR with the merge

The guard checks both directions — an open epic missing from the table, and a listed epic that has since closed:

| row | epic | CI |
|---|---|---|
| present | open | pass |
| absent | open | fail — open and not listed |
| present | **closed** | fail — closed but still listed |
| absent | closed | pass |

There is no ordering in which one PR does both halves. The way through is that the guard reads epic state **live from GitHub** and the README **from the branch**: closing #6 and #112 first puts this branch in the bottom row.

## Verified both ways, under bash

```
GOOD     open=[159]  roadmap=[159]      RESULT: PASS
BROKEN   open=[159]  roadmap=[159 6]    ::error::epic #6 is closed but the Roadmap still lists it
                                        RESULT: FAIL
RESTORED open=[159]  roadmap=[159]      RESULT: PASS
```

My first attempt at that break test reported PASS on the broken README. It ran under zsh, which does not word-split unquoted expansions, so `for n in $roadmap` iterated once with the literal string `159\n6` and `gh issue view` got a garbage argument. CI runs bash. Re-run under bash it fails correctly, as above.

## Also

#159's status column read "not started" while #154, #155 and #156 had all landed. Now "3 of 5 done" — #157 and #158 remain.