### PR TITLE
Screen sharing works, because the picker the seeded config names now exists

### DIFF
--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -632,6 +632,29 @@ in
         # Yaru inherits from Adwaita for anything it does not draw itself.
         adwaita-icon-theme
 
+        # config/hypr/xdph.conf, which the package seeds into
+        # ~/.config/hypr, sets
+        # `custom_picker_binary = hyprland-preview-share-picker`.
+        # xdg-desktop-portal-hyprland execs that name for every ScreenCast
+        # request, so with nothing providing it the exec fails, the backend
+        # reads selection -1 and destroys the session -- screen sharing dies
+        # in every application, with no dialog and no error anywhere a user
+        # looks. Upstream declares it in install/omarchy-base.packages, which
+        # pacman honours and nothing on NixOS reads. (#202)
+        #
+        # From nixpkgs rather than the hyprland input that supplies the portal
+        # at programs.hyprland.portalPackage: that flake publishes only
+        # hyprland and xdg-desktop-portal-hyprland, so there is no picker
+        # there to match. Nothing is mismatched by taking it from nixpkgs
+        # either -- the picker links no Hyprland library (gtk4,
+        # gtk4-layer-shell, cairo, pango and nothing else), and the portal
+        # reaches it by exec plus a selection line on stdout, not an ABI.
+        #
+        # Editing the seeded xdph.conf was the other option and is the wrong
+        # one: the file is upstream's, so the edit is undone by the next
+        # Omarchy bump.
+        hyprland-preview-share-picker
+
         # Omarchy sets a cursor size but never a cursor theme -- on Arch one
         # comes with the desktop packages. NixOS ships none, so Hyprland used
         # its own built-in pointer. Bibata is here rather than Yaru or Adwaita

--- a/tests/session.nix
+++ b/tests/session.nix
@@ -819,6 +819,78 @@ pkgs.testers.runNixOSTest {
         "Install it, or name it here with the reason.")
     print("every keybinding launches something that exists (bar omawrite)")
 
+    # ---- every binary the seeded config names exists ----------------------
+    # The probe above asks this of default/hypr/bindings. Nothing asked it of
+    # config/, which is the tree seeded into ~/.config -- and #202 lived
+    # there: config/hypr/xdph.conf names
+    # `custom_picker_binary = hyprland-preview-share-picker`, Arch installs
+    # that binary from install/omarchy-base.packages alongside the file, and
+    # nothing on NixOS reads that list. So xdg-desktop-portal-hyprland execed
+    # a command that did not exist, read `SHAREDATA returned selection -1` and
+    # destroyed the session: screen sharing failed in every application, with
+    # no dialog, no error, and the one line saying why in the portal's journal.
+    #
+    # The class rather than the line. A config file arrives from the package
+    # and the binary it names arrives from a module, by different routes, and
+    # the two can disagree in silence. So scan the whole seeded tree for the
+    # forms it actually uses -- hyprland's `key = binary`, imv's `= exec
+    # binary`, yaml `command:`, .desktop Exec=, and lua launch_on_start() --
+    # and resolve every name on the real session PATH, which is the same
+    # reason the keybinding probe runs in the VM rather than at build time.
+    #
+    # Comment lines go first: autostart.lua and hyprsunset.conf both ship a
+    # commented sample (`o.launch_on_start("my-service")`), which names
+    # nothing.
+    machine.succeed(
+        "cat > /tmp/cfgprobe.sh <<'CPEOF'\n"
+        "root=$(dirname $(dirname $(readlink -f /run/current-system/sw/bin/omarchy)))\n"
+        "cd $root/config || exit 1\n"
+        "grep -rhIvE '^[[:space:]]*(#|--|//)' . 2>/dev/null |\n"
+        "  sed -nE"
+        " -e 's/^[[:space:]]*custom_picker_binary[[:space:]]*=[[:space:]]*//p'"
+        " -e 's/^[[:space:]]*(exec|exec-once)[[:space:]]*=[[:space:]]*//p'"
+        " -e 's/^[[:space:]]*command:[[:space:]]*//p'"
+        " -e 's/.*=[[:space:]]*exec[[:space:]]+//p'"
+        " -e 's/^(Try)?Exec=//p'"
+        " -e 's/.*launch_on_start\\((.*)\\).*/\\1/p' |\n"
+        # Strip the quoting off both ends rather than naming a quote
+        # character: this is a bash heredoc inside a python string inside a
+        # Nix indented string, and every layer wants its own escape.
+        "  sed -E 's|^[^A-Za-z0-9_./-]+||' |\n"
+        "  awk '{print $1}' |\n"
+        "  sed -E 's|[^A-Za-z0-9_./-]+$||' |\n"
+        "  sort -u\n"
+        "CPEOF")
+    machine.succeed("chmod 0755 /tmp/cfgprobe.sh")
+    named = machine.succeed("bash /tmp/cfgprobe.sh").split()
+    print(f"binaries named by the seeded config: {named}")
+
+    # The guard that makes this a check rather than a green light. Every
+    # pattern above is a grep against upstream's file layout, and a grep that
+    # matches nothing passes silently -- which is #133's failure mode, and the
+    # reason AGENTS.md opens the way it does. If an Omarchy bump moves
+    # xdph.conf or renames the setting, this line goes red and somebody looks,
+    # instead of the whole probe quietly measuring nothing.
+    assert "hyprland-preview-share-picker" in named, (
+        "the seeded config no longer names the share picker -- either upstream "
+        f"dropped it, or these patterns stopped matching (found {named})")
+
+    # tensaku is Omarchy's own image editor and is not in nixpkgs, so imv's
+    # Ctrl+E has nothing to open on any NixOS machine. Named rather than
+    # tolerated, the same way omawrite is above; modules/home.nix already
+    # seeds its state directory against the day it is packaged.
+    expected_absent = {"tensaku-edit"}
+    missing = [
+        n for n in named
+        if n not in expected_absent
+        and machine.execute(user % f"command -v {n} >/dev/null 2>&1")[0] != 0
+    ]
+    assert not missing, (
+        f"the seeded config names binaries nothing provides: {missing}. "
+        "Add them where the session's packages are (modules/nixos.nix), or "
+        "name them here with the reason.")
+    print("every binary the seeded config names is on the session PATH")
+
     # ---- the shell rc files know where they live --------------------------
     # All three opened with a fallback to /usr/share/omarchy for when
     # OMARCHY_PATH is unset, which on NixOS can never exist. Anything sourcing


### PR DESCRIPTION
Closes #202.

## What this fixes

Screen sharing failed in every application on the Omarchy session — no dialog,
no error. `config/hypr/xdph.conf`, seeded into `~/.config/hypr` by the omarchy
package, sets `custom_picker_binary = hyprland-preview-share-picker`. Upstream
declares that binary in `install/omarchy-base.packages`, which pacman honours
and nothing on NixOS reads. `xdg-desktop-portal-hyprland` execed a command that
did not exist, read `SHAREDATA returned selection -1`, and destroyed the
session before any dialog could appear.

## The fix

`hyprland-preview-share-picker` joins `environment.systemPackages` in
`modules/nixos.nix`, beside the icon and cursor themes that are there for
exactly the same reason — the seeded config names them, and on Arch they arrive
with the desktop packages. Not `pkgs/omarchy/default.nix`'s `runtimeDeps`,
which that file scopes to "this package's own scripts call it": nothing in
`bin/` calls the picker, the portal does.

The seeded `xdph.conf` is left alone. It is upstream's file, and an edit there
would be undone by the next bump — verified, v4.0.2 ships it unchanged, so this
neither fixes nor collides with #201.

From nixpkgs (0.2.1) rather than from the `hyprland` flake input that supplies
the portal, because that flake publishes only `hyprland` and
`xdg-desktop-portal-hyprland` — there is no picker in it. No mismatch is
created: the picker links no Hyprland library (gtk4, gtk4-layer-shell, cairo,
pango) and the portal reaches it by exec plus a selection line on stdout, not
an ABI.

## The check, which is the larger half

This is one instance of a class. A config file arrives from the package, the
binary it names arrives from a module, and the two can disagree **in silence**
— because the Arch list that declares the dependency is not read here.

`tests/session.nix` already asked "does every keybinding launch something that
exists" of `default/hypr/bindings`. It now asks the same of the whole seeded
`config/` tree — the tree that was never scanned — covering the forms that tree
actually uses: `custom_picker_binary`, `exec`/`exec-once`, imv's `= exec`, yaml
`command:`, `.desktop` `Exec=`/`TryExec=`, and lua `launch_on_start()`, with
comment lines dropped first because two files ship commented samples.

**No new `checks` entry and no workflow change**, deliberately: the question is
"does this name resolve on a session's PATH", and only the booted VM has that
PATH. A standalone check would have to build the whole desktop closure to learn
the same thing, and the cheap alternatives — grep `modules/nixos.nix` for the
name, or diff against a hand-kept list — are the kind of check that reads like
coverage and isn't. `checks.session` already runs on every pull request. The
marginal cost is about 0.1 s.

Six names today: `gio`, `lp`, `mogrify`, `slurp` already resolve;
`hyprland-preview-share-picker` now does; **`tensaku-edit` does not** — imv
binds Ctrl+E to Omarchy's image editor, which is not in nixpkgs, so that
binding has done nothing on any NixOS machine. It is named in the check with
its reason rather than tolerated silently, the way `omawrite` is in the sibling
probe. Worth its own issue.

## How I proved the check fails

With the package removed and the probe in place, `nix build
.#checks.x86_64-linux.session` exits 1:

```
binaries named by the seeded config: ['gio', 'hyprland-preview-share-picker', 'lp', 'mogrify', 'slurp', 'tensaku-edit']
AssertionError: the seeded config names binaries nothing provides:
['hyprland-preview-share-picker']. Add them where the session's packages are
(modules/nixos.nix), or name them here with the reason.
```

Restored, exit 0:

```
binaries named by the seeded config: ['gio', 'hyprland-preview-share-picker', 'lp', 'mogrify', 'slurp', 'tensaku-edit']
every binary the seeded config names is on the session PATH
```

The probe also asserts it still finds the picker reference at all, so a bump
that moves `xdph.conf` or renames the setting goes red instead of passing on an
empty scan — the "found nothing, so passed" failure this repo has been bitten
by before.

## What was not verified

The journal lines in #202 (`SHAREDATA returned selection -1`) were taken from
the report, not reproduced: the test VM has no GPU and no consumer for the
portal. What is proven is the precondition the issue diagnoses — the binary was
absent from the session PATH — and that it no longer is.

## Checks run locally

`checks.session` red then green as above, `checks.options`, `nix fmt --ci`,
statix, deadnix — all clean.

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (none added)
- [x] If this adds an option: n/a
- [x] If this adds a `checks.*` entry: n/a, and the PR explains why

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5