### PR TITLE
Crash reports go to the repository the rule names, not the one the command names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,14 @@ jobs:
       - name: The installer's generated lock has the fields nix would write
         run: nix build .#checks.x86_64-linux.installer-lock --print-build-logs
 
+      # Where a crash report goes. The prose said Nixarchy and every `gh`
+      # command said Basecamp, so an agent read the rule, concluded correctly,
+      # and then copied a command that filed into somebody else's tracker --
+      # people who cannot act on a NixOS store or rebuild problem. Cheap enough
+      # to sit here: a runCommand over the already-built package, no VM.
+      - name: Crash reports route to the repository the rule names
+        run: nix build .#checks.x86_64-linux.crash-report-repo --print-build-logs
+
       # Same shape, same reason: its dangerous failure is reporting nothing.
       - name: The Omarchy package delta still sees a change
         run: nix build .#checks.x86_64-linux.package-delta --print-build-logs

--- a/flake.nix
+++ b/flake.nix
@@ -1023,6 +1023,14 @@
           flakeTemplate = self.packages.${system}.flake-template;
         };
 
+        # Where a crash report goes. The prose said Nixarchy and every gh
+        # command said Basecamp; this greps the built tree so the two cannot
+        # disagree again.
+        crash-report-repo = import ./tests/crash-report-repo.nix {
+          pkgs = pkgsFor.${system};
+          omarchy = self.packages.${system}.omarchy;
+        };
+
         installer-ui = import ./tests/installer-ui.nix {
           inherit inputs;
           pkgs = pkgsFor.${system};

--- a/pkgs/omarchy/default.nix
+++ b/pkgs/omarchy/default.nix
@@ -1137,11 +1137,29 @@ stdenvNoCC.mkDerivation {
                   --replace-fail 'Most application crashes are upstream bugs in those applications, not Omarchy'"'"'s' 'Most application crashes are upstream bugs in those applications, not the distribution'"'"'s' \
                   --replace-fail 'doing. In the minority of cases where the cause really does sit within Omarchy'"'"'s' 'doing. In the minority of cases where the cause really does sit within Nixarchy'"'"'s or Omarchy'"'"'s'
 
+                # The prompt sets the destination before the skill is read. Left alone it
+                # says "reporting upstream to Omarchy", so the agent arrives at reporting.md
+                # already pointed at Basecamp and the two-project rule reads as an exception.
+                substituteInPlace $out/share/omarchy/bin/omarchy-agent-crash \
+                  --replace-fail 'A process crashed on this Omarchy machine and I want to know why.' 'A process crashed on this Nixarchy machine and I want to know why.' \
+                  --replace-fail 'when a crash is worth reporting upstream to Omarchy. If your harness has no skill' 'when a crash is worth reporting to Nixarchy or Omarchy. If your harness has no skill'
+
                 substituteInPlace $skills/diagnose-crash/reporting.md \
                   --replace-fail '# Reporting a Crash Upstream to Omarchy' '# Reporting a Crash to Nixarchy or Omarchy' \
                   --replace-fail 'Read this only after concluding that a crash is genuinely Omarchy'"'"'s to fix.' 'Read this only after concluding that a crash is genuinely the distribution'"'"'s to fix. Two projects can own it: Nixarchy (<https://github.com/olafkfreund/nixarchy>) for anything specific to NixOS — the store, a rebuild, `nixarchy-apply`, a hardcoded `/usr` path, a replaced `omarchy-*` command — and Omarchy (<https://github.com/basecamp/omarchy>) for anything that would happen identically on Arch. When unsure, file against Nixarchy; the `nixarchy` skill'"'"'s `contributing.md` has the full rule.' \
                   --replace-fail 'Omarchy is a configuration layer over Arch Linux, so a crash' 'Omarchy is a configuration layer and Nixarchy packages it for NixOS, so a crash' \
-                  --replace-fail 'Include what happened, what was expected, steps to reproduce, system details from' 'Include what happened, what was expected, steps to reproduce, `nixos-version` and the locked inputs from `nix flake metadata`, system details from'
+                  --replace-fail 'Include what happened, what was expected, steps to reproduce, system details from' 'Include what happened, what was expected, steps to reproduce, `nixos-version` and the locked inputs from `nix flake metadata`, system details from' \
+                  --replace-fail '## Is it even Omarchy'"'"'s bug?' '## Is it even the distribution'"'"'s bug?' \
+                  --replace-fail 'Omarchy'"'"'s sphere of control is roughly:' 'The distribution'"'"'s sphere of control is roughly the list below. Nixarchy owns the NixOS half of each line -- how the thing is packaged, seeded and exposed on NixOS -- and Omarchy owns the behaviour itself:' \
+                  --replace-fail 'A crash in a program Omarchy merely installs is **not** an Omarchy bug unless' 'A crash in a program the distribution merely installs is **not** its bug unless' \
+                  --replace-fail 'Omarchy'"'"'s own packaging or configuration is implicated.' 'Nixarchy'"'"'s or Omarchy'"'"'s own packaging or configuration is implicated.' \
+                  --replace-fail 'If it is not Omarchy'"'"'s, say so and stop. Suggesting the right upstream project is' 'If it belongs to neither, say so and stop. Suggesting the right upstream project is' \
+                  --replace-fail '1. **It is a verified bug in Omarchy'"'"'s sphere**, established on evidence. Issues' '1. **It is a verified bug in Nixarchy'"'"'s or Omarchy'"'"'s sphere**, established on evidence. Issues' \
+                  --replace-fail 'gh search issues --repo basecamp/omarchy "<program> crash"' 'gh search issues --repo olafkfreund/nixarchy "<program> crash"' \
+                  --replace-fail 'gh issue list --repo basecamp/omarchy --state all --search "<signal> <program>"' 'gh issue list --repo olafkfreund/nixarchy --state all --search "<signal> <program>"' \
+                  --replace-fail 'gh issue view <number> --repo basecamp/omarchy --comments' 'gh issue view <number> --repo olafkfreund/nixarchy --comments' \
+                  --replace-fail 'gh issue comment <number> --repo basecamp/omarchy --body "..."' 'gh issue comment <number> --repo olafkfreund/nixarchy --body "..."' \
+                  --replace-fail 'gh issue create --repo basecamp/omarchy --title "..." --body "..."' 'gh issue create --repo olafkfreund/nixarchy --title "..." --body "..."'
 
                 # The Arch-name lookup omarchy-pkg-add answers with. Generated rather than
                 # hand-written into the script: data/apps.nix already maps every Install

--- a/tests/crash-report-repo.nix
+++ b/tests/crash-report-repo.nix
@@ -1,0 +1,75 @@
+{ pkgs, omarchy }:
+# Where a crash report actually goes, checked against the built tree.
+#
+# `omarchy-crash-watch` announces every core dump and offers an AI diagnosis;
+# clicking runs `omarchy-agent-crash`, which points the agent at the
+# diagnose-crash skill, whose `reporting.md` decides the destination. This port
+# rewrites that file so the destination can be Nixarchy.
+#
+# It rewrote the prose and not the commands. `reporting.md` said "When unsure,
+# file against Nixarchy" three lines above five `gh` invocations that all
+# carried `--repo basecamp/omarchy`. An agent read the rule, concluded
+# correctly, and then copied a command that filed the issue at Basecamp. The
+# narrative was ported; the executable part was not.
+#
+# Prose cannot be asserted, so this asserts the executable part: no `gh` line
+# may name a repo the surrounding text did not choose. It is a grep over an
+# already-built derivation -- no VM, no network, under a second -- and it fails
+# naming the line, which is the whole point of writing it at all.
+pkgs.runCommand "nixarchy-crash-report-repo"
+  {
+    nativeBuildInputs = [ pkgs.gnugrep ];
+  }
+  ''
+    skills=${omarchy}/share/omarchy/default/agents/skills
+    report=$skills/diagnose-crash/reporting.md
+    test -f "$report" || { echo "no diagnose-crash/reporting.md in the built tree" >&2; exit 1; }
+
+    fail=0
+
+    # 1. Every `gh` command must target this port's repository. A `gh` line is
+    #    something a reader copies; a sentence is something they interpret.
+    if bad=$(grep -n '^gh .*--repo basecamp/omarchy' "$report"); then
+      echo "" >&2
+      echo "reporting.md still files against Basecamp from a gh command:" >&2
+      echo "$bad" >&2
+      echo "" >&2
+      echo "Line 3 of that file tells the agent to file against Nixarchy when" >&2
+      echo "unsure. A command that contradicts it is the one that gets run." >&2
+      fail=1
+    fi
+
+    # 2. ...and they must actually name Nixarchy, so this cannot be satisfied
+    #    by deleting the commands.
+    for verb in 'gh search issues' 'gh issue list' 'gh issue view' 'gh issue comment' 'gh issue create'; do
+      if ! grep -q "^$verb .*--repo olafkfreund/nixarchy" "$report"; then
+        echo "no '$verb' line targeting olafkfreund/nixarchy in reporting.md" >&2
+        fail=1
+      fi
+    done
+
+    # 3. Omarchy must still be reachable as a destination: this port routes the
+    #    Arch-identical half there, and a check that forbade the name outright
+    #    would quietly delete that half of the rule.
+    grep -q 'basecamp/omarchy' "$report" || {
+      echo "reporting.md no longer mentions basecamp/omarchy at all." >&2
+      echo "Crashes that would happen identically on Arch belong upstream;" >&2
+      echo "dropping the destination loses that routing." >&2
+      fail=1
+    }
+
+    # 4. The prompt that runs before the skill is read. It set the destination
+    #    first, so porting reporting.md alone left the agent already pointed at
+    #    Basecamp when it arrived.
+    crash=${omarchy}/share/omarchy/bin/omarchy-agent-crash
+    if grep -q 'reporting upstream to Omarchy' "$crash"; then
+      echo "" >&2
+      echo "omarchy-agent-crash still primes the agent with 'reporting upstream" >&2
+      echo "to Omarchy' before the skill is read." >&2
+      fail=1
+    fi
+
+    [ "$fail" -eq 0 ] || exit 1
+    echo "crash reports route to Nixarchy, with Omarchy still reachable"
+    touch $out
+  ''


### PR DESCRIPTION
## The bug

`reporting.md` line 3 — which this port wrote — says:

> …Nixarchy for anything specific to NixOS … **When unsure, file against Nixarchy.**

Three lines later, and for the rest of the file:

```
gh search issues --repo basecamp/omarchy "<program> crash"
gh issue list   --repo basecamp/omarchy --state all --search "<signal> <program>"
gh issue view <number> --repo basecamp/omarchy --comments
gh issue comment <number> --repo basecamp/omarchy --body "..."
gh issue create --repo basecamp/omarchy --title "..." --body "..."
```

An agent reads the rule, concludes correctly, and then copies a command that files the issue at Basecamp. Of the four `--replace-fail` entries on that file, **none touched a `gh` command** — the narrative was ported and the executable part was not.

Found by a user whose crash reports were going to the wrong project.

## What changed

**The framing first, then the commands.** Swapping only the commands leaves an agent reasoning about *"Omarchy's sphere of control"* and then filing to nixarchy, which is a different kind of wrong. So `## Is it even Omarchy's bug?` → `## Is it even the distribution's bug?`, and the sphere-of-control list now says Nixarchy owns the NixOS half of each line and Omarchy the behaviour itself.

**`omarchy-agent-crash` too.** It runs *before* the skill is read and said *"reporting upstream to Omarchy"*, so the agent arrived at `reporting.md` already pointed at Basecamp with the two-project rule reading as an exception. That file had no `substituteInPlace` at all.

**`basecamp/omarchy` stays reachable.** A crash that would happen identically on Arch belongs upstream. The check asserts the name *survives* rather than forbidding it, so this can't be "fixed" by deleting the routing.

## The check

`tests/crash-report-repo.nix` greps the built tree. Prose can't be asserted; a `gh` line can. `runCommand` over an already-built derivation — no VM, no network, under a second — and it fails naming the offending line.

### Per AGENTS.md §1, with the fix reverted

```
reporting.md still files against Basecamp from a gh command:
43:gh search issues --repo basecamp/omarchy "<program> crash"
44:gh issue list --repo basecamp/omarchy --state all --search "<signal> <program>"
62:gh issue view <number> --repo basecamp/omarchy --comments
77:gh issue comment <number> --repo basecamp/omarchy --body "..."
85:gh issue create --repo basecamp/omarchy --title "..." --body "..."

Line 3 of that file tells the agent to file against Nixarchy when
unsure. A command that contradicts it is the one that gets run.
no 'gh search issues' line targeting olafkfreund/nixarchy in reporting.md
no 'gh issue list' line targeting olafkfreund/nixarchy in reporting.md
no 'gh issue view' line targeting olafkfreund/nixarchy in reporting.md
no 'gh issue comment' line targeting olafkfreund/nixarchy in reporting.md
no 'gh issue create' line targeting olafkfreund/nixarchy in reporting.md

omarchy-agent-crash still primes the agent with 'reporting upstream
to Omarchy' before the skill is read.
```

Passes with the fix restored. `patched-files` still green; `nix fmt` leaves the block unchanged (all patterns and replacements are single-line, per the warning above that block).

## Two things the build caught

- The existing block's **last** `--replace-fail` had no trailing `\`, so appended entries became separate commands — `--replace-fail: command not found`, loudly, rather than silently skipping. Worth knowing before extending any of these blocks.
- The check first failed on **my own** replacement: I'd added a trailing `# and again with --repo basecamp/omarchy` comment to a `gh` line and it tripped the rule. The comment went, not the rule — a `gh` line naming Basecamp is exactly what this prevents, and a reader copies the whole line.

## Verified in the built output

```
43:gh search issues --repo olafkfreund/nixarchy "<program> crash"
44:gh issue list --repo olafkfreund/nixarchy --state all --search "<signal> <program>"
62:gh issue view <number> --repo olafkfreund/nixarchy --comments
77:gh issue comment <number> --repo olafkfreund/nixarchy --body "..."
85:gh issue create --repo olafkfreund/nixarchy --title "..." --body "..."

5:## Is it even the distribution's bug?
basecamp/omarchy mentions: 1   (line 3, the two-project rule)

omarchy-agent-crash:35  A process crashed on this Nixarchy machine…
omarchy-agent-crash:45  …reporting to Nixarchy or Omarchy…
```