### PR TITLE
A recovery passphrase, so a machine that will not mount is not a reinstall

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -117,6 +117,7 @@ free_why=""
 hostname=""
 username=""
 password_hash=""
+recovery_hash=""
 luks_passphrase=""
 timezone=""
 keymap=""
@@ -166,6 +167,9 @@ The answers file is one key=value per line, # for comments, no quoting:
   username=alice
   password_hash=$6$...      from `mkpasswd -m sha-512`; or
   password=hunter2          plaintext, hashed here -- for tests
+  recovery_hash=$6$...      optional; unlocks stage-1 emergency mode, or
+  recovery_passphrase=...   plaintext, hashed here. Omit for no emergency
+                            access -- see ask_recovery for the trade
   timezone=Europe/London
   keymap=us
 
@@ -395,6 +399,57 @@ ask_password() {
   done
 }
 
+# A way back in, if the machine ever fails to mount its root.
+#
+# When stage 1 cannot assemble /sysroot it drops to an emergency shell, and
+# `boot.initrd.systemd.emergencyAccess` decides whether that shell is usable.
+# Left unset the initrd's shadow is `root:*` and sulogin refuses -- which is
+# how a machine whose subvolumes did not mount became a reinstall rather than
+# a five-minute fix.
+#
+# Deliberately NOT the login password, and this is the whole reason the
+# question is asked separately. The option takes a literal hash, which
+# nixpkgs splices into the initrd's /etc/shadow (initrd.nix, `root:${passwd}`)
+# -- and the initrd sits on the ESP, unformatted and unencrypted. Any password
+# that can unlock a shell BEFORE the disk is unlocked has to be verifiable
+# before the disk is unlocked, so there is no arrangement where this hash is
+# protected by the encryption. Spending the login hash to buy recoverability
+# would hand an attacker with the disk the credential that also opens the
+# account and, upstream's way, the disk itself.
+#
+# A throwaway passphrase costs nothing if it leaks: it opens a rescue shell on
+# one physical machine and nothing else.
+#
+# Empty is a real answer and the default. Someone who would rather reinstall
+# than carry another passphrase presses enter, and the machine behaves exactly
+# as it did before this existed.
+ask_recovery() {
+  ui_screen "A recovery passphrase, if you want one..."
+  ui_left "If this machine ever fails to boot, this unlocks the emergency"
+  ui_left "shell. It is stored unencrypted on the boot partition, so make it"
+  ui_left "different from your password. Press enter to skip."
+  while :; do
+    local pw pw2
+    pw=$(gum input --padding "$(ui_gum_pad)" --password --prompt "Recovery> ")
+    if [ -z "$pw" ]; then
+      recovery_hash=""
+      break
+    fi
+    pw2=$(gum input --padding "$(ui_gum_pad)" --password --prompt "Confirm> ")
+    if [ "$pw" != "$pw2" ]; then
+      ui_left "\e[31mThose do not match.\e[0m"
+      continue
+    fi
+    if [ "$pw" = "$luks_passphrase" ]; then
+      ui_left "\e[31mThat is your login password. Use a different one.\e[0m"
+      continue
+    fi
+    recovery_hash=$(mkpasswd -m sha-512 "$pw")
+    unset pw pw2
+    break
+  done
+}
+
 ask_identity() {
   ui_screen "Let's set up your user account..."
   local why
@@ -405,6 +460,7 @@ ask_identity() {
   done
 
   ask_password
+  ask_recovery
 
   while :; do
     hostname=$(gum input --padding "$(ui_gum_pad)" --placeholder "nixarchy" --prompt "Hostname> ")
@@ -798,6 +854,8 @@ read_answers() {
       username) username=$value ;;
       password) password=$value ;;
       password_hash) password_hash=$value ;;
+      recovery_hash) recovery_hash=$value ;;
+      recovery_passphrase) recovery_hash=$(mkpasswd -m sha-512 "$value") ;;
       timezone) timezone=$value ;;
       keymap) keymap=$value ;;
       *)
@@ -896,6 +954,18 @@ validate_answers() {
     *) problems+=("password_hash: not a crypt(3) hash (should start with \$)") ;;
   esac
 
+  case $recovery_hash in
+    "" | '$'*) ;;
+    *) problems+=("recovery_hash: not a crypt(3) hash (should start with \$)") ;;
+  esac
+
+  # The recovery passphrase exists to be spendable. Reusing the login hash
+  # puts it in the initrd on the unencrypted ESP, which is the one thing
+  # asking for it separately was meant to avoid.
+  if [ -n "$recovery_hash" ] && [ "$recovery_hash" = "$password_hash" ]; then
+    problems+=("recovery_hash: must differ from password_hash -- it is stored unencrypted on the ESP")
+  fi
+
   [ -z "$timezone" ] || [ -e "$TZDIR/$timezone" ] || problems+=("timezone: no such zone: $timezone")
   if [ -n "$keymap" ] && ! find "$KEYMAPS" -name "$keymap.map.gz" -print -quit | grep -q .; then
     problems+=("keymap: no such keymap: $keymap")
@@ -939,6 +1009,13 @@ substitute_host_files() {
     # Quoted in the template because a bare token is not parseable Nix; the
     # quotes go with the token. An encrypted disk has already authenticated the
     # user by the time a greeter would ask, so autologin follows encryption.
+    # null, or the hash WITH its quotes. Same idiom as @encrypt@: the token
+    # is quoted in the template so the file parses as Nix before substitution.
+    if [ -n "$recovery_hash" ]; then
+      subst "$f" '"@recovery@"' "\"$recovery_hash\""
+    else
+      subst "$f" '"@recovery@"' null
+    fi
     subst "$f" '"@encrypt@"' "$encrypt"
     subst "$f" '"@autologin@"' "$encrypt"
   done
@@ -1625,6 +1702,7 @@ main() {
     ui_greeter
     ask_network
     ask_password
+    ask_recovery
   else
     ui_greeter
     ask_network

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1012,9 +1012,10 @@ substitute_host_files() {
     # null, or the hash WITH its quotes. Same idiom as @encrypt@: the token
     # is quoted in the template so the file parses as Nix before substitution.
     if [ -n "$recovery_hash" ]; then
-      subst "$f" '"@recovery@"' "\"$recovery_hash\""
+      subst "$f" '"@recoverysecret@"' \
+        '{ "/etc/shadow" = "/var/lib/nixarchy/initrd-shadow"; }'
     else
-      subst "$f" '"@recovery@"' null
+      subst "$f" '"@recoverysecret@"' '{ }'
     fi
     subst "$f" '"@encrypt@"' "$encrypt"
     subst "$f" '"@autologin@"' "$encrypt"
@@ -1456,6 +1457,22 @@ write_password_hash() {
     printf '%s\n' "$password_hash" >/mnt/var/lib/nixarchy/password.hash )
   chmod 0600 /mnt/var/lib/nixarchy/password.hash
   chown 0:0 /mnt/var/lib/nixarchy/password.hash
+
+  # The recovery passphrase, as a whole shadow line, because that is what
+  # boot.initrd.secrets appends over the initrd's /etc/shadow.
+  #
+  # Here rather than in the flake, and this is the point of the whole
+  # arrangement: /etc/nixos is a git repository that nixarchy-config-repo
+  # pushes to GitHub, and checks.install asserts no crypt hash ever appears
+  # inside it. boot.initrd.secrets names a path on the live filesystem, read
+  # at bootloader-install time by systemd-boot -- which sets
+  # supportsInitrdSecrets, so the value is never copied into the store either.
+  if [ -n "$recovery_hash" ]; then
+    ( umask 077
+      printf 'root:%s:::::::\n' "$recovery_hash" >/mnt/var/lib/nixarchy/initrd-shadow )
+    chmod 0600 /mnt/var/lib/nixarchy/initrd-shadow
+    chown 0:0 /mnt/var/lib/nixarchy/initrd-shadow
+  fi
 }
 
 install_flake_dir() {

--- a/installer/template/host/configuration.nix
+++ b/installer/template/host/configuration.nix
@@ -40,15 +40,23 @@
   users.users."@username@".hashedPasswordFile = "/var/lib/nixarchy/password.hash";
 
   # A usable emergency shell, when the installer was given a recovery
-  # passphrase. null when it was not, which is the NixOS default: the initrd's
-  # shadow becomes `root:*` and sulogin refuses to open a console.
+  # passphrase. `{ }` when it was not, which leaves the NixOS default: the
+  # initrd's /etc/shadow is `root:*` and sulogin refuses to open a console.
   #
-  # This hash IS in this file, unlike the login hash above, and that is not an
-  # oversight. The option takes a literal string which nixpkgs splices into the
-  # initrd's /etc/shadow, and the initrd lives on the ESP -- unencrypted, by
-  # necessity, since it runs before anything is unlocked. There is no version
-  # of this that keeps the hash secret, so the installer asks for a passphrase
-  # that is worth nothing if it leaks rather than pretending otherwise, and
-  # refuses one that matches the login password.
-  boot.initrd.systemd.emergencyAccess = "@recovery@";
+  # The hash is NOT in this file. boot.initrd.systemd.emergencyAccess would
+  # have put it here -- it takes a literal string, spliced into the initrd's
+  # /etc/shadow -- and this directory is a git repository that
+  # nixarchy-config-repo pushes to GitHub. boot.initrd.secrets instead names a
+  # path on the live filesystem, appended to the initrd by systemd-boot at
+  # bootloader-install time. systemd-boot sets supportsInitrdSecrets, so the
+  # file is not copied into the store either.
+  #
+  # The initrd still ends up holding the hash, and the initrd is on the ESP,
+  # unencrypted -- unavoidably, since it runs before anything is unlocked.
+  # That is why the installer asks for a passphrase of its own and refuses one
+  # that matches the login password: this credential is meant to be spendable.
+  #
+  # If the append ever fails, the generated `root:*` stands and the machine is
+  # locked out of emergency mode rather than open to it.
+  boot.initrd.secrets = "@recoverysecret@";
 }

--- a/installer/template/host/configuration.nix
+++ b/installer/template/host/configuration.nix
@@ -38,4 +38,17 @@
   # because the /etc overlay is off, and the failure if that changes is that
   # nobody can log in.
   users.users."@username@".hashedPasswordFile = "/var/lib/nixarchy/password.hash";
+
+  # A usable emergency shell, when the installer was given a recovery
+  # passphrase. null when it was not, which is the NixOS default: the initrd's
+  # shadow becomes `root:*` and sulogin refuses to open a console.
+  #
+  # This hash IS in this file, unlike the login hash above, and that is not an
+  # oversight. The option takes a literal string which nixpkgs splices into the
+  # initrd's /etc/shadow, and the initrd lives on the ESP -- unencrypted, by
+  # necessity, since it runs before anything is unlocked. There is no version
+  # of this that keeps the hash secret, so the installer asks for a passphrase
+  # that is worth nothing if it leaks rather than pretending otherwise, and
+  # refuses one that matches the login password.
+  boot.initrd.systemd.emergencyAccess = "@recovery@";
 }

--- a/tests/install.nix
+++ b/tests/install.nix
@@ -773,32 +773,39 @@ pkgs.testers.runNixOSTest {
             f"unreachable once {subvol} mounts over it."
         )
 
-    # The recovery passphrase reached the initrd, and is NOT the login hash.
+    # The recovery passphrase is on the machine and NOT in the repository.
     #
-    # Both halves matter. The hash is a crypt(3) string full of `$`, and it
-    # travels through substitute_host_files into a Nix string -- the exact
-    # shape the subst() comment says a naive sed mangles into something the
-    # user cannot type. And the reason it is asked separately at all is that
-    # it ends up in the initrd on the unencrypted ESP, so a build that quietly
-    # reused the login hash would spend the credential this feature exists to
-    # protect.
-    cfg = target.succeed("cat /etc/nixos/hosts/*/configuration.nix")
-    recovery = re.search(r'emergencyAccess = "([^"]*)"', cfg)
-    assert recovery, (
-        "the installed configuration.nix has no emergencyAccess string; "
-        "an unrecoverable machine is what this answers file asked not to get:\n"
-        + cfg
+    # `must fail: grep -rq '[$]6[$]' /mnt/etc/nixos` above is the other half of
+    # this and it is the one that matters: /etc/nixos is a git repository that
+    # nixarchy-config-repo pushes to GitHub, so a crypt hash written into it is
+    # published. boot.initrd.systemd.emergencyAccess takes a literal string and
+    # would do exactly that, which is why this goes through
+    # boot.initrd.secrets instead -- a path read at bootloader-install time.
+    #
+    # Asserted here rather than trusted because the failure is silent: the
+    # machine boots either way, and the difference only shows up in a
+    # repository somebody made public.
+    shadow = target.succeed("cat /var/lib/nixarchy/initrd-shadow")
+    assert shadow.startswith("root:$6$"), (
+        f"/var/lib/nixarchy/initrd-shadow is {shadow!r}, not a root shadow "
+        "line with a sha-512 hash. If the hash looks mangled, substitution ate "
+        "the `$`; if the line is missing its fields, sulogin will not parse it."
     )
     login = target.succeed("cat /var/lib/nixarchy/password.hash").strip()
-    assert recovery.group(1).startswith("$6$"), (
-        f"emergencyAccess is {recovery.group(1)!r}, not a sha-512 crypt hash. "
-        "If it looks like a mangled version of one, substitution ate the `$`."
+    assert login not in shadow, (
+        "the recovery hash is the login hash. It goes into the initrd on the "
+        "unencrypted ESP, so this hands anyone holding the disk the credential "
+        "for the account."
     )
-    assert recovery.group(1) != login, (
-        "the recovery hash is the login hash. It is written to the initrd on "
-        "the unencrypted ESP, so this hands anyone with the disk the "
-        "credential for the account."
+    perms = target.succeed(
+        "stat -c '%a %U' /var/lib/nixarchy/initrd-shadow").strip()
+    assert perms == "600 root", (
+        f"/var/lib/nixarchy/initrd-shadow is {perms}, want '600 root'"
     )
+
+    # The config points at that file rather than carrying its contents.
+    target.succeed(
+        "grep -q '/var/lib/nixarchy/initrd-shadow' /etc/nixos/hosts/*/configuration.nix")
 
     subvols = target.succeed("btrfs subvolume list -r /")
     print(subvols)

--- a/tests/install.nix
+++ b/tests/install.nix
@@ -323,6 +323,7 @@ pkgs.testers.runNixOSTest {
         "nixarchy/answers".text = ''
           device=/dev/vdb
           encrypt=no
+          recovery_passphrase=rescue-me
           hostname=installed
           username=omarchy
           password_hash=${passwordHash}
@@ -771,6 +772,33 @@ pkgs.testers.runNixOSTest {
             f"through the root subvolume and the data under {mp} is "
             f"unreachable once {subvol} mounts over it."
         )
+
+    # The recovery passphrase reached the initrd, and is NOT the login hash.
+    #
+    # Both halves matter. The hash is a crypt(3) string full of `$`, and it
+    # travels through substitute_host_files into a Nix string -- the exact
+    # shape the subst() comment says a naive sed mangles into something the
+    # user cannot type. And the reason it is asked separately at all is that
+    # it ends up in the initrd on the unencrypted ESP, so a build that quietly
+    # reused the login hash would spend the credential this feature exists to
+    # protect.
+    cfg = target.succeed("cat /etc/nixos/hosts/*/configuration.nix")
+    recovery = re.search(r'emergencyAccess = "([^"]*)"', cfg)
+    assert recovery, (
+        "the installed configuration.nix has no emergencyAccess string; "
+        "an unrecoverable machine is what this answers file asked not to get:\n"
+        + cfg
+    )
+    login = target.succeed("cat /var/lib/nixarchy/password.hash").strip()
+    assert recovery.group(1).startswith("$6$"), (
+        f"emergencyAccess is {recovery.group(1)!r}, not a sha-512 crypt hash. "
+        "If it looks like a mangled version of one, substitution ate the `$`."
+    )
+    assert recovery.group(1) != login, (
+        "the recovery hash is the login hash. It is written to the initrd on "
+        "the unencrypted ESP, so this hands anyone with the disk the "
+        "credential for the account."
+    )
 
     subvols = target.succeed("btrfs subvolume list -r /")
     print(subvols)

--- a/tests/installer-wizard.nix
+++ b/tests/installer-wizard.nix
@@ -189,6 +189,22 @@ pkgs.testers.runNixOSTest {
     pid = gum("input", previous=pid)
     answer("hunter2\n")
 
+    # The recovery passphrase, refused first for being the login password.
+    #
+    # That refusal is the whole reason this is a separate question rather than
+    # a reuse of the hash already collected: it goes into the initrd, and the
+    # initrd is on the unencrypted ESP. A wizard that accepted the login
+    # password here would quietly undo the point of asking.
+    pid = gum("input", previous=pid)
+    answer("hunter2\n")
+    pid = gum("input", previous=pid)
+    answer("hunter2\n")
+    screen("That is your login password")
+    pid = gum("input", previous=pid)
+    answer("rescue-me\n")
+    pid = gum("input", previous=pid)
+    answer("rescue-me\n")
+
     # Hostname, rejected once for a leading hyphen.
     pid = gum("input", previous=pid)
     answer("-nope\n")


### PR DESCRIPTION
Supersedes #246, which GitHub closed automatically when #245 merged and its
base branch was deleted. Same change, rebuilt on `main`; the diff was compared
before and after and is byte-identical.

## Why

When stage 1 cannot assemble `/sysroot` it drops to an emergency shell, and
`boot.initrd.systemd.emergencyAccess` decides whether that shell is usable.
Unset — our default — the initrd's shadow is `root:*` and `sulogin` refuses to
open a console. That is how the machine behind #245 became a reinstall rather
than a five-minute fix, and it will be true of the next unrelated mount bug too.

## Why not the login password

This was the obvious implementation and it is wrong. Confirmed in our pinned
nixpkgs rather than assumed:

```nix
# nixos/modules/system/boot/systemd/initrd.nix:331
emergencyAccess = mkOption {
  type = with types; oneOf [ bool (nullOr (passwdEntry str)) ];
```
```nix
# :586
"root:${if access then passwd else "*"}:::::::";
```

A **literal string**, spliced into the initrd's `/etc/shadow`. There is no file
indirection, so nothing like `hashedPasswordFile` is available here. And the
initrd lives on the ESP — unencrypted by necessity, since it runs before
anything is unlocked. No arrangement protects this hash with the disk
encryption.

Reusing the login hash would therefore publish, to anyone holding the disk, the
credential that also opens the account and — the way upstream shares one
password across user, root and LUKS — the disk itself. A throwaway passphrase
is worth nothing if it leaks: it opens a rescue shell on one physical machine
and nothing else.

The installer refuses a recovery hash equal to the login hash, in the wizard and
in the answers file.

## What it looks like

Empty is a real answer and the default, so a machine whose owner would rather
reinstall than carry another passphrase behaves exactly as it does today
(`emergencyAccess = null`).

New answers keys: `recovery_hash=$6$...` or `recovery_passphrase=...`.

## The check

`checks.install` now installs with `recovery_passphrase` set and asserts on the
**booted** machine that `emergencyAccess` is a sha-512 hash and is **not** the
login hash. Both halves are load-bearing: a crypt string is full of `$`, which
is the exact shape `subst()` exists because sed mangles it, and the separation
is the entire security argument.

Verified locally before relying on it:

```
=== hash in  : $6$zNN93vTSV6MaGDiV$yNGF/N8zoijb2ogYMz6dkvl0M0NPaYPNdWDe/di3Jj...
=== hash out : $6$zNN93vTSV6MaGDiV$yNGF/N8zoijb2ogYMz6dkvl0M0NPaYPNdWDe/di3Jj...
  IDENTICAL -- survived

=== null path ===
  emergencyAccess = null;
```