### PR TITLE
Omarchy 4.0.2, whose new browser-policy helper needs root that NixOS does not give it

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [Omarchy](https://omarchy.org) vendored for NixOS — the whole desktop, with its
 menus rewired to Nix instead of pacman.
 
-Omarchy 4.x is not a dotfiles repo, it's an application: **429 shell commands**,
+Omarchy 4.x is not a dotfiles repo, it's an application: **430 shell commands**,
 a QuickShell desktop shell, 22 themes, and Hyprland configured through the Lua
 API introduced in 0.55. Nixarchy packages that tree as a derivation and replaces
 the parts that assume Arch, rather than reimplementing it in Nix.
@@ -38,7 +38,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | | |
 |---|---|
 | Hyprland session, QuickShell bar, 22 themes | as upstream ships them |
-| `omarchy` CLI | all 429 subcommands, `omarchy commands --check` green |
+| `omarchy` CLI | all 430 subcommands, `omarchy commands --check` green |
 | **Install menu** | picks write to a Nix config, not pacman |
 | **Install ▸ Search** | one picker over 137k rows — every nixpkgs package, every NixOS option, and the app selection |
 | **`nixarchy` command** | this port's own commands, and a way through to Omarchy's 431 |
@@ -1497,10 +1497,10 @@ Nothing on the list below is waiting on a decision -- each is either
 impossible, or a tradeoff taken deliberately. In rough order of how much
 someone would miss it:
 
-1. **Upstream is pinned to v4.0.1, which is the latest release.** There is no
+1. **Upstream is pinned to v4.0.2, which is the latest release.** There is no
    bump to take: the tag is current, and Omarchy's default branch (`quattro`)
-   has *diverged* from it -- 98 commits ahead, 35 behind, with its own `version`
-   file still reading `4.0.0.alpha`. Moving to it would drop 35 commits of
+   has *diverged* from it -- 270 commits ahead, 63 behind, with its own `version`
+   file still reading `4.0.0.alpha`. Moving to it would drop 63 commits of
    release work, so the pin stays on the tag until a newer one exists.
 
    The bump machinery has been exercised against that branch rather than left

--- a/flake.lock
+++ b/flake.lock
@@ -503,16 +503,16 @@
     "omarchy": {
       "flake": false,
       "locked": {
-        "lastModified": 1787652758,
-        "narHash": "sha256-dj3etcMp2lpIP2pPvub2tiXFbZYMWl6RDeCHtTEksek=",
+        "lastModified": 1788130066,
+        "narHash": "sha256-DtaDI3gyvK7YVnul2vRmNHHGK86Hn64WfbAVeG4888Y=",
         "owner": "basecamp",
         "repo": "omarchy",
-        "rev": "13f18b2cb7286fb54f87daf571a031aa6af3d8f0",
+        "rev": "346e69e1cec6c4e8924531874af6ba010a1bc99e",
         "type": "github"
       },
       "original": {
         "owner": "basecamp",
-        "ref": "v4.0.1",
+        "ref": "v4.0.2",
         "repo": "omarchy",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
     hyprland.url = "github:hyprwm/Hyprland/0bd11c7a04a63d2785abd53363f09d552175d67d";
 
     omarchy = {
-      url = "github:basecamp/omarchy/v4.0.1";
+      url = "github:basecamp/omarchy/v4.0.2";
       flake = false;
     };
 
@@ -186,7 +186,7 @@
         }
       );
 
-      omarchyVersion = "4.0.1";
+      omarchyVersion = "4.0.2";
     in
     {
       overlays.default = final: _prev: {

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -724,8 +724,25 @@ in
       # install/config/locate.sh
       locate.enable = lib.mkDefault true;
 
-      # cups, cups-browsed, avahi and nss-mdns are all in base.packages
+      # cups, avahi and nss-mdns are all in base.packages. cups-browsed was
+      # too until 4.0.2 dropped it -- "Harden CUPS printer discovery and
+      # administration" -- along with the unit that started it, leaving only a
+      # hardened drop-in for machines that already had it. cups-pk-helper
+      # replaced it for the administration half, and NixOS' own cupsd module
+      # adds that wherever polkit is on, so nothing here has to name it.
+      #
+      # Turning it off is not just comment maintenance: NixOS defaults
+      # services.printing.browsed.enable to services.avahi.enable, which the
+      # lines below set, so `printing.enable` alone did leave cups-browsed
+      # running -- as root, with none of the User=/ProtectSystem= hardening
+      # upstream's drop-in adds, listening for mDNS printer announcements and
+      # creating queues from them. That is the daemon upstream deliberately
+      # removed, so it does not stay on here by inheritance.
+      #
+      # Only browsed goes: avahi stays on for driverless IPP discovery, which
+      # is how modern printers are found and is what cupsd does by itself.
       printing.enable = lib.mkDefault true;
+      printing.browsed.enable = lib.mkDefault false;
       avahi = {
         enable = lib.mkDefault true;
         nssmdns4 = lib.mkDefault true;

--- a/pkgs/omarchy-nvim/default.nix
+++ b/pkgs/omarchy-nvim/default.nix
@@ -27,7 +27,7 @@
 {
   lib,
   stdenvNoCC,
-  omarchyVersion ? "4.0.1",
+  omarchyVersion ? "4.0.2",
 }:
 stdenvNoCC.mkDerivation {
   pname = "omarchy-nvim-config";

--- a/pkgs/omarchy/default.nix
+++ b/pkgs/omarchy/default.nix
@@ -778,6 +778,69 @@ stdenvNoCC.mkDerivation {
     fi
 
     exec setsid uwsm-app -- "$browser_bin" --app="$1" "''${@:2}"'
+
+        # The theme accent stopped reaching the browser in 4.0.2. The session
+        # check caught it: /etc/chromium/policies/managed/color.json was never
+        # written, and wait_until_succeeds sat on it for the full 900 seconds.
+        #
+        # 4.0.1 wrote the policy inline from omarchy-theme-set-browser, as the
+        # user, into whichever policy directories existed -- and the NixOS
+        # module creates those four owned by browserThemeUser (the tmpfiles
+        # rules in modules/nixos.nix) precisely so that unprivileged write
+        # lands. 4.0.2 moved it into a new privileged helper, which sudo- or
+        # pkexec-escalates to root, pins PATH to FHS directories that hold none
+        # of install/mktemp/rm here, and installs color.json as root:root under
+        # an /etc/sudoers.d rule naming a /usr/bin path. None of those three
+        # exist on NixOS, so every path through it fails.
+        #
+        # So the escalation goes and the write is the user's again, which is the
+        # arrangement the tmpfiles rules already provide and the one that has
+        # been shipping. Upstream is hardening against a `chmod a+rw` policy
+        # directory writable by every account on the machine; ours is 0755 owned
+        # by one named desktop user who is in wheel already, so routing the same
+        # write through a NOPASSWD sudo rule would move it rather than restrict
+        # it. Keeping upstream's shape -- root-owned directories plus
+        # security.sudo.extraRules on the store path -- was considered and
+        # rejected for that: it makes the module, the package and every VM user
+        # agree on one path, and buys nothing this configuration does not have.
+        #
+        # The PATH pin is kept rather than deleted, retargeted at the store, so
+        # a hand-run `sudo omarchy-theme-set-browser-policy` still resolves its
+        # coreutils. The color validation, the symlink refusal and the atomic
+        # install are upstream's and untouched -- they are the half of 4.0.2
+        # that does work here.
+        substituteInPlace $out/share/omarchy/bin/omarchy-theme-set-browser-policy \
+          --replace-fail 'export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin' \
+          'export PATH=${lib.makeBinPath [ coreutils ]}' \
+          --replace-fail 'install -m 0644 -o root -g root -T' \
+          'install -m 0644 -T'
+
+        # The escalation itself, and the /usr/bin path it re-execs. sed ranges
+        # rather than more --replace-fail: the blocks they delete quote both '
+        # and ", which would have to be spelled through two layers of shell for
+        # no gain. The greps are what make this loud if upstream reshapes them,
+        # which is the only thing --replace-fail was buying.
+        policy=$out/share/omarchy/bin/omarchy-theme-set-browser-policy
+        for anchor in '^PACKAGED_PATH=/usr/bin/omarchy-theme-set-browser-policy$' '^require_root "$color"$'; do
+          grep -q "$anchor" "$policy" || {
+            echo "omarchy-theme-set-browser-policy no longer escalates where this patch expects: $anchor" >&2
+            exit 1
+          }
+        done
+        sed -i \
+          -e '/^# The path etc\/sudoers.d\/omarchy-theme-browser names/,/^PACKAGED_PATH=/d' \
+          -e '/^# True when sudo would run this exact command/,/^require_root "$color"$/d' \
+          "$policy"
+
+        # Belt and braces, because a sed range that stops matching deletes
+        # nothing and says nothing: the session check greps every shipped bin
+        # for /usr in code, and this is the file that would trip it.
+        ! grep -v '^[[:space:]]*#' "$policy" | grep -q '/usr/' || {
+          echo "omarchy-theme-set-browser-policy still names a /usr path in code:" >&2
+          grep -vn '^[[:space:]]*#' "$policy" | grep '/usr/' >&2
+          exit 1
+        }
+
         # Clicking Spotify offered to install Spotify.
             #
             # Both launchers focus an existing window if there is one, and otherwise

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -1215,6 +1215,27 @@ pkgs.runCommand "nixarchy-options"
         fi
         echo "the lock screen has a PAM stack"
 
+        # ---- printing is on, cups-browsed is not --------------------------
+        # 4.0.2 dropped cups-browsed from base.packages and from the services
+        # it enables -- "Harden CUPS printer discovery and administration".
+        # NixOS defaults services.printing.browsed.enable to
+        # services.avahi.enable, which this module sets, so the daemon
+        # upstream removed kept running here by inheritance: as root, with no
+        # hardening, creating queues from mDNS announcements. Asserted rather
+        # than trusted, because the coupling lives in nixpkgs and a bump can
+        # bring it back without touching a line of this repo.
+        if [ -e "$vm/etc/systemd/system/cups-browsed.service" ]; then
+          echo "cups-browsed is on the machine again -- upstream removed it in 4.0.2." >&2
+          echo "It comes back through services.printing.browsed.enable, which" >&2
+          echo "nixpkgs defaults to services.avahi.enable." >&2
+          exit 1
+        fi
+        test -e "$vm/etc/systemd/system/cups.service" || {
+          echo "printing is off entirely: browsed was meant to go, not CUPS" >&2
+          exit 1
+        }
+        echo "printing is on and cups-browsed is not"
+
         # ---- the user units exist and name store paths --------------------
         # Upstream ships these under default/systemd/user, which is not a
         # systemd search path, so nothing ever loaded them: no lock before


### PR DESCRIPTION
## What this changes, and why

Omarchy 4.0.2 is a security release — shell injection fixed in the theme and
app installers, CUPS discovery hardened, packages signed. Two of its changes
land on this port, and the second one turned out to matter more than the first.

### The browser accent

4.0.1 wrote `/etc/chromium/policies/managed/color.json` inline from
`omarchy-theme-set-browser`, **as the user**, into directories
`systemd.tmpfiles` hands to `browserThemeUser` (`modules/nixos.nix` ~899). The
package patches that script nowhere, because on NixOS it needs no privilege.

4.0.2 moved the write into a new `bin/omarchy-theme-set-browser-policy` which
escalates to a `/usr/bin` path through an `/etc/sudoers.d` rule nothing here
reads, pins `PATH` to FHS directories containing none of the `install`,
`mktemp` and `rm` it then calls, and installs the file `root:root`. The
nightly bump sat on the missing file for its full 900 seconds:

```
machine.wait_until_succeeds("test -s /etc/chromium/policies/managed/color.json")
RequestedAssertionFailed: action timed out after 900.16 seconds
```

Patched rather than replaced: three of the four problems are single anchors,
and upstream's colour validation, symlink refusal and atomic install are worth
keeping. The `PATH` pin is rewritten to `${lib.makeBinPath [ coreutils ]}`
rather than deleted, so a hand-run `sudo omarchy-theme-set-browser-policy`
still resolves its tools.

Upstream's own shape — root-owned dirs plus a `security.sudo` rule on the store
path — was considered and rejected: upstream is hardening against policy
directories writable by every account, while ours are 0755 owned by one named
desktop user who is in `wheel` already. A NOPASSWD rule there moves the write
rather than restricting it.

### CUPS, which is the part worth reading twice

Upstream dropped `cups-browsed` from `omarchy-base.packages`. Chasing why
turned up something about *this* port:

```
$ nix eval .#nixosConfigurations.vm.config.services.printing.browsed.enable
true
```

`services.printing.browsed.enable` defaults to `config.services.avahi.enable`
in nixpkgs (`nixos/modules/services/printing/cupsd.nix:301`), and this module
sets `avahi.enable = true` so that driverless IPP printers are found. So
**cups-browsed has been running on every nixarchy machine** — as root, with
`ExecStart` only and none of the hardening upstream's new drop-in adds —
creating print queues from mDNS announcements on the local network. That is
the daemon 4.0.2 removed, and the comment at `modules/nixos.nix:727` was still
citing its presence in `base.packages` as the reason our printing defaults
were fine.

Off now, with `printing.browsed.enable = lib.mkDefault false`. Avahi stays on;
driverless IPP does not need browsed. `cups-pk-helper`, which 4.0.2 adds, needs
no naming — nixpkgs pulls it in wherever polkit is enabled.

## How I proved the check fails

The browser half, from the real bump run (33740150455) quoted above; green
after, from a watched local run:

```
waiting for success: test -s /etc/chromium/policies/managed/color.json ... in 0.02 seconds
chromium policy: {"BrowserThemeColor": "#1a1b26", ...}
accent matches the theme: 26,27,38
wallpaper renders (delta 4)
SESSION EXIT: 0
```

The CUPS half gets a new assertion in `tests/options.nix`, red then green:

```
red   (browsed.enable = true):  cups-browsed is on the machine again -- upstream removed it in 4.0.2.
green:                           printing is on and cups-browsed is not
```

It fails if a future nixpkgs default ever switches it back on.

There is also a build-time guard that earned its place mid-work: the repo's
own "no shipped command reaches into /usr" check caught an incomplete first
patch —

```
AssertionError: these shipped commands still reach into /usr in code:
omarchy-theme-set-browser-policy.
```

## Checks run locally

- `nix build .#omarchy` — pass
- `nix build .#checks.x86_64-linux.options` — pass, including the new assertion
- `nix build .#checks.x86_64-linux.session` — pass, 140.73s
- `nix fmt` / statix / deadnix — clean

Every existing `--replace-fail` anchor still matched against 4.0.2, and all 332
menu rows and 74 Install rows still resolve.

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed
- [x] If this adds an option: `tests/options.nix` covers both states
- [x] If this adds a `checks.*` entry: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5