### PR TITLE
The install checks get a budget with room in it

### DIFF
--- a/tests/free-space.nix
+++ b/tests/free-space.nix
@@ -270,6 +270,24 @@ in
 pkgs.testers.runNixOSTest {
   name = "nixarchy-free-space";
 
+  # The driver has to lose the race to the job, or a hang is invisible.
+  #
+  # runNixOSTest's globalTimeout defaults to one hour, and this check has been
+  # finishing in 37 to 59 minutes -- a budget sized to the median of something
+  # that legitimately takes most of an hour. On 2026-09-03 three install jobs
+  # overlapped on the one self-hosted machine, this one took 63 minutes against
+  # a tree that had passed the same check at 57 minutes an hour earlier, and
+  # the driver killed it: `timeout reached; test terminating`, exit 143. No
+  # regression, no headroom.
+  #
+  # 85 minutes, deliberately UNDER install-check.yml's `timeout-minutes: 90`.
+  # Which of the two fires first decides what a hang looks like: the driver
+  # ending it is a failure, with a log and a reported check, while GitHub
+  # ending it is recorded as `cancelled` -- which #200 established is the state
+  # nothing reports on and nobody sees. If that job timeout ever moves, this
+  # number moves with it and stays below.
+  globalTimeout = 85 * 60;
+
   nodes.installer =
     { ... }:
     {

--- a/tests/install.nix
+++ b/tests/install.nix
@@ -261,6 +261,24 @@ in
 pkgs.testers.runNixOSTest {
   name = "nixarchy-install";
 
+  # The driver has to lose the race to the job, or a hang is invisible.
+  #
+  # runNixOSTest's globalTimeout defaults to one hour, and this check has been
+  # finishing in 37 to 59 minutes -- a budget sized to the median of something
+  # that legitimately takes most of an hour. On 2026-09-03 three install jobs
+  # overlapped on the one self-hosted machine, this one took 63 minutes against
+  # a tree that had passed the same check at 57 minutes an hour earlier, and
+  # the driver killed it: `timeout reached; test terminating`, exit 143. No
+  # regression, no headroom.
+  #
+  # 85 minutes, deliberately UNDER install-check.yml's `timeout-minutes: 90`.
+  # Which of the two fires first decides what a hang looks like: the driver
+  # ending it is a failure, with a log and a reported check, while GitHub
+  # ending it is recorded as `cancelled` -- which #200 established is the state
+  # nothing reports on and nobody sees. If that job timeout ever moves, this
+  # number moves with it and stays below.
+  globalTimeout = 85 * 60;
+
   nodes.installer =
     { ... }:
     {


### PR DESCRIPTION
## What broke

`main`'s install check failed after the #201 merge — run
[33755198746](https://github.com/olafkfreund/nixarchy/actions/runs/33755198746):

```
target # [    6.998579] systemd[1]: etc-machine\x2did.mount: Deactivated successfully.
timeout reached; test terminating...
Terminated  .../nixos-test-driver -o $out
builder failed with exit code 143
```

The target VM is visibly *fine* at the cut-off — filesystems mounted, boot
loader seeded, systemd seven seconds in. Nothing was broken. It ran out of
clock.

## Why

`runNixOSTest`'s `globalTimeout` defaults to **one hour**, and this check has
been finishing in **37 to 59 minutes**. That is a budget sized to the median of
something that legitimately takes most of an hour.

On 2026-09-03 three install jobs overlapped on the one self-hosted machine —
12:21 `feat/bump-briefing`, 12:26 `main`, 12:28 `feat/verify-screenshare` —
each driving an 8 GB KVM VM. `main` took 63 minutes and the driver killed it.
**It is not a regression**: `main`'s content is exactly what #201's own install
job passed on at 57m25s, an hour earlier. All four open PRs passed the same
check that afternoon (56m, 38m, 59m, 37m).

## The fix, and why this number

`globalTimeout = 85 * 60` on `checks.install` and `checks.free-space` — the two
KVM checks on that runner.

85 is chosen against `install-check.yml`'s `timeout-minutes: 90`, not picked.
**Which of the two fires first decides what a hang looks like from outside**:
the driver ending it is a *failure*, with a log and a reported check, while
GitHub ending it is recorded as **`cancelled`** — the state #200 established
that nothing reports on and nobody sees. So the driver must always lose the
race to the job. If that job timeout ever moves, this moves with it and stays
below.

## What I did not do

**Serialise the install jobs.** The obvious fix — making
`concurrency.group` a constant instead of `install-check-${{ github.ref }}` —
is wrong, and the block's own comment says why: `cancel-in-progress` is true
for pull requests, so a constant group would let a push to any branch **cancel
`main`'s install, or another PR's**. The per-ref scoping is load-bearing.

Contention is the trigger here, but the defect is the missing headroom. If
contention alone were the problem, the same three-way overlap would have failed
all three jobs rather than the one that had already used 59 of its 60 minutes.

## How this is verified

This PR's own `install` job runs `checks.install` under the new budget — that
is the test. `main`'s check gets re-run after merge to confirm the state that
failed now passes.

Locally: both checks evaluate and report the new value.

```
$ nix eval .#checks.x86_64-linux.install.config.globalTimeout
5100
$ nix eval .#checks.x86_64-linux.free-space.config.globalTimeout
5100
```

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (none added)
- [x] If this adds an option: n/a
- [x] If this adds a `checks.*` entry: n/a — changes two existing ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5