### PR TITLE
The menu-command guard covers nixarchy's own commands, in the menu the shell actually renders

### DIFF
--- a/tests/coverage.py
+++ b/tests/coverage.py
@@ -47,19 +47,44 @@ print(f"all {len(rows)} Install rows are mapped or accounted for")
 # A row whose command is gone renders normally and does nothing when chosen,
 # which is the quietest way for an Omarchy bump to break the desktop.
 #
+# Both prefixes, and the merged menu rather than the package's own, because
+# together those two narrownesses left every row nixarchy writes unchecked.
+#
+# The pattern was `\bomarchy-`, so `nixarchy-apply`, `nixarchy-search`,
+# `nixarchy-app-enable`, `nixarchy-app-disable`, `nixarchy-app-remove` and
+# `nixarchy-service-enable` were invisible to it -- our commands, the ones
+# with no upstream keeping their names still, the ones a refactor here renames
+# in a single commit. And the file it read was the package's menu, which is
+# upstream's plus the Ask rows; the rows those commands appear in are written
+# by modules/apps.nix into the merged defaults ($treeMenu) that OMARCHY_PATH
+# points at, so even a widened pattern aimed at the old file would have found
+# nothing to check. Between them: 75 rows -- every Install and Remove row for
+# an app, every service row, Apply changes, Search -- named a command no check
+# had ever confirmed exists. Renaming one of those writeShellApplications and
+# missing its menu row cost nothing at build time and produced a row that
+# still drew, still highlighted, and did nothing when chosen.
+#
+# `have` is two places for the same reason the names are two families:
+# Omarchy's scripts are files in the tree's bin/, ours are packages on the
+# reference machine's system PATH.
+#
 # Two shapes are excluded because they are not invocations. `when:` guards can
 # name an *Arch package* -- install.editor.emacs tests
 # `omarchy-pkg-present omarchy-emacs`, which is a package, not a command. And
 # remove.webapp greps Exec= lines for `omarchy-webapp-handler`, which is a
 # pattern. Both were flagged the first time this ran, and both are fine.
-menu = json.loads(raw)
+tree_raw = open(os.environ["treeMenu"]).read()
+tree_raw = re.sub(r"^\s*//[^\n]*(\n|$)", "", tree_raw, flags=re.M)
+tree_raw = re.sub(r",(\s*[}\]])", r"\1", tree_raw)
+menu = json.loads(tree_raw)
 have = set(os.listdir(os.path.join(os.environ["omarchyPath"], "bin")))
+have |= set(os.listdir(os.path.join(os.environ["vm"], "sw", "bin")))
 not_invocations = {"omarchy-emacs", "omarchy-webapp-handler"}
 
 missing = {}
 for key, row in menu.items():
     for field in ("action", "when", "disabled", "checked"):
-        for cmd in set(re.findall(r"\bomarchy-[a-z0-9-]+", str(row.get(field, "")))):
+        for cmd in set(re.findall(r"\b(?:omarchy|nixarchy)-[a-z0-9-]+", str(row.get(field, "")))):
             if cmd not in have and cmd not in not_invocations:
                 missing.setdefault(cmd, []).append(key)
 
@@ -67,8 +92,8 @@ if missing:
     sys.exit(
         "these menu rows name a command that does not exist:\n  "
         + "\n  ".join(f"{c} <- {' '.join(sorted(k))}" for c, k in sorted(missing.items()))
-        + "\nAn Omarchy bump removed or renamed it; the rows still draw and do "
-        "nothing when chosen."
+        + "\nAn Omarchy bump removed or renamed it, or a rename here did; the "
+        "rows still draw and do nothing when chosen."
     )
 print(f"all {len(menu)} menu rows name commands that exist")
 

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -681,6 +681,13 @@ pkgs.runCommand "nixarchy-options"
     inherit report;
     inherit menuFile vm;
     omarchyPath = "${(pkgs.extend inputs.self.overlays.default).omarchy}/share/omarchy";
+    # The menu the shell actually renders on this machine, which is NOT the
+    # package's own: modules/apps.nix rewrites the rows that would run pacman
+    # and points OMARCHY_PATH at a mirrored tree carrying the result (#210).
+    # Every row nixarchy adds -- Search, Roll back, Back up configuration, the
+    # two home-backup rows, App removal -- exists only in this file, so a
+    # command check pointed at the package's menu could never see one of them.
+    treeMenu = "${inputs.self.nixosConfigurations.vm.config.programs.nixarchy.tree}/default/omarchy/omarchy-menu.jsonc";
     mapped = pkgs.lib.concatStringsSep " " mappedRows;
     serviceProblems = pkgs.lib.concatStringsSep "\n" serviceProblems;
     flatpakProblems = pkgs.lib.concatStringsSep "\n" flatpakProblems;


### PR DESCRIPTION
## What this changes, and why

`tests/coverage.py`'s second half exists to catch a menu row that names a
command which no longer exists — the failure that renders normally, highlights
normally, and does nothing when chosen. It was looking for
`\bomarchy-[a-z0-9-]+`, so it only ever checked Omarchy's commands: the ones
upstream keeps stable and that a bump here would rename loudly. Every
`nixarchy-*` command — ours, with no upstream to keep the names still, the ones
a refactor here renames in a single commit — went unchecked.

Widening the pattern alone would have been a green light. The file the guard
read was the **package's** menu (upstream's rows plus the Ask rows), and every
row that names a `nixarchy-*` command is written by `modules/apps.nix` into the
**merged defaults** that `OMARCHY_PATH` points at (#210). A widened pattern
aimed at the old file would have found `nixarchy-ask` and `nixarchy-local-ai`,
both of which exist, printed a bigger number, and still covered nothing new. So
the guard now reads `$treeMenu` — the file the shell actually renders — and
`have` gains the reference machine's system PATH alongside the tree's `bin/`,
because the two families of commands live in two places: Omarchy's are scripts
in `bin/`, ours are packages on `$PATH`.

What the widened guard newly covers: **75 menu rows** naming **7** commands
that no check had ever confirmed exist — `nixarchy-app-enable` (47 rows),
`nixarchy-app-disable` (15), `nixarchy-service-enable` (8),
`nixarchy-app-remove`, `nixarchy-apply`, `nixarchy-search`. That is every
Install and Remove row for an app, every service row, Apply changes and Search.
The rows checked went from the package's menu to all 349 of the merged one.

Nothing was actually broken — all 7 exist today, so no fix was needed beyond
teaching `have` where they live. Nothing was excused or narrowed away.

## How I proved the check fails

The intermediate state — pattern widened and pointed at the real menu, before
`have` learned that our commands are on the system PATH rather than in the
tree's `bin/`. This is exactly the report the guard would produce the day
someone renames one of these writeShellApplications and misses its menu row:

```
nixarchy-options> every option adds what it should and removes it again
nixarchy-options> all 74 Install rows are mapped or accounted for
nixarchy-options> these menu rows name a command that does not exist:
nixarchy-options>   nixarchy-app-disable <- remove.browser.brave remove.browser.chrome remove.browser.edge remove.browser.firefox remove.browser.zen remove.development.php.php remove.development.php.symfony remove.dictation remove.gaming.heroic remove.gaming.lutris remove.gaming.minecraft remove.gaming.retroarch remove.gaming.steam remove.gaming.xbox-controllers remove.service.dropbox
nixarchy-options>   nixarchy-app-enable <- install.ai.chatgpt install.ai.dictation install.ai.grok-bot install.ai.lm-studio install.browser.brave install.browser.chrome install.browser.edge install.browser.firefox install.browser.zen install.development.clojure install.development.dotnet install.development.elixir.elixir install.development.go install.development.java install.development.javascript.bun install.development.javascript.deno install.development.javascript.node install.development.ocaml install.development.php.php install.development.php.symfony install.development.python install.development.rust install.development.scala install.development.zig install.editor.cursor install.editor.emacs install.editor.helix install.editor.vim install.editor.vscode install.editor.zed install.gaming.heroic install.gaming.lutris install.gaming.minecraft install.gaming.retroarch install.gaming.steam install.gaming.xbox-controllers install.service.1password install.service.bitwarden install.service.dropbox install.service.nordvpn install.service.once install.service.signal install.service.spotify install.terminal.alacritty install.terminal.foot install.terminal.ghostty install.terminal.kitty
nixarchy-options>   nixarchy-app-remove <- remove.package
nixarchy-options>   nixarchy-apply <- install.apply
nixarchy-options>   nixarchy-search <- install.search
nixarchy-options>   nixarchy-service-enable <- install.flatpak.geforce-now install.service.devenv install.service.flatpak install.service.graphics32 install.service.hypr-rdp install.service.openssh install.service.syncthing install.service.tailscale
nixarchy-options> An Omarchy bump removed or renamed it; the rows still draw and do nothing when chosen.
error: builder for '/nix/store/bcd4yn8dwdph0q6x5lm3wziql4alpfcr-nixarchy-options.drv' failed
```

Green with the fix, on this branch's head commit:

```
$ nix build .#checks.x86_64-linux.options --print-build-logs
nixarchy-options> all 74 Install rows are mapped or accounted for
nixarchy-options> all 349 menu rows name commands that exist
```

(74 Install rows unchanged: the mapping half still reads upstream's own menu,
which is the file that half is about.)

## Checks run locally

- `nix build .#checks.x86_64-linux.options` — red then green, above.
- `nix fmt -- --ci`: `formatted 57 files (0 changed)`.
- `statix check .` and `deadnix --fail .`: clean.

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (no new files)
- [x] If this adds an option: `tests/options.nix` covers both states (no new option)
- [x] If this adds a `checks.*` entry: no new entry — this widens an existing
      check inside `checks.options`, which `build.yml` already builds.
