### PR TITLE
Rootless podman and distrobox, gated behind programs.nixarchy.services.boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1601,7 +1601,7 @@ is the shape.
 | --- | --- | --- |
 | [#159](https://github.com/olafkfreund/nixarchy/issues/159) | **remote desktop** — reaching the Hyprland session from elsewhere | 4 of 5 done |
 | [#221](https://github.com/olafkfreund/nixarchy/issues/221) | **sandboxes** — a throwaway NixOS machine from a template, in seconds, with no root and no rebuild | planned, 8 issues |
-| [#230](https://github.com/olafkfreund/nixarchy/issues/230) | **boxes** — an Arch or Debian userland for software NixOS will not run, and its apps in your launcher | planned |
+| [#230](https://github.com/olafkfreund/nixarchy/issues/230) | **boxes** — an Arch or Debian userland for software NixOS will not run, and its apps in your launcher | planned, 8 issues |
 
 **Recently finished:**
 [bare metal to a desktop](https://github.com/olafkfreund/nixarchy/issues/6)

--- a/data/box-templates.nix
+++ b/data/box-templates.nix
@@ -1,0 +1,44 @@
+# What `nixarchy box create --template <t>` feeds to `distrobox-assemble`, and
+# what `nixarchy box promote` prints as a
+# `programs.nixarchy.services.boxes.machines.<name>` snippet.
+#
+# The fifth catalogue: data/apps.nix installs, data/services.nix turns on,
+# data/flatpaks.nix reaches what nixpkgs cannot, data/devenv-presets.nix seeds a
+# project file, and this one assembles a container. Same bar
+# data/devenv-presets.nix already sets for itself, for the same reason: `ini` is
+# pasted into a `distrobox-assemble` block verbatim, in the exact shape
+# distrobox's own manual and INI examples show, with no nixarchy vocabulary in
+# it. A user who outgrows a template grows it from distrobox's own
+# documentation, and ecosystem drift -- a new base image, a renamed field --
+# stays upstream's problem rather than a thing this file has to track.
+#
+# ## What is checked, and what is not
+#
+# `ini` is a string; a typo in a field name is a string with a typo in it and
+# Nix will never say a word. `checks.box-template` (a later issue) reads the
+# generated INI structurally -- does it parse, does it name an `image` -- but
+# does not create a container from it, because the one step that can fail is
+# the first-start package manager update inside the box, which needs a live
+# network `checks.box-template` intentionally does not have. That live check is
+# `checks.box-boot`, also a later issue.
+#
+# ## Fields
+#   label   Shown by `nixarchy box templates`.
+#   ini     The distrobox-assemble block, written flush left: `image`, and any
+#           of `additional_packages`, `init_hooks`, `volume`, `exported_apps`,
+#           `exported_bins`, `entry`, `start_now`, `replace`, `pull` a template
+#           needs. Verbatim upstream syntax -- see the bar above.
+#   note    What the box is for and what it costs, the way data/services.nix's
+#           `note` field does -- not what distrobox is.
+{
+  archlinux = {
+    label = "Arch Linux";
+    note = "distrobox's own default base image. AUR packages, and Arch-only tooling nixpkgs does not carry.";
+    ini = ''
+      image=docker.io/library/archlinux:latest
+      pull=false
+      replace=false
+      start_now=false
+    '';
+  };
+}

--- a/modules/services/boxes.nix
+++ b/modules/services/boxes.nix
@@ -1,0 +1,72 @@
+# Boxes: distrobox, for software NixOS will not run.
+#
+# nixpkgs already answers "this is not packaged" three ways -- Flatpak, nix-ld
+# for a loose binary, an FHS wrapper for something like Steam -- and none of
+# them cover software that wants an entire other distro: a .deb with a
+# postinstall script, an AUR package, a vendor installer that writes to /opt.
+# distrobox is an OCI container tightly integrated with the host (your $HOME,
+# not a sandbox -- see docs/manual/boxes.md for the full "what this is not")
+# and rootless podman is what runs it.
+#
+# Bundled rather than plain for the same reason Docker already is: turning
+# podman on by itself gets you a working container runtime, but the point of
+# this feature is boxes a desktop user can create with no root and no extra
+# setup, and that is this module's job, not upstream's.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.nixarchy;
+  svc = cfg.services.boxes;
+in
+{
+  options.programs.nixarchy.services.boxes = {
+    enable = lib.mkEnableOption ''
+      Boxes: rootless podman plus distrobox, for an Arch or Debian userland
+      when nixpkgs, Flatpak, nix-ld and devenv all answer "no". Off by
+      default -- see docs/manual/boxes.md for when to reach for this instead
+      of those.
+
+      This is a compatibility layer, not a sandbox: a box gets your whole
+      $HOME read-write, all of /dev, and the host root at /run/host. It sits
+      in the menu next to Flatpak, which *is* a sandbox -- do not expect the
+      same isolation
+    '';
+  };
+
+  config = lib.mkIf (cfg.enable && svc.enable) {
+    # A scalar, so mkDefault: someone already running podman their way (or
+    # rootful, deliberately) keeps their configuration and this yields to it.
+    # virtualisation.docker is left untouched -- rootless podman is additive,
+    # not a replacement, and boxes only need podman.
+    virtualisation.podman.enable = lib.mkDefault true;
+
+    # NixOS allocates subuid/subgid ranges to every normal user automatically,
+    # which is all rootless podman needs; nothing else to declare for that
+    # half.
+
+    # A list, so plain assignment -- mkDefault on a list is dropped whole the
+    # moment somebody adds a package of their own (modules/services/default.nix
+    # explains why).
+    #
+    # distrobox itself must never be resolved through a literal /nix/store
+    # path anywhere this repo runs it: it resolves its own support binaries
+    # (distrobox-init, distrobox-export, ...) relative to `dirname "$0"`, so
+    # invoking it via a store path bakes a generation-specific path into every
+    # container it creates -- nix-collect-garbage can delete that path out
+    # from under a running box (nixpkgs#478154, open, no fix). Verified with
+    # `distrobox --dry-run` against the installed package: called by bare name
+    # (through $PATH, which resolves through the system profile) the recorded
+    # entrypoint mount tracks the current generation; called via its own
+    # /nix/store/... path directly, the mount is that exact versioned path.
+    # environment.systemPackages puts /run/current-system/sw/bin on every
+    # interactive shell's PATH, which is sufficient -- so `nixarchy box`
+    # (a later issue) must call `distrobox` by bare name too, and must not
+    # list it in a writeShellApplication's runtimeInputs, which would put its
+    # own store bin/ on PATH ahead of the profile and reintroduce this.
+    environment.systemPackages = [ pkgs.distrobox ];
+  };
+}

--- a/modules/services/default.nix
+++ b/modules/services/default.nix
@@ -65,6 +65,7 @@
 # suggest they use it.
 inputs: {
   imports = [
+    ./boxes.nix
     ./devenv.nix
     (import ./hypr-rdp.nix inputs)
     ./syncthing.nix


### PR DESCRIPTION
## What this changes, and why

Closes the first (gating) child of epic #230 — issue #256. Adds
`programs.nixarchy.services.boxes`, a bundled service off by default (the same
shape `modules/services/syncthing.nix` and `tailscale.nix` already use), which
when enabled turns on rootless podman (`virtualisation.docker` untouched) and
installs `distrobox` — the runtime and package everything else in the epic
builds on. Also adds `data/box-templates.nix`, the distrobox-assemble template
catalogue's shape, with one entry (`archlinux`).

While researching the epic's "verify before building on it" items, I found the
epic's own framing of the GC-survival bug (nixpkgs#478154) was subtly wrong —
it blamed "the hyphenated binaries" specifically. Verified against the real
`distrobox` package on the machine this was written on with `--dry-run` and a
live `podman inspect`, the actual mechanism is about resolving `distrobox` (or
any of its siblings) through a **literal `/nix/store/...` path**, whether via
the dispatcher or a hyphenated binary directly — not about which binary is
called. I corrected issues #256 and #258 before writing any code. The module's
comment states the corrected rule and what it means for the `nixarchy box`
command in issue #258 (no `runtimeInputs = [ pkgs.distrobox ]`, no
`${pkgs.distrobox}/bin/...`).

Also brings the README roadmap row for #230 from `planned` to
`planned, 8 issues`, now that it has been decomposed into #256–#263.

## How I proved the check fails

No new `checks.*` in this PR — deliberately: `tests/options.nix` coverage
(both states of `programs.nixarchy.services.boxes.enable`) is issue #257's
scope, matching how the sandboxes epic split identical work (#222 shipped no
`options.nix` changes; #223 added them). I want to be explicit about a gap
rather than quietly leave it: I deliberately broke this module
(`pkgs.distrobox` → `pkgs.distroboxx`) and reran
`nix build .#checks.x86_64-linux.options` — **it still passed**, because that
suite never sets `services.boxes.enable = true`, so the broken line was never
forced. Restored the correct name and it passes again, unchanged. That is the
honest state: `checks.options` proves this module evaluates without error in
the *off* state (the one every Mode A machine is in), not that its *on* state
does what it claims — #257 is where that coverage is added.

What I did verify directly, live, on the machine this was written on (not
simulated):

- `distrobox create --image docker.io/library/archlinux:latest --name
  box-verify-256` (through the real, already-installed `distrobox`, not this
  PR's code, since the `nixarchy box` command doesn't exist yet) succeeded,
  and `distrobox enter box-verify-256 -- sh -c 'whoami; pwd'` reached a real
  shell as the invoking user.
- `podman inspect box-verify-256 --format '{{range .Mounts}}{{.Source}} ->
  {{.Destination}}{{"\n"}}{{end}}'` recorded
  `/etc/profiles/per-user/olafkfreund/bin/distrobox-init ->
  /usr/bin/entrypoint` — the literal profile path passed in, not a resolved
  store path. Podman does not canonicalise the bind-mount source, which is
  what makes the profile-path rule in the module's comment correct.
- `distrobox --dry-run` run four ways (bare `distrobox create`, bare
  `distrobox-create`, and both through an explicit `/nix/store/...` path)
  showed the recorded entrypoint mount tracks whichever path reached
  `dirname "$0"` — profile path when found via `$PATH`, versioned store path
  when invoked with an explicit store path. Table is in issue #256.
- The container was removed with `distrobox rm --force box-verify-256`
  afterwards; nothing left behind.

The offline-first-start question the epic itself flagged (does `distrobox
enter` survive `pacman -Syy` failing with no network) is still genuinely open
— judged too invasive to test by cutting network to a real container on this
machine's existing podman state. Left open on issue #256, not assumed.

## Checks run locally

- [x] `nix fmt -- --ci` clean (several passes — a local hook reformats `.nix`
      files after edits and needs `nix fmt` re-run to settle; ended clean)
- [x] `nix run nixpkgs#statix -- check .` clean
- [x] `nix run nixpkgs#deadnix -- --fail .` clean
- [x] `nix build .#checks.x86_64-linux.options` — passes both before and
      after the deliberate-break test above (see "How I proved the check
      fails" for why that is not full coverage of the new option)
- [x] New files are `git add`ed and committed before every build (worktree
      flake requires a committed tree)
- [ ] `tests/options.nix` does not yet cover both states of this option —
      explicitly deferred to issue #257, not an oversight
- [ ] No `checks.*` entry added by this PR, so no workflow wiring needed

## Diff honesty

`git diff origin/main --stat` after rebasing onto `origin/main` (this branch
was cut before #251–#254 merged; rebased cleanly, no conflicts):

```
README.md                    |  2 +-
data/box-templates.nix       | 44 +++++++++++++++++++++++++++
modules/services/boxes.nix   | 72 ++++++++++++++++++++++++++++++++++++++++++++
modules/services/default.nix |  1 +
4 files changed, 118 insertions(+), 1 deletion(-)
```

No reindenting of existing code; `git diff -w` reports the same counts as
`git diff`.

Part of #230. Closes #256.
