### PR TITLE
The install builds into the target store when the live one is too small

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -118,6 +118,8 @@ hostname=""
 username=""
 password_hash=""
 recovery_hash=""
+# auto (decide on the plan), live, or target. See run_install.
+build_store_choice="auto"
 luks_passphrase=""
 timezone=""
 keymap=""
@@ -167,6 +169,10 @@ The answers file is one key=value per line, # for comments, no quoting:
   username=alice
   password_hash=$6$...      from `mkpasswd -m sha-512`; or
   password=hunter2          plaintext, hashed here -- for tests
+  build_store=auto          auto, live or target: where the system is built.
+                            auto builds here unless the live store is too
+                            small, which is what a live ISO's RAM-backed
+                            store usually is
   recovery_hash=$6$...      optional; unlocks stage-1 emergency mode, or
   recovery_passphrase=...   plaintext, hashed here. Omit for no emergency
                             access -- see ask_recovery for the trade
@@ -864,6 +870,7 @@ read_answers() {
       username) username=$value ;;
       password) password=$value ;;
       password_hash) password_hash=$value ;;
+      build_store) build_store_choice=$value ;;
       recovery_hash) recovery_hash=$value ;;
       recovery_passphrase) recovery_hash=$(mkpasswd -m sha-512 "$value") ;;
       timezone) timezone=$value ;;
@@ -962,6 +969,11 @@ validate_answers() {
   case $password_hash in
     "" | '$'*) ;;
     *) problems+=("password_hash: not a crypt(3) hash (should start with \$)") ;;
+  esac
+
+  case $build_store_choice in
+    auto | live | target) ;;
+    *) problems+=("build_store: must be auto, live or target, got: $build_store_choice") ;;
   esac
 
   case $recovery_hash in
@@ -1553,8 +1565,9 @@ check_store_space() {
   echo "  machine's memory. It is not the disk you are installing to, which" >&2
   echo "  has room -- so more RAM, or a machine with more, is what changes it." >&2
   echo >&2
-  echo "  Nothing has been written to the target. The disk was formatted;" >&2
-  echo "  the system was not installed." >&2
+  echo "  Building into the target store instead, which has the room. This is" >&2
+  echo "  slower -- every path is written to the disk as it is produced rather" >&2
+  echo "  than copied there at the end -- and it is not a failure." >&2
   echo >&2
   echo "  This normally fetches nothing at all: the image carries the closure" >&2
   echo "  already. Having anything to fetch means what the image baked is not" >&2
@@ -1576,7 +1589,31 @@ run_install() {
     "/mnt/etc/nixos#nixosConfigurations.$hostname.config.system.build.toplevel" 2>&1) || true
   printf '%s\n' "$plan" | head -40
 
-  check_store_space "$plan" || return 1
+  # Where to build. The live store by default, because that is the path every
+  # install has taken and the one the comment below argues for; the target
+  # store when the live one cannot hold the job, which is the only case where
+  # the argument stops applying -- a path that will not fit is not faster to
+  # produce locally, it is impossible.
+  #
+  # --eval-store auto is what makes this safe, and it is the thing that was not
+  # available when the comment below was written. `--store /mnt` alone sets the
+  # EVALUATION store too, which is the failure that comment describes: locked
+  # inputs resolved against an empty store, and nix going to the network for
+  # sources sitting one directory up. Splitting them keeps evaluation here,
+  # where the sources are, and sends only build outputs to the disk.
+  #
+  # --extra-substituters auto?trusted=1 offers this machine's store to the
+  # target one, which is exactly what nixos-install does for the same reason
+  # (its own `sub="auto?trusted=1"`). Combined with always-allow-substitutes in
+  # SUBSTITUTE_FLAGS -- see the comment on it, which is about precisely this
+  # arrangement -- the closure is copied rather than rebuilt.
+  local build_store=()
+  case ${build_store_choice:-auto} in
+    target) build_store=(--store /mnt --eval-store auto --extra-substituters "auto?trusted=1") ;;
+    live) ;;
+    *) check_store_space "$plan" ||
+      build_store=(--store /mnt --eval-store auto --extra-substituters "auto?trusted=1") ;;
+  esac
 
   # Build here, then install what was built. NOT `nixos-install --flake`.
   #
@@ -1599,6 +1636,7 @@ run_install() {
   # before it can be used.
   local system
   system=$(nix "${NIX_FLAGS[@]}" build --no-link --print-out-paths "${SUBSTITUTE_FLAGS[@]}" \
+    "${build_store[@]}" \
     "/mnt/etc/nixos#nixosConfigurations.$hostname.config.system.build.toplevel") || true
 
   # Checked, because set -e will not check it here. The whole install runs as

--- a/tests/free-space.nix
+++ b/tests/free-space.nix
@@ -342,6 +342,14 @@ pkgs.testers.runNixOSTest {
           device=/dev/vdb
           disk_mode=free
           encrypt=no
+          # Build into the target store, so that path is walked by a real
+          # install rather than only by the unit test of the decision.
+          #
+          # Here rather than in checks.install because the two checks should
+          # not take the same path: this one installs beside an existing OS,
+          # which is the harder disk case, and it is the cheaper of the two to
+          # lose if the target-store build turns out slower.
+          build_store=target
           hostname=installed
           username=omarchy
           password_hash=${passwordHash}

--- a/tests/installer-store-space.nix
+++ b/tests/installer-store-space.nix
@@ -1,6 +1,9 @@
 { pkgs, installScript }:
 # check_store_space, driven with plans nix really prints and a df that lies.
 #
+# Its answer selects a build store rather than refusing an install: non-zero
+# means "the live store cannot hold this, build into the target instead".
+#
 # A live ISO's store is a RAM-backed overlay over the squashfs -- half the
 # machine's memory. Everything nix fetches or builds lands there before any of
 # it reaches the disk, and when it fills the install does not stop: it dies
@@ -51,9 +54,9 @@ pkgs.runCommand "nixarchy-installer-store-space" { } ''
     FETCH21='these 489 paths will be fetched (8.1 GiB download, 21.0 GiB unpacked):'
 
     # The reported case: 21 GiB of paths, 7.8G of RAM-backed store.
-    t refuse  "21 GiB needed, 7.8G free"      8371830784        "$FETCH21"
+    t refuse  "21 GiB needed, 7.8G free -> target"      8371830784        "$FETCH21"
     # The same install on a machine with room.
-    t proceed "21 GiB needed, 900G free"      $((900 * GB))     "$FETCH21"
+    t proceed "21 GiB needed, 900G free -> live"      $((900 * GB))     "$FETCH21"
     # Units below GiB are parsed too, or a small overflow reads as no overflow.
     t refuse  "120 MiB needed, 100 MiB free"  $((100 * 1048576)) \
       'these 12 paths will be fetched (40.2 MiB download, 120.5 MiB unpacked):'


### PR DESCRIPTION
Closes #249. #250 taught the installer to *notice*; this makes it *act*.

## What changes

#250 refused when the live store could not hold what the install must fetch.
Better than dying three levels down, but still a machine that does not get
installed. It now chooses a store instead.

The live store stays the default — it is the path every install has taken, and
the comment above `run_install` argues for it. The target store is used only
where that argument stops applying: **a closure that will not fit is not slower
to produce locally, it is impossible.**

```sh
nix build --store /mnt --eval-store auto --extra-substituters "auto?trusted=1"
```

## Why this is now safe when it was not

`install.sh:1502` rejects `--store /mnt`, and the reason it gives is correct:

> `--store` sets the EVALUATION store as well as the build one. Evaluating the
> generated flake against /mnt means resolving every locked input against a
> store that has just been created and contains nothing, so nix goes to the
> network for sources that are sitting in the store one directory up.

`--eval-store auto` answers exactly that: evaluation stays here, where the
sources are; only build outputs go to the disk.

And `--extra-substituters auto?trusted=1` is not invention — `nixos-install`
does the same thing for the same reason (`sub="auto?trusted=1"`), and
`SUBSTITUTE_FLAGS` already carries `always-allow-substitutes` for precisely
this arrangement. Its comment is about NixOS' assembly derivations being
unsubstitutable in a fresh store, which is this exact situation.

## Three things checked, not assumed

The change turns entirely on these:

**1. `nixos-install --system` does not copy a path that is already there.**
Line 294 is `nix-env --store "$mountPoint" --extra-substituters "$sub" -p
.../system --set "$system"` — it sets the profile and substitutes only what is
absent. A path built into `/mnt` is simply found.

**2. `--store X --eval-store auto` substitutes what it can AND builds what it
must.** Run against a scratch store, both cases `rc=0`:

```
A: nixpkgs#hello (cached)
   rc=0  /nix/store/wzr035k…-hello-2.12.3   physically present: yes

B: a runCommand that exists in no cache
   rc=0  /nix/store/bmnpv1…-unbuildable-probe-23558
     don't know how to build these paths:
       …-unbuildable-probe-23558.drv
     copying 0 paths...
     building '…-unbuildable-probe-23558.drv'...
```

The `don't know how to build` line is a note, not an error — nix copies the drv
closure and builds.

**3. It must run as root.** My first attempt at probe B failed on this host's
`nix.settings.build-dir`. That is not a split-store problem and cannot arise in
the installer, which is root already — but it is why the probe is reported as
two runs rather than one.

## Coverage

An answers key selects the store: `build_store=auto` (decide on the plan),
`live`, or `target`.

`checks.free-space` now installs with `target`, so the new path is walked by a
**real install** once per CI run rather than only by the unit test of the
decision. `checks.install` keeps the default. Both paths covered; neither check
costs more than it did.

`checks.installer-store-space` is reframed — its non-zero now means "build into
the target instead", not "refuse".