### PR TITLE
The nightly Omarchy bump PR is a briefing, not a template

### DIFF
--- a/.github/scripts/omarchy-config-delta.sh
+++ b/.github/scripts/omarchy-config-delta.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# What an Omarchy release changes in the tree that lands in ~/.config.
+#
+# modules/home.nix seeds the whole of upstream's config/ into the user's
+# ~/.config -- 41 files today. Those files are not packaged and not patched:
+# they arrive verbatim, and every command they name is expected to be on the
+# session PATH by some other route entirely. That split is where #202 lived.
+# config/hypr/xdph.conf sets
+# `custom_picker_binary = hyprland-preview-share-picker`; upstream declares
+# that binary in install/omarchy-base.packages, which pacman honours and
+# nothing on NixOS reads. xdg-desktop-portal-hyprland execed a command that
+# did not exist and screen sharing failed in every application, with no
+# dialog, no error, and the one line saying why in the portal's journal.
+#
+# So a file list is not enough. For every file this release adds or changes,
+# this also reports the executables it NEWLY names -- the names that were not
+# already there in the old version -- because that is the set a reviewer has
+# to place somewhere before the bump merges.
+#
+# The reference forms are the ones that tree actually uses, taken from the
+# probe in tests/session.nix rather than invented here: hyprland's
+# `key = binary`, imv's `= exec binary`, yaml `command:`, .desktop Exec=, and
+# lua launch_on_start(). Comment lines go first, because autostart.lua and
+# hyprsunset.conf both ship a commented sample naming nothing.
+#
+# Takes directories, not tags, so it can be checked without a network. The
+# workflow unpacks them; tests/config-delta.nix feeds it fixtures.
+#
+# Usage: omarchy-config-delta.sh <old-config-dir> <new-config-dir> [old-tag] [new-tag]
+set -euo pipefail
+
+old_dir=${1:?usage: omarchy-config-delta.sh <old-dir> <new-dir> [old-tag] [new-tag]}
+new_dir=${2:?usage: omarchy-config-delta.sh <old-dir> <new-dir> [old-tag] [new-tag]}
+old_tag=${3:-old}
+new_tag=${4:-new}
+
+[ -d "$new_dir" ] || {
+  echo "config delta: $new_dir is not a directory -- the seeded tree moved," >&2
+  echo "config delta: or it was never unpacked. Refusing to report calm." >&2
+  exit 1
+}
+
+files() { (cd "$1" && find . \( -type f -o -type l \) | sed 's|^\./||' | sort); }
+
+# The executables a config file names. Every pattern here is a grep against
+# upstream's file layout, so the whole set is checked below for having matched
+# anything at all -- a scanner that has stopped matching prints exactly what a
+# release that changed nothing prints.
+refs() {
+  [ -f "$1" ] || return 0
+  grep -hIvE '^[[:space:]]*(#|--|//)' "$1" 2>/dev/null |
+    sed -nE \
+      -e 's/^[[:space:]]*custom_picker_binary[[:space:]]*=[[:space:]]*//p' \
+      -e 's/^[[:space:]]*(exec|exec-once)[[:space:]]*=[[:space:]]*//p' \
+      -e 's/^[[:space:]]*command:[[:space:]]*//p' \
+      -e 's/.*=[[:space:]]*exec[[:space:]]+//p' \
+      -e 's/^(Try)?Exec=//p' \
+      -e 's/.*launch_on_start\((.*)\).*/\1/p' |
+    sed -E 's|^[^A-Za-z0-9_./-]+||' |
+    awk '{print $1}' |
+    sed -E 's|[^A-Za-z0-9_./-]+$||' |
+    grep -vE '^$' | sort -u || true
+}
+
+old_files=$(files "$old_dir" 2>/dev/null || true)
+new_files=$(files "$new_dir")
+
+added=$(comm -13 <(echo "$old_files") <(echo "$new_files") | grep -vE '^$' || true)
+removed=$(comm -23 <(echo "$old_files") <(echo "$new_files") | grep -vE '^$' || true)
+
+changed=""
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  cmp -s "$old_dir/$f" "$new_dir/$f" || changed="$changed$f"$'\n'
+done < <(comm -12 <(echo "$old_files") <(echo "$new_files"))
+changed=${changed%$'\n'}
+
+# The guard that keeps this from being a green light. If not one file in the
+# whole new tree names an executable, the patterns above have stopped matching
+# upstream's layout -- and the report they produce is indistinguishable from a
+# quiet release. See AGENTS.md section 1.
+any_ref=""
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  if [ -n "$(refs "$new_dir/$f")" ]; then
+    any_ref=yes
+    break
+  fi
+done <<<"$new_files"
+[ -n "$any_ref" ] || {
+  echo "config delta: nothing in $new_dir names an executable, which cannot" >&2
+  echo "config delta: be true -- the reference patterns have stopped matching." >&2
+  echo "config delta: See the refs() forms here against tests/session.nix." >&2
+  exit 1
+}
+
+if [ -z "$added" ] && [ -z "$removed" ] && [ -z "$changed" ]; then
+  echo "No change to the seeded config tree between $old_tag and $new_tag."
+  exit 0
+fi
+
+echo "### Config $new_tag seeds into \`~/.config\`"
+echo
+echo "\`config/\`, $old_tag → $new_tag. modules/home.nix copies this tree into"
+echo "the user's \`~/.config\` verbatim, so every line of it reaches a machine"
+echo "without passing through the package."
+echo
+
+[ -n "$added" ] && {
+  echo "**Added**"
+  echo
+  echo "$added" | sed 's|^|- `config/|;s|$|`|'
+  echo
+}
+
+[ -n "$removed" ] && {
+  echo "**Removed**"
+  echo
+  echo "$removed" | sed 's|^|- `config/|;s|$|`|'
+  echo
+}
+
+[ -n "$changed" ] && {
+  echo "**Changed**"
+  echo
+  echo "$changed" | sed 's|^|- `config/|;s|$|`|'
+  echo
+}
+
+# The half #202 would have been caught by.
+new_names=""
+for f in $added $changed; do
+  before=$(refs "$old_dir/$f")
+  after=$(refs "$new_dir/$f")
+  fresh=$(comm -13 <(echo "$before") <(echo "$after") | grep -vE '^$' || true)
+  [ -n "$fresh" ] || continue
+  new_names="$new_names$(echo "$fresh" | sed "s|^|- \`|;s|\$|\` — named by \`config/$f\`|")"$'\n'
+done
+
+if [ -n "$new_names" ]; then
+  echo "**Executables these files newly name**"
+  echo
+  printf '%s' "$new_names"
+  echo
+  echo "Each of these has to reach the session PATH by some other route: the"
+  echo "seeded file names it, and upstream satisfies it from an Arch package"
+  echo "list nothing on NixOS reads. That is #202 exactly -- screen sharing"
+  echo "failed in every application because \`config/hypr/xdph.conf\` named a"
+  echo "picker binary nothing here provided. Place each one, or decide out"
+  echo "loud that it stays absent."
+  echo
+else
+  echo "No file this release adds or changes names an executable it did not"
+  echo "already name."
+  echo
+fi
+
+exit 0

--- a/.github/scripts/omarchy-patched-files.sh
+++ b/.github/scripts/omarchy-patched-files.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Which of the files upstream changed are files this port has its hands on.
+#
+# An Omarchy release touches 167 files (4.0.1 -> 4.0.2). Twenty-seven of them
+# are bins this port replaces outright with a NixOS stub, a few dozen more are
+# patched by substituteInPlace, one is copied here and pinned by sha256, and
+# the whole of config/ is seeded into ~/.config. Everything else upstream
+# changed is carried through untouched and needs no thought. The intersection
+# is the part that does -- and it is five files out of 167, which is a
+# reviewer's ten seconds rather than an afternoon of diffing.
+#
+# 4.0.2 is the example. `bin/omarchy-plymouth-set` is in the intersection, and
+# the commits behind it are "security/plymouth-publication-race (#8934)" and
+# "Stop an installed theme from running code (#7884)". A security fix landed
+# upstream in a file this port replaces entirely with a stub. Harmless here --
+# the stub does not run theme code either -- but that is a conclusion somebody
+# should reach on purpose, and nothing in the bump PR said the file had moved.
+#
+# The set of files this port patches is DERIVED from what the repo already
+# states, never listed here. A hand-kept list is the thing that goes stale in
+# silence: it keeps naming a bin that was deleted and stops naming the one
+# added last week, and the report stays reassuring throughout. The four
+# statements it reads:
+#
+#   pkgs/omarchy/nix-bin/*                     bins replaced by a stub
+#   substituteInPlace $out/share/omarchy/PATH  files patched in the package
+#   ${src}/PATH beside a sha256sum             a file copied here and pinned
+#   seed_dir "${omarchyPath}/config"           the tree seeded into ~/.config
+#
+# Each of those is a grep, and a grep that matches nothing passes quietly, so
+# all four must produce something or this refuses to print. tests/patched-
+# files.nix runs it against the real repo files for that reason.
+#
+# Attribution is a second pass, because it needs a network and this does not:
+# --list prints the intersecting paths, the workflow asks GitHub which commits
+# in the range touched each one, and the second call renders them.
+#
+# Usage: omarchy-patched-files.sh [--list] <changed-files> <repo-root> \
+#          [attribution-file] [old-tag] [new-tag]
+#
+#   changed-files     one upstream path per line (gh api compare .files[].filename)
+#   attribution-file  optional, "<path><TAB><commit subject>" lines
+set -euo pipefail
+
+list_only=""
+[ "${1:-}" = "--list" ] && {
+  list_only=yes
+  shift
+}
+
+changed_file=${1:?usage: omarchy-patched-files.sh [--list] <changed-files> <repo-root> [attribution] [old-tag] [new-tag]}
+root=${2:?usage: omarchy-patched-files.sh [--list] <changed-files> <repo-root> [attribution] [old-tag] [new-tag]}
+attrib=${3:-}
+old_tag=${4:-old}
+new_tag=${5:-new}
+
+pkg=$root/pkgs/omarchy/default.nix
+home=$root/modules/home.nix
+
+# Each source emits "<upstream path><TAB><why this port cares>". A path ending
+# in / is a prefix: everything under it counts.
+stubs=$(
+  find "$root/pkgs/omarchy/nix-bin" -maxdepth 1 -type f -printf 'bin/%f\n' 2>/dev/null |
+    sort || true
+)
+# Literal paths only. `substituteInPlace $out/share/omarchy/bin/$f` inside a
+# loop leaves the prefix `bin/`, and a prefix of `bin/` matches every bin
+# upstream touched -- 5 files worth reading would become 100 nobody reads. The
+# names those loops iterate are recoverable one line above them, so take them
+# from there instead.
+patched=$(
+  {
+    grep -ohE 'substituteInPlace \$out/share/omarchy/[A-Za-z0-9._/-]+' "$pkg" 2>/dev/null |
+      sed 's|.*share/omarchy/||' | grep -vE '/$' || true
+    grep -ohE '^ *for f in (omarchy-[A-Za-z0-9._-]+ *)+; do' "$pkg" 2>/dev/null |
+      sed -E 's/^ *for f in //;s/; do$//' | tr ' ' '\n' | sed 's|^|bin/|' || true
+  } | grep -vE '^$' | sort -u || true
+)
+pinned=$(
+  grep -ohE '\$\{src\}/[A-Za-z0-9._/-]+' "$pkg" 2>/dev/null |
+    sed 's|^\${src}/||' | sort -u || true
+)
+seeded=$(
+  grep -ohE 'seed_dir "\$\{omarchyPath\}/[A-Za-z0-9._/-]+"' "$home" 2>/dev/null |
+    sed -E 's|.*omarchyPath\}/||;s|"$|/|' | sort -u || true
+)
+
+# See the header: four greps against files that move. All four have to find
+# something, or the intersection below is empty for a reason that has nothing
+# to do with this release.
+derived_or_die() {
+  [ -n "$1" ] || {
+    echo "patched files: found nothing from $2." >&2
+    echo "patched files: that source moved or was renamed. Refusing to report" >&2
+    echo "patched files: an empty intersection as if it meant nothing changed." >&2
+    exit 1
+  }
+}
+derived_or_die "$stubs" "pkgs/omarchy/nix-bin/"
+derived_or_die "$patched" "substituteInPlace in pkgs/omarchy/default.nix"
+derived_or_die "$pinned" "\${src}/ in pkgs/omarchy/default.nix"
+derived_or_die "$seeded" "seed_dir in modules/home.nix"
+
+reasons() {
+  echo "$stubs" | sed 's|$|\treplaced entirely by a NixOS stub in `pkgs/omarchy/nix-bin/`|'
+  echo "$patched" | sed 's|$|\tpatched by `substituteInPlace` in `pkgs/omarchy/default.nix`|'
+  echo "$pinned" | sed 's|$|\tread straight out of the source by `pkgs/omarchy/default.nix` (copied, rewritten, or sha256-pinned)|'
+  echo "$seeded" | sed 's|$|\tseeded into `~/.config` by `modules/home.nix`|'
+}
+
+ours=$(reasons | grep -vE '^[[:space:]]*$' | sort -u)
+total=$(grep -cvE '^\s*$' "$changed_file" || true)
+
+# One pass over the changed files, matching each against the derived set --
+# exact for a path, prefix for anything ending in /.
+hits=""
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  # No `| head -1` here. Under `set -o pipefail` head closing the pipe early
+  # kills the loop with SIGPIPE and the whole command substitution reports
+  # failure, which under `set -e` ends the script with no output and no
+  # message -- exactly the silent-empty failure this script exists to prevent.
+  why=""
+  while IFS=$'\t' read -r p reason; do
+    [ -n "$why" ] && continue
+    case "$p" in
+    */) case "$f" in "$p"*) why=$reason ;; esac ;;
+    *) if [ "$f" = "$p" ]; then why=$reason; fi ;;
+    esac
+  done <<<"$ours"
+  if [ -n "$why" ]; then hits="$hits$f"$'\t'"$why"$'\n'; fi
+done <"$changed_file"
+hits=${hits%$'\n'}
+
+if [ -n "$list_only" ]; then
+  [ -n "$hits" ] && echo "$hits" | cut -f1
+  exit 0
+fi
+
+echo "### Files this port patches that $new_tag changed"
+echo
+
+if [ -z "$hits" ]; then
+  echo "$total files changed between $old_tag and $new_tag, and none of them is"
+  echo "a file this port replaces, patches, pins or seeds. Nothing here needs a"
+  echo "second reading."
+  exit 0
+fi
+
+count=$(echo "$hits" | wc -l)
+echo "$total files changed between $old_tag and $new_tag. $count of them are files"
+echo "this port has its hands on -- where upstream's change and this port's"
+echo "change meet. The rest is carried through untouched."
+echo
+
+echo "$hits" | while IFS=$'\t' read -r f reason; do
+  echo "- \`$f\` — $reason"
+  [ -n "$attrib" ] && [ -f "$attrib" ] && {
+    awk -F'\t' -v want="$f" '$1 == want { print "  - " $2 }' "$attrib"
+  }
+done
+echo
+echo "Read the subjects, not the diffs. An upstream fix in a file this port"
+echo "replaces with a stub does not reach a nixarchy machine -- which is fine"
+echo "right up until it is a security fix, and then it is a decision somebody"
+echo "has to make on purpose."
+
+exit 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,17 @@ jobs:
       - name: The Omarchy package delta still sees a change
         run: nix build .#checks.x86_64-linux.package-delta --print-build-logs
 
+      # The rest of the bump PR body. The config delta scans the seeded tree
+      # for the executables it names -- the class of bug #202 was -- and the
+      # patched-files intersection derives what this port has its hands on by
+      # grepping four statements the repo makes about itself. Both fail by
+      # falling quiet, so both are fed a known answer here.
+      - name: The seeded-config delta still sees a change
+        run: nix build .#checks.x86_64-linux.config-delta --print-build-logs
+
+      - name: The patched-file intersection still finds what this port patches
+        run: nix build .#checks.x86_64-linux.patched-files --print-build-logs
+
   # Every preset in data/devenv-presets.nix, scaffolded with the real
   # `nixarchy dev init` and handed to a real devenv to evaluate.
   #

--- a/.github/workflows/omarchy.yml
+++ b/.github/workflows/omarchy.yml
@@ -116,6 +116,150 @@ jobs:
             echo "DELTA_EOF"
           } >> "$GITHUB_OUTPUT"
 
+      # The next three steps are the rest of the briefing. Everything above
+      # answers "does it still build here"; none of it answers "what did
+      # upstream decide, and does any of it land on something we changed".
+      # That was left to a human with 167 changed files and a git client.
+      #
+      # Everything below writes into $RUNNER_TEMP rather than the checkout.
+      # create-pull-request stages the whole working tree, so a scratch file
+      # left in the repo is a scratch file committed to the bump branch.
+      #
+      # All three are continue-on-error, and each writes a fallback line
+      # rather than nothing when it cannot do its job. A briefing is worth
+      # having and is worth nobody's bump: a GitHub API hiccup must not be the
+      # reason a security release sits unadopted, which has already happened
+      # here twice for other reasons. An empty section reads as "upstream
+      # changed nothing", so a failed section has to say it failed.
+      - name: What upstream says this release changed
+        if: steps.rel.outputs.changed == 'true'
+        continue-on-error: true
+        id: notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Upstream's own words. A diff says what moved; only the release note
+        # says why, and 4.0.2 is the case that proved the difference: the
+        # package delta reported `cups-browsed` as "removed" and nothing more,
+        # while the note called it "Harden CUPS printer discovery and
+        # administration" -- which is what led to finding that nixarchy had
+        # been running that daemon as root.
+        #
+        # Blockquoted, not pasted flat: upstream's headings would otherwise
+        # outrank the PR body's own and the reader loses track of who is
+        # speaking. The words are untouched.
+        run: |
+          tag="${{ steps.rel.outputs.latest }}"
+          # A tag can exist with no release attached, and a release can exist
+          # with an empty body. Both are silence, and silence in a PR body has
+          # to say which kind it is -- an absent section reads as "upstream
+          # said nothing", which is also what a broken API call reads as.
+          body=$(gh api "repos/basecamp/omarchy/releases/tags/$tag" --jq '.body // ""' 2>/dev/null || true)
+          {
+            echo "notes<<NOTES_EOF"
+            echo "### What upstream says about $tag"
+            echo
+            if [ -n "$(printf '%s' "$body" | tr -d '[:space:]')" ]; then
+              printf '%s\n' "$body" | sed 's/^/> /'
+            else
+              echo "_No release notes: \`$tag\` has no GitHub release, or its release"
+              echo "body is empty. Read the compare view instead._"
+            fi
+            echo "NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: What this release changes in the tree seeded into ~/.config
+        if: steps.rel.outputs.changed == 'true'
+        continue-on-error: true
+        id: config
+        # modules/home.nix copies upstream's config/ into ~/.config verbatim,
+        # so those 41 files reach a machine without passing through the
+        # package or any check that reads it. #202 lived exactly there:
+        # config/hypr/xdph.conf named `hyprland-preview-share-picker`, upstream
+        # satisfies that from an Arch package list nothing on NixOS reads, and
+        # screen sharing failed in every application with no dialog at all.
+        run: |
+          cur="${{ steps.rel.outputs.current }}"
+          new="${{ steps.rel.outputs.latest }}"
+          for tag in "$cur" "$new"; do
+            mkdir -p "$RUNNER_TEMP/cfg-$tag"
+            curl -fsSL "https://codeload.github.com/basecamp/omarchy/tar.gz/refs/tags/$tag" |
+              tar xz -C "$RUNNER_TEMP/cfg-$tag" --strip-components=1 || true
+          done
+
+          {
+            echo "config<<CONFIG_EOF"
+            bash .github/scripts/omarchy-config-delta.sh \
+              "$RUNNER_TEMP/cfg-$cur/config" "$RUNNER_TEMP/cfg-$new/config" \
+              "$cur" "$new" ||
+              echo "_The config delta could not run -- see the job log. This is" \
+                "not a report that nothing changed._"
+            echo "CONFIG_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Which files this port patches upstream touched
+        if: steps.rel.outputs.changed == 'true'
+        continue-on-error: true
+        id: patched
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # The strongest of the three. 167 files changed in 4.0.2 and five of
+        # them were files this port replaces with a stub -- including
+        # omarchy-plymouth-set, where the upstream change was
+        # "security/plymouth-publication-race (#8934)". A security fix landing
+        # in a file we do not ship is fine, and is also a decision somebody
+        # should make deliberately rather than never hear about.
+        #
+        # Two passes over the script because attribution needs a network and
+        # the intersection does not: --list names the files, the loop asks
+        # which commits IN THE RANGE touched each, and the second call renders
+        # them. Restricted to the range on purpose -- the newest commit
+        # touching a file is often years older than this release, and an
+        # attribution that quietly cites it is worse than none.
+        run: |
+          cur="${{ steps.rel.outputs.current }}"
+          new="${{ steps.rel.outputs.latest }}"
+          cmp="repos/basecamp/omarchy/compare/$cur...$new"
+
+          gh api "$cmp" --jq '.files[].filename' > "$RUNNER_TEMP/changed.txt" || true
+          gh api "$cmp" --jq '.commits[].sha' | sort > "$RUNNER_TEMP/range.txt" || true
+
+          # An empty compare is not "upstream changed nothing" -- upstream
+          # changed something, that is why this job is running. It is a failed
+          # fetch, and the script downstream would faithfully report "0 files
+          # changed, none of them ours", which is the calm this whole briefing
+          # exists to stop.
+          if [ ! -s "$RUNNER_TEMP/changed.txt" ]; then
+            {
+              echo "patched<<PATCHED_EOF"
+              echo "### Files this port patches that $new changed"
+              echo
+              echo "_The upstream compare could not be fetched -- see the job"
+              echo "log. Nothing was checked; this is not a clean result._"
+              echo "PATCHED_EOF"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          : > "$RUNNER_TEMP/attrib.txt"
+          while IFS= read -r f; do
+            gh api "repos/basecamp/omarchy/commits?sha=$new&path=$f&per_page=20" \
+              --jq '.[] | .sha + "\t" + (.commit.message | split("\n")[0])' |
+              while IFS="$(printf '\t')" read -r sha subject; do
+                grep -qx "$sha" "$RUNNER_TEMP/range.txt" || continue
+                printf '%s\t%s\n' "$f" "$subject"
+              done >> "$RUNNER_TEMP/attrib.txt"
+          done < <(bash .github/scripts/omarchy-patched-files.sh \
+            --list "$RUNNER_TEMP/changed.txt" .)
+
+          {
+            echo "patched<<PATCHED_EOF"
+            bash .github/scripts/omarchy-patched-files.sh \
+              "$RUNNER_TEMP/changed.txt" . "$RUNNER_TEMP/attrib.txt" "$cur" "$new" ||
+              echo "_The patched-file intersection could not run -- see the job" \
+                "log. This is not a report that nothing this port touches moved._"
+            echo "PATCHED_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Check nothing became unmapped or unwired
         if: steps.rel.outputs.changed == 'true'
         run: |
@@ -187,7 +331,13 @@ jobs:
             - all Install rows are still mapped in `data/apps.nix`
             - **a booted session renders its wallpaper**
 
+            ${{ steps.notes.outputs.notes }}
+
             ${{ steps.delta.outputs.delta }}
+
+            ${{ steps.config.outputs.config }}
+
+            ${{ steps.patched.outputs.patched }}
 
             If something is wrong anyway, roll back with
             `nixos-rebuild --rollback` or the boot menu, and open an issue.

--- a/.github/workflows/omarchy.yml
+++ b/.github/workflows/omarchy.yml
@@ -99,19 +99,19 @@ jobs:
         # only worth reading while someone is deciding about this bump.
         run: |
           for tag in "${{ steps.rel.outputs.current }}" "${{ steps.rel.outputs.latest }}"; do
-            : > "pkgs-$tag.txt"
+            : > "$RUNNER_TEMP/pkgs-$tag.txt"
             for list in omarchy-base omarchy-other; do
               curl -fsSL \
                 "https://raw.githubusercontent.com/basecamp/omarchy/$tag/install/$list.packages" \
-                >> "pkgs-$tag.txt" || true
+                >> "$RUNNER_TEMP/pkgs-$tag.txt" || true
             done
           done
 
           {
             echo "delta<<DELTA_EOF"
             bash .github/scripts/omarchy-package-delta.sh \
-              "pkgs-${{ steps.rel.outputs.current }}.txt" \
-              "pkgs-${{ steps.rel.outputs.latest }}.txt" \
+              "$RUNNER_TEMP/pkgs-${{ steps.rel.outputs.current }}.txt" \
+              "$RUNNER_TEMP/pkgs-${{ steps.rel.outputs.latest }}.txt" \
               "${{ steps.rel.outputs.current }}" "${{ steps.rel.outputs.latest }}"
             echo "DELTA_EOF"
           } >> "$GITHUB_OUTPUT"

--- a/flake.nix
+++ b/flake.nix
@@ -963,6 +963,19 @@
           pkgs = pkgsFor.${system};
         };
 
+        # The other two halves of that PR body. Same shape, same reason: both
+        # report on a release by grepping upstream's file layout, and a grep
+        # that has stopped matching prints what a quiet release prints. See
+        # tests/config-delta.nix and tests/patched-files.nix.
+        config-delta = import ./tests/config-delta.nix {
+          inherit inputs;
+          pkgs = pkgsFor.${system};
+        };
+        patched-files = import ./tests/patched-files.nix {
+          inherit inputs;
+          pkgs = pkgsFor.${system};
+        };
+
         # `nix run .#review` watches the pinned packages; this watches that
         # it can still see them. See tests/review-pins.nix.
         review-pins = import ./tests/review-pins.nix {

--- a/tests/config-delta.nix
+++ b/tests/config-delta.nix
@@ -1,0 +1,187 @@
+{ pkgs, ... }:
+# The config delta that goes in every Omarchy bump PR.
+#
+# modules/home.nix seeds upstream's whole config/ tree into ~/.config, and the
+# executables those files name arrive by a completely different route -- which
+# is how #202 shipped: config/hypr/xdph.conf named a share picker that nothing
+# on NixOS provided, and screen sharing failed everywhere, silently.
+#
+# So this script has two dangerous silences, not one. "No change to the seeded
+# config tree" is what a reader sees when upstream changed nothing AND when the
+# file walk stopped finding files; "no file names an executable it did not
+# already name" is what they see when nothing new was named AND when the
+# reference patterns stopped matching upstream's syntax. Both are checked here
+# against a known answer, and the second is what the script's own guard exists
+# for.
+#
+# Directories, not tags, because a check has no network -- the workflow does
+# the fetching.
+let
+  # Shaped like the real tree: hyprland conf, an imv config, a .desktop, lua.
+  old = pkgs.runCommand "old-config" { } ''
+    mkdir -p $out/hypr $out/imv $out/autostart
+    cat > $out/hypr/xdph.conf <<'EOF'
+    screencopy {
+        custom_picker_binary = hyprland-preview-share-picker
+    }
+    EOF
+    cat > $out/hypr/autostart.lua <<'EOF'
+    -- o.launch_on_start("my-service")
+    o.launch_on_start("hypridle")
+    EOF
+    cat > $out/imv/config <<'EOF'
+    <Ctrl+e> = exec tensaku-edit "$imv_current_file"
+    EOF
+    cat > $out/autostart/print-applet.desktop <<'EOF'
+    [Desktop Entry]
+    Exec=system-config-printer-applet
+    EOF
+    cat > $out/goes-away.conf <<'EOF'
+    exec-once = doomed-daemon
+    EOF
+  '';
+
+  # xdph.conf gains a second name, autostart.lua gains one, a file appears and
+  # a file disappears -- and hypr/autostart.lua keeps the name it already had,
+  # which must NOT be reported as new.
+  new = pkgs.runCommand "new-config" { } ''
+    mkdir -p $out/hypr $out/imv $out/autostart
+    cat > $out/hypr/xdph.conf <<'EOF'
+    screencopy {
+        custom_picker_binary = hyprland-preview-share-picker
+    }
+    exec-once = xdph-warmup
+    EOF
+    cat > $out/hypr/autostart.lua <<'EOF'
+    -- o.launch_on_start("my-service")
+    o.launch_on_start("hypridle")
+    o.launch_on_start("omarchy-battery-monitor")
+    EOF
+    cat > $out/imv/config <<'EOF'
+    <Ctrl+e> = exec tensaku-edit "$imv_current_file"
+    EOF
+    cat > $out/autostart/print-applet.desktop <<'EOF'
+    [Desktop Entry]
+    Exec=system-config-printer-applet
+    EOF
+    mkdir -p $out/herdr
+    cat > $out/herdr/config.toml <<'EOF'
+    command: herdr-agent
+    EOF
+  '';
+
+  # Same files, same contents, written in a different order: not a change.
+  same = pkgs.runCommand "same-config" { } ''
+    cp -r ${old} $out
+    chmod -R u+w $out
+  '';
+
+  # A tree where the reference patterns match nothing. Stands in for the day a
+  # bump changes the syntax under them: the script must refuse rather than
+  # report a quiet release.
+  mute = pkgs.runCommand "mute-config" { } ''
+    mkdir -p $out
+    echo 'colour = "#ff0000"' > $out/theme.toml
+  '';
+in
+pkgs.runCommand "nixarchy-config-delta"
+  {
+    nativeBuildInputs = with pkgs; [
+      bash
+      coreutils
+      diffutils
+      findutils
+      gnugrep
+      gnused
+      gawk
+    ];
+  }
+  ''
+    delta=${../.github/scripts/omarchy-config-delta.sh}
+    fail=0
+
+    report=$(bash "$delta" ${old} ${new} v4.0.1 v4.0.2)
+
+    # The file walk, in all three directions.
+    added_block=$(echo "$report" | sed -n '/\*\*Added\*\*/,/\*\*Removed\*\*/p')
+    echo "$added_block" | grep -q 'config/herdr/config.toml' || {
+      echo "config delta: a new file is missing from Added" >&2
+      fail=1
+    }
+    removed_block=$(echo "$report" | sed -n '/\*\*Removed\*\*/,/\*\*Changed\*\*/p')
+    echo "$removed_block" | grep -q 'config/goes-away.conf' || {
+      echo "config delta: a deleted file is missing from Removed" >&2
+      fail=1
+    }
+    changed_block=$(echo "$report" | sed -n '/\*\*Changed\*\*/,/newly name/p')
+    for c in config/hypr/xdph.conf config/hypr/autostart.lua; do
+      echo "$changed_block" | grep -q "$c" || {
+        echo "config delta: edited file $c is missing from Changed" >&2
+        fail=1
+      }
+    done
+
+    # A file nobody touched belongs in no list at all.
+    echo "$report" | grep -q 'print-applet' && {
+      echo "config delta: an untouched file was reported as a change" >&2
+      fail=1
+    }
+
+    # The half #202 turns on: names that are NEW, and only those.
+    names=$(echo "$report" | sed -n '/newly name/,$p')
+    for want in xdph-warmup omarchy-battery-monitor herdr-agent; do
+      echo "$names" | grep -q "$want" || {
+        echo "config delta: newly named executable $want was not reported" >&2
+        fail=1
+      }
+    done
+    # hypridle was named by the same file before this release, and
+    # tensaku-edit's file did not change. Reporting either would bury the
+    # three above in noise a reviewer has already read.
+    for quiet in hypridle tensaku-edit hyprland-preview-share-picker; do
+      echo "$names" | grep -q "$quiet" && {
+        echo "config delta: $quiet was named before this release and is not new" >&2
+        fail=1
+      }
+    done
+    # The commented sample in autostart.lua names nothing.
+    echo "$names" | grep -q 'my-service' && {
+      echo "config delta: a commented-out sample was read as a reference" >&2
+      fail=1
+    }
+
+    # Silence has to mean silence.
+    quiet=$(bash "$delta" ${same} ${old} v1 v2)
+    echo "$quiet" | grep -q 'No change to the seeded config tree' || {
+      echo "config delta: an unchanged tree was reported as a change" >&2
+      echo "$quiet" >&2
+      fail=1
+    }
+
+    # And a broken scan must not look like silence. This is the case the
+    # script's own guard exists for: every reference pattern is a grep against
+    # upstream's file layout, and a grep that matches nothing passes quietly.
+    if bash "$delta" ${old} ${mute} v1 v2 > mute.out 2>&1; then
+      echo "config delta: a tree naming no executable at all was accepted" >&2
+      cat mute.out >&2
+      fail=1
+    else
+      grep -q 'stopped matching' mute.out || {
+        echo "config delta: the empty-scan guard fired without saying why" >&2
+        cat mute.out >&2
+        fail=1
+      }
+    fi
+
+    [ "$fail" -eq 0 ] || {
+      echo >&2
+      echo "What the config delta actually printed:" >&2
+      echo "$report" >&2
+      exit 1
+    }
+
+    echo "the config delta names what moved in the seeded tree, names the"
+    echo "executables that arrived with it, and refuses to be quiet when its"
+    echo "own patterns stop matching"
+    touch $out
+  ''

--- a/tests/patched-files.nix
+++ b/tests/patched-files.nix
@@ -1,0 +1,152 @@
+{ pkgs, ... }:
+# The "files this port patches that upstream changed" section of every Omarchy
+# bump PR.
+#
+# The script derives that set from four statements the repo already makes --
+# pkgs/omarchy/nix-bin/*, substituteInPlace paths in pkgs/omarchy/default.nix,
+# ${src}/ paths in the same file, and seed_dir in modules/home.nix -- rather
+# than from a list somebody keeps by hand. Which trades one failure for
+# another: a hand-kept list goes stale loudly the first time somebody reads it,
+# while four greps go stale in perfect silence and report "none of the 167
+# files upstream changed is one we touch" forever.
+#
+# So this runs the real greps against the real repo files, not fixtures of
+# them. If pkgs/omarchy/default.nix stops writing `substituteInPlace
+# $out/share/omarchy/...`, or the bins move out of nix-bin/, this goes red
+# here instead of going quiet in a PR body nobody can check.
+#
+# The changed-file list is a fixture, because that half comes from the network.
+let
+  # The real 4.0.1 -> 4.0.2 compare, trimmed: two bins this port replaces with
+  # a stub, one it patches, one file it reads straight out of the source, one
+  # seeded config file, and four upstream changes that need no thought here.
+  changed = builtins.toFile "changed.txt" ''
+    bin/omarchy-plymouth-set
+    bin/omarchy-refresh-sddm
+    bin/omarchy-version-channel
+    bin/omarchy-theme-bg-next
+    config/hypr/xdph.conf
+    default/plymouth/omarchy.script
+    install/omarchy-base.packages
+    themes/catppuccin/alacritty.toml
+    README.md
+  '';
+
+  attrib = builtins.toFile "attrib.txt" ''
+    bin/omarchy-plymouth-set	Merge pull request #8934 from ErikMelton/security/plymouth-publication-race
+    bin/omarchy-refresh-sddm	Merge pull request #8934 from ErikMelton/security/plymouth-publication-race
+  '';
+in
+pkgs.runCommand "nixarchy-patched-files"
+  {
+    nativeBuildInputs = with pkgs; [
+      bash
+      coreutils
+      findutils
+      gnugrep
+      gnused
+      gawk
+    ];
+  }
+  ''
+    script=${../.github/scripts/omarchy-patched-files.sh}
+    fail=0
+
+    # The real statements, in the layout the script expects to find them in.
+    mkdir -p root/pkgs/omarchy root/modules
+    cp -r ${../pkgs/omarchy/nix-bin} root/pkgs/omarchy/nix-bin
+    cp ${../pkgs/omarchy/default.nix} root/pkgs/omarchy/default.nix
+    cp ${../modules/home.nix} root/modules/home.nix
+    chmod -R u+w root
+
+    report=$(bash "$script" ${changed} root ${attrib} v4.0.1 v4.0.2)
+
+    # One line per source of "this port has its hands on it", so a single grep
+    # that has stopped matching cannot hide behind the other three.
+    for want in bin/omarchy-plymouth-set bin/omarchy-refresh-sddm \
+      bin/omarchy-version-channel config/hypr/xdph.conf \
+      default/plymouth/omarchy.script; do
+      echo "$report" | grep -q "$want" || {
+        echo "patched files: $want is a file this port touches and is missing" >&2
+        fail=1
+      }
+    done
+
+    # And each with the right reason, because the reason is what tells a
+    # reviewer whether upstream's fix reaches a machine here at all.
+    echo "$report" | grep 'omarchy-plymouth-set' | grep -q 'nix-bin' || {
+      echo "patched files: a stubbed bin is not described as stubbed" >&2
+      fail=1
+    }
+    echo "$report" | grep 'xdph.conf' | grep -q 'seeded' || {
+      echo "patched files: a seeded config file is not described as seeded" >&2
+      fail=1
+    }
+
+    # The other half, and the one that decides whether this is readable at
+    # all. `substituteInPlace $out/share/omarchy/bin/$f` inside a loop would
+    # derive the prefix `bin/`, which matches every bin upstream touched --
+    # 167 changed files would come back as a hundred "worth a second look",
+    # which is the same as none.
+    for noise in bin/omarchy-theme-bg-next install/omarchy-base.packages \
+      themes/catppuccin/alacritty.toml README.md; do
+      echo "$report" | grep -q "$noise" && {
+        echo "patched files: $noise is untouched here and was reported anyway" >&2
+        fail=1
+      }
+    done
+
+    # The count in the prose is the count in the list.
+    echo "$report" | grep -q '^9 files changed' || {
+      echo "patched files: the changed-file total is wrong or missing" >&2
+      fail=1
+    }
+
+    # Attribution, which is the whole reason to read this section: a security
+    # fix landing upstream in a file this port replaces with a stub.
+    echo "$report" | grep -q 'plymouth-publication-race' || {
+      echo "patched files: the upstream commit subject was not rendered" >&2
+      fail=1
+    }
+
+    # --list is what the workflow asks before it goes to the network.
+    listed=$(bash "$script" --list ${changed} root)
+    [ "$(echo "$listed" | wc -l)" = 5 ] || {
+      echo "patched files: --list printed $(echo "$listed" | wc -l) paths, expected 5" >&2
+      echo "$listed" >&2
+      fail=1
+    }
+    echo "$listed" | grep -q ' ' && {
+      echo "patched files: --list printed prose, not bare paths" >&2
+      fail=1
+    }
+
+    # The guard. Four greps against files that move; if any of them finds
+    # nothing, the intersection is empty for a reason that has nothing to do
+    # with the release, and an empty intersection reads as "nothing to see".
+    mkdir -p empty/pkgs/omarchy/nix-bin empty/modules
+    touch empty/pkgs/omarchy/default.nix empty/modules/home.nix
+    if bash "$script" ${changed} empty > empty.out 2>&1; then
+      echo "patched files: a repo stating none of the four was accepted" >&2
+      cat empty.out >&2
+      fail=1
+    else
+      grep -q 'Refusing to report' empty.out || {
+        echo "patched files: the empty-derivation guard fired without saying why" >&2
+        cat empty.out >&2
+        fail=1
+      }
+    fi
+
+    [ "$fail" -eq 0 ] || {
+      echo >&2
+      echo "What the report actually said:" >&2
+      echo "$report" >&2
+      exit 1
+    }
+
+    echo "the intersection names every file this port replaces, patches, reads"
+    echo "or seeds, names nothing else, and refuses to report an empty"
+    echo "intersection when it is the derivation that broke"
+    touch $out
+  ''


### PR DESCRIPTION
## What this changes

When a bump PR needed a human, it handed them a fixed list of assertions, one
package delta, and 167 changed files to diff by hand.

4.0.2 is why that matters. The package delta said `cups-browsed` was removed and
nothing else; it was the **release note** — "Harden CUPS printer discovery and
administration" — that made it a security decision worth chasing, and chasing it
is how we found nixarchy had been running that daemon as root.

Three sections, in the shape `omarchy-package-delta.sh` already set: a pure
script taking files or directories, a thin workflow step that fetches them, and
a fixture check with a known answer.

**Release notes, blockquoted verbatim.** Upstream's own words carry intent; a
diff never will. A tag with no release, and a release with an empty body, both
say so out loud — an absent section reads exactly like "upstream said nothing".

**The config delta**, over the tree `modules/home.nix` seeds into `~/.config`.
Those 41 files reach a machine without passing through the package, and for
every file a release adds or changes it also reports the executables that file
*newly* names — which is #202 exactly. The reference forms come from the probe
in `tests/session.nix` rather than being invented twice.

**The intersection, and the strongest of the three.** Of the 167 files 4.0.2
changed, **seven** are files this port replaces, patches, reads or seeds, each
with the upstream commit that touched it.

## The live dry run, v4.0.1 → v4.0.2

```
### Files this port patches that v4.0.2 changed

- `bin/omarchy-install-font` — replaced entirely by a NixOS stub in `pkgs/omarchy/nix-bin/`
  - Quote install-app and install-font names like install-and-launch (#7843)
- `bin/omarchy-plymouth-set` — replaced entirely by a NixOS stub
  - Merge pull request #8934 from ErikMelton/security/plymouth-publication-race
- `bin/omarchy-refresh-plymouth` — replaced entirely by a NixOS stub
  - Merge pull request #8934 …/security/plymouth-publication-race
- `bin/omarchy-refresh-sddm` — replaced entirely by a NixOS stub
  - Merge pull request #8934 …/security/plymouth-publication-race
- `bin/omarchy-migrate` — replaced entirely by a NixOS stub
  - Merge pull request #9002 …/remove-legacy-installer-privileged-files
- `bin/omarchy-setup-security-fingerprint` — patched by `substituteInPlace`
  - Merge pull request #9002 …/remove-legacy-installer-privileged-files
- `bin/omarchy-version-channel` — patched by `substituteInPlace`
  - Merge pull request #9214 from omacom/rc-channel-pacman

Read the subjects, not the diffs. An upstream fix in a file this port
replaces with a stub does not reach a nixarchy machine -- which is fine
right up until it is a security fix, and then it is a decision somebody
has to make on purpose.
```

Two of those are worth ten seconds each: a **plymouth publication race fix**
landing in three files we replace with stubs, and *"repair legacy paths and
privileged files from retired installers"* landing on the fingerprint setup we
patch.

The config delta is correctly **empty** for this pair (`diff -r` of the two
`config/` trees agrees). Because that is a thin demonstration, it was also run
on v3.8.4 → v4.0.2, which moved the tree: 14 added, 31 removed, 15 changed, and
under *executables these files newly name*, `gio` and `tensaku-edit` — the same
pair #203's probe found from the other direction. Nothing new, the right answer,
and it would have been on the 4.0.0 bump PR before #202 ever happened.

## Derived, never listed

The port's file set comes from four statements the repo already makes:
`pkgs/omarchy/nix-bin/*`, the `substituteInPlace` paths in
`pkgs/omarchy/default.nix`, the `${src}/` paths beside them, and `seed_dir` in
`modules/home.nix`. A hand-kept list goes stale in silence — and so do four
greps, so **all four must find something or the script refuses to print**, and
`tests/patched-files.nix` runs them against the real repo files rather than
fixtures of them.

## How I proved the checks fail (AGENTS.md §1)

Four breaks, four different red messages:

```
config delta: newly named executable xdph-warmup was not reported
config delta: a tree naming no executable at all was accepted
patched files: bin/omarchy-version-channel is a file this port touches and is missing
patched files: found nothing from pkgs/omarchy/nix-bin/. That source moved or was
               renamed. Refusing to report an empty intersection as if it meant
               nothing changed.
```

## And a bug this work found in #198

The package-delta step wrote `pkgs-$tag.txt` **into the checkout**, and
`create-pull-request` stages the whole working tree — it takes no `add-paths`.
The first bump to get past its checks would have carried two stray text files
onto `main`, auto-merged. Nothing caught it because no run has ever reached that
step and then succeeded: every one since has failed earlier, first on the
mapping check, then on the session check. Second commit moves them to
`$RUNNER_TEMP`, which the three new steps already use for this reason.

## For the reviewer

`build.yml` gains two `nix build .#checks…` lines in `lint` and `flake.nix`
gains two `checks` entries — additive coverage, not a gate change; the coverage
guard was run locally and reports `missing:` and `ungated:` both empty. **No
trigger, timeout, concurrency group or permissions block was touched.** The one
thing in `omarchy.yml` beyond a step body is `continue-on-error: true` on the
three new steps: a briefing must never be the reason a bump stops.

Attribution is deliberately restricted to commits **inside** the compare range.
Querying `commits?path=…` unrestricted also returns older commits — citing one
would be an attribution that is quietly wrong.

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed
- [x] If this adds an option: n/a
- [x] If this adds a `checks.*` entry: `build.yml`'s `lint` job builds both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5