### PR TITLE
The manual page about many machines is in the manual's sidebar

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -39,6 +39,7 @@ nav:
   - { path: /manual/gaming,                   title: Gaming }
   - { path: /manual/security,                 title: Security }
   - { path: /manual/system-snapshots,         title: System Snapshots }
+  - { path: /manual/many-machines,            title: "Many machines, one repo" }
   - { path: /manual/dual-boot-install,        title: Dual Boot Install }
   - { path: /manual/unattended-installs,      title: Unattended Installs }
   - { path: /manual/troubleshooting,          title: Troubleshooting }


### PR DESCRIPTION
## What this changes, and why

`docs/manual/many-machines.md` shipped with #147 and was never added to the
`nav` list in `docs/_config.yml`. GitHub Pages has been serving it at
`/nixarchy/manual/many-machines` (HTTP 200) ever since, with nothing on the
site linking to it — the only way to arrive was to already know the URL.

One line. The title is quoted because a comma inside a YAML flow mapping
separates entries: unquoted, `Many machines, one repo` parses as two
malformed keys rather than one title.

## How I proved the check fails

No check — this is a docs nav entry. What I did instead, before and after:

```
$ curl -s -o /dev/null -w "%{http_code}\n" https://olafkfreund.github.io/nixarchy/manual/many-machines
200
$ curl -s https://olafkfreund.github.io/nixarchy/manual/ | grep -c 'many-machines'
0          <- live, and unreachable

$ ruby -ryaml -e 'p YAML.load_file("docs/_config.yml")["nav"].map{|n| n["title"]}'
[... "System Snapshots", "Many machines, one repo", "Dual Boot Install", ...]
```

## Checks run locally

`nix fmt` / statix / deadnix are clean (no Nix touched).

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (none added)
- [x] If this adds an option: n/a
- [x] If this adds a `checks.*` entry: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5