### PR TITLE
The installer says when the live store cannot hold what it must fetch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,16 @@ jobs:
       - name: The installer's generated lock has the fields nix would write
         run: nix build .#checks.x86_64-linux.installer-lock --print-build-logs
 
+      # Whether the live store can hold what the install must fetch. A live
+      # ISO's store is a RAM-backed overlay at half the machine's memory, and
+      # when it fills the install dies several levels under an error naming
+      # none of it -- reaching one user as a machine with no bootloader.
+      # checks.install cannot see this: it installs onto a machine whose store
+      # fits, which is the only shape that does not fail. So the decision is
+      # unit-tested here instead, in seconds.
+      - name: The installer refuses a build the live store cannot hold
+        run: nix build .#checks.x86_64-linux.installer-store-space --print-build-logs
+
       # Where a crash report goes. The prose said Nixarchy and every `gh`
       # command said Basecamp, so an agent read the rule, concluded correctly,
       # and then copied a command that filed into somebody else's tracker --

--- a/flake.nix
+++ b/flake.nix
@@ -1018,6 +1018,11 @@
         # The installer's interactive screens, at every width worth caring
         # about. Nothing else draws them: every other harness passes
         # --answers, which is exactly how #133 shipped.
+        installer-store-space = import ./tests/installer-store-space.nix {
+          pkgs = pkgsFor.${system};
+          installScript = ./installer/install.sh;
+        };
+
         installer-lock = import ./tests/installer-lock.nix {
           pkgs = pkgsFor.${system};
           flakeTemplate = self.packages.${system}.flake-template;

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1490,14 +1490,83 @@ install_flake_dir() {
   git -C /mnt/etc/nixos add -A
 }
 
+# Refuse a build the live store has no room for, and say which number is the
+# problem.
+#
+# The store on a live ISO is a RAM-backed overlay -- half the machine's memory,
+# so 7.8G on a 16 GiB laptop -- over the read-only squashfs. `du` reports the
+# squashfs too, which is why it can say 18G while there is nothing left to
+# write. Every path nix has to fetch or build lands in that overlay before
+# anything reaches the disk.
+#
+# When it fills, the install does not stop: it dies partway with "No space left
+# on device", several levels under a "1 dependency failed" that names none of
+# it. installer/vm.nix says exactly this about the test VM, which escapes with
+# writableStoreUseTmpfs = false and a real disk. The ISO has no such escape, so
+# a user meets it as a machine that installed and has no bootloader. One did.
+#
+# A fixed threshold would not catch it. The machine that failed had 7.8G free
+# when it started, which passes any figure worth setting; it filled during the
+# build. The only number that decides it is the one the dry-run already prints
+# -- "(8.1 GiB download, 21.0 GiB unpacked)" -- against what df says is left.
+#
+# Tolerant on purpose: an unparseable plan proceeds. This exists to name a
+# failure that already happens, not to invent a new way to refuse.
+check_store_space() {
+  local plan=$1 size unit want free store
+  store=$(df -P /nix/store 2>/dev/null | awk 'NR==2 {print $1}')
+
+  read -r size unit <<<"$(printf '%s\n' "$plan" |
+    sed -n 's/.*[(,] *\([0-9.]*\) \([KMG]iB\) unpacked.*/\1 \2/p' | head -1)"
+  [ -n "$size" ] && [ -n "$unit" ] || return 0
+
+  case $unit in
+    KiB) want=$(awk "BEGIN{printf \"%.0f\", $size*1024}") ;;
+    MiB) want=$(awk "BEGIN{printf \"%.0f\", $size*1048576}") ;;
+    GiB) want=$(awk "BEGIN{printf \"%.0f\", $size*1073741824}") ;;
+    *) return 0 ;;
+  esac
+
+  free=$(df -B1 -P /nix/store 2>/dev/null | awk 'NR==2 {print $4}')
+  case $free in ''|*[!0-9]*) return 0 ;; esac
+
+  # A margin, because the figure is what the paths occupy and not what nix
+  # needs in flight to put them there.
+  [ "$want" -lt "$((free - free / 10))" ] && return 0
+
+  echo "nixarchy-install: the live store cannot hold what this install must fetch." >&2
+  echo >&2
+  echo "  needs : $(numfmt --to=iec "$want" 2>/dev/null || echo "$want bytes") unpacked" >&2
+  echo "  free  : $(numfmt --to=iec "$free" 2>/dev/null || echo "$free bytes") on ${store:-/nix/store}" >&2
+  echo >&2
+  echo "  On a live ISO this is a RAM-backed overlay, sized at half the" >&2
+  echo "  machine's memory. It is not the disk you are installing to, which" >&2
+  echo "  has room -- so more RAM, or a machine with more, is what changes it." >&2
+  echo >&2
+  echo "  Nothing has been written to the target. The disk was formatted;" >&2
+  echo "  the system was not installed." >&2
+  echo >&2
+  echo "  This normally fetches nothing at all: the image carries the closure" >&2
+  echo "  already. Having anything to fetch means what the image baked is not" >&2
+  echo "  what this flake asks for, which is a bug worth reporting with the" >&2
+  echo "  two numbers above." >&2
+  return 1
+}
+
 run_install() {
   # What would have to be built, printed before doing it. On a machine with no
   # network an unseeded build input is the difference between an install and a
   # confusing cascade of source downloads, and this names it once rather than
   # leaving it to be inferred from whatever failed first.
-  nix "${NIX_FLAGS[@]}" build --dry-run "${SUBSTITUTE_FLAGS[@]}" \
-    "/mnt/etc/nixos#nixosConfigurations.$hostname.config.system.build.toplevel" 2>&1 |
-    head -40 || true
+  #
+  # Captured rather than piped straight to the log, because check_store_space
+  # reads the same plan: the sizes it decides on are the ones printed here.
+  local plan
+  plan=$(nix "${NIX_FLAGS[@]}" build --dry-run "${SUBSTITUTE_FLAGS[@]}" \
+    "/mnt/etc/nixos#nixosConfigurations.$hostname.config.system.build.toplevel" 2>&1) || true
+  printf '%s\n' "$plan" | head -40
+
+  check_store_space "$plan" || return 1
 
   # Build here, then install what was built. NOT `nixos-install --flake`.
   #

--- a/tests/installer-store-space.nix
+++ b/tests/installer-store-space.nix
@@ -1,0 +1,72 @@
+{ pkgs, installScript }:
+# check_store_space, driven with plans nix really prints and a df that lies.
+#
+# A live ISO's store is a RAM-backed overlay over the squashfs -- half the
+# machine's memory. Everything nix fetches or builds lands there before any of
+# it reaches the disk, and when it fills the install does not stop: it dies
+# partway with "No space left on device", several levels under a "1 dependency
+# failed" that names none of it. installer/vm.nix says as much about the test
+# VM, which escapes with writableStoreUseTmpfs = false. The ISO cannot.
+#
+# One user met it as a machine that installed and had no bootloader, and only
+# found it by running df himself: 7.8G, 100% used, nothing left.
+#
+# A fixed threshold would not have caught that. He had 7.8G free when the
+# install started, which passes any figure worth setting -- it filled during
+# the build. The decision has to come from the size nix itself prints, so this
+# checks the parse and the comparison rather than a constant.
+#
+# A runCommand and not a VM: the function is shell, the inputs are strings, and
+# the 25-minute install check cannot see this case at all -- it installs onto a
+# machine whose store fits, which is the only shape that does not fail.
+pkgs.runCommand "nixarchy-installer-store-space" { } ''
+    # The function on its own. Extracting it rather than sourcing install.sh,
+    # which runs a wizard when sourced.
+    sed -n '/^check_store_space()/,/^}/p' ${installScript} > f.sh
+    test -s f.sh || { echo "check_store_space is not in install.sh any more" >&2; exit 1; }
+
+    cat > t.sh <<'EOF'
+    . ./f.sh
+    # $FREE bytes available, so the comparison is what is under test and not
+    # whatever the builder happens to be sitting on.
+    df() {
+      case "$*" in
+        *-B1*) printf 'F 1B-blocks Used Available Cap Mounted\noverlay 8000000000 0 %s 100%% /nix/store\n' "$FREE" ;;
+        *)     printf 'F Size Used Avail Cap Mounted\noverlay 7.8G 7.8G 0 100%% /nix/store\n' ;;
+      esac
+    }
+    fails=0
+    t() {
+      want=$1 name=$2 free=$3 plan=$4
+      if FREE=$free check_store_space "$plan" >out 2>&1; then got=proceed; else got=refuse; fi
+      if [ "$got" = "$want" ]; then
+        echo "  ok      $name ($got)"
+      else
+        echo "  FAILED  $name: wanted $want, got $got"; sed 's/^/            /' out
+        fails=$((fails + 1))
+      fi
+    }
+
+    GB=1073741824
+    FETCH21='these 489 paths will be fetched (8.1 GiB download, 21.0 GiB unpacked):'
+
+    # The reported case: 21 GiB of paths, 7.8G of RAM-backed store.
+    t refuse  "21 GiB needed, 7.8G free"      8371830784        "$FETCH21"
+    # The same install on a machine with room.
+    t proceed "21 GiB needed, 900G free"      $((900 * GB))     "$FETCH21"
+    # Units below GiB are parsed too, or a small overflow reads as no overflow.
+    t refuse  "120 MiB needed, 100 MiB free"  $((100 * 1048576)) \
+      'these 12 paths will be fetched (40.2 MiB download, 120.5 MiB unpacked):'
+    # The normal install: the image carries the closure, nothing is fetched.
+    t proceed "nothing to fetch"              8371830784        'these 0 derivations will be built'
+    # Tolerance. This exists to name a failure that already happens; a plan it
+    # cannot read must not become a new way to refuse an install that would work.
+    t proceed "unparseable plan"              1                 'some other nix message entirely'
+    t proceed "builds, no sizes printed"      1                 'these 4 derivations will be built:'
+    exit $fails
+  EOF
+    bash t.sh
+
+    echo "check_store_space refuses what will not fit and nothing else"
+    touch $out
+''


### PR DESCRIPTION
The cheap half of #249. Does not fix the ceiling — makes it legible.

## What the user saw

A machine installed, rebooted, and had **no bootloader entry**. He found the
cause himself with `df` on the live ISO:

```
Filesystem      Size  Used Avail Use% Mounted on
overlay         7.8G  7.8G     0 100% /nix/store
/dev/nvme1n1p2  930G   30G  900G   4% /mnt/nix
18G     /nix/store
```

A live ISO's store is a RAM-backed overlay over the squashfs — half the
machine's memory, so 7.8G on his 16 GiB laptop. Everything nix fetches or
builds lands there before any of it reaches the disk. `du` reports the squashfs
too, which is why it says 18G while there is nothing left to write.

When it fills, the install does not stop. It dies partway with `No space left
on device`, several levels under a `1 dependency failed` that names none of it.

## This was already written down

`installer/vm.nix:150-154`, about the test VM:

> the writable store is the RAM-backed tmpfs below. The install then dies
> partway through with "No space left on device", three levels underneath a
> "1 dependency failed" that names none of it.

The VM escapes with `writableStoreUseTmpfs = false` and a real disk. **The ISO
has no such escape.** The condition was understood and fixed where it was cheap,
while the place a user meets it stayed exposed — and it reached him as a missing
bootloader, exactly as that comment predicts.

## Why not a threshold

The obvious implementation does not work. He had **7.8G free when the install
started**, which passes any figure worth setting; it filled *during* the build.

The only number that decides it is the one nix already prints. `run_install`
was running `--dry-run` and sending the plan to the log; it now keeps that
output and reads the sizes out of it — `(8.1 GiB download, 21.0 GiB unpacked)`
against `df`.

## The message

Names both numbers, then the three things he had to work out for himself: that
the full filesystem is RAM and not the disk being installed to, that the disk
was formatted and the system was not, and that **having anything to fetch is
itself the bug** — the image carries the closure, so a fetch means what it baked
is not what the flake asks for. That is the #238 shape, which is what he
actually hit.

Tolerant on purpose: an unparseable plan proceeds. This names a failure that
already happens and must not become a new way to refuse an install that works.

## The check

`checks.installer-store-space` — a `runCommand`, seconds, no VM. It extracts
the function and drives it with plans nix really prints against a `df` that
lies, so the comparison is what is under test rather than whatever the builder
is sitting on.

`checks.install` cannot see this case at all: it installs onto a machine whose
store fits, which is the only shape that does not fail.

Green:

```
  ok      21 GiB needed, 7.8G free (refuse)
  ok      21 GiB needed, 900G free (proceed)
  ok      120 MiB needed, 100 MiB free (refuse)
  ok      nothing to fetch (proceed)
  ok      unparseable plan (proceed)
  ok      builds, no sizes printed (proceed)
```

Red first, by deleting the comparison:

```
FAILED  21 GiB needed, 7.8G free: wanted refuse, got proceed
FAILED  120 MiB needed, 100 MiB free: wanted refuse, got proceed
```

Refs #249