### PR TITLE
A second install cannot write the store into the root subvolume

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1133,6 +1133,30 @@ partition_free_space() {
 }
 
 format_disk() {
+  # Leave /mnt clean, because disko will not.
+  #
+  # disko's mount phase asks `findmnt` whether each mountpoint is already
+  # mounted and SKIPS the ones that are. After a first install that failed
+  # partway -- the bootloader step is the one that has actually happened --
+  # /mnt, /mnt/nix, /mnt/home and /mnt/var/log are all still mounted. The
+  # second run then destroys and reformats the disk underneath them, and
+  # every child mount is skipped as "already mounted" while `@` is the only
+  # subvolume anything is written through.
+  #
+  # The result installs and boots as far as the LUKS prompt. Then fstab
+  # mounts the real (empty) @nix over /nix, the store disappears, stage 2
+  # cannot find its init, and the machine drops to emergency mode -- where
+  # the initrd's root account is locked by design and there is nothing the
+  # user can do. Reported from a real install; @nix, @home and @log were
+  # empty and 21G sat in @/nix, @/home and @/var/log.
+  if findmnt -rno TARGET /mnt >/dev/null 2>&1; then
+    umount -R /mnt || {
+      echo "nixarchy-install: something is mounted at /mnt and will not unmount." >&2
+      echo "  Formatting now would install into the wrong subvolumes. Reboot and retry." >&2
+      exit 1
+    }
+  fi
+
   # Before the passphrase file and before the disko script: in free-space mode
   # the layout the script evaluates addresses partitions that do not exist yet.
   if [ "$disk_mode" = free ]; then
@@ -1156,6 +1180,31 @@ format_disk() {
   "$script"
 
   rm -f /tmp/nixarchy-luks.key
+}
+
+# Prove disko mounted what the layout asked for.
+#
+# The layout gives /nix, /home and /var/log their own subvolumes, and the
+# installed system's fstab mounts them. If they are not mounted HERE, the
+# install still succeeds -- it just writes all of it into `@`, and the
+# machine bricks on first boot when the empty subvolumes mount over the
+# top. Nothing downstream notices, which is why this is checked rather
+# than assumed.
+#
+# `findmnt --mountpoint` matches only a real mountpoint, so a plain
+# directory inside `@` does not satisfy it.
+verify_subvolume_mounts() {
+  local mp missing=""
+  for mp in /mnt /mnt/nix /mnt/home /mnt/var/log; do
+    findmnt -rno TARGET --mountpoint "$mp" >/dev/null 2>&1 || missing="$missing $mp"
+  done
+  if [ -n "$missing" ]; then
+    echo "nixarchy-install: disko did not mount:$missing" >&2
+    echo "  Installing now would put the store and home inside the root" >&2
+    echo "  subvolume, and the machine would not boot. Nothing was installed." >&2
+    findmnt -R /mnt >&2 || true
+    return 1
+  fi
 }
 
 generate_hardware_config() {
@@ -1657,6 +1706,7 @@ main() {
   # `|| rc=$?` was always meant to receive.
   {
     format_disk &&
+      verify_subvolume_mounts &&
       generate_hardware_config &&
       install_flake_dir &&
       write_password_hash &&

--- a/tests/install.nix
+++ b/tests/install.nix
@@ -748,6 +748,30 @@ pkgs.testers.runNixOSTest {
     # Read-only is asserted through `subvolume list -r`, which lists only
     # read-only subvolumes: a baseline that could be written to is one that
     # can drift into being a copy of the machine rather than of the install.
+    # The store, home and the journal are on the subvolumes the layout
+    # promised -- not sitting inside `@` with empty subvolumes mounted over
+    # the top of them.
+    #
+    # That shape installs cleanly and boots as far as the LUKS prompt, then
+    # fstab mounts the empty @nix over /nix, stage 2 loses its init, and the
+    # machine drops to an emergency mode whose root account is locked. It was
+    # reported from a real install and nothing in this suite could see it:
+    # every check installs once onto a fresh disk, and the fault needs a
+    # second run over mounts a failed first run left behind.
+    #
+    # Asserted on the BOOTED machine rather than on /mnt during the install,
+    # because that is where it bites -- the installer is checked separately by
+    # verify_subvolume_mounts, which refuses to install into this state at all.
+    for mp, subvol in [("/nix", "@nix"), ("/home", "@home"), ("/var/log", "@log")]:
+        got = target.succeed(
+            f"findmnt -no SOURCE --mountpoint {mp}").strip()
+        assert f"[/{subvol}]" in got, (
+            f"{mp} is not mounted from the {subvol} subvolume (findmnt says "
+            f"{got!r}). If it is not a mountpoint at all, the install wrote "
+            f"through the root subvolume and the data under {mp} is "
+            f"unreachable once {subvol} mounts over it."
+        )
+
     subvols = target.succeed("btrfs subvolume list -r /")
     print(subvols)
     readonly = [line.split(" path ", 1)[1].strip()


### PR DESCRIPTION
## The bug

disko's mount phase guards every mount with device and target only:

```sh
if ! findmnt "/dev/mapper/cryptroot" "/mnt/home" > /dev/null 2>&1; then
  mount "/dev/mapper/cryptroot" "/mnt/home" -o subvol=@home -o X-mount.mkdir
fi
```

(read from the generated `diskoScript`, not inferred). **The subvolume is not
part of the test.** So anything already mounted at that target from that device
makes disko skip it silently — and `install.sh` never unmounted `/mnt` before
formatting.

The result: `@` is the only subvolume written through. `@nix`, `@home` and
`@log` stay empty, and the install succeeds. Then at first boot fstab mounts
the empty `@nix` over `/nix`, the store vanishes, stage 2 cannot find its init,
`/sysroot` stops being an OS tree, and the machine drops to emergency mode —
where the initrd's root account is locked by design, so there is nothing the
user can do but reinstall.

## Provenance, stated honestly

This on-disk shape was **observed on a real machine** — a tester found `@nix`,
`@home` and `@log` empty with 21G in `@/nix`, `@/home` and `@/var/log`, and
diagnosed the boot failure from it. That part is his and it is confirmed.

What is **not** confirmed is the sequence that produced it on his machine. An
earlier version of this description asserted he had installed twice; he has
since said he installed once and then repaired the machine by hand from a
chroot, so that attribution was wrong and is withdrawn. His root cause remains
under investigation separately — the unexplained half is why his first install
left no bootloader at all.

The defect fixed here stands on its own: `install.sh` formats over whatever is
mounted at `/mnt`, and disko will not notice. Whether or not that is what
happened to him, it is reachable — any retry after a failed install reaches it.

## The fix

Two guards, because either alone leaves a way in:

- **`format_disk` unmounts `/mnt`** before touching the disk, and refuses to
  format if it cannot. Removes the trigger.
- **`verify_subvolume_mounts`** runs between `format_disk` and the install and
  refuses to continue unless `/mnt`, `/mnt/nix`, `/mnt/home` and `/mnt/var/log`
  are all real mountpoints. Removes the class: any future reason disko mounts
  less than the layout asked for now fails in seconds naming the mountpoints,
  rather than 25 minutes later as a machine that will not boot.

## The check

Nothing in the suite could see this — every check installs once onto a fresh
disk. `checks.install` now asserts on the **booted** target that `/nix`,
`/home` and `/var/log` are mounted from `@nix`, `@home` and `@log`.

The `[/@nix]` form the assertion matches was confirmed against a real image
rather than assumed:

```
$ findmnt -no SOURCE --mountpoint /mnt/nix
/dev/nbd1p2[/@nix]
```

A clean install is unaffected — the VM image built from `2edee7f` has 2150
entries in `@nix/store` and 0 in `@/nix/store`.