### PR TITLE
The manual's Tailscale example is one that evaluates, and a check keeps it that way

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,12 @@ jobs:
       - name: The release notes still see what changed
         run: nix build .#checks.x86_64-linux.release-notes --print-build-logs
 
+      # Prose, checked the way the app and subcommand counts already are: an
+      # option path in the README or the manual is a claim about the option
+      # set, and #214 shipped one that had been false for a release.
+      - name: The documentation only quotes options that exist
+        run: nix build .#checks.x86_64-linux.doc-options --print-build-logs
+
   # Every preset in data/devenv-presets.nix, scaffolded with the real
   # `nixarchy dev init` and handed to a real devenv to evaluate.
   #

--- a/README.md
+++ b/README.md
@@ -582,7 +582,6 @@ list would have been quietly wrong:
 |---|---|
 | Steam | `programs.steam` — an FHS wrapper, or it will not run |
 | 1Password | `programs._1password-gui` — a setuid helper, or it cannot unlock |
-| Tailscale | `services.tailscale` — a daemon |
 | Xbox controllers | `hardware.xpadneo` — a kernel driver |
 | Firefox | `programs.firefox` — so policies and extensions stay declarative |
 
@@ -590,10 +589,22 @@ list would have been quietly wrong:
 app's own option path:
 
 ```nix
-programs.nixarchy.apps.tailscale = {
+programs.nixarchy.apps._1password = {
   enable = true;
-  settings.useRoutingFeatures = "client";   # → services.tailscale.useRoutingFeatures
+  settings.polkitPolicyOwners = [ "you" ];   # → programs._1password-gui.polkitPolicyOwners
 };
+```
+
+Services — Tailscale, remote desktop, Syncthing, OpenSSH — are the companion
+catalogue in `data/services.nix` and a file of their own. A service nixarchy
+only relays gets upstream's own line, `services.openssh.enable = true;`; one it
+integrates gets an option, `programs.nixarchy.services.tailscale.enable`. There
+is no `settings` passthrough on those, because upstream's options are still
+upstream's and are written beside ours:
+
+```nix
+programs.nixarchy.services.tailscale.enable = true;   # + trusts the interface
+services.tailscale.useRoutingFeatures = "client";     # upstream's option, untouched
 ```
 
 ## Usage

--- a/data/apps.nix
+++ b/data/apps.nix
@@ -12,7 +12,7 @@
 #   attr       nixpkgs attribute, for apps that are only a package.
 #   option     NixOS option path for apps that are a module rather than a
 #              package. `settings` is merged HERE, which is what makes
-#              `apps.tailscale.settings.useRoutingFeatures` land in the right
+#              `apps._1password.settings.polkitPolicyOwners` land in the right
 #              place. An app with an `option` must NOT also set `attr`: the
 #              module owns installing its own package.
 #   unfree     Marks a package nixpkgs licenses as unfree. nixarchy defaults

--- a/docs/manual/other-packages.md
+++ b/docs/manual/other-packages.md
@@ -69,14 +69,52 @@ files on disk, and for those the row enables a NixOS option instead:
 |---|---|---|
 | Steam | `programs.steam` | Needs an FHS wrapper to run at all |
 | 1Password | `programs._1password-gui` | Unlocking needs a setuid helper |
-| Tailscale | `services.tailscale` | It is a daemon |
 | Firefox | `programs.firefox` | Policies and extensions become declarative |
 | Xbox controllers | `hardware.xpadneo` | A kernel driver |
 
-Rows like these accept settings. `nixarchy-apps.nix` is an ordinary NixOS
-module, so you can write, for example,
-`programs.nixarchy.apps.tailscale.settings.useRoutingFeatures = "client";`
-directly beside the selection and it lands in `services.tailscale`.
+Rows like these — and only these, the ones with an option to merge into —
+accept settings. `apps.nix` is an ordinary NixOS module, so you can write
+
+```nix
+programs.nixarchy.apps._1password.settings.polkitPolicyOwners = [ "you" ];
+```
+
+beside the selection, and it is merged into `programs._1password-gui`.
+
+## Services are the other file
+
+Tailscale is not on that list, and neither is anything else that is a decision
+about the machine rather than a package. Those live in `services.nix`, beside
+`apps.nix` in `~/.config/nixarchy/`, with a catalogue of their own. It holds
+two kinds of line, and the difference is what you need to know before tuning
+one:
+
+```nix
+services.openssh.enable = true;                        # upstream's own option
+programs.nixarchy.services.tailscale.enable = true;    # a nixarchy option
+```
+
+The first kind is there because nixarchy had nothing to add: you get the real
+NixOS option, the same line every wiki page and forum answer will show you.
+Configure it exactly as its own documentation says.
+
+The second kind is there because turning the thing on usefully takes more than
+one option — Tailscale needs the firewall to trust the interface, or this host
+can reach your tailnet and nothing on your tailnet can reach it.
+
+Bundled services have no `settings` passthrough and do not need one. Upstream's
+options are not re-declared and not taken away, so you write them directly, in
+the same file:
+
+```nix
+programs.nixarchy.services.tailscale.enable = true;
+services.tailscale.useRoutingFeatures = "client";   # upstream's option, untouched
+```
+
+That is the design rather than an omission. An option copied from upstream goes
+stale and cannot be removed once people depend on it, so nixarchy declares only
+what it genuinely integrates and leaves the rest of `services.tailscale` where
+you already know how to look it up.
 
 ## Unfree software
 

--- a/flake.nix
+++ b/flake.nix
@@ -1040,6 +1040,14 @@
           pkgs = pkgsFor.${system};
         };
 
+        # The other half of that: every option path the README and the manual
+        # quote, checked against the option set they claim to describe. See
+        # tests/doc-options.nix and #214.
+        doc-options = import ./tests/doc-options.nix {
+          inherit inputs;
+          pkgs = pkgsFor.${system};
+        };
+
         # Built, not evaluated, and onto a config that already exists. See
         # tests/integration.nix for the three bugs that shipped because every
         # other check here starts from a clean machine.

--- a/tests/doc-option-paths.py
+++ b/tests/doc-option-paths.py
@@ -1,0 +1,61 @@
+"""Every `programs.nixarchy.*` path our prose quotes, checked against the real
+option set.
+
+Argument 1 is a JSON file written by tests/doc-options.nix: {"options": [...],
+"groups": [...]}. The rest are documents to scan, or directories to walk for
+them -- prose is the .md and .html; the rest of docs/ is screenshots, and a
+JPEG read as text is a crash rather than a finding.
+
+The distinction between the two lists is the whole check. A leaf option may be
+freeform -- `apps.firefox.settings` takes any attribute at all -- so anything
+below a leaf is accepted without pretending to know what nixpkgs allows there.
+A group is just the attrset the module system builds on the way to the leaves,
+and accepting anything below one would accept
+`programs.nixarchy.apps.tailscale.settings.useRoutingFeatures`, which is the
+sentence that made this file exist.
+"""
+
+import json
+import pathlib
+import re
+import sys
+
+# Deliberately anchored on our own prefix. Prose quotes plenty of option paths
+# that are NixOS' rather than ours -- `services.tailscale.useRoutingFeatures`
+# is a real thing to write and no list here can say whether it exists.
+PATH = re.compile(r"programs\.nixarchy(?:\.[A-Za-z0-9_-]+)*")
+
+known = json.load(open(sys.argv[1]))
+options, groups = set(known["options"]), set(known["groups"])
+
+documents = []
+for arg in sys.argv[2:]:
+    path = pathlib.Path(arg)
+    if path.is_dir():
+        documents += sorted(p for p in path.rglob("*") if p.suffix in (".md", ".html"))
+    else:
+        documents.append(path)
+
+found, bad = 0, []
+for doc in documents:
+    for line_no, line in enumerate(doc.open(), 1):
+        for path in PATH.findall(line):
+            found += 1
+            if path in options or path in groups:
+                continue
+            if any(path.startswith(opt + ".") for opt in options):
+                continue
+            bad.append((doc, line_no, path))
+
+# A regex that has stopped matching passes silently, and a check that passes
+# silently is the failure mode this whole file is arguing against.
+if found == 0:
+    sys.exit("no `programs.nixarchy.*` path found in any document: the scan "
+             "matched nothing, which is a broken scan rather than clean prose")
+
+for doc, line_no, path in bad:
+    print(f"{doc}:{line_no}: {path} is not an option", file=sys.stderr)
+if bad:
+    sys.exit(f"{len(bad)} option path(s) quoted in prose do not exist")
+
+print(f"{found} `programs.nixarchy.*` paths quoted in prose, all of them real")

--- a/tests/doc-options.nix
+++ b/tests/doc-options.nix
@@ -1,0 +1,89 @@
+{ inputs, pkgs }:
+# The option paths our documentation quotes, against the option set that exists.
+#
+# #214 is the case: `programs.nixarchy.apps.tailscale.settings.useRoutingFeatures`
+# sat in the manual as a worked example a reader was invited to copy, for as
+# long as it took someone to try it. Tailscale had moved to the services
+# catalogue and the option was gone; nothing noticed, because prose is not
+# built.
+#
+# The repo already refuses to trust prose about numbers -- build.yml derives
+# the app and subcommand counts from the data and fails when the README
+# disagrees. An option path is the same class of claim, and cheaper: the
+# module system already knows every option that exists.
+let
+  inherit (pkgs) lib;
+
+  eval = inputs.nixpkgs.lib.nixosSystem {
+    system = pkgs.stdenv.hostPlatform.system;
+    modules = [
+      inputs.self.nixosModules.nixarchy
+      inputs.home-manager.nixosModules.home-manager
+      {
+        programs.nixarchy.enable = true;
+        home-manager = {
+          useGlobalPkgs = true;
+          useUserPackages = true;
+          sharedModules = [ inputs.self.homeManagerModules.nixarchy ];
+          users.tester = {
+            programs.nixarchy.enable = true;
+            home.stateVersion = "25.05";
+          };
+        };
+        users.users.tester = {
+          isNormalUser = true;
+          home = "/home/tester";
+        };
+        boot.loader.grub.device = "/dev/sda";
+        fileSystems."/" = {
+          device = "/dev/sda1";
+          fsType = "ext4";
+        };
+        system.stateVersion = "25.05";
+      }
+    ];
+  };
+
+  # Both halves, because `programs.nixarchy` is two namespaces wearing one
+  # name: the system module declares apps, services and the installer's
+  # settings, the Home Manager module declares the theme, neovim and plugins.
+  # A reader writing one of those paths does not know or care which module it
+  # came from, and a check that knew only the system half would call
+  # `programs.nixarchy.defaultTheme` a mistake.
+  systemOptions = eval.options.programs.nixarchy;
+  homeOptions = (eval.options.home-manager.users.type.getSubOptions [ ]).programs.nixarchy;
+
+  # Leaves and branches kept apart, because what may follow them differs: a
+  # leaf can be freeform and take attributes nothing here can enumerate, a
+  # branch takes exactly the names below it. See tests/doc-option-paths.py.
+  walk =
+    prefix: attrs:
+    lib.concatLists (
+      lib.mapAttrsToList (
+        name: value:
+        let
+          path = "${prefix}.${name}";
+        in
+        if lib.isOption value then
+          [ { option = path; } ]
+        # `_type` marks a module-system value that is not a nested option set.
+        else if lib.isAttrs value && !(value ? _type) then
+          [ { group = path; } ] ++ walk path value
+        else
+          [ ]
+      ) attrs
+    );
+
+  nodes = walk "programs.nixarchy" systemOptions ++ walk "programs.nixarchy" homeOptions;
+
+  known = pkgs.writeText "nixarchy-options.json" (
+    builtins.toJSON {
+      options = lib.catAttrs "option" nodes;
+      groups = lib.catAttrs "group" nodes;
+    }
+  );
+in
+pkgs.runCommand "doc-options" { nativeBuildInputs = [ pkgs.python3 ]; } ''
+  python3 ${./doc-option-paths.py} ${known} ${../README.md} ${../docs}
+  touch $out
+''


### PR DESCRIPTION
Closes #214.

`programs.nixarchy.apps.tailscale.settings.useRoutingFeatures` stopped existing
when Tailscale moved to `data/services.nix` as a bundled service. It stayed in
the manual as a **worked example a reader is invited to copy**, in the README as
the same claim, and in `data/apps.nix`'s header as the example of a mechanism
that file no longer carries.

## The docs

**The paragraph is replaced, not deleted.** "You can pass settings through" is
still true of apps that have an option to merge into, so the example is now
`apps._1password.settings.polkitPolicyOwners`.

Tuning a **bundled service** is a different question and now gets its own
answer: upstream's options are neither re-declared nor taken away, so you write
them beside the nixarchy toggle in the same file —

```nix
programs.nixarchy.services.tailscale.enable = true;
services.tailscale.useRoutingFeatures = "client";   # upstream's option, untouched
```

Both examples were **evaluated before they were written down**, which is the
whole lesson of this issue:

```json
{"onepassword":["you"],"routing":"client","tailscaleEnabled":true,"trusted":["tailscale0","lo"]}
```

Tailscale is also removed from the "rows that are modules, not packages" table
in both places — it has not been an app row since #90.

## `checks.doc-options`, which is the half that matters

`build.yml` already derives the app and subcommand counts from data and fails
when the prose disagrees. **An option path quoted in prose is the same class of
claim**, and the module system already knows the answer.

The check walks the real option set into **leaves and branches** — anything may
follow a freeform leaf like `settings`, only declared names may follow a branch
— and that distinction is what rejects the tailscale path rather than accepting
it on a prefix match. It walks **both** `programs.nixarchy` namespaces, system
and Home Manager: a system-only scan reports `defaultTheme`, `neovim` and
`plugins` as typos, which was caught during the red run.

Scoped to `programs.nixarchy.*` — prose quotes NixOS' own paths too and nothing
here can vouch for those. The regex needs a name character after each dot, so a
trailing period or backtick cannot be absorbed into a path. **A scan that
matches nothing exits 1**, because an empty scan and clean prose look identical
otherwise.

## How I proved it fails

Three ways, per AGENTS.md §1:

```
with the old prose:      fails, naming both offending lines
                         (README.md:591, other-packages.md:78)
with the regex broken:   no programs.nixarchy.* path found in any document:
                         the scan matched nothing, which is a broken scan
                         rather than clean prose
as merged:               59 `programs.nixarchy.*` paths quoted in prose,
                         all of them real
```

That last number is after rebasing onto current `main`, so the scan includes
`docs/manual/remote-desktop.md` from #211 — **the checker's first real act was
to validate a page written today by someone else.**

Registered in `flake.nix` and named in `build.yml`'s `lint` job, so the coverage
guard at `build.yml:114-173` is satisfied.

## One left, in a file I could not touch

`modules/apps.nix:74-76` still carries
`example = lib.literalExpression (if name == "tailscale" then …)` — a dead
branch, since no app is named tailscale any more. Harmless (the option docs just
show `{ }`), but it is the last tailscale reference in the apps machinery.
Another agent is in that file; worth a one-line follow-up.

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed
- [x] If this adds an option: n/a
- [x] If this adds a `checks.*` entry: `build.yml`'s `lint` job builds it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5