### PR TITLE
The screenshot editor, imv's Ctrl+E and clipboard image-open all open satty, which we were already shipping

### DIFF
--- a/modules/home.nix
+++ b/modules/home.nix
@@ -334,6 +334,12 @@ in
 
       sessionVariables.OMARCHY_PATH = omarchyPath;
 
+      # Same reason as the NixOS module's copy: upstream's default screenshot
+      # editor, tensaku-edit, is not in nixpkgs, so the Edit on the screenshot
+      # notification was dead (#204). Set here too because this module is also
+      # usable standalone, without programs.nixarchy.
+      sessionVariables.OMARCHY_SCREENSHOT_EDITOR = lib.mkDefault "satty-edit";
+
       # Seed, don't manage: these files are copied, never symlinked. Omarchy
       # expects the user to edit ~/.config/hypr/*.lua by hand and rewrites
       # ~/.local/state/omarchy at runtime, both of which Home Manager's

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -576,12 +576,23 @@ in
     environment = {
       # The single indirection point. bin/, shell/, themes/ and the Hyprland
       # Lua defaults are all resolved relative to this.
-      sessionVariables.OMARCHY_PATH = "${cfg.package}/share/omarchy";
+      sessionVariables = {
+        OMARCHY_PATH = "${cfg.package}/share/omarchy";
 
-      # The replacement omarchy-update reads this. It is a plain script inside
-      # the package with no way to see module options, and it is reached from
-      # the shell's bar widget and notifications as well as the menu.
-      sessionVariables.NIXARCHY_FLAKE = cfg.flake;
+        # omarchy-capture-screenshot defaults this to tensaku-edit, which is an
+        # Arch package and is not in nixpkgs, so the Edit on every screenshot
+        # notification did nothing (#204). satty-edit is the wrapper the
+        # omarchy package puts around satty -- already installed on every
+        # machine here, and named by nothing until now. mkDefault so a machine
+        # that does package tensaku, or wants gimp, just says so.
+        OMARCHY_SCREENSHOT_EDITOR = lib.mkDefault "satty-edit";
+
+        # The replacement omarchy-update reads this. It is a plain script
+        # inside the package with no way to see module options, and it is
+        # reached from the shell's bar widget and notifications as well as the
+        # menu.
+        NIXARCHY_FLAKE = cfg.flake;
+      };
 
       # Omarchy's scripts are unwrapped by design (wrapping breaks the CLI's
       # metadata scan), so their dependencies have to be on the session PATH.

--- a/pkgs/omarchy/default.nix
+++ b/pkgs/omarchy/default.nix
@@ -95,6 +95,7 @@
   retroarch-joypad-autoconfig,
   localsend,
   runCommand,
+  writeShellScriptBin,
   writeText,
   fontconfig,
   tldr,
@@ -280,6 +281,29 @@ let
     libxkbcommon # xkbcli, for the keyboard-layout widget
     xdg-user-dirs # xdg-user-dirs-update
     satty # screenshot annotation
+
+    # #204: three user-facing paths -- the screenshot notification's Edit,
+    # imv's Ctrl+E, and opening an image from clipboard history -- reached for
+    # `tensaku-edit`, Omarchy's own editor, which is an Arch package and is not
+    # in nixpkgs. All three silently did nothing while satty, right above, was
+    # installed on every machine and named by nothing.
+    #
+    # A wrapper rather than pointing the three call sites straight at satty,
+    # because satty takes the image as `--filename FILE`, not as a positional:
+    # `satty /tmp/shot.png` exits with "the following required arguments were
+    # not provided", which is the same silence again. And the screenshot path
+    # cannot carry the flag itself -- upstream passes the editor to
+    # omarchy-notification-send as `--exec "$SCREENSHOT_EDITOR" "$FILEPATH"`,
+    # and that script rejects a multi-word command ("--exec takes the command
+    # as separate words, not one quoted string"), so OMARCHY_SCREENSHOT_EDITOR
+    # has to be a single program that takes a bare path.
+    #
+    # Named satty-edit rather than tensaku-edit: shadowing upstream's name
+    # would need no patches at all, but it would also make packaging the real
+    # tensaku later a collision instead of a choice.
+    (writeShellScriptBin "satty-edit" ''
+      exec ${satty}/bin/satty --filename "$@"
+    '')
     wl-screenrec # screen recording
 
     # The screensaver is ASCII art driven through text effects, and ttfx is
@@ -698,6 +722,20 @@ stdenvNoCC.mkDerivation {
             substituteInPlace $out/share/omarchy/default/systemd/user/omarchy-speaker-tuning.service \
               --replace-fail 'ExecStart=/usr/bin/pipewire' \
               'ExecStart=/run/current-system/sw/bin/pipewire'
+
+            # The two image-editor call sites that hardcode tensaku-edit, which
+            # is not packaged anywhere here -- see the satty-edit wrapper in the
+            # runtime dependencies above for why a wrapper and not satty itself.
+            #
+            # The third, omarchy-capture-screenshot, is deliberately NOT patched:
+            # it reads OMARCHY_SCREENSHOT_EDITOR, and the modules set that. Using
+            # upstream's own knob leaves one less patch to re-anchor on a bump.
+            substituteInPlace $out/share/omarchy/bin/omarchy-clipboard-open \
+              --replace-fail 'exec tensaku-edit "$path"' \
+              'exec satty-edit "$path"'
+            substituteInPlace $out/share/omarchy/config/imv/config \
+              --replace-fail 'exec tensaku-edit "$imv_current_file"' \
+              'exec satty-edit "$imv_current_file"'
 
             # 1Password'"'"'s Chromium extension, installed the way NixOS installs one.
             #

--- a/tests/session.nix
+++ b/tests/session.nix
@@ -875,11 +875,11 @@ pkgs.testers.runNixOSTest {
         "the seeded config no longer names the share picker -- either upstream "
         f"dropped it, or these patterns stopped matching (found {named})")
 
-    # tensaku is Omarchy's own image editor and is not in nixpkgs, so imv's
-    # Ctrl+E has nothing to open on any NixOS machine. Named rather than
-    # tolerated, the same way omawrite is above; modules/home.nix already
-    # seeds its state directory against the day it is packaged.
-    expected_absent = {"tensaku-edit"}
+    # Empty since #204: tensaku-edit was the one entry, and imv's Ctrl+E now
+    # names satty-edit, which the omarchy package ships. Kept as the escape
+    # hatch the assertion below points at -- a name goes in here with its
+    # reason, the way omawrite is named in the sibling keybinding probe.
+    expected_absent = set()
     missing = [
         n for n in named
         if n not in expected_absent


### PR DESCRIPTION
Closes #204.

Three user-facing paths reached for `tensaku-edit`, Omarchy's own image editor.
It is in upstream's **Arch** package list, is not in nixpkgs, and is packaged
nowhere here — so the Edit on every screenshot notification, Ctrl+E in imv, and
opening an image from clipboard history all silently did nothing.

Meanwhile `satty` has been a runtime dependency of the omarchy package all
along, commented `# screenshot annotation`, installed on every machine, and
named by no config anywhere. **We shipped an annotator and defaulted to one we
do not ship.**

## satty is not a drop-in, and that mattered

```
$ satty /path/shot.png
error: unexpected argument '/path/shot.png' found
Usage: satty [OPTIONS] --filename <FILENAME>
```

It takes the image as `--filename FILE`. A positional exits non-zero — which
would have been the same silent failure wearing a different hat.

And the screenshot path cannot carry the flag itself: upstream hands the editor
to `omarchy-notification-send` as `--exec "$SCREENSHOT_EDITOR" "$FILEPATH"`, and
that script deliberately refuses a multi-word command string. The editor has to
be **one program taking a bare path** — hence a `satty-edit` wrapper in the
runtime dependencies, beside the `pacman` and `localsend` shims that exist for
the same class of reason.

Named `satty-edit` rather than shadowing upstream's `tensaku-edit`: shadowing
would need zero patches, but it would make packaging real tensaku later a
collision instead of a choice.

## Two kinds of call site

`omarchy-capture-screenshot` **needs no patch**: it reads
`OMARCHY_SCREENSHOT_EDITOR`, so both modules set it with `mkDefault` — a machine
that packages tensaku, or prefers gimp, just says so. Using upstream's own knob
is one less anchor to re-check on every bump.

The other two hardcode the name and get the `substituteInPlace --replace-fail`
treatment this file already applies 78 times.

`default/hypr/apps/system.lua`'s `dev.tensaku.Tensaku` window rules are left
alone — harmless, and still correct for the day tensaku arrives.

## How I proved the check fails

`tests/session.nix`'s seeded-config scan (from #203) listed `tensaku-edit` in
`expected_absent` with its reason. **That entry is gone** — the cleanest form of
this proof, a check going from "tolerated with a note" to "resolves".

With the imv patch reverted to a no-op:

```
binaries named by the seeded config: ['gio', 'hyprland-preview-share-picker', 'lp', 'mogrify', 'slurp', 'tensaku-edit']
AssertionError: the seeded config names binaries nothing provides: ['tensaku-edit'].
error: Cannot build '…-vm-test-run-nixarchy-session.drv'.
```

Restored:

```
binaries named by the seeded config: ['gio', 'hyprland-preview-share-picker', 'lp', 'mogrify', 'satty-edit', 'slurp']
every binary the seeded config names is on the session PATH
```

And `pkgs/verify.sh`'s probe from #205 goes from
`✗ screenshot editor is not installed — tensaku-edit` to
`✓ screenshot editor  satty-edit`.

## Checks run locally

`checks.session` (red then green above), `checks.options`, `nix fmt -- --ci`,
`statix check`, `deadnix --fail`. No workflow files touched.

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (none added)
- [x] If this adds an option: n/a — sets an existing upstream variable
- [x] If this adds a `checks.*` entry: n/a — removes an exemption from an existing one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5