### PR TITLE
A machine can say which nixarchy built it

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -187,6 +187,32 @@
       );
 
       omarchyVersion = "4.0.2";
+
+      # Which nixarchy built this machine (#208), for nixarchy-version.
+      #
+      # `self` is the only place the answer exists, and it is only reachable
+      # here -- pkgs/omarchy/default.nix cannot see the flake it belongs to --
+      # so the two values are computed once and threaded into the package.
+      #
+      # Not a tag: a flake cannot know its own, and the ordinary consumer
+      # flake.nix tracks main and has none. Not a hand-kept literal beside
+      # omarchyVersion either; that is the class of stale string #201 had to
+      # fix. A rev cannot go stale.
+      #
+      # `dirtyShortRev` is what a working copy with uncommitted changes gets
+      # instead of `shortRev` -- it reads "800af40-dirty", which is the honest
+      # thing for a machine built from someone's checkout to say. Neither
+      # exists when the source is not a git tree at all, hence the last
+      # fallback.
+      nixarchyRev = self.shortRev or self.dirtyShortRev or "unknown";
+      nixarchyDate =
+        let
+          d = self.lastModifiedDate or "";
+        in
+        if d == "" then
+          "unknown"
+        else
+          "${lib.substring 0 4 d}-${lib.substring 4 2 d}-${lib.substring 6 2 d}";
     in
     {
       overlays.default = final: _prev: {
@@ -281,6 +307,7 @@
         omarchy = final.callPackage ./pkgs/omarchy {
           src = omarchy;
           version = omarchyVersion;
+          inherit nixarchyRev nixarchyDate;
           # The compositor the Lua config is written against, not nixpkgs'.
           inherit (hyprland.packages.${final.stdenv.hostPlatform.system}) hyprland;
 

--- a/pkgs/omarchy/default.nix
+++ b/pkgs/omarchy/default.nix
@@ -3,6 +3,11 @@
   stdenvNoCC,
   src,
   version,
+  # Which nixarchy this is (#208). Computed in flake.nix, because `self` is
+  # reachable there and nowhere else, and spliced into nix-bin/nixarchy-version
+  # below.
+  nixarchyRev,
+  nixarchyDate,
   # Runtime dependencies, derived by grepping every script in upstream `bin/`
   # for the commands it shells out to. Regenerate with:
   #   nix run .#deps-report
@@ -945,6 +950,34 @@ stdenvNoCC.mkDerivation {
                   # yet unreachable to the scripts that call it.
                   [ -e "$out/bin/$name" ] || ln -s "$target" "$out/bin/$name"
                 done
+
+                # nixarchy-version, told which nixarchy it is (#208).
+                #
+                # The values come from `self` in flake.nix -- see the note on the
+                # nixarchyRev argument. Spliced at build time the way omarchy-version's
+                # version is, and for the same reason: nothing at runtime can work out
+                # which revision built this store path.
+                substituteInPlace $out/share/omarchy/bin/nixarchy-version \
+                  --replace-fail '@omarchyversion@' '${version}' \
+                  --replace-fail '@nixarchyrev@' '${nixarchyRev}' \
+                  --replace-fail '@nixarchydate@' '${nixarchyDate}'
+
+                # And that the command actually prints what this build put in it.
+                #
+                # --replace-fail above catches a placeholder that stops existing; it
+                # cannot catch the substituteInPlace itself being dropped, which would
+                # ship a script printing "@nixarchyrev@" with a perfectly green build.
+                # AGENTS.md section 1: the check has to be able to fail. The script is
+                # deliberately free of runtime dependencies so it can simply be run here.
+                printed=$(bash $out/share/omarchy/bin/nixarchy-version)
+                case $printed in
+                  *'${version}'*'${nixarchyRev}'*'${nixarchyDate}'*) ;;
+                  *)
+                    echo "nixarchy-version does not print what this build set:" >&2
+                    echo "$printed" >&2
+                    exit 1
+                    ;;
+                esac
 
                 # Agent skills. omarchy-provision-user symlinks every directory under
                 # default/agents/skills/ into ~/.claude/skills, ~/.agents/skills,

--- a/pkgs/omarchy/nix-bin/nixarchy-version
+++ b/pkgs/omarchy/nix-bin/nixarchy-version
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# nixarchy:new
+# omarchy:summary=Print the Omarchy version and the nixarchy revision this machine was built from
+# omarchy:examples=nixarchy-version
+
+# `omarchy --version` answers "which Omarchy", never "which nixarchy".
+#
+# Two machines can both say 4.0.2 and differ by every commit in this port --
+# tags are v4.0.2-1, where the -1 counts packaging revisions against an
+# unchanged upstream. Before this, "does this machine have the screen sharing
+# fix?" could only be answered by reading flake.lock.
+#
+# What is printed is the revision and its date, not a version or a tag, and
+# that is deliberate: a flake cannot know its own tag (`self` exposes rev,
+# shortRev and lastModified, and nothing else), and most machines are not on a
+# tag at all -- the ordinary flake.nix says `github:olafkfreund/nixarchy` with
+# no ref and tracks main. A tag printed there would be a lie. A rev is true on
+# every machine, maps to the tag when there is one, and cannot go stale the way
+# a hand-kept `nixarchyRelease = "1"` literal beside omarchyVersion would --
+# which is the literal #201 had to fix with a sed.
+#
+# Both values are spliced in by pkgs/omarchy/default.nix from what the flake
+# actually built. The Omarchy half is the same `version` omarchy-version is
+# spliced with, rather than a call out to it, so this script has no runtime
+# dependency at all and the build can run it to check the splice worked.
+
+set -euo pipefail
+
+printf 'Omarchy   %s\n' '@omarchyversion@'
+printf 'nixarchy  %s  %s\n' '@nixarchyrev@' '@nixarchydate@'

--- a/pkgs/verify.sh
+++ b/pkgs/verify.sh
@@ -46,6 +46,27 @@ say_dim() { printf '    %s%s%s\n' "$dim" "$1" "$off"; }
 printf '\n%snixarchy: what the VM could not check%s\n' "$bold" "$off"
 say_dim "Run this inside a running Omarchy session."
 
+# ---- what this machine is ------------------------------------------------
+# First, because "what are you actually running" is the first question when
+# something is wrong, and every answer below is only meaningful against it.
+# A value, not a verdict: 4.0.2 is neither good nor bad, it is the fact the
+# rest of this output has to be read against.
+head_ "Version"
+if command -v nixarchy-version >/dev/null 2>&1; then
+  # Two lines, "Omarchy   4.0.2" and "nixarchy  800af40  2026-09-03", printed
+  # as two values. Here-string rather than a pipe: a `while read` on the right
+  # of a pipe runs in a subshell, and the pass/fail counters it increments
+  # would be discarded at the end of it.
+  while read -r label value; do
+    ok "$label" "$value"
+  done <<<"$(nixarchy-version)"
+else
+  # Not a failure. This script is run on machines that do not have nixarchy at
+  # all -- that is what the Omarchy-is-absent handling below exists for -- and
+  # on an older one that predates the command.
+  hmm "nixarchy-version not on PATH" "nothing here can say which nixarchy this is"
+fi
+
 # ---- the session ---------------------------------------------------------
 head_ "Session"
 if [ -z "${WAYLAND_DISPLAY:-}" ]; then


### PR DESCRIPTION
Closes #208.

`omarchy --version` answers "which Omarchy" — 4.0.2. Nothing answered "which
nixarchy". Tags are `v4.0.2-1`, where the `-1` counts this port's packaging
revisions against an unchanged upstream, so two machines can both say 4.0.2 and
differ by every commit here. *"Does this machine have the screen sharing fix?"*
could only be answered by reading `flake.lock`.

```
$ nixarchy-version
Omarchy   4.0.2
nixarchy  c87c3a9  2026-09-03
```

## Why a revision and not a version

**A flake cannot know its own tag** — `self` exposes `rev`, `shortRev` and
`lastModified`, nothing else — and most machines are not on a tag anyway: the
ordinary `flake.nix` says `github:olafkfreund/nixarchy` with no `ref` and tracks
`main`. A tag printed there would be a lie.

A rev is true everywhere, maps to the tag when there is one, and cannot go stale
the way a hand-kept `nixarchyRelease = "1"` beside `omarchyVersion` would — that
is exactly the literal #201 had to fix with a `sed` after an auto-merged bump
left it reading 4.0.1.

A dirty tree has no `rev`, so `dirtyShortRev` is the fallback and a machine built
from a working copy prints `800af40-dirty` rather than an empty string. Verified,
not assumed.

## How the value gets there

`self` is reachable in `flake.nix` and nowhere else, so `nixarchyRev` and
`nixarchyDate` are computed once beside `omarchyVersion` and passed to the
existing `callPackage`; `pkgs/omarchy/default.nix` splices them into the new bin
at build time, exactly as `omarchyVersion` already reaches `omarchy-version`.

Rejected: reading `.git/HEAD` (impure, and there is no `.git` in a store path);
a separate `writeShellApplication` outside the omarchy derivation (a second
thing to install, not on the desktop's PATH); and calling `omarchy-version` at
runtime for the Omarchy half — dropped so the script has **no runtime
dependency at all**, which is what lets the build execute it.

## verify.sh

Both lines at the top, as values rather than verdicts, because "what are you
actually running" is the first question when something is wrong and everything
below is read against it:

```
Version
  ✓ Omarchy                            4.0.2
  ✓ nixarchy                           c87c3a9  2026-09-03
```

It notes rather than fails when the command is absent, matching how the file
already handles machines without Omarchy.

## How I proved the check fails

The check is in the package build — `nix build .#omarchy`, already run on every
pull request, so **no new `checks.*` entry and no workflow change** (the
coverage guard already exempts `omarchy`).

`--replace-fail` alone is not the check: it catches a placeholder that stops
existing, but not the `substituteInPlace` being *deleted*, which would ship a
script printing `@nixarchyrev@` on a green build. So the build runs the command
and asserts it prints what this build set. With the splice removed:

```
> Running phase: installPhase
> nixarchy-version does not print what this build set:
> Omarchy   @omarchyversion@
> nixarchy  @nixarchyrev@  @nixarchydate@
```

Restored: green.

It lives there rather than in `tests/options.nix` (evaluation cannot read a
built script without IFD) or `checks.session` (booting a VM to read two strings
is an hour of queue for nothing).

## Not done, deliberately

The About window and `nixarchy-doctor`. The doctor runs *before* nixarchy is
installed, where there is no revision to report; About is cosmetic. Both are
easy to add later if wanted.

`omarchy commands --check` still reports 430 — the `nixarchy-*` bins are not
indexed as subcommands — so no README figure moves.

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed
- [x] If this adds an option: n/a
- [x] If this adds a `checks.*` entry: n/a — asserted inside `nix build .#omarchy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5