### PR TITLE
AGENTS.md says what the checks cost now, and puts the roadmap remedy where the mistake is made

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,23 @@ Two mechanical traps that produced fake green results here, live:
   this repo is developed on are zsh. Put `#!/usr/bin/env bash` on the script
   and run it as a script, not by pasting into your shell.
 
+And the same rule read backwards, for the day a check goes red on you: **ask
+whether it was testing the property or the arrangement.** #220 moved the menu
+from an override fragment to the full merged defaults, and two checks failed
+that had been correct for months — one asserted every row has an action, which
+is only true of a fragment (a submenu parent legitimately has none), and one
+asserted "no key of ours starts with `setup.plugin`", which was a fair proxy
+for "we cannot shadow upstream's plugin menu" only while our file held our rows
+alone. Nothing had regressed. Both checks had encoded the shape of a file
+rather than the property they existed to protect, and both read as a regression
+the moment the shape legitimately changed.
+
+So when a deliberate design change turns a check red, the first question is not
+how to satisfy the check. It is whether the check still describes the thing you
+care about. If it does not, retarget it — and say so in the PR, because
+"I changed a check that was failing" and "that check was measuring the wrong
+thing" are very different sentences to a reviewer.
+
 ## 2. A bug found by hand is not fixed until something can see it
 
 §1 governs checks you write. This is the same argument one step earlier, about
@@ -126,13 +143,21 @@ your question:
 | check | what it proves | cost |
 |---|---|---|
 | `options` | every option asserted in both states | cheap — evaluation only |
+| `package-delta`, `config-delta`, `patched-files`, `release-notes`, `review-pins` | scripts against fixtures | seconds |
+| `vm-toplevel`, `reference-toplevel` | the closures build | eval plus a fetch |
 | `omarchy` (package) | the vendored tree assembles | minutes |
 | `installer-ui`, `installer-wizard` | the installer's screens and questions | minutes |
 | `session`, `coexist`, `integration`, `plugin` | booted VMs | ~10–20 min each |
-| `install` | full install onto a blank disk, reboot, rebuild-builds-nothing | **~25 min, one self-hosted runner** |
+| `install` | full install onto a blank disk, reboot, rebuild-builds-nothing | ~29 min, one self-hosted runner |
+| `free-space` | install beside an existing OS, which survives | ~27 min, same runner, same job |
+| `install-iso`, `iso-budget` | the ISO installs offline, and fits | nightly only |
 
-`checks.install` gates every pull request and there is exactly one machine
-that can run it. Seven concurrent PRs queue for about three hours. Every push
+`install` and `free-space` are one job. `install-check.yml` runs them
+back to back on the single self-hosted machine, so the number that
+governs your merge latency is **their sum: 55 minutes of a 58-minute job,
+against a 90-minute timeout** (run 33798891329; every other step in that job
+totalled four seconds). It gates every pull request, and with
+runs that long a handful of concurrent PRs queue for hours. Every push
 to your branch cancels and restarts your own run (that is deliberate — a PR
 only needs an answer about its current head), but the queue is shared:
 batching your pushes is a courtesy to everyone else's merge latency.
@@ -222,7 +247,13 @@ Do not retry-until-green. A flaky pass is a bug report you deleted.
   behaves belongs upstream, not patched here — a patch carried here is
   re-applied at every source bump; a fix landed upstream arrives for free.
 - **The `epic` label** — applying or removing it has CI consequences (§9)
-  that outlive your session.
+  that outlive your session. When a human does ask for an epic, the README
+  Roadmap row is part of that change, not a follow-up: an epic opened with the
+  label and no row turns `main` red and fails **every** subsequent PR until
+  somebody notices. That has now happened five times (#105, #148, #159, #174,
+  and #221/#230 in one evening), every time to an agent who had read §9 — which
+  is filed under a check failing, and so is read by whoever finds the wreckage
+  rather than by whoever causes it.
 
 When in doubt, the cost asymmetry decides: a question costs a minute; an
 unwanted force-push or a misrouted issue costs a human an evening.


### PR DESCRIPTION
Three corrections to `AGENTS.md`, each earned by something that happened rather
than by re-reading the file. Docs only; no code, no checks.

## 1. §5's cost table was wrong, and it is the number agents plan with

It said `install` is **~25 min**, which was true when the job did one install.
It does two. Measured on run 33798891329:

| step | seconds |
|---|---|
| `checks.install` | 1722 |
| `checks.free-space` | 1594 |
| every other step in the job | 4 |

58m44s against a 90-minute timeout. `free-space` was not in the table at all —
nor were the five fixture checks, the two closure builds, or the nightly ISO
pair — in a section whose whole advice is "pick the cheapest check that can
answer your question". The knock-on was worse: "seven concurrent PRs queue for
about three hours" was sized on 25-minute runs.

Every check name added was verified to exist in `flake.nix`'s `checks` block,
which is §2's rule applied to §5.

## 2. The roadmap trap is filed under the symptom, not the action

§9 describes it precisely and names four victims (#105, #148, #159, #174). It
got a fifth this evening — #221 and #230, from an agent that had read the file.

That is structural rather than careless. §9 is titled *"When a check fails for
reasons unrelated to your change"*, so it is read by whoever finds `main` red.
The agent who is about to turn it red is standing in §10, asking whether it may
apply the `epic` label — and §10 said only that the label "has CI consequences
(§9)". It now names the consequence and says the README Roadmap row is part of
that change, not a follow-up.

Five occurrences of one trap seemed like the strongest signal in the file that
something needed rewording rather than repeating.

## 3. A rule §1 was missing

Both of #220's CI failures were checks that had encoded the **shape of a file**
rather than the property they existed to protect: one asserted every menu row
has an action (true only of an override fragment — a submenu parent
legitimately has none), the other asserted "no key of ours starts with
`setup.plugin`" (a fair proxy for "we cannot shadow upstream's plugin menu",
but only while our file held our rows alone). Nothing had regressed. Both read
as regressions the moment the shape legitimately changed.

§1 says prove your check fails. Nothing said to ask whether it is failing for
the right reason. Added at the end of §1, with the instruction to say so in the
PR — because "I changed a failing check" and "that check was measuring the
wrong thing" are very different sentences to a reviewer.

## Checks run locally

- [x] every check name in the new table exists in `flake.nix`'s `checks` block
      (scripted against the same `awk` the coverage guard uses)
- [x] no `.nix` touched, so `nix fmt` is unaffected
- 228 → 258 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5