### PR TITLE
A cache upload that fails does not redden a build that succeeded

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,29 @@ jobs:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: cachix/cachix-action@v17
+        # A failed cache upload must not fail a build that succeeded. #235: three
+        # of four concurrent pull requests went red in `Post Run
+        # cachix/cachix-action@v17` -- every build step had passed, the daemon
+        # was walking the store skipping paths already in the cache, then it
+        # aborted with exit code 3. The fourth, running in the same
+        # five-minute window, pushed fine. That reads as a ceiling on cachix's
+        # side rather than anything in the change, and a red check that means
+        # "the cache was busy" teaches everyone to re-run without reading --
+        # the habit AGENTS.md 9 exists to prevent.
+        #
+        # `continue-on-error` on the step, not `skipPush`, because pushing
+        # from pull requests is what fills the cache before main needs it. A
+        # post step's continue-on-error is read off the SAME step definition
+        # as the main one -- ActionRunner.ContinueOnError => Action
+        # .ContinueOnError, and the post runner is created with
+        # `actionRunner.Action = Action` -- so this covers the post-job push,
+        # which is where #235 fails.
+        #
+        # What it also covers, stated because it was not free: a failure in
+        # the main step -- installing cachix, adding the substituter -- stops
+        # failing the job too. That one only costs cache misses; the build
+        # steps below still decide the result.
+        continue-on-error: true
         with:
           name: nixarchy
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -117,6 +140,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: cachix/cachix-action@v17
+        # A cache upload failing must not fail a build that succeeded (#235).
+        continue-on-error: true
         with:
           name: nixarchy
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -132,6 +157,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: cachix/cachix-action@v17
+        # A cache upload failing must not fail a build that succeeded (#235).
+        continue-on-error: true
         with:
           name: nixarchy
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -629,6 +656,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: cachix/cachix-action@v17
+        # A cache upload failing must not fail a build that succeeded (#235).
+        continue-on-error: true
         with:
           name: nixarchy
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/omarchy.yml
+++ b/.github/workflows/omarchy.yml
@@ -35,6 +35,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: cachix/cachix-action@v17
+        # A cache upload failing must not fail a build that succeeded (#235).
+        continue-on-error: true
         with:
           name: nixarchy
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: cachix/cachix-action@v17
+        # A cache upload failing must not fail a build that succeeded (#235).
+        continue-on-error: true
         with:
           name: nixarchy
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}


### PR DESCRIPTION
Proposes a fix for #235. **CI-gate change (AGENTS.md §10): a human merges this, not me.**

## What this changes, and why

`.github/workflows/build.yml`'s `omarchy` job went red on three of four
concurrent pull requests on 2026-09-03, in `Post Run cachix/cachix-action@v17`,
after every build step had passed — the daemon walked the store logging
`Skipping /nix/store/...` and then aborted with exit code 3. The fourth PR,
running in the same five-minute window, pushed fine. The artefact was built and
correct; only the upload broke, and a red check that means "the cache was busy"
is exactly what AGENTS.md §9 says trains people to re-run without reading.

`continue-on-error: true` on every `cachix/cachix-action@v17` step — build.yml
×4, omarchy.yml, update.yml — rather than only the job the issue named, because
all six are the same step calling the same action's post step.

`continue-on-error`, not `skipPush` for pull requests, because pushing from PR
runs is what fills the cache before main needs it. The trade it does make,
stated because it is not free: a failure in the *main* cachix step (installing
cachix, adding the substituter) also stops failing the job. That one costs cache
misses only; the build steps still decide the result.

Not fixed here: the second half of #235, that `gh run view --log-failed` and the
per-job logs API return nothing for a failing post step. That is GitHub's log
plumbing.

## How I proved the check fails

Run **33883698304** on this branch, from a temporary `probe` workflow (two jobs,
identical but for the one line under test) since removed from the branch. A stub
`cachixBin` exits 3 on the push, which is #235's failure with #235's exit code,
while every earlier step passes:

**Without `continue-on-error` — job RED, and nothing but the post step failed:**

```
== the same, unguarded - expected RED => failure
   Run cachix/cachix-action@v17 => success
   The build step passes, as it did on all four runs in #235 => success
   Post Run cachix/cachix-action@v17 => failure
```
```
Post Run cachix/cachix-action@v17  [stub] Aborting workers.
Post Run cachix/cachix-action@v17  ##[error]Action failed with error: Error: The process
  '.../dist/push-paths.sh' failed with exit code 3
```

**With `continue-on-error: true` — same forced failure, same error line in the
log, job GREEN:**

```
== post-step failure, continue-on-error - expected GREEN => success
   Post Run cachix/cachix-action@v17 => success
```
```
Post Run cachix/cachix-action@v17  [stub] Aborting workers.
Post Run cachix/cachix-action@v17  ##[error]Action failed with error: Error: The process
  '.../dist/push-paths.sh' failed with exit code 3
```

That is the whole claim: `continue-on-error` on a `uses:` step reaches its POST
step. The runner takes it off the same step definition —
`ActionRunner.ContinueOnError => Action?.ContinueOnError` (ActionRunner.cs:41)
with the post runner created as `actionRunner.Action = Action` (ActionRunner.cs:131),
applied in `StepsRunner.cs:353`.

One thing worth recording from the first attempt (run 33883428617): faking the
failure with a **bad auth token** does not reproduce #235. Cachix logs the 403,
says `Failed to push`, and exits **0** — the job is green and the paths are
silently not cached. Only a non-zero exit reddens the job.

## Checks run locally

Workflow YAML only; no `.nix` file is touched, so `nix fmt`/statix/deadnix have
nothing to say about this diff. Parsed each file with `yq` and counted the
`continue-on-error` steps.

- [x] `nix fmt` / statix / deadnix are clean (no .nix files changed)
- [x] New files are `git add`ed (none added)
- [ ] If this adds an option: n/a
- [ ] If this adds a `checks.*` entry: n/a