### PR TITLE
Something watches the watchers, and says so out loud

### DIFF
--- a/.github/scripts/check-menu-mapping.py
+++ b/.github/scripts/check-menu-mapping.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Every Omarchy Install row names a package. Is it one this port maps?
+
+Upstream's rows install with `omarchy-pkg-present <arch-package>`. If nothing
+in data/ maps that package to nixpkgs, modules/apps.nix does not rewire the
+row, and it reaches a user still trying to run pacman. This is the check that
+holds data/apps.nix to the claim it makes about itself.
+
+It is one file with two callers because it used to be two copies with one
+caller each, and they drifted. build.yml learned to look in data/services.nix
+when `tailscale` moved there and became a service; omarchy.yml did not. So the
+nightly Omarchy bump failed on a row that was mapped all along, twice, and
+Omarchy 4.0.2 -- a security release -- sat unadopted behind a false positive
+in our own checker. Two copies of a question is one copy too many.
+
+Both catalogues count, and both spell it the same way:
+
+    data/apps.nix       arch = "brave-bin"    an Install-menu app
+    data/services.nix   arch = "tailscale"    a row that became a service
+
+data/arch-extras.nix is deliberately NOT consulted. It exists for packages
+"nothing in the menu selects" -- fonts from Style > Font, the system packages
+behind omarchy-install-dev-env -- and it carries no menuId, so modules/apps.nix
+generates no rewrite from it. A row naming one of those really is unmapped in
+the sense this check means: it would still run pacman. Absorbing arch-extras
+here would turn a real break into a green light.
+
+Usage: check-menu-mapping.py <omarchy-menu.jsonc> <catalogue.nix>...
+"""
+
+import re
+import sys
+
+
+def main(argv):
+    if len(argv) < 3:
+        sys.exit(f"usage: {argv[0]} <omarchy-menu.jsonc> <catalogue.nix>...")
+
+    menu, catalogues = argv[1], argv[2:]
+
+    known = set()
+    for c in catalogues:
+        known |= set(re.findall(r'arch = "([^"]+)"', open(c).read()))
+
+    raw = open(menu).read()
+    # JSONC. Strip comment lines the way MenuModel.js does before parsing.
+    rows = re.sub(r"^\s*//[^\n]*(\n|$)", "", raw, flags=re.M)
+
+    # Only the install tree: remove.* rows are derived from these.
+    wanted = set()
+    for rid, body in re.findall(r'"(install\.[a-z0-9.\-]+)":\s*(\{[^}]*\})', rows):
+        m = re.search(r"omarchy-pkg-present\s+([a-z0-9._@+\-]+)", body)
+        if m:
+            wanted.add((rid, m.group(1)))
+
+    if not wanted:
+        sys.exit(
+            "no install rows found in the menu -- either it changed shape or "
+            "this check stopped being able to read it, which is worse"
+        )
+
+    missing = sorted((r, a) for r, a in wanted if a not in known)
+    for rid, arch in missing:
+        names = " or ".join(catalogues)
+        print(f"::error::{rid} installs '{arch}', which {names} does not map")
+    if missing:
+        sys.exit(f"{len(missing)} unmapped Install rows")
+
+    print(f"all {len(wanted)} Install rows are mapped")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/.github/scripts/omarchy-package-delta.sh
+++ b/.github/scripts/omarchy-package-delta.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# What an Omarchy release adds to, and drops from, the set it installs.
+#
+# Omarchy pins no versions -- both package lists are bare Arch names, whatever
+# Arch shipped that day -- so there is no version to match. What there is, and
+# what nothing here looked at until now, is the SET. When upstream adds a
+# package or drops one, that is a decision about how the desktop is put
+# together, and this port either mirrors it or knowingly does not.
+#
+# 4.0.2 is the example that earned this script. It dropped `cups-browsed` and
+# added `cups-pk-helper` -- the release notes call it "Harden CUPS printer
+# discovery and administration" -- while modules/nixos.nix still justified its
+# printing defaults with the comment "cups, cups-browsed, avahi and nss-mdns
+# are all in base.packages". Three lines of diff, pointing straight at a
+# comment that had stopped being true.
+#
+# Comparing the whole list against data/apps.nix instead would report 201 of
+# 206 packages as unmapped, because `base`, `bluez` and `bat` reach a nixarchy
+# machine through the NixOS module rather than the app catalogue. The delta
+# between two releases is the part that carries a decision.
+#
+# Takes files, not tags, so it can be checked without a network. The workflow
+# fetches them; tests/package-delta.nix feeds it fixtures.
+#
+# Usage: omarchy-package-delta.sh <old.packages> <new.packages> [old-tag] [new-tag]
+set -euo pipefail
+
+old_file=${1:?usage: omarchy-package-delta.sh <old> <new> [old-tag] [new-tag]}
+new_file=${2:?usage: omarchy-package-delta.sh <old> <new> [old-tag] [new-tag]}
+old_tag=${3:-old}
+new_tag=${4:-new}
+
+# Comments and blank lines are not packages.
+clean() { grep -vE '^\s*(#|$)' "$1" | sort -u; }
+
+added=$(comm -13 <(clean "$old_file") <(clean "$new_file"))
+removed=$(comm -23 <(clean "$old_file") <(clean "$new_file"))
+
+if [ -z "$added" ] && [ -z "$removed" ]; then
+  echo "No change to the package set between $old_tag and $new_tag."
+  exit 0
+fi
+
+echo "### Packages $new_tag changes"
+echo
+echo "Upstream's install lists, $old_tag → $new_tag. Each line is a decision"
+echo "this port either mirrors or knowingly does not."
+echo
+
+[ -n "$added" ] && {
+  echo "**Added**"
+  echo
+  echo "$added" | sed 's/^/- `/;s/$/`/'
+  echo
+}
+
+[ -n "$removed" ] && {
+  echo "**Removed**"
+  echo
+  echo "$removed" | sed 's/^/- `/;s/$/`/'
+  echo
+  echo "A removal is the one worth reading twice: upstream dropping a package"
+  echo "is often a security decision, and a comment in this repo may still be"
+  echo "citing it as a reason for something."
+  echo
+}
+
+exit 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,17 @@ jobs:
       - name: deadnix
         run: nix run nixpkgs#deadnix -- --fail .
 
+      # Cheap, and it belongs with the other things that are checked before
+      # anything is built: it reads files rather than making them. `nix run
+      # .#review` watches every hand-pinned package; this watches that it can
+      # still see them, which is how that script rots.
+      - name: The nightly review can still read every pin
+        run: nix build .#checks.x86_64-linux.review-pins --print-build-logs
+
+      # Same shape, same reason: its dangerous failure is reporting nothing.
+      - name: The Omarchy package delta still sees a change
+        run: nix build .#checks.x86_64-linux.package-delta --print-build-logs
+
   # Every preset in data/devenv-presets.nix, scaffolded with the real
   # `nixarchy dev init` and handed to a real devenv to evaluate.
   #
@@ -403,37 +414,13 @@ jobs:
 
       - name: Verify every Install row is mapped
         run: |
-          # data/apps.nix claims CI keeps it from rotting. This is that check.
-          # Upstream's Install rows name their package as
-          # `omarchy-pkg-present <arch-package>`; every one of those has to
-          # appear in data/apps.nix or a new Omarchy app silently reaches the
-          # menu as a row that still tries to run pacman.
-          menu=result/share/omarchy/default/omarchy/omarchy-menu.jsonc
-          # Both catalogues. A row is mapped if data/apps.nix claims its
-          # package or data/services.nix does -- tailscale moved from one to
-          # the other when it became a service, and its `arch` moved with it.
-          # A check that read only apps would have called that row unmapped,
-          # and been wrong: it is answered, just not by the file it used to be.
-          python3 - "$menu" data/apps.nix data/services.nix <<'PY'
-          import re, sys
-          menu, appsfile, svcfile = sys.argv[1], sys.argv[2], sys.argv[3]
-          raw = open(menu).read()
-          rows = re.sub(r'^\s*//[^\n]*(\n|$)', '', raw, flags=re.M)
-          known = set(re.findall(r'arch = "([^"]+)"', open(appsfile).read()))
-          known |= set(re.findall(r'arch = "([^"]+)"', open(svcfile).read()))
-          # Only the install tree: remove.* rows are derived from these.
-          wanted = set()
-          for rid, body in re.findall(r'"(install\.[a-z0-9.\-]+)":\s*(\{[^}]*\})', rows):
-              m = re.search(r'omarchy-pkg-present\s+([a-z0-9._@+\-]+)', body)
-              if m:
-                  wanted.add((rid, m.group(1)))
-          missing = sorted((r, a) for r, a in wanted if a not in known)
-          if missing:
-              for r, a in missing:
-                  print(f"::error::{r} installs '{a}', which data/apps.nix does not map")
-              sys.exit(f"{len(missing)} unmapped Install rows")
-          print(f"all {len(wanted)} Install rows are mapped")
-          PY
+          # data/apps.nix claims CI keeps it from rotting. This is that check,
+          # and omarchy.yml runs the same script against the newest Omarchy --
+          # it used to run its own copy, which drifted and failed on a row
+          # that was mapped. See the script's header.
+          python3 .github/scripts/check-menu-mapping.py \
+            result/share/omarchy/default/omarchy/omarchy-menu.jsonc \
+            data/apps.nix data/services.nix
 
       - name: Verify every mapped app still evaluates
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -138,7 +138,12 @@ jobs:
     name: report a failure
     runs-on: ubuntu-latest
     needs: [install, install-iso]
-    if: failure()
+    # cancelled() too. On 2026-09-02 install-iso hit its 180-minute timeout,
+    # which GitHub records as cancelled rather than failed, and this job --
+    # the one whose whole purpose is that a 03:00 failure does not cost a day
+    # -- did not run. A watchdog that only barks at one of the two ways its
+    # subject can die is not a watchdog.
+    if: failure() || cancelled()
     permissions:
       issues: write
     steps:
@@ -153,10 +158,16 @@ jobs:
           RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           title="nightly: the install checks are failing"
+          # Which of the two it was. A timeout and a failed assertion want
+          # different first moves, and the issue is the only place anyone
+          # sees either.
+          what="failed"
+          [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ] &&
+            what="timed out or was cancelled"
           # One issue, reopened and commented, rather than a new one each
           # night: a check broken for a week should read as one problem, not
           # seven.
-          body="The nightly install checks failed: $RUN"
+          body="The nightly install checks $what: $RUN"
           body="$body
 
           Both jobs run on the self-hosted runner on p510. If the failure is
@@ -166,7 +177,7 @@ jobs:
           existing=$(gh issue list --state open --search "$title in:title" \
             --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "Still failing: $RUN"
+            gh issue comment "$existing" --body "Still failing ($what): $RUN"
           else
             gh issue create --title "$title" --label installer --body "$body"
           fi

--- a/.github/workflows/omarchy.yml
+++ b/.github/workflows/omarchy.yml
@@ -11,10 +11,26 @@ permissions:
   contents: write
   pull-requests: write
 
+# One bump at a time. There was no concurrency block here at all, so a
+# workflow_dispatch during the 04:00 run raced the schedule for the same branch
+# ref. cancel-in-progress is false because the loser would be a half-finished
+# bump, and a bump that stops in the middle is worse than one that waits.
+concurrency:
+  group: omarchy-bump
+  cancel-in-progress: false
+
 jobs:
   bump:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 45, not the 20 this had. The session check below builds Hyprland, and
+    # build.yml gives the same closure 30 minutes WITH the hyprland cache
+    # configured; this job also builds .#omarchy from a source that just
+    # changed, so it is guaranteed a cache miss on the way in. At 20 it was
+    # killed twice, on 2026-08-31 and 09-01, at 20m21s and 20m24s -- and a
+    # timeout is recorded as cancelled, not failed, so the report step below
+    # never ran either. Two silent nights and a security release left on the
+    # shelf.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
@@ -30,6 +46,8 @@ jobs:
             jq -r .tag_name)
           current=$(grep -oE 'github:basecamp/omarchy/[^"]+' flake.nix | cut -d/ -f3)
           echo "latest=$latest" >> "$GITHUB_OUTPUT"
+          # The version being left behind, for the package delta below.
+          echo "current=$current" >> "$GITHUB_OUTPUT"
           echo "$current -> $latest"
           [ "$current" = "$latest" ] && echo "changed=false" >> "$GITHUB_OUTPUT" ||
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -39,6 +57,18 @@ jobs:
         run: |
           sed -i "s|github:basecamp/omarchy/[^\"]*|github:basecamp/omarchy/${{ steps.rel.outputs.latest }}|" flake.nix
           nix flake update omarchy
+
+          # The tag is written in three places, and this used to move one of
+          # them. omarchyVersion is what the package calls itself and what
+          # omarchy-nvim defaults to, so an auto-merged bump left both naming
+          # the version before it -- the store path said 4.0.1 while the tree
+          # was 4.0.2. Rewritten here rather than reported later, because the
+          # place to fix a stale copy is the thing that made it stale.
+          ver="${{ steps.rel.outputs.latest }}"
+          ver="${ver#v}"
+          sed -i "s|omarchyVersion = \"[^\"]*\"|omarchyVersion = \"$ver\"|" flake.nix
+          sed -i "s|omarchyVersion ? \"[^\"]*\"|omarchyVersion ? \"$ver\"|" \
+            pkgs/omarchy-nvim/default.nix
 
       # Everything below is the same set of assertions build.yml makes, run
       # against the new Omarchy rather than the pinned one. Each answers a
@@ -54,26 +84,50 @@ jobs:
         if: steps.rel.outputs.changed == 'true'
         run: nix build .#omarchy --print-build-logs
 
+      - name: What packages this release adds and drops
+        if: steps.rel.outputs.changed == 'true'
+        id: delta
+        # Omarchy pins no versions -- its install lists are bare Arch names --
+        # so the only thing to compare between releases is the set itself.
+        # 4.0.2 is why this exists: it dropped cups-browsed and added
+        # cups-pk-helper ("Harden CUPS printer discovery and administration"),
+        # while modules/nixos.nix still justified its printing defaults with a
+        # comment naming cups-browsed as being in base.packages. Three lines of
+        # diff, pointing at a comment that had stopped being true.
+        #
+        # It goes in the PR body rather than the nightly review because it is
+        # only worth reading while someone is deciding about this bump.
+        run: |
+          for tag in "${{ steps.rel.outputs.current }}" "${{ steps.rel.outputs.latest }}"; do
+            : > "pkgs-$tag.txt"
+            for list in omarchy-base omarchy-other; do
+              curl -fsSL \
+                "https://raw.githubusercontent.com/basecamp/omarchy/$tag/install/$list.packages" \
+                >> "pkgs-$tag.txt" || true
+            done
+          done
+
+          {
+            echo "delta<<DELTA_EOF"
+            bash .github/scripts/omarchy-package-delta.sh \
+              "pkgs-${{ steps.rel.outputs.current }}.txt" \
+              "pkgs-${{ steps.rel.outputs.latest }}.txt" \
+              "${{ steps.rel.outputs.current }}" "${{ steps.rel.outputs.latest }}"
+            echo "DELTA_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Check nothing became unmapped or unwired
         if: steps.rel.outputs.changed == 'true'
         run: |
-          python3 - result/share/omarchy/default/omarchy/omarchy-menu.jsonc data/apps.nix <<'PY'
-          import re, sys
-          raw = open(sys.argv[1]).read()
-          rows = re.sub(r'^\s*//[^\n]*(\n|$)', '', raw, flags=re.M)
-          known = set(re.findall(r'arch = "([^"]+)"', open(sys.argv[2]).read()))
-          wanted = {}
-          for rid, body in re.findall(r'"(install\.[a-z0-9.\-]+)":\s*(\{[^}]*\})', rows):
-              m = re.search(r'omarchy-pkg-present\s+([a-z0-9._@+\-]+)', body)
-              if m:
-                  wanted[rid] = m.group(1)
-          missing = {r: a for r, a in wanted.items() if a not in known}
-          for r, a in missing.items():
-              print(f"::error::new Install row {r} wants '{a}', unmapped in data/apps.nix")
-          if missing:
-              sys.exit(f"{len(missing)} new apps need mapping")
-          print(f"all {len(wanted)} Install rows still mapped")
-          PY
+          # The same script build.yml runs on every pull request, against the
+          # newest Omarchy instead of the pinned one. It was an inline copy
+          # here until that copy fell behind build.yml's -- it never learned
+          # to look in data/services.nix, so it failed the v4.0.2 bump on
+          # install.service.tailscale, which services.nix had mapped all
+          # along. A security release sat unadopted for three days behind it.
+          python3 .github/scripts/check-menu-mapping.py \
+            result/share/omarchy/default/omarchy/omarchy-menu.jsonc \
+            data/apps.nix data/services.nix
 
       # Booting the session builds the closure on the way, so there is no
       # separate closure step: it would double an hour-long Hyprland compile
@@ -88,6 +142,19 @@ jobs:
       # pure black while every other check here passed, because a wallpaper
       # wider than GL_MAX_TEXTURE_SIZE draws nothing at all and Qt still
       # reports the image Ready.
+      - name: Add hyprland binary cache
+        if: steps.rel.outputs.changed == 'true'
+        # Nixarchy pins Hyprland ahead of nixpkgs, so without this the runner
+        # compiles a compositor from source. build.yml has had this since it
+        # started building the same closure; this job never did, which is the
+        # other half of why it kept running out of its budget.
+        run: |
+          sudo tee -a /etc/nix/nix.conf >/dev/null <<'EOF'
+          extra-substituters = https://hyprland.cachix.org
+          extra-trusted-public-keys = hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE=
+          EOF
+          sudo systemctl restart nix-daemon || true
+
       - name: Boot a session and check the desktop renders
         if: steps.rel.outputs.changed == 'true'
         run: |
@@ -99,7 +166,13 @@ jobs:
         id: pr
         uses: peter-evans/create-pull-request@v7
         with:
-          branch: update/omarchy
+          # The version is in the branch name, not just the title. With a
+          # constant name, a bump that stops for a human -- a new app to map,
+          # a moved anchor -- is overwritten by the next night's run, and the
+          # state you were about to read is gone. Per version, the stuck one
+          # waits where you left it while the next release still gets a clean
+          # attempt of its own. delete-branch below keeps them from piling up.
+          branch: update/omarchy-${{ steps.rel.outputs.latest }}
           title: "Omarchy ${{ steps.rel.outputs.latest }}"
           commit-message: "Omarchy ${{ steps.rel.outputs.latest }}"
           body: |
@@ -113,6 +186,8 @@ jobs:
             - every menu row it overrides still exists
             - all Install rows are still mapped in `data/apps.nix`
             - **a booted session renders its wallpaper**
+
+            ${{ steps.delta.outputs.delta }}
 
             If something is wrong anyway, roll back with
             `nixos-rebuild --rollback` or the boot menu, and open an issue.
@@ -132,7 +207,15 @@ jobs:
           echo "merged Omarchy ${{ steps.rel.outputs.latest }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Report what needs a human
-        if: failure() && steps.rel.outputs.changed == 'true'
+        # cancelled() as well as failure(): the timeout that killed this job
+        # twice reports as cancelled, and a report step that only fires on
+        # failure() is silent for exactly the case nobody is watching.
+        #
+        # And no `changed` guard. It was there to keep quiet on the nights
+        # with nothing to do, but a failure in the release probe itself leaves
+        # `changed` unset, so the guard turned the one unexplained failure
+        # into no report at all.
+        if: failure() || cancelled()
         run: |
           echo "Omarchy ${{ steps.rel.outputs.latest }} needs manual work." >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,51 @@
+name: review
+
+# What needs updating, and what is quietly broken.
+#
+# Everything else here watches one thing and reports on its own run. Nothing
+# watched the watchers, and it showed: on 2026-08-31 and 09-01 the Omarchy bump
+# was killed by its own 20-minute timeout, which GitHub records as *cancelled*
+# and `if: failure()` does not catch; on 09-02 it failed on a false positive in
+# its own mapping check. Three nights, no issue, no notification, and Omarchy
+# 4.0.2 -- a security release -- left unadopted the whole time.
+#
+# The answer is not another per-workflow reporter. It is one job that asks, out
+# loud and in one place: is anything we pin behind upstream, and did the jobs
+# that are supposed to tell us that actually run and pass?
+#
+# The logic is in pkgs/review.sh, not here, for the reason doctor.sh and
+# verify.sh are scripts: `nix run .#review` gives the same answer at a prompt
+# as it does at 06:00, so it can be tested by the person changing it.
+
+on:
+  schedule:
+    # 06:00 UTC. After nightly's 03:00, omarchy's 04:00 and Monday's update at
+    # 05:00 have finished, so it reviews the night that just happened rather
+    # than the one before.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Review, and say so
+        # always(), because a review that only reports when it feels like it is
+        # the thing this workflow exists to replace.
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # gh has no git remote to infer the repository from in a job that
+          # may not have checked out -- the exact bug that broke nightly.yml's
+          # reporter, fixed there in 9da7465 and set here from the start.
+          GH_REPO: ${{ github.repository }}
+        run: nix run .#review -- --report

--- a/README.md
+++ b/README.md
@@ -1216,7 +1216,26 @@ the image `Ready`. So the session test boots a machine, screenshots it through
 qemu, and compares the screen's average colour to the wallpaper's own.
 
 If they all pass, the bump merges itself. When one fails, the run summary
-names which of them broke and which file to edit. **A new app in Omarchy's Install menu is usually one line** in
+names which of them broke and which file to edit.
+
+**And something watches the watchers.** `review.yml` runs at 06:00, after the
+others have finished, and asks two questions in one place: is anything this
+repo pins behind what upstream ships, and did the jobs that are supposed to
+answer that actually run and pass? Findings go into a single issue, edited in
+place each night and closed automatically when everything is green.
+
+It exists because the daily check above once failed for three nights running
+and nobody heard: twice it was killed by its own timeout -- which GitHub
+records as *cancelled*, and `if: failure()` does not catch -- and once it
+failed on a false positive in a copy of a check that had drifted from the
+original. A security release sat unadopted the whole time. The same script
+runs at a prompt:
+
+```
+nix run .#review
+```
+
+**A new app in Omarchy's Install menu is usually one line** in
 `data/apps.nix` — `attr` for a plain nixpkgs package, `option` for something
 that needs a NixOS module. The menu rewiring and its Remove row are generated
 from that entry.

--- a/flake.nix
+++ b/flake.nix
@@ -469,6 +469,25 @@
           text = builtins.readFile ./pkgs/verify.sh;
         };
 
+        # `nix run .#review` -- what needs updating, and what is quietly
+        # broken. An app rather than a check because it asks GitHub what
+        # upstream ships and what CI did last night, and a check has no
+        # network. The half that needs neither is checks.review-pins.
+        review = pkgsFor.${system}.writeShellApplication {
+          name = "nixarchy-review";
+          runtimeInputs = with pkgsFor.${system}; [
+            gh
+            curl
+            git
+            gnugrep
+            gnused
+            coreutils
+            python3
+            nix
+          ];
+          text = builtins.readFile ./pkgs/review.sh;
+        };
+
         # `nix run github:olafkfreund/nixarchy#doctor` -- reads the running
         # system and prints the configuration it would need. Runnable before
         # nixarchy is an input anywhere, which is the only entry point someone
@@ -932,6 +951,21 @@
         # this proves the wizard can be answered, which no harness passing
         # --answers has ever done. See tests/installer-wizard.nix.
         installer-wizard = import ./tests/installer-wizard.nix {
+          inherit inputs;
+          pkgs = pkgsFor.${system};
+        };
+
+        # The package delta that goes in every Omarchy bump PR. Its dangerous
+        # failure is silence, so this feeds it a known answer. See
+        # tests/package-delta.nix.
+        package-delta = import ./tests/package-delta.nix {
+          inherit inputs;
+          pkgs = pkgsFor.${system};
+        };
+
+        # `nix run .#review` watches the pinned packages; this watches that
+        # it can still see them. See tests/review-pins.nix.
+        review-pins = import ./tests/review-pins.nix {
           inherit inputs;
           pkgs = pkgsFor.${system};
         };

--- a/pkgs/flake-pins.py
+++ b/pkgs/flake-pins.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""What this flake pins, and in which of the three ways it can pin it.
+
+`nix run .#review` asks a different question of each shape, so the shape has
+to be read out of flake.lock rather than guessed:
+
+    rev   github:hyprwm/Hyprland/0bd11c7a...   a commit, deliberately
+    tag   github:basecamp/omarchy/v4.0.1       a release
+    ref   github:NixOS/nixpkgs/nixos-unstable  a branch, or the default one
+
+Only the root's own inputs. flake.lock also carries every input of every
+input -- hyprland alone brings a dozen -- and those are upstream's business,
+not a pin anyone here can move.
+
+Prints name, kind, owner/repo, the ref or rev, and the locked lastModified,
+tab separated. Nothing else, so the caller stays a shell loop.
+"""
+
+import json
+import sys
+
+
+def main():
+    lock = json.load(open("flake.lock"))
+    nodes = lock["nodes"]
+
+    for name, node_name in sorted(nodes["root"]["inputs"].items()):
+        node = nodes[node_name]
+        original = node.get("original", {})
+        locked = node.get("locked", {})
+
+        # Anything not on GitHub has no releases API to ask, and this repo
+        # pins nothing that way today.
+        if original.get("type") != "github":
+            continue
+
+        repo = f"{original.get('owner')}/{original.get('repo')}"
+        ref = original.get("ref", "")
+
+        if original.get("rev"):
+            kind, at = "rev", original["rev"]
+        elif ref[:1] == "v" and ref[1:2].isdigit():
+            kind, at = "tag", ref
+        else:
+            # No ref at all still means a branch -- the default one.
+            kind, at = "ref", ref or "(default)"
+
+        print("\t".join([name, kind, repo, at, str(locked.get("lastModified", 0))]))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pkgs/review.sh
+++ b/pkgs/review.sh
@@ -1,0 +1,410 @@
+#!/usr/bin/env bash
+# What needs updating, and what is quietly broken. Run it nightly, or now.
+#
+# The repo already watches Omarchy every night and merges the bump itself. What
+# it did not have was anyone watching the watchers: on 2026-08-31 and 09-01 the
+# Omarchy job was killed by its own timeout -- recorded as *cancelled*, which
+# `if: failure()` does not catch -- and on 09-02 it failed on a false positive.
+# Three nights, no issue, no notification, and a security release left on the
+# shelf. Nothing was broken about the checks; nothing was listening.
+#
+# So this reports rather than acts. Two questions, one table:
+#
+#   is anything we pin behind what upstream ships?
+#   did the jobs that are supposed to answer that actually run, and pass?
+#
+# It is a script rather than YAML for the reason doctor.sh and verify.sh are:
+# something that only ever executes on a schedule is something nobody can test.
+# `nix run .#review` gives the same answer at a prompt as it does at 06:00.
+#
+# Usage:
+#   nix run .#review              print the table
+#   nix run .#review -- --report  and sync the rolling issue
+#   nix run .#review -- --list-pins   what we pin, no network (checks.review-pins)
+#
+# Exit status is 0 whether or not there are findings. Findings are the output,
+# not an error -- the same rule verify.sh states in its own header. Only being
+# unable to look is a failure.
+set -uo pipefail
+
+bold=$(printf '\033[1m')
+dim=$(printf '\033[2m')
+red=$(printf '\033[31m')
+green=$(printf '\033[32m')
+yellow=$(printf '\033[33m')
+off=$(printf '\033[0m')
+
+mode=table
+case "${1-}" in
+  --report) mode=report ;;
+  --list-pins) mode=pins ;;
+  "") ;;
+  *)
+    echo "usage: review [--report|--list-pins]" >&2
+    exit 2
+    ;;
+esac
+
+# Every hand-pinned package: name, the file that pins it, the GitHub repo to
+# ask. Kept here rather than derived, because the point of the list is to be
+# read -- a pin nobody remembers is exactly the one that goes stale.
+#
+# grok-bot is absent on purpose: it is pinned to a Cursor CDN commit hash with
+# no queryable "latest", so there is nothing to compare it against. Its
+# staleness is probed by date instead, below.
+pins=$(
+  cat <<'EOF'
+once	pkgs/apps/once.nix	basecamp/once
+hey-cli	pkgs/apps/hey-cli.nix	basecamp/hey-cli
+omacalc	pkgs/apps/omacalc.nix	omacom/omacalc
+omacut	pkgs/apps/omacut.nix	omacom/omacut
+omawrite	pkgs/apps/omawrite.nix	omacom/omawrite
+ttfx	pkgs/apps/ttfx.nix	omacom/ttfx
+EOF
+)
+
+pinned_version() {
+  # The first `version = "x"` in the file. Every pkgs/apps/*.nix states it
+  # once, at the top; the updateScripts already read it exactly this way.
+  sed -n 's/.*version = "\([^"]*\)".*/\1/p' "$1" | head -1
+}
+
+if [ "$mode" = pins ]; then
+  # No network, no gh, no nix: just what the tree claims to pin. This is what
+  # checks.review-pins asserts on, because the way this script rots is someone
+  # restructuring a `version =` line and every probe below silently reporting
+  # nothing at all.
+  while IFS=$'\t' read -r name file _repo; do
+    [ -n "$name" ] || continue
+    printf '%s\t%s\t%s\n' "$name" "$file" "$(pinned_version "$file")"
+  done <<<"$pins"
+  exit 0
+fi
+
+findings=0
+rows=""
+
+row() { rows="$rows| $1 | $2 | $3 | $4 |"$'\n'; }
+ok() { row "$1" "$2" "$3" "ok"; }
+finding() {
+  row "$1" "$2" "$3" "**$4**"
+  findings=$((findings + 1))
+}
+
+# ---------------------------------------------------------------- upstream --
+
+latest_tag() {
+  # A release if the project cuts them, the newest tag if it does not.
+  # omacom/omacalc publishes no releases at all and answers 404, which is a
+  # fact about that repo rather than an error worth reporting.
+  # On a 404 gh prints the error body to STDOUT and exits non-zero, so the
+  # status is the only thing worth believing: taken on emptiness alone, this
+  # reported omacalc's "latest version" as a JSON blob about Not Found.
+  local repo=$1 tag=""
+  tag=$(gh api "repos/$repo/releases/latest" --jq .tag_name 2>/dev/null) ||
+    tag=$(gh api "repos/$repo/tags" \
+      --jq 'map(.name) | map(select(test("^v?[0-9]"))) | .[0] // empty' 2>/dev/null) ||
+    tag=""
+  printf '%s' "$tag"
+}
+
+echo "${bold}Looking upstream${off}" >&2
+
+omarchy_pin=$(grep -oE 'github:basecamp/omarchy/[^"]+' flake.nix | head -1 | cut -d/ -f3)
+omarchy_latest=$(latest_tag basecamp/omarchy)
+if [ -z "$omarchy_latest" ]; then
+  finding "omarchy" "$omarchy_pin" "?" "cannot reach GitHub"
+elif [ "$omarchy_pin" != "$omarchy_latest" ]; then
+  finding "omarchy" "$omarchy_pin" "$omarchy_latest" "bump (omarchy.yml should do this nightly)"
+else
+  ok "omarchy" "$omarchy_pin" "$omarchy_latest"
+fi
+
+# Does the newest Omarchy's Install menu name a package no catalogue maps? The
+# menu is in the source tree, so this answers "can we adopt it" without
+# building anything -- and it is the question that blocked v4.0.2.
+if [ -n "$omarchy_latest" ] && [ -x .github/scripts/check-menu-mapping.py ] ||
+  [ -f .github/scripts/check-menu-mapping.py ]; then
+  menu=$(mktemp)
+  if curl -fsSL \
+    "https://raw.githubusercontent.com/basecamp/omarchy/$omarchy_latest/default/omarchy/omarchy-menu.jsonc" \
+    -o "$menu" 2>/dev/null; then
+    if out=$(python3 .github/scripts/check-menu-mapping.py \
+      "$menu" data/apps.nix data/services.nix 2>&1); then
+      ok "menu rows ($omarchy_latest)" "${out#all }" "mapped"
+    else
+      finding "menu rows ($omarchy_latest)" "-" \
+        "$(echo "$out" | grep -c '::error::') unmapped" \
+        "map them in data/apps.nix"
+    fi
+  fi
+  rm -f "$menu"
+fi
+
+while IFS=$'\t' read -r name file repo; do
+  [ -n "$name" ] || continue
+  have=$(pinned_version "$file")
+  latest=$(latest_tag "$repo")
+  latest=${latest#v}
+  if [ -z "$latest" ]; then
+    finding "$name" "$have" "?" "cannot reach GitHub"
+  elif [ "$have" != "$latest" ]; then
+    finding "$name" "$have" "$latest" "bump $file"
+  else
+    ok "$name" "$have" "$latest"
+  fi
+done <<<"$pins"
+
+# grok-bot pins a CDN build by commit hash. Nothing upstream answers "is there
+# a newer one", so the only honest signal is how long it has been since anyone
+# looked.
+age_days=$(( ($(date +%s) - $(git log -1 --format=%ct -- pkgs/apps/grok-bot.nix)) / 86400 ))
+if [ "$age_days" -gt 60 ]; then
+  finding "grok-bot" "$(pinned_version pkgs/apps/grok-bot.nix)" "unknowable" \
+    "pinned by CDN commit, untouched for $age_days days -- check by hand"
+else
+  ok "grok-bot" "$(pinned_version pkgs/apps/grok-bot.nix)" "checked ${age_days}d ago"
+fi
+
+# ------------------------------------------------------------- consistency --
+
+# The tag is written in three places. omarchy.yml rewrites all three now, but
+# it did not always, and a mismatch means the store path names a version the
+# tree is not.
+nvim_version=$(sed -n 's/.*omarchyVersion ? "\([^"]*\)".*/\1/p' \
+  pkgs/omarchy-nvim/default.nix | head -1)
+pkg_version=$(sed -n 's/.*omarchyVersion = "\([^"]*\)".*/\1/p' flake.nix | head -1)
+if [ "$pkg_version" = "${omarchy_pin#v}" ] && [ "$nvim_version" = "${omarchy_pin#v}" ]; then
+  ok "version literals" "$pkg_version" "match the pin"
+else
+  finding "version literals" "flake $pkg_version / nvim $nvim_version" \
+    "${omarchy_pin#v}" "one of the three copies is stale"
+fi
+
+# Is what main vendors actually released? The bump merges itself, so main can
+# move to a new Omarchy without anyone noticing that the newest ISO on the
+# releases page still carries the old one -- release.yml only fires on a tag,
+# and nothing pushes tags. Publishing an image is the one step worth a person;
+# forgetting it for a fortnight is not.
+release=$(gh api "repos/{owner}/{repo}/releases" \
+  --jq '.[0] | "\(.tag_name)\t\(.published_at)"' 2>/dev/null)
+if [ -z "$release" ]; then
+  finding "release" "${pkg_version:-?}" "?" "cannot reach GitHub"
+else
+  IFS=$'\t' read -r rel_tag rel_when <<<"$release"
+  # v4.0.1-5 -> 4.0.1: the tag is the Omarchy version plus a packaging number,
+  # and release.yml already asserts that half matches what the flake vendors.
+  rel_omarchy=${rel_tag#v}
+  rel_omarchy=${rel_omarchy%-*}
+  rel_age=$((($(date +%s) - $(date -d "$rel_when" +%s)) / 86400))
+  if [ "$rel_omarchy" = "$pkg_version" ]; then
+    ok "release" "$rel_tag" "vendors $pkg_version, ${rel_age}d old"
+  else
+    finding "release" "$rel_tag (Omarchy $rel_omarchy)" "main vendors $pkg_version" \
+      "no ISO for it -- tag v$pkg_version-1 to publish one"
+  fi
+fi
+
+# The quickshell override carries a DELETE THIS. Nothing tested the condition,
+# so it would have outlived its reason silently.
+if grep -q 'quickshell = final.quickshell.overrideAttrs' flake.nix; then
+  pinned=$(sed -n '/quickshell = final.quickshell.overrideAttrs/,/};/p' flake.nix |
+    sed -n 's/.*version = "\([^"]*\)".*/\1/p' | head -1)
+  upstream=$(nix eval --raw nixpkgs#quickshell.version 2>/dev/null)
+  if [ -z "$upstream" ]; then
+    ok "quickshell override" "$pinned" "nixpkgs version unread"
+  elif [ "$(printf '%s\n%s\n' "$pinned" "$upstream" | sort -V | tail -1)" = "$upstream" ]; then
+    finding "quickshell override" "$pinned" "$upstream" \
+      "nixpkgs caught up -- delete the override, close #35"
+  else
+    ok "quickshell override" "$pinned" "nixpkgs has $upstream, still needed"
+  fi
+fi
+
+# ------------------------------------------------------------------ inputs --
+
+# The flake's own pins. Omarchy declares no versions -- its package lists are
+# bare Arch names, whatever Arch shipped that day -- so there is nothing to
+# match version-for-version. What matters is the other direction: Omarchy 4.x
+# configures Hyprland through the Lua API that landed in 0.55, so this repo has
+# to carry a Hyprland new enough to read the configs it vendors. That is a
+# floor, and a floor nobody was watching.
+#
+# Three shapes of pin, three different questions:
+#
+#   rev   is there a release newer than the commit we sit on?
+#   tag   is there a newer tag?
+#   ref   has the branch we track actually moved lately?
+#
+# Age alone is not a finding. nixpkgs is eleven days old and healthy;
+# nix-systems has not needed a commit in three years. A pin that stopped moving
+# when it was supposed to keep moving is the thing worth saying.
+echo "${bold}Reading the flake's pins${off}" >&2
+
+inputs=$(python3 pkgs/flake-pins.py 2>/dev/null)
+
+while IFS=$'\t' read -r name kind repo at modified; do
+  [ -n "$name" ] || continue
+  # omarchy has its own probe above, which also checks the menu. One pin
+  # should not be able to produce two rows.
+  [ "$name" = omarchy ] && continue
+  age=$((($(date +%s) - modified) / 86400))
+  case "$kind" in
+    rev)
+      # A commit is as reproducible as a tag, and sometimes ahead of every tag
+      # -- hyprland is pinned past v0.56.2 because that tag does not build in
+      # the sandbox. So ask whether the newest tag is ahead of US, rather than
+      # whether we happen to be sitting on one.
+      newest=$(latest_tag "$repo")
+      if [ -z "$newest" ]; then
+        # Not necessarily a problem: sops-nix has exactly one tag, called
+        # `assets`, which is why flake.nix pins it by rev in the first place.
+        # Tell those apart from a GitHub that is not answering.
+        if gh api "repos/$repo/tags" --jq length >/dev/null 2>&1; then
+          ok "$name" "${at:0:9} (${age}d)" "upstream publishes no version tags"
+        else
+          finding "$name" "${at:0:9} (${age}d)" "?" "cannot reach GitHub"
+        fi
+      else
+        ahead=$(gh api "repos/$repo/compare/$newest...$at" --jq .ahead_by 2>/dev/null)
+        if [ -z "$ahead" ]; then
+          ok "$name" "${at:0:9} (${age}d)" "$newest, not comparable"
+        elif [ "$ahead" -gt 0 ]; then
+          ok "$name" "${at:0:9} (${age}d)" "$ahead commits past $newest"
+        else
+          finding "$name" "${at:0:9} (${age}d)" "$newest" \
+            "upstream tagged a release this pin does not have"
+        fi
+      fi
+      ;;
+    tag)
+      newest=$(latest_tag "$repo")
+      if [ -z "$newest" ]; then
+        ok "$name" "$at" "tag list unreadable"
+      elif [ "$newest" = "$at" ]; then
+        ok "$name" "$at" "newest"
+      else
+        finding "$name" "$at" "$newest" "newer tag available"
+      fi
+      ;;
+    ref)
+      # A branch that has not moved in four months is either a very quiet
+      # project or a ref that no longer means what it says -- disko's `latest`
+      # is the one to watch here.
+      if [ "$at" != "(default)" ] && [ "$age" -gt 120 ]; then
+        finding "$name" "$at, ${age}d" "-" \
+          "a ref chosen on purpose that has not moved in $age days"
+      else
+        ok "$name" "$at" "${age}d old"
+      fi
+      ;;
+  esac
+done <<<"$inputs"
+
+# ---------------------------------------------------------------- CI health --
+
+echo "${bold}Asking what CI did${off}" >&2
+
+# Every scheduled workflow, and how long it may go without a run before its
+# silence is itself the finding. review.yml is not in this list: a job that
+# reports on its own last run has nothing to say on the night it is the thing
+# that broke.
+ci() {
+  local wf=$1 stale_hours=$2 line conclusion when age
+  line=$(gh run list --workflow "$wf" --limit 1 \
+    --json conclusion,createdAt --jq '.[0] | "\(.conclusion)\t\(.createdAt)"' \
+    2>/dev/null)
+  if [ -z "$line" ]; then
+    finding "$wf" "-" "no runs at all" "is the workflow disabled?"
+    return
+  fi
+  IFS=$'\t' read -r conclusion when <<<"$line"
+  age=$((($(date +%s) - $(date -d "$when" +%s)) / 3600))
+  case "$conclusion" in
+    success) : ;;
+    null | "")
+      # Still going. Not a finding -- this job runs at 06:00 and nightly can
+      # still be installing a desktop.
+      ok "$wf" "${age}h ago" "still running"
+      return
+      ;;
+    cancelled)
+      # The one that went unreported for two nights. Almost always a timeout.
+      finding "$wf" "${age}h ago" "cancelled" "timed out, most likely -- raise the budget or split the job"
+      return
+      ;;
+    *)
+      finding "$wf" "${age}h ago" "$conclusion" "read the run"
+      return
+      ;;
+  esac
+  if [ "$age" -gt "$stale_hours" ]; then
+    finding "$wf" "${age}h ago" "last run passed" "but nothing has run for ${age}h"
+  else
+    ok "$wf" "${age}h ago" "$conclusion"
+  fi
+}
+
+ci build.yml 192
+ci nightly.yml 30
+ci omarchy.yml 30
+ci update.yml 200
+ci release.yml 8760
+
+# -------------------------------------------------------------------- print --
+
+when=$(date -u +%F)
+table="| what | have | upstream | |"$'\n'"|---|---|---|---|"$'\n'"$rows"
+
+echo
+if [ "$findings" -eq 0 ]; then
+  echo "${green}${bold}All green${off} -- nothing pinned is behind and every job ran and passed."
+else
+  echo "${yellow}${bold}$findings thing(s) need attention${off}"
+fi
+echo
+echo "$table" | sed "s/\*\*/${red}/;s/\*\*/${off}/"
+echo "${dim}$when${off}"
+
+[ "$mode" = report ] || exit 0
+
+# ------------------------------------------------------------------- report --
+
+# One issue, edited in place, closed when the table is clean. A check broken
+# for a week should read as one problem, not seven -- the same reasoning
+# nightly.yml's reporter states, and the same find-or-create shape.
+title="Nightly review: what needs updating and fixing"
+# The run that wrote this, when there is one. Run from a prompt there is not,
+# and half a URL is worse than none.
+if [ -n "${GITHUB_RUN_ID:-}" ]; then
+  run="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+else
+  run="(run by hand)"
+fi
+
+existing=$(gh issue list --state open --search "\"$title\" in:title" \
+  --json number --jq '.[0].number // empty' 2>/dev/null)
+
+if [ "$findings" -eq 0 ]; then
+  if [ -n "$existing" ]; then
+    gh issue close "$existing" --comment "All green as of $when. $run"
+    echo "closed #$existing"
+  else
+    echo "nothing to report"
+  fi
+  exit 0
+fi
+
+body="Reviewed $when. $run
+
+$table
+
+Edited in place each night by \`review.yml\`, and closed automatically when
+everything is green. Run it yourself with \`nix run .#review\`."
+
+if [ -n "$existing" ]; then
+  gh issue edit "$existing" --body "$body"
+  echo "updated #$existing"
+else
+  gh issue create --title "$title" --label dependencies --body "$body"
+fi

--- a/tests/package-delta.nix
+++ b/tests/package-delta.nix
@@ -1,0 +1,113 @@
+{ pkgs, ... }:
+# The package delta that goes in every Omarchy bump PR.
+#
+# Omarchy pins no versions, so the only thing to compare between releases is
+# the SET of packages it installs -- and a set diff has exactly one dangerous
+# failure: reporting nothing. "No change to the package set" is what a reader
+# sees both when upstream changed nothing and when the script stopped being
+# able to read the lists, and those two mean opposite things.
+#
+# So this feeds it fixtures with a known answer. Files, not tags, because a
+# check has no network -- the workflow does the fetching.
+let
+  # Shaped like upstream's: comments, blank lines, one package per line.
+  old = builtins.toFile "old.packages" ''
+    # Omarchy base
+    base
+    bat
+
+    cups
+    cups-browsed
+    cups-pdf
+    hyprland
+  '';
+
+  new = builtins.toFile "new.packages" ''
+    # Omarchy base
+    base
+    bat
+
+    cups
+    cups-pk-helper
+    hyprland
+  '';
+
+  # Same content, different order and spacing: a set comparison must not care.
+  reordered = builtins.toFile "reordered.packages" ''
+    hyprland
+    bat
+
+    # a comment that moved
+    cups-browsed
+    base
+    cups
+    cups-pdf
+  '';
+in
+pkgs.runCommand "nixarchy-package-delta"
+  {
+    nativeBuildInputs = with pkgs; [
+      bash
+      coreutils
+      gnugrep
+      gnused
+    ];
+  }
+  ''
+    delta=${../.github/scripts/omarchy-package-delta.sh}
+    fail=0
+
+    report=$(bash "$delta" ${old} ${new} v4.0.1 v4.0.2)
+
+    # The real 4.0.1 -> 4.0.2 change, which is what this fixture models.
+    echo "$report" | grep -q 'cups-pk-helper' || {
+      echo "delta: an added package is missing from the report" >&2
+      fail=1
+    }
+    for gone in cups-browsed cups-pdf; do
+      echo "$report" | grep -q "$gone" || {
+        echo "delta: removed package $gone is missing from the report" >&2
+        fail=1
+      }
+    done
+
+    # Added and removed must not be confused for each other -- the whole point
+    # of reading a removal twice is knowing it was one.
+    added_block=$(echo "$report" | sed -n '/\*\*Added\*\*/,/\*\*Removed\*\*/p')
+    echo "$added_block" | grep -q 'cups-pk-helper' || {
+      echo "delta: cups-pk-helper is not under Added" >&2
+      fail=1
+    }
+    echo "$added_block" | grep -q 'cups-browsed' && {
+      echo "delta: a removed package is listed under Added" >&2
+      fail=1
+    }
+
+    # A package present in both must appear in neither list.
+    for unchanged in base bat cups hyprland; do
+      echo "$report" | grep -qE "^- \`$unchanged\`$" && {
+        echo "delta: unchanged package $unchanged was reported as a change" >&2
+        fail=1
+      }
+    done
+
+    # Silence has to mean silence. Order and blank lines are not changes, and
+    # this is the case that would otherwise let a broken read look like calm.
+    quiet=$(bash "$delta" ${old} ${reordered} v1 v2)
+    echo "$quiet" | grep -q 'No change to the package set' || {
+      echo "delta: reordering the same packages was reported as a change" >&2
+      echo "$quiet" >&2
+      fail=1
+    }
+
+    [ "$fail" -eq 0 ] || {
+      echo >&2
+      echo "What the delta actually printed:" >&2
+      echo "$report" >&2
+      exit 1
+    }
+
+    echo "the package delta names what moved, in the right direction,"
+    echo "and stays quiet when nothing did"
+    touch $out
+  ''

--- a/tests/review-pins.nix
+++ b/tests/review-pins.nix
@@ -1,0 +1,116 @@
+{ pkgs, ... }:
+# The half of `nix run .#review` that can be checked without a network.
+#
+# review.sh answers "is anything we pin behind upstream", and the way it rots
+# is not the comparison -- it is the reading. Someone restructures a
+# `version = "x"` line, or renames a file under pkgs/apps, and every probe for
+# that package quietly reports nothing at all. A watcher that has stopped
+# seeing one of its subjects looks exactly like a watcher with nothing to
+# report, which is the failure mode this whole change exists to end.
+#
+# So this asserts on --list-pins: no network, no gh, no GitHub. Every pin the
+# script claims to watch must still be findable, and must still yield a
+# version that looks like one.
+let
+  # The pins review.sh is expected to see. Hardcoded here rather than derived
+  # from the script, because a list derived from the thing it checks agrees
+  # with it by construction and proves nothing.
+  expected = [
+    "once"
+    "hey-cli"
+    "omacalc"
+    "omacut"
+    "omawrite"
+    "ttfx"
+  ];
+in
+pkgs.runCommand "nixarchy-review-pins"
+  {
+    nativeBuildInputs = with pkgs; [
+      bash
+      gnused
+      coreutils
+      # flake-pins.py reads flake.lock; review.sh --list-pins does not need it,
+      # but they are checked together.
+      python3
+    ];
+  }
+  ''
+    # review.sh reads the pin files relative to the repository root, the way
+    # it does when someone runs it at a prompt.
+    mkdir -p pkgs
+    cp -r ${../pkgs/apps} pkgs/apps
+
+    bash ${../pkgs/review.sh} --list-pins > pins.txt || {
+      echo "review.sh --list-pins failed outright" >&2
+      exit 1
+    }
+
+    fail=0
+
+    for name in ${builtins.concatStringsSep " " expected}; do
+      line=$(grep -E "^$name	" pins.txt || true)
+      if [ -z "$line" ]; then
+        echo "review: $name is no longer in the pin list" >&2
+        echo "  the script watches it, or it does not -- silence is the bug." >&2
+        fail=1
+        continue
+      fi
+
+      file=$(printf '%s' "$line" | cut -f2)
+      version=$(printf '%s' "$line" | cut -f3)
+
+      # A version that does not start with a digit is the shape of a failed
+      # read, not of a release: an empty field, or a stray match.
+      case "$version" in
+        [0-9]*) ;;
+        *)
+          echo "review: $name ($file) yielded version '$version'" >&2
+          echo "  the pin moved or its version line changed shape." >&2
+          fail=1
+          ;;
+      esac
+    done
+
+    got=$(wc -l < pins.txt)
+    want=${toString (builtins.length expected)}
+    if [ "$got" != "$want" ]; then
+      echo "review: the pin list has $got entries, expected $want" >&2
+      echo "  a pin was added or removed; update tests/review-pins.nix too." >&2
+      fail=1
+    fi
+
+    if [ "$fail" -ne 0 ]; then
+      echo >&2
+      echo "What review.sh --list-pins actually printed:" >&2
+      cat pins.txt >&2
+      exit 1
+    fi
+
+    # And the flake's own pins, read out of flake.lock by the same script the
+    # review uses. Its silent failure is identical in shape: a lock format it
+    # no longer parses yields no rows, and no rows reads as nothing to report.
+    cp ${../flake.lock} flake.lock
+    python3 ${../pkgs/flake-pins.py} > pins-flake.txt || {
+      echo "flake-pins.py could not read flake.lock" >&2
+      exit 1
+    }
+
+    # One of each shape, because the review asks a different question of each
+    # and a classifier that has collapsed to one answer is the bug.
+    for want_line in "omarchy	tag" "hyprland	rev" "nixpkgs	ref"; do
+      name=''${want_line%%	*}
+      kind=''${want_line##*	}
+      got=$(grep -E "^$name	" pins-flake.txt | cut -f2)
+      [ "$got" = "$kind" ] || {
+        echo "review: flake.lock pins $name as '$got', expected '$kind'" >&2
+        echo "  the review asks a different question of each shape." >&2
+        cat pins-flake.txt >&2
+        exit 1
+      }
+    done
+
+    echo "all $want pins are readable, and every version looks like one"
+    echo "and flake.lock still classifies tag, rev and ref pins apart"
+    touch $out
+  ''


### PR DESCRIPTION
## What this changes, and why

The daily Omarchy check failed three nights running and told nobody.

Twice — 2026-08-31 and 09-01 — it was killed by its own 20-minute timeout at
20m21s and 20m24s. A timeout is recorded as **cancelled**, and the step that
writes the triage summary is `if: failure()`, which does not fire on
cancellation. On 09-02 it failed differently: its copy of the menu-mapping
check never learned to look in `data/services.nix`, so it reported
`install.service.tailscale` as unmapped when `services.nix` has mapped it
since it became a service. `build.yml`'s copy of the same check knows better.

Omarchy **v4.0.2 — a security release** — has been unadopted the whole time,
and no issue was ever opened, because there is not one `cancelled()` anywhere
in `.github/`.

So, three fixes and a watchdog:

- **one mapping check with two callers**, in `.github/scripts/`. It was two
  copies with one caller each, and they drifted.
- **`timeout-minutes: 45`** and the `hyprland.cachix.org` substituter
  `build.yml` has always had for the same closure — without it, this job
  compiles a compositor from source inside its own budget.
- **the bump rewrites all three places the tag is written**, not one, so an
  auto-merge stops leaving `omarchyVersion` naming the release before it.
- **`if: failure() || cancelled()`** on both reporters.

Then `nix run .#review`: is anything pinned behind upstream, and did the jobs
that answer that actually run and pass — including the runs that were
cancelled and the ones that never happened. Findings go to one issue, edited
in place nightly and closed when the table is clean. It is a script rather
than YAML for the reason `doctor.sh` and `verify.sh` are scripts: something
that only ever executes on a schedule is something nobody can test.

**Maintainer sign-off needed (AGENTS.md §9):** the `omarchy.yml` timeout, the
`if:` conditions on both reporters, and `review.yml`'s new schedule trigger.

## How I proved the check fails

The mapping fix, against Omarchy v4.0.2's real menu — this is the live bug:

```
$ python3 .github/scripts/check-menu-mapping.py menu-402.jsonc data/apps.nix
::error::install.service.tailscale installs 'tailscale', which data/apps.nix does not map
1 unmapped Install rows
exit=1                      <- exactly what run 33589688043 hit

$ python3 .github/scripts/check-menu-mapping.py menu-402.jsonc data/apps.nix data/services.nix
all 37 Install rows are mapped
exit=0
```

That also answers the adoption question: 4.0.2's menu is fully mapped.

`checks.review-pins` covers the way `review.sh` actually rots — not the
comparison, but someone restructuring a `version =` line until every probe
reports nothing, which looks exactly like good news. RED, with `hey-cli`'s
version line removed:

```
> review: hey-cli (pkgs/apps/hey-cli.nix) yielded version '\([^'
>   the pin moved or its version line changed shape.
>
> What review.sh --list-pins actually printed:
> once      pkgs/apps/once.nix      0.3.2
> hey-cli   pkgs/apps/hey-cli.nix   \([^
```

GREEN, restored: `all 6 pins are readable, and every version looks like one`.

And the script's own live output, which is the state of the repo right now:

```
| omarchy      | v4.0.1  | v4.0.2    | bump (omarchy.yml should do this nightly) |
| hey-cli      | 1.3.0   | 1.4.0     | bump pkgs/apps/hey-cli.nix                |
| nightly.yml  | 21h ago | cancelled | timed out, most likely                   |
| omarchy.yml  | 20h ago | failure   | read the run                             |
| ...12 more rows, all ok                                                        |
```

That is issue #195, opened by `nix run .#review -- --report`. A second run
edited it in place rather than opening a duplicate.

## Checks run locally

- `nix build .#checks.x86_64-linux.review-pins` — green, red first as above
- `nix build .#checks.x86_64-linux.options` — green
- the coverage guard from `build.yml`, run by hand: `missing:[] ungated:[]`
- `yamllint` on all four touched workflows — clean

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [x] If this adds an option: n/a
- [x] If this adds a `checks.*` entry: `build.yml`'s `lint` job builds
      `checks.review-pins` (workflow edit needs maintainer sign-off — see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5