### PR TITLE
The Roadmap lists the two epics that were filed tonight

### DIFF
--- a/README.md
+++ b/README.md
@@ -1589,6 +1589,8 @@ is the shape.
 | epic | what it is for | |
 | --- | --- | --- |
 | [#159](https://github.com/olafkfreund/nixarchy/issues/159) | **remote desktop** — reaching the Hyprland session from elsewhere | 4 of 5 done |
+| [#221](https://github.com/olafkfreund/nixarchy/issues/221) | **sandboxes** — a throwaway NixOS machine from a template, in seconds, with no root and no rebuild | planned, 8 issues |
+| [#230](https://github.com/olafkfreund/nixarchy/issues/230) | **boxes** — an Arch or Debian userland for software NixOS will not run, and its apps in your launcher | planned |
 
 **Recently finished:**
 [bare metal to a desktop](https://github.com/olafkfreund/nixarchy/issues/6)


### PR DESCRIPTION
## What this changes, and why

main is red. `build.yml`'s roadmap guard requires every open `epic` to carry a
row in the README's Roadmap, and I filed #221 and #230 tonight with the label
and without one:

```
::error::epic #221 is open and not in the README's Roadmap
::error::epic #230 is open and not in the README's Roadmap
```

The guard is right and the mistake is mine — AGENTS.md §10 says plainly that
applying the `epic` label "has CI consequences (§9) that outlive your session",
and I applied it twice without doing the other half.

Two rows, no functional change.

## How I proved the check fails

The guard's own logic, run against the tree before and after:

Before — `comm -23` of open epics against roadmap rows:
```
open epics : 159 221 230
roadmap has: 159
STILL MISSING: 221 230
```

After:
```
open epics : 159 221 230
roadmap has: 159 221 230
GUARD PASSES: every open epic has a roadmap row
```

## Checks run locally

- [x] the roadmap guard's exact `sed`/`grep`/`comm` pipeline, above
- [x] no `.nix` touched, so `nix fmt` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5