### PR TITLE
A release opens a discussion, so the notes have somewhere to be answered

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,11 @@ on:
 
 permissions:
   contents: write
+  # --discussion-category on the publish step below opens an Announcements
+  # discussion for the release. Without this the whole `gh release create`
+  # call fails, taking the release with it -- the discussion is the smaller
+  # half and must not be able to cost the larger one.
+  discussions: write
 
 # Never cancel a release mid-upload. A half-attached release is worse than a
 # late one, and two tags pushed together should queue rather than race.
@@ -263,10 +268,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
+          # --discussion-category, rather than posting the notes somewhere a
+          # second time. GitHub opens an Announcements discussion carrying this
+          # release's body and links the two, so there is one text and no copy
+          # to drift: an edited release edits the discussion with it.
+          #
+          # It also gives the notes a place that takes replies. A release page
+          # cannot be asked a question; the thing someone wants to say after
+          # reading "cups-browsed was running as root and is now off" belongs
+          # under it rather than in a new issue.
           gh release create "$TAG" out/* \
             --title "$TAG" \
             --notes-file notes.md \
             --generate-notes \
+            --discussion-category announcements \
             --prerelease
 
       # 5.6 GB of parts on the runner's root filesystem, which is the small


### PR DESCRIPTION
## What

`gh release create` gains `--discussion-category announcements`, so publishing a
release opens a linked Announcements discussion carrying the same notes.

## Why not repost them

The obvious version of this is a step that copies the notes into a discussion
after the release. **That would be a second source of truth**, and stale prose is
what this repo has spent the day finding bugs in — #214 was a manual telling
people to write an option that no longer exists, and #215 was an assertion
carrying a walkthrough that had drifted from the page.

`--discussion-category` is GitHub's own mechanism: it creates the discussion
from the release body and **links the two**, so editing the release edits the
discussion with it. One text, no copy, nothing to drift.

## Why it is worth having at all

Now that #207 generates real notes — what the vendored Omarchy moved to, which
defaults changed, which options appeared — a release page is the one place they
**cannot be replied to**. Someone reading *"cups-browsed was running as root and
is now off"* has a question, and today the only outlet is a new issue.

## The permission, which needs sign-off (AGENTS.md §10)

`permissions:` gains `discussions: write`. That is a CI-gate change and yours to
merge rather than mine.

It is also **not optional and not safe to omit**: without it the whole
`gh release create` call fails, taking the release with it rather than skipping
the discussion. The comment on the permission says exactly that, because the
failure mode is the wrong way round — the smaller half must not be able to cost
the larger one.

Verified before writing it: Discussions are enabled on this repo and
`announcements` exists as a category slug.

```
$ gh api repos/{owner}/{repo} --jq .has_discussions
true
$ gh api graphql … discussionCategories
announcements  general  ideas  polls  q-a  show-and-tell
```

## How this gets proven

There is no local check for it — `gh release create` only runs on a tag push,
and it is the one command in this repo that cannot be rehearsed without
publishing something. **The proof is the first tagged release**, which is
`v4.0.2-1`. If the category name or the permission is wrong, that release fails
loudly at the publish step rather than half-succeeding, and the tag can be
deleted and re-pushed.

Worth knowing before merging: this makes the *next* tag the test.

- [x] `nix fmt` / statix / deadnix are clean (no Nix changed)
- [x] New files are `git add`ed (none added)
- [x] If this adds an option: n/a
- [x] If this adds a `checks.*` entry: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5