### PR TITLE
A release now says what changed, and refuses when it cannot see

### DIFF
--- a/.github/scripts/release-notes.sh
+++ b/.github/scripts/release-notes.sh
@@ -1,0 +1,409 @@
+#!/usr/bin/env bash
+# What changed for someone running nixarchy, between two tags.
+#
+# release.yml has always written a fixed preamble -- which image to download,
+# how to put the split one back together, how to check the sums -- and then let
+# `gh release --generate-notes` append the merged-PR list under it. Between
+# v4.0.1-5 and v4.0.2-1 that meant fifty-five PR titles and nothing that said
+# the vendored Omarchy had moved to a security release, that a root daemon had
+# been turned off, or that screen sharing works again. A person deciding
+# whether to upgrade reads a preamble about the download and then a list about
+# the repository.
+#
+# So this derives the four things that are actually about their machine, in the
+# order somebody wants them:
+#
+#   1. which Omarchy is vendored, and what upstream's package set did
+#   2. what changed in `programs.nixarchy.*` and in the defaults this port sets
+#   3. which pinned packages moved
+#   4. everything else, from the commit subjects
+#
+# Everything is DERIVED. Sections 1 and 3 read files out of git, section 2 asks
+# Nix to evaluate the option set at both revisions and diffs the answer, and
+# section 4 is the log. Nothing here reads a commit message and decides what it
+# meant, because the failure mode of hand-written release notes is that the
+# interesting change is the one nobody wrote down.
+#
+# An app, not a check: it runs git, evaluates two revisions of the flake, and
+# asks GitHub what upstream shipped. A sandboxed derivation can do none of
+# those. What it does have is tests/release-notes.nix, which drives this whole
+# script against a fixture repository with a known answer.
+#
+# Two classes of failure, treated differently on purpose:
+#
+#   A scan that stops matching is fatal. Every section greps for a shape --
+#   `github:basecamp/omarchy/<tag>` in flake.nix, `version = "..."` in
+#   pkgs/apps, `= lib.mkDefault ...` under modules -- and when one of those
+#   shapes changes, the honest report is not "nothing changed", it is "I can no
+#   longer see". This repo has shipped that bug before (see
+#   tests/package-delta.nix), so an empty scan exits non-zero and names the
+#   pattern that rotted.
+#
+#   A network failure is not. GitHub being slow during a release should not
+#   stop the release; it should leave a loud line in the notes saying which
+#   part is missing and where to look it up by hand.
+#
+# Usage: release-notes.sh <from-tag> <to-ref>
+set -euo pipefail
+
+from=${1:?usage: release-notes.sh <from-tag> <to-ref>}
+to=${2:-HEAD}
+
+# Wired in by the flake so the app carries its sibling; overridable so the
+# fixture check can run this script straight out of the tree.
+delta_script=${NIXARCHY_PACKAGE_DELTA:-@delta@}
+
+die() {
+  echo "release-notes: $*" >&2
+  exit 1
+}
+
+from_rev=$(git rev-parse "$from^{commit}")
+to_rev=$(git rev-parse "$to^{commit}")
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# --- 1. what this release is ------------------------------------------------
+
+# The vendored Omarchy is a flake input, so its tag is in flake.nix at both
+# revisions. `|| true` keeps the empty case alive as far as the check below,
+# which is the one worth reporting properly.
+pin_at() {
+  git show "$1:flake.nix" |
+    grep -oE 'github:basecamp/omarchy/[^"]+' | head -1 | cut -d/ -f3 || true
+}
+
+old_omarchy=$(pin_at "$from_rev")
+new_omarchy=$(pin_at "$to_rev")
+for pair in "$from:$old_omarchy" "$to:$new_omarchy"; do
+  [ -n "${pair#*:}" ] || die \
+    "no github:basecamp/omarchy/<tag> in flake.nix at ${pair%%:*}: the scan for the vendored version has stopped matching, and 'unchanged' would be a lie"
+done
+
+echo "## What this release is"
+echo
+if [ "$old_omarchy" = "$new_omarchy" ]; then
+  echo "Omarchy \`$new_omarchy\`, packaged for NixOS -- the same upstream release"
+  echo "\`$from\` vendored. Everything below is this port's own work."
+else
+  echo "Omarchy \`$new_omarchy\`, packaged for NixOS, up from \`$old_omarchy\` in"
+  echo "\`$from\`. Upstream's notes for it:"
+  echo "<https://github.com/basecamp/omarchy/releases/tag/$new_omarchy>"
+fi
+echo
+
+if [ "$old_omarchy" != "$new_omarchy" ]; then
+  # Same lists, same script, same reasoning as the bump PR: Omarchy pins no
+  # versions, so the set of packages it installs is the only thing to diff.
+  fetched=yes
+  for tag in "$old_omarchy" "$new_omarchy"; do
+    : >"$work/pkgs-$tag.txt"
+    for list in omarchy-base omarchy-other; do
+      curl -fsSL --max-time 30 \
+        "https://raw.githubusercontent.com/basecamp/omarchy/$tag/install/$list.packages" \
+        >>"$work/pkgs-$tag.txt" || fetched=no
+    done
+  done
+
+  if [ "$fetched" = yes ]; then
+    bash "$delta_script" \
+      "$work/pkgs-$old_omarchy.txt" "$work/pkgs-$new_omarchy.txt" \
+      "$old_omarchy" "$new_omarchy"
+  else
+    echo "**Upstream's package lists could not be fetched**, so the package"
+    echo "delta between \`$old_omarchy\` and \`$new_omarchy\` is missing from these"
+    echo "notes rather than absent from the release. Compare"
+    echo "\`install/omarchy-base.packages\` between the two tags by hand."
+    echo
+  fi
+
+  # What a fresh ~/.config is seeded from. A change to one of these is a change
+  # to what a new machine starts with, and it reaches nobody through this
+  # repo's own diff, because the file lives in a flake input.
+  #
+  # The paths are the ones modules/home.nix actually copies out of the vendored
+  # tree -- config/ wholesale, plus four files by name -- and not `default/`
+  # entire: default/pacman/ moves in most Omarchy releases and means nothing
+  # here, and default/omarchy/omarchy-menu.jsonc is generated rather than
+  # seeded, because it carries this port's install-row rewrites.
+  seeded_paths='^(config/|default/hypr/|default/tensaku/|icon[.]txt|logo[.]txt)'
+  if compare=$(curl -fsSL --max-time 30 \
+    "https://api.github.com/repos/basecamp/omarchy/compare/$old_omarchy...$new_omarchy"); then
+    seeded=$(echo "$compare" | jq -r '.files[]?.filename' | grep -E "$seeded_paths" || true)
+    if [ -n "$seeded" ]; then
+      echo "**Seeded config files that changed.** A machine installed from this"
+      echo "release starts with these. One you already run keeps the copies in"
+      echo "your \`~/.config\`, which are yours."
+      echo
+      # shellcheck disable=SC2016  # $/ is sed anchoring a line, not a variable
+      echo "$seeded" | sed 's/^/- `/;s/$/`/'
+    else
+      echo "Nothing changed under the trees a new \`~/.config\` is seeded from,"
+      echo "so a fresh install starts with the same files \`$from\` gave it."
+    fi
+    echo
+  else
+    echo "**GitHub could not be asked which files upstream changed**, so these"
+    echo "notes do not say whether the files a new \`~/.config\` is seeded from"
+    echo "moved. Compare \`config/\` between the two tags by hand."
+    echo
+  fi
+fi
+
+# --- 2. configuration changes -----------------------------------------------
+
+echo "## Configuration changes"
+echo
+
+# The option set, evaluated rather than read. A commit message says what
+# somebody meant to change; `options.programs.nixarchy` says what the module
+# system will accept, and what it does when you say nothing.
+#
+# Submodule options stop here: `apps.<name>` is one option, not a tree. That is
+# deliberate -- the interesting default lives at the leaf that has one.
+# shellcheck disable=SC2016  # this is Nix source, not shell: nothing here expands
+options_apply='o:
+  let
+    isOpt = v: (v._type or "") == "option";
+    go = path: v:
+      if isOpt v then
+        (let d = builtins.tryEval (if v ? default then builtins.toJSON v.default else "");
+         in { "${path}" =
+                if !(v ? default) then "(no default)"
+                else if d.success then d.value
+                else "(not representable)"; })
+      else if builtins.isAttrs v then
+        builtins.foldl'"'"' (a: n: a // go (path + "." + n) v.${n}) { }
+          (builtins.filter (n: builtins.substring 0 1 n != "_") (builtins.attrNames v))
+      else { };
+  in go "programs.nixarchy" o'
+
+# The fixture check has no network and cannot evaluate a flake inside a
+# sandbox, so it hands the two option maps over directly. Nothing else sets
+# these.
+options_at() { # rev outfile
+  if [ -n "${NIXARCHY_OPTIONS_FROM:-}" ] && [ "$1" = "$from_rev" ]; then
+    # --no-preserve, because the fixture hands over store files and the
+    # normalisation below rewrites this copy in place.
+    cp --no-preserve=mode "$NIXARCHY_OPTIONS_FROM" "$2"
+  elif [ -n "${NIXARCHY_OPTIONS_TO:-}" ] && [ "$1" = "$to_rev" ]; then
+    cp --no-preserve=mode "$NIXARCHY_OPTIONS_TO" "$2"
+  else
+    # allRefs, because a tag's commit need not be on the checked-out branch.
+    nix eval --json \
+      "git+file://$(git rev-parse --show-toplevel)?rev=$1&allRefs=1#nixosConfigurations.vm.options.programs.nixarchy" \
+      --apply "$options_apply" >"$2"
+  fi
+
+  # A store path in a default is the same package under a different hash on
+  # every rebuild. Strip the hash and what is left -- omarchy-4.0.1 ->
+  # omarchy-4.0.2 -- is the part a reader wanted.
+  sed -i -E 's#/nix/store/[a-z0-9]{32}-#store:#g' "$2"
+}
+
+options_at "$from_rev" "$work/opts-from.json"
+options_at "$to_rev" "$work/opts-to.json"
+for f in "$work/opts-from.json" "$work/opts-to.json"; do
+  [ "$(jq -r 'length' "$f")" -gt 0 ] || die \
+    "the option set at one of the two revisions came back empty: this walk of options.programs.nixarchy has stopped finding options, and 'no option changed' would be a lie"
+done
+
+# One row per finding: C(hanged default), A(dded), R(emoved).
+jq -s -r '
+  .[0] as $a | .[1] as $b
+  | ( [ ($a | keys[]) as $k
+        | select($b | has($k))
+        | select($a[$k] != $b[$k])
+        | "C\t\($k)\t\($a[$k])\t\($b[$k])" ]
+    + [ ([$b | keys[]] - [$a | keys[]])[] | "A\t\(.)" ]
+    + [ ([$a | keys[]] - [$b | keys[]])[] | "R\t\(.)" ] )[]
+' "$work/opts-from.json" "$work/opts-to.json" >"$work/optdiff.tsv"
+
+# The added rows need their default, which the set difference above does not
+# carry. Joined back on here rather than in jq, where it reads worse.
+changed_defaults=$(grep -c '^C' "$work/optdiff.tsv" || true)
+added_options=$(grep -c '^A' "$work/optdiff.tsv" || true)
+removed_options=$(grep -c '^R' "$work/optdiff.tsv" || true)
+
+if [ "$changed_defaults" -gt 0 ]; then
+  # First, in bold, on purpose. An option whose default moved is the one class
+  # of change that reaches a machine whose configuration nobody edited.
+  echo "**Defaults that changed.** These take effect on a machine whose"
+  echo "\`configuration.nix\` says nothing about them."
+  echo
+  awk -F'\t' '$1 == "C" { printf "- `%s`: `%s` → `%s`\n", $2, $3, $4 }' "$work/optdiff.tsv"
+  echo
+fi
+
+if [ "$added_options" -gt 0 ]; then
+  echo "**New options.**"
+  echo
+  awk -F'\t' '$1 == "A" { print $2 }' "$work/optdiff.tsv" |
+    while read -r key; do
+      # shellcheck disable=SC2016  # the backticks are markdown, not a command
+      printf -- '- `%s` (default `%s`)\n' "$key" \
+        "$(jq -r --arg k "$key" '.[$k]' "$work/opts-to.json")"
+    done
+  echo
+fi
+
+if [ "$removed_options" -gt 0 ]; then
+  echo "**Options that are gone.** A build that still sets one of these fails."
+  echo "A renamed option appears here and under new options, both."
+  echo
+  awk -F'\t' '$1 == "R" { printf "- `%s`\n", $2 }' "$work/optdiff.tsv"
+  echo
+fi
+
+if [ $((changed_defaults + added_options + removed_options)) -eq 0 ]; then
+  echo "No option was added, removed or given a different default:"
+  echo "\`programs.nixarchy\` means what it meant under \`$from\`."
+  echo
+fi
+
+# The other half of "configuration", and the half the option diff cannot see:
+# defaults this port sets for options NixOS declares.
+# `services.printing.browsed.enable = lib.mkDefault false` in #201 turned off a
+# daemon that had been running as root on every machine, and it is not an
+# option of ours -- so to the walk above it does not exist at all.
+# [.] rather than \., because this pattern is handed to awk as well as to grep
+# and awk warns about the escape.
+mkdefault_body='[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]*=[[:space:]]*(lib[.])?mk(Default|Force)'
+present=$(git grep -hE "$mkdefault_body" "$to_rev" -- modules | wc -l || true)
+[ "${present:-0}" -gt 0 ] || die \
+  "no '= lib.mkDefault ...' line anywhere under modules/ at $to: the scan for the defaults this port sets has stopped matching, and reporting that none of them moved would be a lie"
+
+# -U0 so only changed lines come through, and the +++ header is tracked so each
+# one can say which module it is in.
+#
+# The line is quoted as written, which means without the attribute set it sits
+# inside: #201's shows as `printing.browsed.enable = ...`, not
+# `services.printing.browsed.enable = ...`. Reconstructing that prefix needs a
+# Nix parser rather than a diff, and the file name plus the leaf is enough to
+# find it. If that stops being true, the fix is to evaluate the two
+# configurations and diff them, not to teach awk about nesting.
+sysdefaults=$(git diff -U0 "$from_rev" "$to_rev" -- modules |
+  awk -v re="^[+-][ \t]*$mkdefault_body" '
+    /^\+\+\+ b\// { file = substr($0, 7); next }
+    $0 ~ re { printf "%s\t%s\t%s\n", substr($0, 1, 1), file, substr($0, 2) }
+  ' || true)
+
+if [ -n "$sysdefaults" ]; then
+  echo "**NixOS defaults this port sets.** Not options of ours -- these are"
+  echo "settings nixarchy chooses on your behalf, and a machine that never"
+  echo "mentioned them follows the new value."
+  echo
+  echo "$sysdefaults" | awk -F'\t' '
+    { gsub(/^[ \t]+|[ \t]+$/, "", $3)
+      printf "- %s `%s` in `%s`\n", ($1 == "+" ? "now" : "no longer"), $3, $2 }'
+  echo
+else
+  echo "No NixOS default this port sets moved."
+  echo
+fi
+
+# --- 3. package changes -----------------------------------------------------
+
+# The hand-pinned apps. Everything else follows nixpkgs or upstream's own
+# flake and moves when the lock does; these move because somebody edited a
+# version and a hash, which is a decision worth naming.
+versions_at() { # rev -> "name<TAB>version" for every pkgs/apps/*.nix that pins one
+  local rev=$1 f name v
+  for f in $(git ls-tree --name-only "$rev" pkgs/apps/); do
+    case $f in
+    *.nix) ;;
+    *) continue ;;
+    esac
+    name=$(basename "$f" .nix)
+    # The one-liner pkgs/apps/once.nix's own updateScript uses to find the
+    # version it is about to rewrite. head -1 because those updateScripts
+    # quote the pattern again further down the same file.
+    v=$(git show "$rev:$f" | sed -n 's/.*version = "\([^"]*\)".*/\1/p' | head -1 || true)
+    if [ -n "$v" ]; then
+      printf '%s\t%s\n' "$name" "$v"
+    fi
+  done
+}
+
+versions_at "$from_rev" | sort >"$work/pins-from.tsv"
+versions_at "$to_rev" | sort >"$work/pins-to.tsv"
+[ -s "$work/pins-to.tsv" ] || die \
+  "no 'version = \"...\"' line in any pkgs/apps/*.nix at $to: the scan for this repo's pinned versions has stopped matching, and reporting that no package moved would be a lie"
+
+pinmoves=$(join -t"$(printf '\t')" "$work/pins-from.tsv" "$work/pins-to.tsv" | awk -F'\t' '$2 != $3')
+newpins=$(join -t"$(printf '\t')" -v2 "$work/pins-from.tsv" "$work/pins-to.tsv")
+droppedpins=$(join -t"$(printf '\t')" -v1 "$work/pins-from.tsv" "$work/pins-to.tsv")
+
+echo "## Package changes"
+echo
+echo "Packages this repo pins by hand, rather than taking from nixpkgs."
+echo
+if [ -z "$pinmoves$newpins$droppedpins" ]; then
+  # Said out loud. An absent section reads the same whether nothing moved or
+  # the scan above stopped finding versions, and those mean opposite things.
+  echo "None of them moved. Still at the versions \`$from\` shipped:"
+  echo
+  awk -F'\t' '{ printf "- `%s` %s\n", $1, $2 }' "$work/pins-to.tsv"
+  echo
+else
+  if [ -n "$pinmoves" ]; then
+    echo "$pinmoves" | awk -F'\t' '{ printf "- `%s` %s → %s\n", $1, $2, $3 }'
+  fi
+  if [ -n "$newpins" ]; then
+    echo "$newpins" | awk -F'\t' '{ printf "- `%s` %s, packaged here for the first time\n", $1, $2 }'
+  fi
+  if [ -n "$droppedpins" ]; then
+    echo "$droppedpins" | awk -F'\t' '{ printf "- `%s` is no longer packaged here (was %s)\n", $1, $2 }'
+  fi
+  echo
+fi
+
+# --- 4. everything else -----------------------------------------------------
+
+echo "## Everything else"
+echo
+echo "Every merged change, grouped by where in the tree it landed. This repo"
+echo "writes commit subjects as full sentences, so they are already the notes."
+echo
+
+# Grouped by path rather than by judgement. The order below IS the rule: the
+# first bucket a commit touches wins, so a change that moves the installer and
+# its documentation is filed under the installer. Nothing here reads a subject
+# and decides what kind of change it was, because that is the step that turns
+# derived notes back into invented ones.
+bucket() { # rev -> label
+  local files
+  files=$(git show --pretty=format: --name-only "$1")
+  case $files in
+  *installer/* | *vm/*) echo "Installing, and the ISO" ;;
+  *modules/* | *data/*) echo "The desktop and what it configures" ;;
+  *pkgs/*) echo "Packaged programs and the vendored tree" ;;
+  *tests/* | *.github/*) echo "Checks and CI" ;;
+  *docs/* | *.md*) echo "Documentation" ;;
+  *) echo "Elsewhere" ;;
+  esac
+}
+
+: >"$work/log.tsv"
+while read -r rev; do
+  [ -n "$rev" ] || continue
+  printf '%s\t%s\n' "$(bucket "$rev")" "$(git log -1 --format=%s "$rev")" >>"$work/log.tsv"
+done < <(git log --no-merges --format=%H "$from_rev..$to_rev")
+
+[ -s "$work/log.tsv" ] || die "no commits between $from and $to"
+
+for label in \
+  "The desktop and what it configures" \
+  "Installing, and the ISO" \
+  "Packaged programs and the vendored tree" \
+  "Checks and CI" \
+  "Documentation" \
+  "Elsewhere"; do
+  grep -F "$label$(printf '\t')" "$work/log.tsv" >"$work/bucket" || continue
+  echo "### $label"
+  echo
+  cut -f2- "$work/bucket" | sed 's/^/- /'
+  echo
+done
+
+echo "$(wc -l <"$work/log.tsv") changes since \`$from\`."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,13 @@ jobs:
       - name: The patched-file intersection still finds what this port patches
         run: nix build .#checks.x86_64-linux.patched-files --print-build-logs
 
+      # And the release notes those deltas go into, which have four scans to
+      # rot rather than one -- the Omarchy pin, the pinned versions, the
+      # mkDefault lines, and the option set -- and where reporting nothing
+      # reaches every person deciding whether to upgrade.
+      - name: The release notes still see what changed
+        run: nix build .#checks.x86_64-linux.release-notes --print-build-logs
+
   # Every preset in data/devenv-presets.nix, scaffolded with the real
   # `nixarchy dev init` and handed to a real devenv to evaluate.
   #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,11 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.tag || github.ref }}
+          # The notes below are derived from the range between this tag and the
+          # one before it, which a depth-1 checkout does not contain: there is
+          # no previous tag to name and no commit to read. Whole history, and
+          # the tags with it.
+          fetch-depth: 0
 
       - name: The tag names the Omarchy the flake vendors
         run: |
@@ -181,11 +186,44 @@ jobs:
           SIZE: ${{ steps.split.outputs.size }}
           NETISO: ${{ steps.split.outputs.netiso }}
           NETSIZE: ${{ steps.split.outputs.netsize }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
+          # What actually changed, first. Everything below this is about the
+          # download; this part is about the machine, and it is the half a
+          # person deciding whether to upgrade came for.
+          #
+          # The previous tag is the nearest one reachable from this commit --
+          # not the newest tag in the repository, which on a re-run of an old
+          # release would be a tag from the future.
+          previous=$(git describe --tags --abbrev=0 "$TAG^" 2>/dev/null || true)
+          : > notes.md
+          if [ -z "$previous" ]; then
+            echo "::warning::no tag before $TAG; publishing without notes"
+          elif nix run .#release-notes -- "$previous" "$TAG" > derived.md; then
+            cat derived.md >> notes.md
+            printf '\n' >> notes.md
+          else
+            # Not fatal. The image is built and the checksums are real; what is
+            # missing is the summary, and saying so is better than either
+            # discarding the release or publishing a page that implies nothing
+            # changed. build.yml runs checks.release-notes on every pull
+            # request, so this should have been caught long before a tag.
+            echo "::error::release-notes failed; see the job log"
+            {
+              echo "**These notes could not be derived.** The tooling that"
+              echo "reads what changed between \`$previous\` and \`$TAG\` refused"
+              echo "rather than report nothing; see this job's log."
+              echo "The images below are unaffected."
+              echo
+            } >> notes.md
+          fi
+
           # A fixed preamble; --generate-notes appends the PR list under it.
           # The README is the manual, so this says only what someone holding
           # the download needs and links to the rest.
-          cat > notes.md <<EOF
+          cat >> notes.md <<EOF
+          ## Getting it
+
           Omarchy $OMARCHY, packaged for NixOS. Two images, and the difference
           is what they carry.
 

--- a/flake.nix
+++ b/flake.nix
@@ -499,6 +499,36 @@
           text = builtins.readFile ./pkgs/review.sh;
         };
 
+        # `nix run .#release-notes <from-tag> <to-ref>` -- what changed for
+        # someone running nixarchy, between two releases. release.yml puts its
+        # output above the download instructions on the release page.
+        #
+        # An app for the same reason `review` is one: it evaluates the option
+        # set at two revisions and asks GitHub what upstream shipped, and a
+        # check has neither a network nor a second checkout. The half that
+        # needs neither is checks.release-notes, which drives this whole script
+        # against a fixture repository.
+        #
+        # It carries omarchy-package-delta.sh rather than reimplementing it:
+        # the question "what did this Omarchy release add and drop" already has
+        # an answer here, and two of them would disagree eventually.
+        release-notes = pkgsFor.${system}.writeShellApplication {
+          name = "nixarchy-release-notes";
+          runtimeInputs = with pkgsFor.${system}; [
+            git
+            curl
+            jq
+            nix
+            gawk
+            gnugrep
+            gnused
+            coreutils
+          ];
+          text = builtins.replaceStrings [ "@delta@" ] [ "${./.github/scripts/omarchy-package-delta.sh}" ] (
+            builtins.readFile ./.github/scripts/release-notes.sh
+          );
+        };
+
         # `nix run github:olafkfreund/nixarchy#doctor` -- reads the running
         # system and prints the configuration it would need. Runnable before
         # nixarchy is an input anywhere, which is the only entry point someone
@@ -983,6 +1013,15 @@
           pkgs = pkgsFor.${system};
         };
         patched-files = import ./tests/patched-files.nix {
+          inherit inputs;
+          pkgs = pkgsFor.${system};
+        };
+
+        # The release notes, against a fixture repository whose diff is known.
+        # Same dangerous failure as the delta above, over more scans: a release
+        # note that reads calm because a grep stopped matching. See
+        # tests/release-notes.nix.
+        release-notes = import ./tests/release-notes.nix {
           inherit inputs;
           pkgs = pkgsFor.${system};
         };

--- a/tests/release-notes.nix
+++ b/tests/release-notes.nix
@@ -1,0 +1,260 @@
+{ pkgs, ... }:
+# The release notes, against a repository with a known answer.
+#
+# `.github/scripts/release-notes.sh` derives what a release changed by grepping
+# for four shapes: the Omarchy pin in flake.nix, `version = "..."` under
+# pkgs/apps, `= lib.mkDefault ...` under modules, and the option set Nix
+# evaluates. Each of those can stop matching -- someone reformats a line,
+# renames a file, moves an option -- and when one does, the script produces a
+# release note that reads calm and says nothing. That is the same failure
+# tests/package-delta.nix was written for, one level up and with more surface.
+#
+# So: a fixture git repository with two revisions whose diff is known, driven
+# through the real script. The option maps are handed over rather than
+# evaluated, and the two GitHub fetches are simply allowed to fail, because a
+# sandboxed derivation has no network and cannot evaluate a flake -- and a
+# failed fetch is itself one of the things asserted on here, since the script's
+# contract is that it says so out loud rather than printing an empty section.
+#
+# The four negative cases at the bottom are the point of the whole file: a
+# scan that has stopped matching must exit non-zero, not report calm.
+let
+  # A default that moved, one option gained, one lost. Shaped exactly like the
+  # `nix eval` in the script: every value is a JSON document in a string.
+  optsFrom = builtins.toFile "opts-from.json" (
+    builtins.toJSON {
+      "programs.nixarchy.enable" = "false";
+      "programs.nixarchy.theme" = "\"tokyo-night\"";
+      "programs.nixarchy.retired" = "true";
+    }
+  );
+
+  optsTo = builtins.toFile "opts-to.json" (
+    builtins.toJSON {
+      "programs.nixarchy.enable" = "false";
+      "programs.nixarchy.theme" = "\"catppuccin\"";
+      "programs.nixarchy.services.rdp.enable" = "false";
+    }
+  );
+
+  # The same map twice: nothing changed, and the script must say that in
+  # words rather than by leaving the section out.
+  optsSame = optsFrom;
+in
+pkgs.runCommand "nixarchy-release-notes"
+  {
+    nativeBuildInputs = with pkgs; [
+      bash
+      git
+      curl
+      jq
+      gawk
+      gnugrep
+      gnused
+      coreutils
+    ];
+  }
+  ''
+    export HOME=$TMPDIR
+    export GIT_CONFIG_GLOBAL=$TMPDIR/gitconfig
+    export GIT_CONFIG_SYSTEM=/dev/null
+    notes=${../.github/scripts/release-notes.sh}
+    export NIXARCHY_PACKAGE_DELTA=${../.github/scripts/omarchy-package-delta.sh}
+    export NIXARCHY_OPTIONS_FROM=${optsFrom}
+    export NIXARCHY_OPTIONS_TO=${optsTo}
+    fail=0
+
+    git init -q -b main "$TMPDIR/repo"
+    cd "$TMPDIR/repo"
+    git config user.email fixture@example.invalid
+    git config user.name fixture
+
+    commit() { git add -A && git commit -q -m "$1"; }
+
+    # --- the release being left behind ---
+    mkdir -p modules pkgs/apps installer docs
+    cat > flake.nix <<'EOF'
+    {
+      inputs.omarchy.url = "github:basecamp/omarchy/v4.0.1";
+      outputs = { ... }: { };
+    }
+    EOF
+    cat > modules/nixos.nix <<'EOF'
+    {
+      services.printing.enable = lib.mkDefault true;
+      services.avahi.enable = lib.mkDefault true;
+    }
+    EOF
+    printf '  version = "0.3.1";\n' > pkgs/apps/once.nix
+    printf '  version = "0.3.2";\n' > pkgs/apps/ttfx.nix
+    commit "The release before this one"
+    git tag v-old
+
+    # --- three commits, three different corners of the tree ---
+    echo 'ask() { :; }' > installer/wizard.sh
+    commit "The installer asks one more question (#900)"
+
+    echo 'a manual page' > docs/manual.md
+    commit "Docs: the page that was missing (#901)"
+
+    # And the release itself: an upstream bump, a pinned version, and a NixOS
+    # default turned off -- the shape of the real v4.0.2-1.
+    sed -i 's|omarchy/v4.0.1|omarchy/v4.0.2|' flake.nix
+    sed -i 's|0.3.1|0.4.0|' pkgs/apps/once.nix
+    cat >> modules/nixos.nix <<'EOF'
+    {
+      services.printing.browsed.enable = lib.mkDefault false;
+    }
+    EOF
+    commit "Omarchy 4.0.2, and a daemon that should not have been running (#902)"
+
+    report=$(bash "$notes" v-old main) || {
+      echo "release-notes: the script failed on the fixture repository" >&2
+      exit 1
+    }
+
+    has() { # pattern, what it is about
+      echo "$report" | grep -qF "$1" || {
+        echo "release-notes: missing $2" >&2
+        echo "  looked for: $1" >&2
+        fail=1
+      }
+    }
+
+    # 1. What this release is. Both tags named, in the right direction.
+    has 'up from `v4.0.1`' "the Omarchy version this release moved on from"
+    has 'Omarchy `v4.0.2`' "the Omarchy version this release vendors"
+
+    # A sandbox has no network, and the contract for that is a loud line rather
+    # than a quiet absence. This is the case that would otherwise let a release
+    # note say nothing about a security bump and look complete doing it.
+    has 'package lists could not be fetched' \
+      "the notice that the upstream package delta is missing"
+    has 'could not be asked which files upstream changed' \
+      "the notice that the seeded-config comparison is missing"
+
+    # 2. Configuration. The default that moved comes first and carries both
+    # values; a machine that never mentioned it follows the new one.
+    has '`programs.nixarchy.theme`: `"tokyo-night"` → `"catppuccin"`' \
+      "the option whose default changed"
+    has '`programs.nixarchy.services.rdp.enable` (default `false`)' \
+      "the added option and its default"
+    has '`programs.nixarchy.retired`' "the removed option"
+
+    # An option that did not move must appear in none of the three lists.
+    echo "$report" | grep -q 'programs.nixarchy.enable' && {
+      echo "release-notes: an unchanged option was reported as a change" >&2
+      fail=1
+    }
+
+    # The half the option walk cannot see: a NixOS default this port sets.
+    # This is #201's cups-browsed, which is not an option of ours at all.
+    has 'now `services.printing.browsed.enable = lib.mkDefault false;`' \
+      "the NixOS default this release turned off"
+    has 'in `modules/nixos.nix`' "the module a changed default lives in"
+
+    # 3. Packages. The one that moved, and not the one that did not.
+    has '`once` 0.3.1 → 0.4.0' "the pinned package whose version moved"
+    echo "$report" | grep -q 'ttfx 0.3.2 →' && {
+      echo "release-notes: an unmoved pin was reported as having moved" >&2
+      fail=1
+    }
+
+    # 4. The log, grouped by where each change landed. Buckets are decided by
+    # path, so this asserts the subject lands under the right heading rather
+    # than merely appearing somewhere.
+    installers=$(echo "$report" | sed -n '/^### Installing/,/^### /p')
+    echo "$installers" | grep -qF "The installer asks one more question (#900)" || {
+      echo "release-notes: the installer commit is not under the installer heading" >&2
+      fail=1
+    }
+    docsbucket=$(echo "$report" | sed -n '/^### Documentation/,/^### /p')
+    echo "$docsbucket" | grep -qF "Docs: the page that was missing (#901)" || {
+      echo "release-notes: the docs commit is not under the documentation heading" >&2
+      fail=1
+    }
+    has '3 changes since `v-old`' "the count of changes"
+
+    # Silence has to mean silence: two identical option maps produce a
+    # sentence, not an absent section.
+    quiet=$(NIXARCHY_OPTIONS_TO=${optsSame} bash "$notes" v-old main)
+    echo "$quiet" | grep -q 'No option was added, removed or given a different' || {
+      echo "release-notes: an unchanged option set produced no sentence saying so" >&2
+      fail=1
+    }
+    # ...except the NixOS default, which did move in this fixture and must
+    # still be reported when nothing else did.
+    echo "$quiet" | grep -q 'services.printing.browsed.enable' || {
+      echo "release-notes: a changed NixOS default vanished when no option changed" >&2
+      fail=1
+    }
+
+    # --- the four scans, broken on purpose ------------------------------------
+    #
+    # Each of these is a shape the script greps for. When one stops matching,
+    # "nothing changed" is the wrong answer and a non-zero exit is the right
+    # one. This is the whole reason the file exists.
+    rots() { # branch, description, what the script must say
+      git checkout -q -b "$1" main
+    }
+
+    expect_refusal() { # description, expected substring
+      refused=$(bash "$notes" v-old "$2" 2>&1) && {
+        echo "release-notes: $1 -- the script reported success instead of refusing" >&2
+        echo "$refused" >&2
+        fail=1
+        return
+      }
+      echo "$refused" | grep -q "$3" || {
+        echo "release-notes: $1 -- refused, but not with the reason expected" >&2
+        echo "  looked for: $3" >&2
+        echo "$refused" >&2
+        fail=1
+      }
+    }
+
+    rots rot-pin
+    sed -i 's|github:basecamp/omarchy/v4.0.2|path:/somewhere/else|' flake.nix
+    commit "The Omarchy pin no longer looks like a github ref"
+    expect_refusal "an unreadable Omarchy pin" rot-pin \
+      "the scan for the vendored version has stopped matching"
+
+    git checkout -q main
+    rots rot-versions
+    sed -i 's|version = |theVersion: |' pkgs/apps/*.nix
+    commit "Every pinned version is written another way"
+    expect_refusal "unreadable pinned versions" rot-versions \
+      "the scan for this repo's pinned versions has stopped matching"
+
+    git checkout -q main
+    rots rot-mkdefault
+    sed -i 's|lib.mkDefault |defaultTo |g' modules/nixos.nix
+    commit "mkDefault is spelled some other way now"
+    expect_refusal "an unreadable set of NixOS defaults" rot-mkdefault \
+      "the scan for the defaults this port sets has stopped matching"
+
+    git checkout -q main
+    empty=$(mktemp)
+    echo '{}' > "$empty"
+    refused=$(NIXARCHY_OPTIONS_TO="$empty" bash "$notes" v-old main 2>&1) && {
+      echo "release-notes: an empty option set was reported as no change" >&2
+      echo "$refused" >&2
+      fail=1
+    }
+    echo "$refused" | grep -q 'has stopped finding options' || {
+      echo "release-notes: an empty option set refused, but not for that reason" >&2
+      echo "$refused" >&2
+      fail=1
+    }
+
+    [ "$fail" -eq 0 ] || {
+      echo >&2
+      echo "What the notes actually said:" >&2
+      echo "$report" >&2
+      exit 1
+    }
+
+    echo "the release notes name what moved, in the right section,"
+    echo "and refuse rather than report calm when a scan stops matching"
+    touch $out
+  ''


### PR DESCRIPTION
## What this changes, and why

A release here publishes an ISO with a fixed preamble — which image to
download, how to reassemble the split one, how to check the sums — and then
whatever `--generate-notes` appends. For the release that is next, `v4.0.2-1`,
that would be **55 PR titles** and no statement that the vendored Omarchy moved
to a *security* release, that a daemon running as root was turned off, or that
no option was removed.

`nix run .#release-notes <from-tag> <to-ref>` derives the notes instead, in the
order a reader wants them: what this release is, configuration changes, package
changes, then the log. `release.yml` puts the output **above** the preamble —
the preamble stays, because the download instructions are what someone holding
the ISO actually needs.

**Everything is derived, nothing is read off a commit message.** The option set
is `nix eval`'d at both revisions and diffed, so an option added, removed, or
given a different default is reported whether or not anyone mentioned it. The
half a diff cannot see — defaults this port sets for options *NixOS* declares —
is a separate scan of `= lib.mkDefault …` under `modules/`, which is what
catches #201's `printing.browsed.enable = false`.

## What it says about v4.0.2-1

Run against the real range, `v4.0.1-5 → main`:

```
## What this release is
Omarchy `v4.0.2`, packaged for NixOS, up from `v4.0.1` in `v4.0.1-5`.

**Added**    cups-pk-helper
**Removed**  cups-browsed, cups-pdf

Nothing changed under the trees a new ~/.config is seeded from,
so a fresh install starts with the same files v4.0.1-5 gave it.

## Configuration changes
**Defaults that changed.**
- programs.nixarchy.package: "store:omarchy-4.0.1" → "store:omarchy-4.0.2"

**New options.**  19, including the whole of services.hypr-rdp.*,
programs.nixarchy.fleet.*, services.devenv.* and flatpaks.*

**NixOS defaults this port sets.**
- now `printing.browsed.enable = lib.mkDefault false;` in modules/nixos.nix
- now `flatpak.uninstallUnmanaged = lib.mkDefault cfg.flatpaks.uninstallUnmanaged;`

## Package changes
None of the hand-pinned packages moved.

## Everything else
55 changes, grouped by where in the tree they landed.
```

**19 options added, none removed**, and the only `programs.nixarchy.*` default
that moved is `package` — the Omarchy bump restated. So no existing
`configuration.nix` changes meaning on this upgrade, and that is a finding
rather than an absence: it is what the option diff exists to be able to say.

## The check

`checks.release-notes` builds a fixture repository with a known diff and drives
the real script over it. **Its negative cases are the point**: each scan is
broken on purpose and must exit non-zero rather than report that nothing
changed — the failure `tests/package-delta.nix` exists for, one level up, with
four scans instead of one (the Omarchy pin reworded, `version = "…"` reworded,
`lib.mkDefault` renamed, an empty option map).

Red, per AGENTS §1:

```
release-notes: an empty option set was reported as no change
release-notes: missing the option whose default changed
  looked for: `programs.nixarchy.theme`: `"tokyo-night"` → `"catppuccin"`
```

Restored, green. `nix build .#release-notes` also builds, so shellcheck is
clean.

## Decisions worth a reviewer's eye

**Grouping is by path, first match wins, in a fixed order** — installer/vm,
modules/data, pkgs, tests/.github, docs, then Elsewhere. **No subject is ever
read to decide what kind of change it was.** The cost is visible and accepted:
#177 pins `hypr-rdp` and touches only `flake.nix`, so it lands in "Elsewhere".
That is better than a taxonomy someone has to keep honest by hand.

**Two failure classes, deliberately different.** A rotted scan is fatal and
names the pattern that stopped matching. A failed GitHub fetch is not — it
leaves a bold line saying which part is missing, because losing a release over
a slow API is worse than a note with a hole in it. The fixture asserts both
fetch-failure lines, since a sandbox has no network.

**Seeded config files** come from the compare API filtered to exactly the paths
`modules/home.nix` copies — deliberately not all of `default/`, since
`default/pacman/` moves most releases and means nothing here.

**A known limit, commented in the script:** mkDefault lines are quoted as
written, so #201's reads `printing.browsed.enable` without its `services.`
prefix. Reconstructing that needs a Nix parser; the honest fix would be to diff
two evaluated configurations, not to teach awk about nesting.

## For a human (AGENTS §10)

This adds a `checks` entry and so names it in `build.yml`'s lint job.
`release.yml` gains `fetch-depth: 0` — a depth-1 checkout has no previous tag
and no commits to read — and its notes step now calls the app. **No trigger,
timeout, concurrency group or permissions block was touched.** On failure it
annotates `::error::` and publishes anyway with a "these notes could not be
derived" block: the ISO and its checksums are unaffected, and `build.yml`
catches rot on every PR long before a tag.

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed
- [x] If this adds an option: n/a
- [x] If this adds a `checks.*` entry: `build.yml`'s `lint` job builds it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5