### PR TITLE
The install job runs its two installs at once

### DIFF
--- a/.github/workflows/install-check.yml
+++ b/.github/workflows/install-check.yml
@@ -196,22 +196,38 @@ jobs:
       # No installer action, no cachix. The runner is a NixOS machine with a
       # warm store, which is most of why this is ten minutes rather than an
       # hour.
-      - name: Install onto a blank disk and boot the result
-        if: needs.gate.outputs.relevant == 'true'
-        run: nix build .#checks.x86_64-linux.install --print-build-logs
-
-      # The same machine, and the one check in the repo whose failure means
-      # somebody's other operating system did not survive. Here rather than in
-      # build.yml for exactly the reason at the top of this file: it boots a
-      # VM, installs, and boots the result, and a push to main would cancel it
-      # there.
       #
-      # After the blank-disk install, not before: if the installer is broken in
-      # some way that has nothing to do with partitioning, checks.install says
-      # so in a tenth of the log.
-      - name: Install into free space and prove the neighbour survived
+      # Both installs in ONE nix invocation, so nix runs them at the same time
+      # rather than one after the other. Measured on run 33798891329, which is
+      # what #231 is about: install took 1722s, free-space 1594s, and every
+      # other step in the job totalled four. Two independent derivations, run
+      # serially, on a machine with forty cores.
+      #
+      # The envelope fits with room: each is memorySize 6144, cores 4,
+      # diskSize 32768, so two at once asks 12 GB and 8 cores of a 40-core,
+      # 94 GB box. Each also carries its own globalTimeout of 85 minutes, so
+      # the driver still loses the race against this job's 90 and fails with a
+      # log instead of being recorded as cancelled.
+      #
+      # What this gives up, stated because it was deliberate: free-space used
+      # to run second, so that an installer broken in a way that has nothing to
+      # do with partitioning was reported by checks.install "in a tenth of the
+      # log". Now both fail together and the reader filters. That is affordable
+      # because nix prefixes every line with the derivation it came from --
+      # `vm-test-run-nixarchy-install>` and `vm-test-run-nixarchy-free-space>`
+      # -- so the two logs interleave without becoming one.
+      #
+      # free-space is the one check in the repo whose failure means somebody's
+      # other operating system did not survive. It is here rather than in
+      # build.yml for the reason at the top of this file: it boots a VM,
+      # installs, and boots the result, and a push to main would cancel it
+      # there.
+      - name: Install onto a blank disk, and into free space beside a neighbour
         if: needs.gate.outputs.relevant == 'true'
-        run: nix build .#checks.x86_64-linux.free-space --print-build-logs
+        run: |
+          nix build --print-build-logs --max-jobs 2 \
+            .#checks.x86_64-linux.install \
+            .#checks.x86_64-linux.free-space
 
       - name: Report what it cost
         if: always() && needs.gate.outputs.relevant == 'true'


### PR DESCRIPTION
Rewritten. **The urgency this was filed for is gone**, and the body says so
rather than leaving the old numbers standing.

## What I removed, and why

The original carried a second change to `tests/install.nix`, wrapping the log
dump in `try/finally` because *"if the 1800s runs out, `execute()` raises"*.

**It does not raise.** `test-driver`'s `machine/__init__.py:988-995` builds the
command as `timeout <seconds> bash -c …` inside the guest:

```python
timeout_str = f"timeout {timeout.total_seconds()}"
... f"{timeout_str} bash -c {shlex.quote(command)} | (base64 -w 0; echo)\n"
...
return (rc, output.decode(errors="replace"))
```

An expiry is the shell's `124`, and `execute` **returns** `(124, output)`. So
the log dump the original protected had already run, before the
`assert rc == 0` that would report it. There was nothing to fix, and that half
is dropped rather than kept with a better story attached to it.

## What remains

One workflow change: both installs in a single `nix build`, so nix runs two
independent derivations at once instead of one after the other.

The envelope fits — each is `memorySize = 6144`, `cores = 4`,
`diskSize = 32768`, so two at once asks 12 GB and 8 cores. Each keeps its own
`globalTimeout = 85 * 60`, under this job's `timeout-minutes: 90`, so the
driver still loses the race and fails with a log rather than being recorded as
`cancelled`.

## What it costs

`free-space` ran **second** deliberately, so that an installer broken in a way
unrelated to partitioning was reported by `checks.install` *"in a tenth of the
log"*. Both now fail together. Nix prefixes every line with its derivation
(`vm-test-run-nixarchy-install>` / `vm-test-run-nixarchy-free-space>`), so the
logs interleave without merging — but a reader has to filter.

## The honest recommendation

This was filed because the job measured **55 minutes** on run 33798891329 —
two-thirds of the budget, with timeouts recorded as `cancelled`.

Eight completed runs today:

```
  35m  success   39m  success   27m  success   19m  success
  20m  success   31m  success   23m  success    6m  failure
  median 27m   max 39m
```

**27 minutes of a 90-minute budget.** The p620 runners came online in between,
and that fixed the problem this PR was written for.

So the trade has changed sides. It buys perhaps ten minutes off a job that is
no longer close to its limit, and it spends the failure ordering that was put
there on purpose. I would still merge it — the ceiling matters when p510 takes
a run and contention returns, both of which happened today — but it is a
convenience now, not a fix, and it is a CI-gate change either way (§10), so
this is a proposal and the call is yours.

Closes #231