### PR TITLE
The RDP assertion says why it stopped you and points at the page for the rest

### DIFF
--- a/modules/secrets.md
+++ b/modules/secrets.md
@@ -87,10 +87,12 @@ No credentials set (-u/-p). Use -u <user> -p <pass> to require authentication.
 
 and then serves the session **unauthenticated**. It fails open. So the module
 in `modules/services/` is the only thing standing between a missing secret and
-an RDP daemon with no password, and it must assert with a message naming the
-three commands (read the host pubkey → add it to `.sops.yaml` → `sops edit`)
-rather than let a rebuild succeed into that state. Never make the service
-start passwordless as a convenience for the first-boot case.
+an RDP daemon with no password, and it must assert rather than let a rebuild
+succeed into that state. The message says why the rebuild stopped and the
+one-line shape of the fix, and points at `docs/manual/remote-desktop.md` for
+the commands; it used to name them itself, and #215 is what that cost — two
+copies of a workflow, of which the one in the module was the wrong one. Never
+make the service start passwordless as a convenience for the first-boot case.
 
 There is a second, sharper edge to this, and it is the one a future reader is
 most likely to "simplify" away. The warning above and the actual enforcement

--- a/modules/services/hypr-rdp.nix
+++ b/modules/services/hypr-rdp.nix
@@ -131,7 +131,10 @@ in
       expects is your tailnet, which needs no firewall change at all.
 
       Requires a sops secret for the password. Enabling this without one fails
-      the rebuild rather than starting a desktop anyone can connect to
+      the rebuild rather than starting a desktop anyone can connect to.
+
+      The four decisions this asks of you, and how to reach it once it runs,
+      are `docs/manual/remote-desktop.md`
     '';
 
     package = lib.mkOption {
@@ -276,6 +279,13 @@ in
               programs.nixarchy.services.hypr-rdp.user directly.
             '';
           }
+          # The steps live on the manual page and are not repeated here. They
+          # drifted once already: this message said `sops edit` bare, with
+          # nothing in the closure providing sops, and put the declaration
+          # where a relative sopsFile resolves one directory too deep once
+          # nixarchy-apply copies the menu's services.nix into the flake. What
+          # stays is the reason the rebuild stopped, which a reader needs at
+          # the moment it stops them.
           {
             assertion = svc.passwordSecret != null;
             message = ''
@@ -284,28 +294,24 @@ in
               start -- it logs a warning and serves your desktop to anyone who
               connects. So this stops the rebuild instead.
 
-              Encrypt a password for this host:
-
-                # 1. this host's public key, as an age recipient
-                nix-shell -p ssh-to-age --run \
-                  'ssh-keyscan localhost 2>/dev/null | ssh-to-age'
-
-                # 2. add it under `keys:` in .sops.yaml, and name it in the
-                #    creation rule for hosts/<name>/secrets.yaml
-
-                # 3. write the password into the encrypted file
-                sops edit hosts/<name>/secrets.yaml
-
-              Then declare it and point this option at it:
+              The shape of the fix, once the password exists as a sops secret:
 
                 sops.secrets.hypr-rdp-password.sopsFile = ./secrets.yaml;
                 programs.nixarchy.services.hypr-rdp.passwordSecret =
                   "hypr-rdp-password";
 
-              Step 1 needs an SSH host key, which exists only where
-              services.openssh.enable is true -- sops-nix has no other key
-              source on a nixarchy machine and will say so itself. That is the
-              same fail-closed shape as this assertion, one layer down.
+              Encrypting it is four steps -- read this host's SSH host key as
+              an age recipient, name it in a .sops.yaml creation rule, `sops
+              edit` the password in, `git add` the encrypted file. They are
+              written out, with the wrappers that provide sops and ssh-to-age,
+              under "The password, and why the rebuild fails without one":
+
+                docs/manual/remote-desktop.md
+                https://olafkfreund.github.io/nixarchy/manual/remote-desktop
+
+              The first of them needs services.openssh.enable = true and a
+              rebuild after it: the host key it reads does not exist until
+              sshd has generated one.
             '';
           }
           {


### PR DESCRIPTION
Closes #215.

`modules/services/hypr-rdp.nix`'s `passwordSecret` assertion carried the whole
sops workflow. **That was right while there was nowhere to point** — a rebuild
that stops with an unexplained assertion is worse than a long message — and
#211 changed it.

`docs/manual/remote-desktop.md` now has the same workflow plus three things the
message did not: a `nix-shell` wrapper for `sops` (nothing in the closure
provides it), the declaration in `hosts/<name>/configuration.nix` rather than
the menu-managed `services.nix` — where a relative `sopsFile` resolves one
directory too deep once `nixarchy-apply` copies that file into the flake
(`modules/apps.nix:788`) — and a personal age key as a second recipient, so the
person who wrote the password can still read it.

The message was not merely duplicated. It was **the less correct of the two
copies**, which is the usual fate of a duplicated instruction.

## The assertion stays

Its reason is load-bearing and unchanged, verbatim:

> hypr-rdp with no password does not refuse to start — it logs a warning and
> serves your desktop to anyone who connects. So this stops the rebuild instead.

What it keeps beyond that: the two-line shape of the fix, the four steps **named**
so an offline reader knows what they are in for and can recognise where they
are, and the `services.openssh` ordering constraint (the host key does not exist
until sshd has generated one). What it drops is the commands, now one path and
one URL away.

`git add` is named for the first time — an untracked `secrets.yaml` fails with
"path does not exist", which is not a self-explaining error.

## The other two halves

`modules/secrets.md` had the same problem in one sentence, and a worse version
of it: it *prescribed* the duplication — "a message naming the three commands".
Left alone, that would have argued the next contributor straight back into #215.
It now describes the pointer.

`enable` gains a line naming the page; it is the module's entry point and where
a reader looks for the long form. The other option descriptions were checked and
left alone — they state what an option does and why its default is what it is,
which is condensed reasoning rather than duplication.

## The test, and why it needed no change

`tests/options.nix`'s `hyprRdpAssertion` matches the message on the infix
`passwordSecret` only, deliberately: it asserts *that* the assertion fires and
that it does not fire when a secret is named — not what the text says. The new
wording keeps that infix.

It was left alone rather than tightened onto the new path, because matching a
doc path from a test would make the test the thing that breaks when the manual
is reorganised, for no added coverage of the refusal.

Seen failing, with `assertion` forced true:

```
hyprRdpAssertion: on= off=
these options do not take effect both ways: hyprRdpAssertion
an option that cannot be turned off is not an option.
```

Green on restore. `nix fmt --ci`, `statix check`, `deadnix --fail` clean.

## One thing a reviewer should weigh

The message now hardcodes `https://olafkfreund.github.io/nixarchy/manual/remote-desktop`.
**There is no precedent for a URL in a module message here** — no file under
`modules/` mentions github.io — and nothing checks that it resolves, so a
manual reorganisation would rot it silently. Both references were verified
before this PR (the file is on `main`; the URL returns 200), and the
repo-relative path sits on the line above as the fallback, which is the form
`README.md` uses throughout.

Deliberately not fixed here: the general check for it belongs with #214, which
is about prose naming things that no longer exist. One checker for *"anything we
name must exist"* — covering `docs/`, `README.md` and module messages — is
better than two half-checkers, and #214 is where that argument already lives.

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (none added)
- [x] If this adds an option: n/a
- [x] If this adds a `checks.*` entry: n/a — `checks.options` already covers it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5