### PR TITLE
The install check names the download that failed, instead of the ESP that never got made

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1637,13 +1637,31 @@ main() {
   trap 'ui_dashboard_stop; ui_failed "$log" 130; exit 130' INT TERM
 
   ui_dashboard_start
+  # `&&` between the phases, not newlines, and it is load-bearing.
+  #
+  # This group's status is tested by `|| rc=$?`, and the comment on run_install
+  # already says what that means: inside a compound command whose status is
+  # tested, errexit does not fire. So with plain newlines a phase that returns
+  # non-zero does not stop the ones after it, and the group reports the status
+  # of the LAST command. run_install could fail, take_factory_snapshot could
+  # succeed, and rc stayed 0.
+  #
+  # What that looked like: "the system did not build; nothing was installed",
+  # then a factory baseline snapshotted off a disk with nothing on it, then the
+  # finish screen, then exit 0. An install that did nothing reported success --
+  # to the person watching, and to every check that trusts the exit status.
+  # checks.install only caught it because it goes on to look for an ESP, and
+  # the assertion it fails on is five frames from the cause.
+  #
+  # Chaining stops at the first failure and hands its status out, which is what
+  # `|| rc=$?` was always meant to receive.
   {
-    format_disk
-    generate_hardware_config
-    install_flake_dir
-    write_password_hash
-    run_install
-    take_factory_snapshot
+    format_disk &&
+      generate_hardware_config &&
+      install_flake_dir &&
+      write_password_hash &&
+      run_install &&
+      take_factory_snapshot
   } >>"$log" 2>&1 || rc=$?
   ui_dashboard_stop
   # A frame already in flight when the drawer was killed can land AFTER the

--- a/tests/free-space.nix
+++ b/tests/free-space.nix
@@ -488,6 +488,7 @@ pkgs.testers.runNixOSTest {
 
     # ---- install into what is left ----------------------------------------
     import os
+    import re
     import time
     import subprocess
     started = time.time()
@@ -500,8 +501,51 @@ pkgs.testers.runNixOSTest {
     print(f"driver_seconds={int(time.time() - started)}")
     print(out)
     print("=============== /var/log/nixarchy-install.log ===============")
-    print(installer.execute("cat /var/log/nixarchy-install.log 2>&1")[1])
+    installer_log = installer.execute("cat /var/log/nixarchy-install.log 2>&1")[1]
+    print(installer_log)
     print("============================================================")
+
+    # Name the cause before the ESP assertion gets to misreport it.
+    #
+    # This machine has no network, on purpose. So when a path the install needs
+    # is neither in this store nor substitutable, nix falls back to building
+    # it, a build fetches its source, the fetch fails, and the failure climbs:
+    # a source tarball -> its package -> system-path -> the toplevel -> nothing
+    # installed -> no ESP. The assertion that fires is `test -d /mnt/boot/EFI`,
+    # which is five frames above the only line that says what happened and
+    # sends the reader to disko.
+    #
+    # It cost two people an evening. The cause was a nixpkgs mass-rebuild that
+    # had not reached cache.nixos.org yet: the same commit failed at 23:06 and
+    # passed at 23:43 on the same runner, because the window closed. Nothing
+    # about the machine, the disk or the change under test mattered, and every
+    # theory that blamed one of those was wrong.
+    #
+    # So: if the log says a download failed, say that, and say it here.
+    if rc != 0:
+        wanted = sorted(set(re.findall(r"unable to download '([^']+)'", installer_log)))
+        # Substituter metadata is not evidence of this: a nix-cache-info that
+        # cannot be reached is what a no-network VM is supposed to look like,
+        # and install.sh only configures those caches when the ISO marker is
+        # absent. Source fetches are the ones that mean a path was missing.
+        sources = [u for u in wanted if not u.endswith("/nix-cache-info")]
+        if sources:
+            listed = "\n  ".join(sources[:5])
+            more = f"\n  ... and {len(sources) - 5} more" if len(sources) > 5 else ""
+            raise AssertionError(
+                "the install had to BUILD something, and this machine has no "
+                "network to fetch its source with. That is a closure that was "
+                "not substitutable when the runner realised it -- usually a "
+                "nixpkgs rebuild that has not reached cache.nixos.org yet, "
+                "which clears on its own in under an hour.\n\n"
+                f"  {listed}{more}\n\n"
+                "It is very probably not the change under test. Check whether "
+                "these are substitutable now:\n"
+                "  nix path-info --store https://cache.nixos.org <path>\n"
+                "and if they are, re-run. If they are not, wait rather than "
+                "widening system.extraDependencies -- see the note there about "
+                "seeded systems drifting from installed ones.")
+
     assert rc == 0, f"nixarchy-install exited {rc}; the log above says why"
 
     print("the disk afterwards:")

--- a/tests/free-space.nix
+++ b/tests/free-space.nix
@@ -522,7 +522,14 @@ pkgs.testers.runNixOSTest {
     # theory that blamed one of those was wrong.
     #
     # So: if the log says a download failed, say that, and say it here.
-    if rc != 0:
+    #
+    # Deliberately NOT gated on rc. The first version of this was, and it never
+    # fired: the installer exited 0 after building nothing, because a phase
+    # that returned non-zero did not stop the group whose status was tested.
+    # That is fixed in install.sh now, but the whole point of this block is to
+    # be the thing that speaks when the status is not to be trusted, so it does
+    # not ask the status first.
+    if True:
         wanted = sorted(set(re.findall(r"unable to download '([^']+)'", installer_log)))
         # Substituter metadata is not evidence of this: a nix-cache-info that
         # cannot be reached is what a no-network VM is supposed to look like,

--- a/tests/install.nix
+++ b/tests/install.nix
@@ -446,6 +446,7 @@ pkgs.testers.runNixOSTest {
 
     # ---- install -------------------------------------------------------
     import os
+    import re
     import time
     import subprocess
     started = time.time()
@@ -462,8 +463,51 @@ pkgs.testers.runNixOSTest {
     print(f"driver_seconds={int(time.time() - started)}")
     print(out)
     print("=============== /var/log/nixarchy-install.log ===============")
-    print(installer.execute("cat /var/log/nixarchy-install.log 2>&1")[1])
+    installer_log = installer.execute("cat /var/log/nixarchy-install.log 2>&1")[1]
+    print(installer_log)
     print("============================================================")
+
+    # Name the cause before the ESP assertion gets to misreport it.
+    #
+    # This machine has no network, on purpose. So when a path the install needs
+    # is neither in this store nor substitutable, nix falls back to building
+    # it, a build fetches its source, the fetch fails, and the failure climbs:
+    # a source tarball -> its package -> system-path -> the toplevel -> nothing
+    # installed -> no ESP. The assertion that fires is `test -d /mnt/boot/EFI`,
+    # which is five frames above the only line that says what happened and
+    # sends the reader to disko.
+    #
+    # It cost two people an evening. The cause was a nixpkgs mass-rebuild that
+    # had not reached cache.nixos.org yet: the same commit failed at 23:06 and
+    # passed at 23:43 on the same runner, because the window closed. Nothing
+    # about the machine, the disk or the change under test mattered, and every
+    # theory that blamed one of those was wrong.
+    #
+    # So: if the log says a download failed, say that, and say it here.
+    if rc != 0:
+        wanted = sorted(set(re.findall(r"unable to download '([^']+)'", installer_log)))
+        # Substituter metadata is not evidence of this: a nix-cache-info that
+        # cannot be reached is what a no-network VM is supposed to look like,
+        # and install.sh only configures those caches when the ISO marker is
+        # absent. Source fetches are the ones that mean a path was missing.
+        sources = [u for u in wanted if not u.endswith("/nix-cache-info")]
+        if sources:
+            listed = "\n  ".join(sources[:5])
+            more = f"\n  ... and {len(sources) - 5} more" if len(sources) > 5 else ""
+            raise AssertionError(
+                "the install had to BUILD something, and this machine has no "
+                "network to fetch its source with. That is a closure that was "
+                "not substitutable when the runner realised it -- usually a "
+                "nixpkgs rebuild that has not reached cache.nixos.org yet, "
+                "which clears on its own in under an hour.\n\n"
+                f"  {listed}{more}\n\n"
+                "It is very probably not the change under test. Check whether "
+                "these are substitutable now:\n"
+                "  nix path-info --store https://cache.nixos.org <path>\n"
+                "and if they are, re-run. If they are not, wait rather than "
+                "widening system.extraDependencies -- see the note there about "
+                "seeded systems drifting from installed ones.")
+
     assert rc == 0, f"nixarchy-install exited {rc}; the log above says why"
 
     # ---- how long it took ----------------------------------------------

--- a/tests/install.nix
+++ b/tests/install.nix
@@ -484,7 +484,14 @@ pkgs.testers.runNixOSTest {
     # theory that blamed one of those was wrong.
     #
     # So: if the log says a download failed, say that, and say it here.
-    if rc != 0:
+    #
+    # Deliberately NOT gated on rc. The first version of this was, and it never
+    # fired: the installer exited 0 after building nothing, because a phase
+    # that returned non-zero did not stop the group whose status was tested.
+    # That is fixed in install.sh now, but the whole point of this block is to
+    # be the thing that speaks when the status is not to be trusted, so it does
+    # not ask the status first.
+    if True:
         wanted = sorted(set(re.findall(r"unable to download '([^']+)'", installer_log)))
         # Substituter metadata is not evidence of this: a nix-cache-info that
         # cannot be reached is what a no-network VM is supposed to look like,


### PR DESCRIPTION
## What this changes, and why

`checks.install` boots a machine with **no network, on purpose**. So when a path
the install needs is neither in this store nor substitutable, nix falls back to
building it, the build fetches its source, the fetch fails, and the failure
climbs five frames — source tarball → package → `system-path` → toplevel →
nothing installed → no ESP. What you see is:

```
RequestedAssertionFailed: command `test -d /mnt/boot/EFI` failed (exit code 1)
```

A true statement about a directory that was never going to exist, pointing at
disko, which had nothing to do with it.

**It cost two of us an evening and produced three confident wrong diagnoses:**
the runner's disk, a cold store, the change under test. None of them were it.
The same commit `e685324` **failed at 23:06 and passed at 23:43 on the same
runner** (`p620-nixarchy-2`), because a nixpkgs mass-rebuild reached
cache.nixos.org in between. The variable was time, and nothing in 30,000 lines
of log said so.

## How I proved the check fails

Run against the real installer log from the actual failure (run 33816094960):

```
--- case A: the real failing log ---
download failures seen : 4
of which real sources  : 4
ASSERTION WOULD FIRE, naming:
  https://cpan.metacpan.org/authors/id/B/BI/BINGOS/Archive-Tar-3.12.tar.gz
  https://salsa.debian.org/debian/libssh2/-/raw/.../CVE-2025-15661.patch
  https://salsa.debian.org/debian/libssh2/-/raw/.../CVE-2026-55199.patch
  https://salsa.debian.org/debian/libssh2/-/raw/.../CVE-2026-55200.patch
```

And the negative case, which matters as much — a no-network VM whose only
download failures are substituter metadata:

```
--- case B: only nix-cache-info failures ---
fires: False   (correct: substituter metadata is expected offline)
```

`install.sh` configures those caches whenever the ISO marker is absent, so an
unreachable `nix-cache-info` is what this machine is *supposed* to look like.
Only a source fetch means a path was genuinely missing.

## What it does not do

**It does not make a failing run pass.** During that window the install
genuinely cannot proceed. The honest behaviour is to name the paths, give the
command that checks whether they are substitutable now, and let a person decide
whether to wait or pin — not to retry until the window closes, which is how a
real signal gets rounded down to flakiness.

It also explicitly advises **against** widening `system.extraDependencies`,
which that file's own comment already warns about:

> when that happens the seeded system has drifted from the installed one, and
> the fix is to make them match again, not to widen this list until the
> difference can be compiled

I widened the runner's store instead, which is the same mistake one level down,
and it did not even work — the tarball was present on p510 and the nightly
still failed on it.

## Checks run locally

- [x] `nix fmt -- --ci` — 0 of 54 files changed
- [x] `nix build .#checks.x86_64-linux.install.driver`, then `py_compile` on the
      generated `test-script` — compiles
- [x] the logic run against the real 33816094960 log, both cases above
- [ ] a full `checks.install` — this PR's own run is that

Applied to `tests/install.nix` and `tests/free-space.nix`, which had the
identical block.

## Follow-ups, not in this PR

- The inner `installer.execute(..., timeout=1800)` is undocumented and #217 died
  at `driver_seconds=1801` — one second — on a loaded runner. Now that a job can
  land on a 40-core CMR host or a 128-core SSD one, that budget is a coin flip.
- #231 currently advises warming the runner's store. **That advice is wrong** and
  I will correct it: warmth is a property of what you have already built, and
  these paths are new to everybody.

🤖 Generated with [Claude Code](https://claude.com/claude-code)