### PR TITLE
Answering No goes back to the questions instead of leaving a dead terminal

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -692,7 +692,17 @@ ask_encrypt() {
   case $rc in
     0) encrypt=true ;;
     130) encrypt=false ;;
-    *) exit 1 ;;
+    *)
+      # Refusing here is right -- "no" to a destructive question must not mean
+      # "do it anyway, differently" -- but it used to refuse in silence, and on
+      # the ISO a silent exit leaves a terminal with nothing on it. Say what
+      # happened, and say the thing the person most needs to hear.
+      ui_left ""
+      ui_left "\e[1mStopped before anything was written.\e[0m"
+      ui_left "\e[90mNo disk has been changed. Power off, or reboot to try again.\e[0m"
+      ui_left ""
+      exit 1
+      ;;
   esac
 }
 
@@ -1579,12 +1589,27 @@ main() {
   else
     ui_greeter
     ask_network
-    ask_keymap
-    ask_identity
-    ask_device
-    ask_disk_mode
-    ask_encrypt
-    confirm_summary || exit 1
+
+    # "No" at the summary goes back to the questions, and that is the whole
+    # reason the summary exists: somebody reads it, sees the hostname is wrong,
+    # and says no. Exiting was the one response that made the screen useless --
+    # and worse than useless on the ISO, where `Restart = "no"` means nothing
+    # respawns and `conflicts = getty@tty1` means the login prompt does not come
+    # back either. The installer left the user looking at a terminal with
+    # nothing running on it, which reads exactly like a crash and can only be
+    # escaped by a power cycle (#240).
+    #
+    # The network question stays outside the loop: it is the one step that
+    # changes something outside this script, and asking somebody to reconnect
+    # to wifi because they mistyped a hostname would be its own small insult.
+    while :; do
+      ask_keymap
+      ask_identity
+      ask_device
+      ask_disk_mode
+      ask_encrypt
+      confirm_summary && break
+    done
   fi
 
   if [ -n "$from_repo" ]; then

--- a/tests/installer-wizard.nix
+++ b/tests/installer-wizard.nix
@@ -220,8 +220,70 @@ pkgs.testers.runNixOSTest {
     # CONSUMES what it reads, and "Hostname" and "wizardbox" are on one row, so
     # matching the first swallowed the second and the wait never returned. The
     # rows are asserted from the full console log further down instead.
-    screen("Does this look right")
+    # Say NO first, and prove it goes back to the questions (#240).
+    #
+    # A user reported "the installer crashes if I say no". It did not crash: it
+    # exited 1 in silence, and on the ISO `Restart = "no"` means nothing
+    # respawns while `conflicts = getty@tty1` means the login prompt does not
+    # come back -- so the screen simply stopped, escapable only by a power
+    # cycle. Exiting is the one answer that makes a summary screen useless,
+    # because the screen exists so somebody can say "no, the hostname is wrong".
+    #
+    # Every automated path here has always answered yes: the unattended
+    # installs, the VM tests, the ISO check. "No" is a branch only a human
+    # takes, which is why this went unnoticed until somebody took it.
+    summary = gum("confirm")
+    # `n`, not the arrow key. gum's own hint line offers both -- it draws
+    # "enter submit • y Yes • n No" -- and the arrow is what a person presses,
+    # so that is what I reached for first. It failed in CI while passing here.
+    #
+    # An arrow is the three bytes ESC [ C, and this test types one byte at a
+    # time on purpose: the comment on answer() explains that qemu's 16550 has a
+    # sixteen-byte FIFO and drops what overflows it. bubbletea only reads those
+    # three as a key if they arrive inside its escape timeout; arriving slowly
+    # they are ESC, then a bracket, then a letter, none of which move the
+    # selection. So the widget stayed on Yes, the dry run ran to completion,
+    # and this test sat waiting for questions that had already been answered --
+    # with `wizard.service: Deactivated successfully` in the log, an exit 0
+    # that looks nothing like the failure it was.
+    #
+    # `n` is one byte with no timing to lose.
+    answer("n")
+
+    # Back at the top of the loop. Anchoring on the keyboard heading is what
+    # makes this a real assertion: wait_for_console_text CONSUMES what it
+    # matches, so the first `screen(...)` for this line was used up hundreds of
+    # lines ago. Seeing it a second time can only mean the questions ran again.
+    screen(r"Let's set up your keyboard")
+    gum("choose")
+    answer("\n")
+
+    # And the rest of them, briefly -- the answers are re-entered because the
+    # loop re-asks, which is the behaviour under test. Same values, so the
+    # summary assertions below still describe what was typed.
+    screen(r"Let's set up your user account")
+    pid = gum("input")
+    answer("wizard\n")
+    pid = gum("input", previous=pid)
+    answer("hunter2\n")
+    pid = gum("input", previous=pid)
+    answer("hunter2\n")
+    pid = gum("input", previous=pid)
+    answer("wizardbox\n")
+    gum("filter")
+    answer("\x7f\x7f\x7f")
+    answer("Europe/London")
+    answer("\n")
+    screen(r"Let's choose where to install nixarchy")
+    gum("choose")
+    answer("\n")
+    screen("Everything on /dev/vdc will be overwritten")
     gum("confirm")
+    answer("\n")
+
+    # Now yes, on a confirm that is not the one we said no to.
+    screen("Does this look right")
+    gum("confirm", previous=summary)
     answer("\n")
 
     screen("dry run: no disk touched")

--- a/tests/installer-wizard.nix
+++ b/tests/installer-wizard.nix
@@ -284,6 +284,19 @@ pkgs.testers.runNixOSTest {
     answer("hunter2\n")
     pid = gum("input", previous=pid)
     answer("hunter2\n")
+
+    # The recovery passphrase is asked again, because the loop re-asks
+    # everything -- and it is SKIPPED here with an empty answer.
+    #
+    # Two reasons. It is the default path and the first pass does not take it,
+    # so between them both branches of ask_recovery are walked. And omitting it
+    # is what broke this test when #247 landed: the second pass typed the
+    # hostname into the recovery prompt, its confirmation appeared where the
+    # hostname screen was expected, and the run sat for the full 900 seconds.
+    # A re-asked question has to be re-answered, every one of them.
+    pid = gum("input", previous=pid)
+    answer("\n")
+
     pid = gum("input", previous=pid)
     answer("wizardbox\n")
     gum("filter")


### PR DESCRIPTION
Closes #240. Reported by somebody installing on a laptop: *"if I say No before
the final step, the installer crashes."*

## It did not crash

It exited 1 in silence, and three individually reasonable decisions combined
into a dead end:

| | |
|---|---|
| `install.sh:1587` | `confirm_summary \|\| exit 1` — No is treated as a fatal error |
| `cd.nix:366` | `Restart = "no"` — *"Finished, aborted or crashed, do not respawn a TUI in a loop"* |
| `cd.nix:347` | `conflicts = [ "getty@tty1.service" ]` — *"the load-bearing line"* |

The installer stopped, nothing respawned it, and the login prompt it had
displaced did not come back. The user was left looking at a terminal with
nothing running on it, escapable only by a power cycle.

**Exiting is the one answer that makes a summary screen useless.** The screen
exists so somebody can read it, see the hostname is wrong, and say no.

## What changes

**No loops back to the questions.** `ask_network` stays outside the loop — it is
the one step that changes something beyond this script, and asking somebody to
reconnect to wifi because they mistyped a hostname would be its own small
insult.

**The encryption prompt still refuses**, which is right — "no" to a destructive
question must not mean "do it anyway, differently" — but it now says so, and
says the sentence that matters at that moment:

```
Stopped before anything was written.
No disk has been changed. Power off, or reboot to try again.
```

## How I proved the check fails

`checks.installer-wizard` now answers **No** at the summary and asserts the
questions come back. It anchors on the keyboard heading appearing a **second**
time — `wait_for_console_text` consumes what it matches, so a second sighting
can only mean the loop ran.

With the old behaviour restored, the check fails exactly as the user did:

```
machine # systemd[1]: wizard.service: Main process exited, code=exited, status=1/FAILURE
machine # systemd[1]: wizard.service: Failed with result 'exit-code'.
machine: waiting for Let's set up your keyboard to appear on console
!!! RequestedAssertionFailed: action timed out after 180.02 seconds (timeout=180.0)
```

With the fix in place the check completes and cleans up.

## Why this survived every automated path

The unattended installs, the VM tests and the ISO check have **always answered
yes**. "No" is a branch only a human takes — which is why three real bugs came
out of one person's install session this morning and none of them could have
come from CI:

- #238 — the install builds nothing and produces an unbootable machine
- #239 — the log dies with the live session, so a failed install leaves nothing to read
- #240 — this one

All three are on the paths that only exist when a person is sitting in front of
the machine: saying no, looking for a log after a reboot, and needing the thing
to boot.

## Checks run locally

- [x] `bash -n installer/install.sh`
- [x] `nix build .#checks.x86_64-linux.installer-wizard` — **red** with the bug
      restored, **green** with the fix (outputs above)
- [x] `nix fmt -- --ci`
- [x] the generated test-script compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)