### PR TITLE
The install log lands on the disk, so a failed install still has something to read

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1610,6 +1610,9 @@ main() {
   # log instead. A wall of store paths tells nobody anything they can act on,
   # and it makes an ordinary install look like something going wrong.
   local log=/var/log/nixarchy-install.log
+  # Set once the log has been copied somewhere that outlives this session, so
+  # the failure screen can name a path that will still exist after a reboot.
+  local target_log=""
   local started rc=0 elapsed
   started=$(date +%s)
 
@@ -1690,8 +1693,38 @@ main() {
     } >/dev/ttyS0 2>&1 || true
   fi
 
+  # And onto the disk, where it survives the reboot the next screen offers.
+  #
+  # The log lives on the live ISO. That is fine while somebody is looking at
+  # it and useless the moment they do the thing the installer just told them
+  # to do: a user whose install failed rebooted, found no bootloader entry,
+  # went looking for a log and found two empty directories -- the target's
+  # /var/log, which is a freshly created btrfs subvolume with nothing in it,
+  # and nothing at all where the real log had been (#239). The serial dump
+  # above is how checks.install reads this, and a laptop has no serial port.
+  #
+  # /mnt is still mounted here; nothing unmounts it before the finish screen.
+  #
+  # Mode 0600 and root-owned, and NOT copied to the ESP. The ESP was the
+  # tempting place -- FAT32, readable from a live USB or another OS, exactly
+  # where you want a diagnostic when the root filesystem will not mount. But
+  # FAT32 has no permissions, so anything written there is readable by anyone
+  # who picks up the disk, and this installer handles a crypt hash that
+  # installer/template/host/configuration.nix already describes as
+  # "offline-crackable at leisure by anyone who reads it". Nothing is known to
+  # put a secret in this log -- write_password_hash writes to a file under
+  # umask 077 and disko takes the passphrase from a key file, so its trace
+  # shows a path rather than the secret -- but "nothing is known to" is not
+  # the standard for putting a file somewhere unreadable permissions cannot
+  # protect it.
+  if [ -d /mnt/var/log ]; then
+    ( umask 077 && cat "$log" >/mnt/var/log/nixarchy-install.log ) 2>/dev/null \
+      && chown 0:0 /mnt/var/log/nixarchy-install.log 2>/dev/null \
+      && target_log=/var/log/nixarchy-install.log
+  fi
+
   if [ "$rc" -ne 0 ]; then
-    ui_failed "$log" "$rc"
+    ui_failed "$log" "$rc" "${target_log:-}"
     exit "$rc"
   fi
 

--- a/installer/lib/dashboard.sh
+++ b/installer/lib/dashboard.sh
@@ -133,7 +133,7 @@ ui_finished() {
 # thing the dashboard has been hiding. Put the tail of it on screen rather than
 # leaving a person with a cleared terminal and a failure they cannot describe.
 ui_failed() {
-  local log=$1 rc=$2
+  local log=$1 rc=$2 target_log=${3:-}
   ui_init
   ui_clear
   echo
@@ -145,6 +145,14 @@ ui_failed() {
   tail -25 "$log" 2>/dev/null | sed "s/^/$(printf '%*s' "${UI_PAD:-0}" '')/"
   echo
   ui_left "\e[90mThe whole log is at $log. Nothing was rebooted.\e[0m"
+  # The path above is on the live system and goes away with it. If a copy
+  # reached the disk, say so -- that is the one a person can still read after
+  # the reboot this screen is about to offer them, and not saying it is how
+  # somebody ends up with an unbootable machine and no diagnostic (#239).
+  if [ -n "$target_log" ]; then
+    ui_left "\e[90mA copy is on the new system at $target_log, readable from a"
+    ui_left "\e[90mlive USB if this machine will not boot.\e[0m"
+  fi
   echo
 
   # Twenty-five lines is enough to recognise a failure and rarely enough to

--- a/tests/install.nix
+++ b/tests/install.nix
@@ -546,6 +546,25 @@ pkgs.testers.runNixOSTest {
     # different bugs to chase.
     installer.succeed("test -d /mnt/etc/nixos/.git")
     installer.succeed("test -d /mnt/boot/EFI")
+
+    # The install log reached the disk (#239).
+    #
+    # Asserted under /mnt rather than on the installer, because on the
+    # installer it is always there and always will be -- that is the copy that
+    # dies with the live session. A user whose install failed rebooted, found
+    # no bootloader entry, went looking for the log and found nothing: the
+    # target's /var/log is a freshly made subvolume and the real log was on an
+    # ISO that no longer existed. The serial dump this test reads everything
+    # through is exactly why CI could not see that; a laptop has no serial
+    # port.
+    installer.succeed("test -s /mnt/var/log/nixarchy-install.log")
+
+    # Root-only, because it is deliberately NOT on the ESP. FAT32 has no
+    # permissions, and an installer that handles a crypt hash should not put
+    # its transcript somewhere permissions cannot protect it.
+    mode = installer.succeed(
+        "stat -c '%a %U' /mnt/var/log/nixarchy-install.log").strip()
+    assert mode == "600 root", f"the install log is {mode}, not 600 root"
     print("install wrote a flake and an ESP")
 
     # ---- the login hash is NOT in the repository -----------------------


### PR DESCRIPTION
Closes #239. Third of three bugs from one person's install session this morning.

## What happened to them

The install failed, they rebooted as the screen told them to, found no
bootloader entry, and went looking for a log. There was none anywhere they could
reach. Their words: *"the log folder is also empty"*.

Both places they looked were empty, for different reasons, and both are correct
behaviour:

- **The target's `/var/log`** is the `@log` btrfs subvolume
  (`installer/disk-config.nix:44`). Nothing was installed, so it is a freshly
  created empty subvolume.
- **The real log**, `/var/log/nixarchy-install.log` (`install.sh:1612`), is on
  the **live ISO**. It ceases to exist at the reboot the installer had just
  recommended.

The only path off the live system was:

```sh
if [ -w /dev/ttyS0 ]; then ... cat "$log" ... fi
```

which is how `checks.install` reads it, and which does nothing on a laptop. **The
diagnostic existed exactly until the user did what they were told.**

## What changes

The log is copied to `/mnt/var/log/nixarchy-install.log` before the finish or
failure screen, while `/mnt` is still mounted. On a successful install it becomes
the machine's own record of how it was made; on a failed one it is the only
record that survives.

`ui_failed` names it as well — it named the live-session path, which is correct
and about to stop being true.

## The ESP decision, stated because it was tempting

**Not copied to the ESP.** That was the obvious place: FAT32, readable from a
live USB or another OS, exactly where a diagnostic belongs when the root
filesystem will not mount.

But FAT32 has no permissions, and this installer handles a crypt hash that
`installer/template/host/configuration.nix` already describes as
*"offline-crackable at leisure by anyone who reads it"*.

Nothing is *known* to put a secret in this log — `write_password_hash` writes
under `umask 077`, and disko takes the LUKS passphrase from a key file so its
`set -x` trace carries a path rather than the secret. But "nothing is known to"
is not the standard for putting a file somewhere permissions cannot protect it.
So: `0600 root` on the target, inside the LUKS volume when there is one.

Happy to add the ESP copy if you would rather have the recoverability; it is a
real trade and I would rather you made it than have me assume.

## The check

`checks.install` asserts both:

```python
installer.succeed("test -s /mnt/var/log/nixarchy-install.log")
mode = installer.succeed("stat -c '%a %U' /mnt/var/log/nixarchy-install.log").strip()
assert mode == "600 root", f"the install log is {mode}, not 600 root"
```

**Under `/mnt`, not on the installer** — that distinction is the whole point. On
the installer the file is always there and always will be; that is the copy that
dies. Asserting it there would have passed for this user's install too.

## Why CI could not have found this

The serial dump means CI *always* has the log, so it never notices the log going
missing. And CI never reboots into the installed system as a person does.

That is the pattern across all three bugs from this session — #238 (an install
that builds nothing), #241 (No leaves a dead terminal) and this one all live on
paths that only exist when somebody is sitting in front of the machine: needing
it to boot, saying no, and looking for a log afterwards.

## Checks run locally

- [x] `bash -n installer/install.sh`, `bash -n installer/lib/dashboard.sh`
- [x] `nix fmt -- --ci` — 0 of 54 changed
- [x] `nix build .#checks.x86_64-linux.install.driver` + `py_compile` on the generated test-script
- [ ] `checks.install` end to end — this PR's own run, now that #238 has unblocked it

🤖 Generated with [Claude Code](https://claude.com/claude-code)