### PR TITLE
The generated flake carries the timestamp nix would have written into it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,16 @@ jobs:
       - name: The nightly review can still read every pin
         run: nix build .#checks.x86_64-linux.review-pins --print-build-logs
 
+      # The lock the installer writes, checked for the fields nix would have
+      # written itself. installer/mkFlake.nix assembles that node by hand, and a
+      # hand-assembled node can be missing a field without failing: the flake
+      # evaluates and whatever reads it takes a fallback. `lastModified` went
+      # missing exactly that way, which changed the omarchy derivation on the
+      # installed machine, which made an offline install build what it meant to
+      # copy -- surfacing 25 minutes later as a missing ESP.
+      - name: The installer's generated lock has the fields nix would write
+        run: nix build .#checks.x86_64-linux.installer-lock --print-build-logs
+
       # Same shape, same reason: its dangerous failure is reporting nothing.
       - name: The Omarchy package delta still sees a change
         run: nix build .#checks.x86_64-linux.package-delta --print-build-logs

--- a/flake.nix
+++ b/flake.nix
@@ -205,6 +205,15 @@
       # exists when the source is not a git tree at all, hence the last
       # fallback.
       nixarchyRev = self.shortRev or self.dirtyShortRev or "unknown";
+      #
+      # `lastModifiedDate` is absent, not empty, when a lock node has no
+      # `lastModified` -- which is what installer/mkFlake.nix used to write,
+      # and is why the offline install broke the first time this landed: the
+      # generated flake evaluated a DIFFERENT omarchy than the installer had
+      # seeded, for want of one field. mkFlake now writes it. The fallback
+      # stays for the machines whose flake.lock was generated before it did:
+      # they get "unknown" and a rebuild that has a network, rather than an
+      # evaluation error on a system they cannot rebuild to fix.
       nixarchyDate =
         let
           d = self.lastModifiedDate or "";
@@ -1009,6 +1018,11 @@
         # The installer's interactive screens, at every width worth caring
         # about. Nothing else draws them: every other harness passes
         # --answers, which is exactly how #133 shipped.
+        installer-lock = import ./tests/installer-lock.nix {
+          pkgs = pkgsFor.${system};
+          flakeTemplate = self.packages.${system}.flake-template;
+        };
+
         installer-ui = import ./tests/installer-ui.nix {
           inherit inputs;
           pkgs = pkgsFor.${system};

--- a/installer/mkFlake.nix
+++ b/installer/mkFlake.nix
@@ -29,6 +29,20 @@ runCommand "nixarchy-flake-template"
     nativeBuildInputs = [ jq ];
     inherit rev url;
     inherit (self) narHash;
+
+    # And the timestamp, which nix writes into every lock node it produces and
+    # this one was leaving out (#208).
+    #
+    # An input node without it evaluates: `self.lastModified` is simply absent
+    # on the other side, so anything reading it takes its fallback. That made
+    # the omission invisible until something in the closure DEPENDED on it --
+    # nixarchy-version, which prints the build's date. This flake evaluates to
+    # a different omarchy than the one the installer seeded, the offline
+    # install cannot copy what it now has to build, and it walks back to the
+    # source bootstrap and dies fetching a Debian patch for libssh2. The rev
+    # was never the problem: shortRev is identical on both sides.
+    lastModified = toString self.lastModified;
+
     passthru = { inherit url rev; };
   }
   ''
@@ -55,7 +69,7 @@ runCommand "nixarchy-flake-template"
     # target would re-resolve every input against whatever is current, so the
     # first `nixos-rebuild switch` would build a different system from the one
     # just installed -- and it needs a network the offline ISO does not have.
-    jq --arg rev "$rev" --arg narHash "$narHash" '
+    jq --arg rev "$rev" --arg narHash "$narHash" --argjson lastModified "$lastModified" '
       # nixarchy inherits our root inputs verbatim. NOT a name-to-name map:
       # once nix has disambiguated names, root.nixpkgs points at a node called
       # "nixpkgs_2", and inventing the mapping rather than copying it points
@@ -84,7 +98,8 @@ runCommand "nixarchy-flake-template"
             owner: "olafkfreund",
             repo: "nixarchy",
             rev: $rev,
-            narHash: $narHash
+            narHash: $narHash,
+            lastModified: $lastModified
           },
           original: {
             type: "github",

--- a/tests/installer-lock.nix
+++ b/tests/installer-lock.nix
@@ -1,0 +1,72 @@
+{ pkgs, flakeTemplate }:
+# The lock the installer writes, checked for the fields nix would have written
+# itself.
+#
+# installer/mkFlake.nix builds the `nixarchy` node of the generated flake.lock
+# by hand, because there is nothing to lock against at build time -- the flake
+# it describes does not exist until the installer renames a directory. A node
+# assembled by hand is a node that can be missing a field, and a lock missing a
+# field does not fail: it evaluates, and whatever reads that field takes its
+# fallback.
+#
+# That is not hypothetical. `lastModified` was left out, `self.lastModifiedDate`
+# was therefore absent inside the installed machine's evaluation, and
+# nixarchy-version's date became "unknown" -- which changed the omarchy
+# derivation, which changed system-path, which meant the offline install had to
+# BUILD a system it was supposed to copy, on a machine with no network. It died
+# fetching a Debian patch for libssh2 and reported a missing ESP. Two days.
+#
+# So this asserts the shape of that node instead of trusting the next person to
+# remember. It is a runCommand over an already-built derivation: no VM, no
+# network, seconds. The 25-minute install check can see the same bug, but only
+# after the damage and only as something four levels away.
+pkgs.runCommand "nixarchy-installer-lock"
+  {
+    nativeBuildInputs = [ pkgs.jq ];
+  }
+  ''
+    lock=${flakeTemplate}/flake.lock
+    test -f "$lock" || { echo "no flake.lock in the generated template" >&2; exit 1; }
+
+    node=$(jq -c '.nodes.nixarchy.locked // empty' "$lock")
+    if [ -z "$node" ]; then
+      echo "the generated lock has no nixarchy node at all:" >&2
+      jq -c '.nodes | keys' "$lock" >&2
+      exit 1
+    fi
+    echo "nixarchy node: $node"
+
+    # Every field mkFlake writes by hand. `lastModified` is the one that went
+    # missing and the reason this check exists, but the others are hand-written
+    # too and would fail just as quietly.
+    for field in type owner repo rev narHash lastModified; do
+      if ! jq -e --arg f "$field" 'has($f)' <<<"$node" >/dev/null; then
+        echo "" >&2
+        echo "the nixarchy lock node has no '$field'." >&2
+        echo "" >&2
+        echo "installer/mkFlake.nix writes this node by hand, so a field it" >&2
+        echo "omits is simply absent on the installed machine -- the flake" >&2
+        echo "still evaluates and whatever reads it takes a fallback." >&2
+        echo "" >&2
+        echo "For lastModified specifically: self.lastModifiedDate goes" >&2
+        echo "absent, nixarchy-version's date becomes \"unknown\", and that" >&2
+        echo "string is spliced into the omarchy derivation. The installed" >&2
+        echo "system then differs from the one checks.install seeded, so an" >&2
+        echo "offline install has to build what it meant to copy and dies" >&2
+        echo "fetching a source it cannot reach." >&2
+        exit 1
+      fi
+    done
+
+    # A number, not a string: nix writes it as one, and `jq` comparing a string
+    # to a number silently says no rather than complaining.
+    kind=$(jq -r '.lastModified | type' <<<"$node")
+    [ "$kind" = "number" ] || {
+      echo "lastModified is a $kind; nix writes a number" >&2; exit 1; }
+
+    jq -e '.lastModified > 0' <<<"$node" >/dev/null || {
+      echo "lastModified is not a positive timestamp" >&2; exit 1; }
+
+    echo "the generated lock carries every field mkFlake writes by hand"
+    touch $out
+  ''


### PR DESCRIPTION
Fixes the `checks.install` failure that has been red on every commit since #212.

## What was wrong

`installer/mkFlake.nix` writes the `nixarchy` node of the generated `flake.lock`
**by hand** — `type`, `owner`, `repo`, `rev`, `narHash` — because there is
nothing to lock against at build time. It left out **`lastModified`**, which nix
writes into every node it produces itself.

A node without it evaluates fine. `self.lastModified` is simply **absent** on
the other side, so anything reading it takes its fallback. That is why the
omission was harmless for months — until #212 added a reader:

```nix
nixarchyDate = let d = self.lastModifiedDate or ""; in if d == "" then "unknown" else ...
```

`nixarchyDate` becomes `"unknown"` inside the installed machine's evaluation,
and that string is spliced into the omarchy package. It is in the derivation's
own builder text:

```
nixarchydate@' '2026-09-04'
```

So the machine evaluated a **different omarchy** than `checks.install` seeded →
different `system-path` → the offline install had to **build** what it was
meant to copy → no network → it walked back to the source bootstrap and died
fetching a Debian patch for libssh2, surfacing four frames later as a missing
ESP.

**The rev was never the problem.** `shortRev` is identical on both sides.

## The bisect

| sha | install check |
|---|---|
| `e37bf83` (immediately before #212) | **success** |
| `e685324` (#212) | failure |
| every commit since | failure, identical signature |

## This was already fixed, and I lost it

`ec8b7bf` on `feat/nixarchy-version` fixed exactly this and **passed its install
check** (run 33794456864 — "these 4 derivations will be built"). Its commit
message predicted today's log verbatim: *"it walks back to the source bootstrap
and dies fetching a Debian patch for libssh2."*

`git merge-base --is-ancestor ec8b7bf origin/main` → **no**. I rebased #212
twice; the second rebase dropped that commit, and `git diff ec8b7bf fa09855`
shows only the removal of those lines. The head that merged never ran an install
check, because my force-push superseded the one in flight. Two of my mistakes
compounding: the fix was lost, and the gate that would have caught it did not
run.

## How I proved the check fails

`checks.installer-lock` asserts the generated node carries every field mkFlake
writes by hand. Broken (the `lastModified` line deleted):

```
nixarchy node: {"type":"github","owner":"olafkfreund","repo":"nixarchy","rev":"0d3e2b29...","narHash":"sha256-b584..."}
the nixarchy lock node has no 'lastModified'.
error: Cannot build '/nix/store/vnmlpz656aw79v6y4arym3x81qsdgsbj-nixarchy-installer-lock.drv'
```

Restored:

```
nixarchy node: {...,"narHash":"sha256-ZLE0...","lastModified":1788509865}
the generated lock carries every field mkFlake writes by hand
```

Seconds, no VM, no network — against a 25-minute install check whose version of
this news is an assertion about a directory that was never created.

## What is not changed

`flake.nix`'s `"unknown"` fallback stays. A machine installed before this has a
lock without the field, and printing "unknown" is better than an evaluation
error on a system it cannot rebuild to fix.

## Checks run locally

- [x] `nix build .#checks.x86_64-linux.installer-lock` — red when broken, green when restored (above)
- [x] `nix fmt -- --ci` — 0 of 55 changed
- [x] the coverage guard's own pipeline — every `checks.*` is named by a workflow
- [ ] `checks.install` — this PR's own run is the real proof. It should report
      "these 4 derivations will be built" rather than "these 1287"

## Needs a human

The `build.yml` step naming `checks.installer-lock` is a CI-gate edit (AGENTS.md
§3). It is wired here because the coverage guard fails otherwise, and flagged
for sign-off as the PR template asks.

## Worth arguing separately

`nixarchyRev` and `nixarchyDate` are build inputs to the desktop package, so
**every commit to nixarchy changes the omarchy derivation** and everything
downstream — even when nothing in the package changed. Writing the revision to
`/etc/nixarchy/version` and reading it at runtime would make this class of drift
impossible rather than merely fixed, and stop commits invalidating the desktop.
Bigger than restoring a lost line; its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)