### PR TITLE
Declarative MicroVM sandboxes stay inert until a machine is declared

### DIFF
--- a/data/services.nix
+++ b/data/services.nix
@@ -102,6 +102,18 @@
 
   # ── Development ───────────────────────────────────────────────
 
+  microvm = {
+    label = "Sandboxes (MicroVMs)";
+    category = "Development";
+    kind = "bundled";
+    # There is no upstream line at all -- the module is not in nixpkgs, and
+    # data/services.nix's own bar ("if the answer is one line, it is
+    # plain") does not apply when there is no line. Turning it on usefully
+    # is an import, a group, a catalogue and a command; see
+    # modules/services/microvm.nix for the inertness argument.
+    note = "Permanent NixOS sandboxes from a template, booted with no image build and no bootloader -- the host's own /nix/store, shared read-only. Bundled because declaring a machine is what turns on the system user, the kvm group grant, the kernel modules and the microvm CLI; a machine you never declare gets none of them.";
+  };
+
   devenv = {
     label = "devenv";
     category = "Development";

--- a/modules/services/default.nix
+++ b/modules/services/default.nix
@@ -60,13 +60,18 @@
 # `package` option -- which is what modules/nixos.nix and modules/home.nix
 # already do for omarchy and omarchy-nvim-config. hypr-rdp follows them.
 #
-# Only that one module is applied to `inputs`. The others keep the ordinary
-# module signature, because giving them an argument they do not use would
-# suggest they use it.
+# hypr-rdp and microvm are the two that take `inputs`, for two different
+# reasons: hypr-rdp reaches `inputs.self.overlays.default` for a package
+# nixpkgs does not carry; microvm.nix imports
+# `inputs.microvm.nixosModules.host`, the module whose own default is the
+# whole reason it needs the inertness gate documented at its top. The others
+# keep the ordinary module signature, because giving them an argument they
+# do not use would suggest they use it.
 inputs: {
   imports = [
     ./devenv.nix
     (import ./hypr-rdp.nix inputs)
+    (import ./microvm.nix inputs)
     ./syncthing.nix
     ./tailscale.nix
   ];

--- a/modules/services/microvm.nix
+++ b/modules/services/microvm.nix
@@ -1,0 +1,239 @@
+# Declarative sandboxes: permanent MicroVMs that come up at boot.
+#
+# The other half of #221's "two halves, both wanted". The user-scoped half
+# (create/destroy freely, no root, `~/.local/state/nixarchy/microvm/<name>/`)
+# is `nixarchy-vm`, #224's CLI over the templates data/microvm-templates.nix
+# already builds. This is the half for a machine you keep: declare it here,
+# rebuild, and it autostarts under systemd with a state directory root owns.
+#
+# ## Why this earns a module (data/services.nix's own bar)
+#
+# Turning a machine on is not one upstream line. It needs the template
+# resolved to a module (a typo has to fail at evaluation, not at boot), the
+# `kvm` group granted to whoever should be allowed to touch it, and the port
+# a declarative machine forwards compiled into that machine's own closure
+# rather than passed at launch -- #221's argument for why SSH exists only
+# here.
+#
+# ## The inertness gate, measured rather than assumed
+#
+# `inputs.microvm.nixosModules.host` sets `microvm.host.enable = true` the
+# moment it is imported. This module imports it unconditionally below --
+# the same way `modules/services/default.nix` carries `inputs.sops-nix
+# .nixosModules.sops` into every nixarchy machine, always present and inert
+# until used -- so every effect of that default (the `microvm` system user,
+# `/var/lib/microvms` tmpfiles rule, memlock login limits, the `tap`/
+# `vhost_net` kernel modules, the setuid `qemu-bridge-helper`,
+# `hardware.ksm.enable`, and the `microvm` CLI that drags Nix into the host
+# closure) lives inside upstream's own
+# `config = lib.mkIf config.microvm.host.enable { ... }`
+# (nixos-modules/host/default.nix in the pinned commit) -- so one line, set
+# OUTSIDE this module's own `mkIf`, is the entire gate. `machines != { }` on
+# top of the service being wanted: a user who turns the service on but
+# declares no machine gets nothing running, same as never having asked.
+inputs:
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.nixarchy;
+  svc = cfg.services.microvm;
+
+  # data/microvm-templates.nix's own bar is "exactly a NixOS module" -- so
+  # resolving `template` to `.module` is the whole translation this needs.
+  templates = import ../../data/microvm-templates.nix;
+
+  wanted = cfg.enable && svc.enable;
+in
+{
+  imports = [ inputs.microvm.nixosModules.host ];
+
+  options.programs.nixarchy.services.microvm = {
+    enable = lib.mkEnableOption ''
+      declarative MicroVM sandboxes: permanent, template-built NixOS guests
+      that come up at boot under systemd, with a forwarded SSH port and state
+      under /var/lib/microvms.
+
+      Off by default, and off leaves nothing behind -- no `microvm` system
+      user, no tap/vhost_net kernel modules, no qemu-bridge-helper wrapper,
+      no `microvm` CLI in the closure. Every one of those is upstream's own
+      `microvm.host.enable`, which this module turns on for you only once you
+      declare a machine below.
+
+      For a throwaway machine you create and destroy on a whim, `nixarchy-vm`
+      needs none of this -- it never touches the host at all. This option is
+      for the machine you want to keep.
+    '';
+
+    user = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = cfg.user;
+      defaultText = lib.literalExpression "config.programs.nixarchy.user";
+      description = ''
+        Who joins the `kvm` group. Defaults to `programs.nixarchy.user`
+        rather than `lib.mkDefault`, so a definition of your own outranks it
+        the way `programs.nixarchy.services.hypr-rdp.user` does.
+
+        Null skips the group grant entirely -- there is no session to infer a
+        user from any more than hypr-rdp's module can.
+      '';
+    };
+
+    machines = lib.mkOption {
+      default = { };
+      description = ''
+        Permanent MicroVMs, keyed by name. Each becomes a
+        `microvm@<name>.service`, wanted by `microvms.target` when
+        `autostart` is true, with state under `/var/lib/microvms/<name>`.
+      '';
+      type = lib.types.attrsOf (
+        lib.types.submodule {
+          options = {
+            template = lib.mkOption {
+              type = lib.types.enum (builtins.attrNames templates);
+              example = "shell";
+              description = ''
+                Which entry of data/microvm-templates.nix this machine boots.
+                An enum drawn from that catalogue, so naming a template that
+                does not exist fails the rebuild at evaluation rather than
+                leaving a machine that will not start.
+              '';
+            };
+
+            autostart = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = "Whether this machine is wanted by microvms.target and comes up at boot.";
+            };
+
+            sshPort = lib.mkOption {
+              type = lib.types.nullOr lib.types.port;
+              default = null;
+              example = 2222;
+              description = ''
+                Host port forwarded to the guest's port 22, and the only
+                door in besides the console. Null means console only --
+                `microvm -s <name>` shells into it (#224's CLI), and nothing
+                listens.
+
+                Compiled into this machine's own closure, not passed at
+                launch: #221's argument for why SSH belongs to the
+                declarative half and not the disposable templates, which
+                share one closure across every VM of a template and so
+                cannot each carry a different port.
+              '';
+            };
+
+            memory = lib.mkOption {
+              type = lib.types.ints.positive;
+              default = 1024;
+              description = "Guest RAM in MiB, `microvm.mem` on the guest.";
+            };
+
+            cores = lib.mkOption {
+              type = lib.types.ints.positive;
+              default = 1;
+              description = "Guest vCPUs, `microvm.vcpu` on the guest.";
+            };
+
+            shares = lib.mkOption {
+              type = lib.types.listOf (
+                lib.types.submodule (
+                  { config, ... }:
+                  {
+                    options = {
+                      source = lib.mkOption {
+                        type = lib.types.str;
+                        description = "Host path to share.";
+                      };
+                      mountPoint = lib.mkOption {
+                        type = lib.types.str;
+                        description = "Where it appears inside the guest.";
+                      };
+                      tag = lib.mkOption {
+                        type = lib.types.str;
+                        default = baseNameOf config.mountPoint;
+                        description = "virtiofs tag. Defaults to the mount point's basename, which is unique unless two shares share one.";
+                      };
+                    };
+                  }
+                )
+              );
+              default = [ ];
+              description = ''
+                Extra host directories to share, beyond the read-only store
+                and the per-VM state directory modules/microvm/guest.nix
+                already mounts. Appended to `microvm.shares` -- a list, so
+                plain assignment, per modules/services/default.nix's rule.
+              '';
+            };
+
+            modules = lib.mkOption {
+              type = lib.types.listOf lib.types.deferredModule;
+              default = [ ];
+              description = ''
+                Extra NixOS modules for this machine, evaluated alongside its
+                template. A machine grows in NixOS vocabulary this way,
+                rather than nixarchy inventing a second one.
+              '';
+            };
+          };
+        }
+      );
+    };
+  };
+
+  config = lib.mkMerge [
+    {
+      # See the module header: everything upstream's host module adds lives
+      # inside ITS OWN `mkIf config.microvm.host.enable`, so this is the
+      # entire gate and it has to sit outside ours.
+      microvm.host.enable = lib.mkDefault (wanted && svc.machines != { });
+    }
+
+    (lib.mkIf wanted {
+      users.users = lib.optionalAttrs (svc.user != null) {
+        ${svc.user}.extraGroups = [ "kvm" ];
+      };
+
+      microvm.vms = lib.mapAttrs (_: m: {
+        inherit (m) autostart;
+        config = {
+          imports = [
+            templates.${m.template}.module
+            ../microvm/guest.nix
+          ]
+          ++ m.modules;
+
+          microvm = {
+            mem = m.memory;
+            vcpu = m.cores;
+            # A list on both sides, so plain assignment merges rather than
+            # replaces: modules/microvm/guest.nix's ro-store and hostdir
+            # shares survive alongside whatever a machine adds here.
+            inherit (m) shares;
+            # SLiRP (modules/microvm/guest.nix's `type = "user"` interface)
+            # forwards ports without any host network surgery -- upstream's
+            # own option docs say so ("When using the SLiRP user networking
+            # (default), this option allows to forward ports"). No tap
+            # interface is needed for this alone; `boot.kernelModules`
+            # gaining `tap`/`vhost_net` is upstream's host module reacting to
+            # `host.enable`, not to this machine's own interface type.
+            forwardPorts = lib.optional (m.sshPort != null) {
+              from = "host";
+              host.port = m.sshPort;
+              guest.port = 22;
+            };
+          };
+
+          # Only worth anything with a port to reach it on -- modules/
+          # microvm/guest.nix's `dev` user has a blank password and no other
+          # way in, so this is scoped to sshPort rather than always on.
+          services.openssh.enable = m.sshPort != null;
+        };
+      }) svc.machines;
+    })
+  ];
+}

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -129,6 +129,87 @@ let
       off = mentions "passwordSecret" (failedAssertions rdpOn);
     };
 
+    # ---- microvm: #221's inertness table, each row with a real off state --
+    #
+    # This is the check the PR body's "break it, watch it fail" argument is
+    # built on. Deleting the `microvm.host.enable` line in
+    # modules/services/microvm.nix (leaving the import) makes every case in
+    # this group fail at once, because every one of them is a consequence of
+    # that single gate rather than of anything they individually configure.
+    microvmHostUser = {
+      on = mvOn.users.users ? microvm;
+      off = mvOff.users.users ? microvm;
+    };
+
+    microvmStateDir = {
+      on = mvOn.systemd.tmpfiles.settings ? "10-microvm";
+      off = mvOff.systemd.tmpfiles.settings ? "10-microvm";
+    };
+
+    microvmUnits =
+      let
+        has =
+          cfg:
+          cfg.systemd.services ? "microvm-tap-interfaces@"
+          && cfg.systemd.services ? "microvm-virtiofsd@"
+          && cfg.systemd.targets ? microvms;
+      in
+      {
+        on = has mvOn;
+        off = has mvOff;
+      };
+
+    microvmCommand =
+      let
+        has = cfg: builtins.any (p: pkgs.lib.getName p == "microvm") cfg.environment.systemPackages;
+      in
+      {
+        on = has mvOn;
+        off = has mvOff;
+      };
+
+    # kvm is not in extraGroups today (modules/nixos.nix grants input and,
+    # conditionally, docker -- never kvm), so this is a real pair: the group
+    # is a capability nobody asked for on a machine that never declared a
+    # sandbox, the same argument modules/nixos.nix already makes for docker.
+    microvmKvmGroup = {
+      on = builtins.elem "kvm" (mvOn.users.users.someone.extraGroups or [ ]);
+      off = builtins.elem "kvm" (mvOff.users.users.someone.extraGroups or [ ]);
+    };
+
+    # Every field below compares the "sandbox" machine, which set the field
+    # explicitly, against "plain", which left it at its default -- both from
+    # the SAME evaluation of mvOn, so what is measured is that the value
+    # actually follows what was declared rather than a hardcoded default
+    # that happens to read true once.
+    microvmAutostart = {
+      on = mvOn.microvm.vms.sandbox.autostart == false;
+      off = mvOn.microvm.vms.plain.autostart == false;
+    };
+
+    microvmMemory = {
+      on = (mvVm mvOn "sandbox").microvm.mem == 4096;
+      off = (mvVm mvOn "plain").microvm.mem == 4096;
+    };
+
+    microvmCores = {
+      on = (mvVm mvOn "sandbox").microvm.vcpu == 3;
+      off = (mvVm mvOn "plain").microvm.vcpu == 3;
+    };
+
+    microvmShare = {
+      on = builtins.elem "extra" (map (s: s.tag) (mvVm mvOn "sandbox").microvm.shares);
+      off = builtins.elem "extra" (map (s: s.tag) (mvVm mvOn "plain").microvm.shares);
+    };
+
+    # A typo in `template` has to fail the rebuild, not produce a machine
+    # that never boots -- data/microvm-templates.nix's own catalogue is
+    # exactly the enum modules/services/microvm.nix draws from.
+    microvmTemplate = {
+      on = mvTemplateOk.success;
+      off = mvTemplateBad.success;
+    };
+
     # preinstallsExclude is the per-application half of preinstalls, and the
     # only removal path for an app the selection does not carry. Both ways:
     # Pinta is there by default and gone when named.
@@ -477,6 +558,130 @@ let
 
   rdpUnitOf = cfg: cfg.systemd.user.services.hypr-rdp.serviceConfig or { };
 
+  # ---- microvm, whose whole promise is that "off" leaves nothing --------
+  #
+  # #221 measured `inputs.microvm.nixosModules.host` against `main` before
+  # designing anything: `microvm.host.enable = true` the instant it is
+  # imported, and with it a system user, memlock limits, the tap/vhost_net
+  # kernel modules, a setuid qemu-bridge-helper, KSM and a `microvm` CLI that
+  # drags Nix into the closure. modules/services/default.nix imports it
+  # unconditionally (the same way sops-nix is always present and inert), so
+  # every one of those has to come from `machines != {}` alone.
+  #
+  # mvOff never enables the service at all -- the state most nixarchy
+  # machines are actually in, and where every row of #221's table must read
+  # "false".
+  mvOff = configWith { user = "someone"; };
+
+  # mvOn declares two machines rather than one, so the per-machine cases
+  # below can prove a passthrough varies with its input instead of merely
+  # being present: "sandbox" sets every field explicitly, "plain" leaves
+  # them at their defaults, and "off" for those cases is the plain machine
+  # reading back the default rather than a second full evaluation.
+  mvOn = configWith {
+    user = "someone";
+    services.microvm = {
+      enable = true;
+      machines = {
+        sandbox = {
+          template = "shell";
+          autostart = false;
+          memory = 4096;
+          cores = 3;
+          sshPort = 2222;
+          shares = [
+            {
+              source = "/tmp/nixarchy-options-test-share";
+              mountPoint = "/mnt/extra";
+              tag = "extra";
+            }
+          ];
+        };
+        plain = {
+          template = "shell";
+        };
+      };
+    };
+  };
+
+  mvVm = cfg: name: cfg.microvm.vms.${name}.config.config;
+
+  # The enum in modules/services/microvm.nix's `template` option is the
+  # whole claim that a typo fails at evaluation rather than at boot. Forcing
+  # the guest's own toplevel is what actually walks through
+  # `templates.${m.template}.module`, so a name the catalogue does not have
+  # throws here rather than merely constructing a lazy, never-forced value.
+  mvTemplateOk =
+    builtins.tryEval
+      (mvVm (configWith {
+        services.microvm.enable = true;
+        services.microvm.machines.x.template = "shell";
+      }) "x").system.build.toplevel.outPath;
+  mvTemplateBad =
+    builtins.tryEval
+      (mvVm (configWith {
+        services.microvm.enable = true;
+        services.microvm.machines.x.template = "not-a-real-template";
+      }) "x").system.build.toplevel.outPath;
+
+  # The cache promise, stated where it can be measured (#221): the guest
+  # closure served to `microvm -c <name>` has to be the same closure CI
+  # already pushed, or "the first launch is a download" is hopeful rather
+  # than true. Same NAME and template in both evaluations -- upstream's own
+  # eval-config sets `networking.hostName = lib.mkDefault name;`
+  # (nixos-modules/host/options.nix in the pinned commit), and that name
+  # becomes part of `system.build.toplevel`'s own derivation name, so two
+  # DIFFERENTLY-named machines would never share an outPath regardless of
+  # this invariant -- that would be measuring the name, not the promise.
+  # What varies here is deliberately only memory, cores and share SOURCE --
+  # same share tag and mount point, since varying those would be a genuine
+  # guest config change (nixos-modules/microvm/mounts.nix keys the generated
+  # mount unit on `tag`, never on `source`).
+  mvInvariantOf =
+    memCfg:
+    mvVm (configWith {
+      services.microvm.enable = true;
+      services.microvm.machines.vm = {
+        template = "shell";
+      }
+      // memCfg;
+    }) "vm";
+
+  mvInvariantSmall = mvInvariantOf {
+    memory = 512;
+    cores = 1;
+    shares = [
+      {
+        source = "/tmp/nixarchy-options-invariant-a";
+        mountPoint = "/mnt/extra";
+        tag = "extra";
+      }
+    ];
+  };
+
+  mvInvariantBig = mvInvariantOf {
+    memory = 8192;
+    cores = 8;
+    shares = [
+      {
+        source = "/tmp/nixarchy-options-invariant-b-a-very-different-path";
+        mountPoint = "/mnt/extra";
+        tag = "extra";
+      }
+    ];
+  };
+
+  microvmProblems =
+    pkgs.lib.optional
+      (mvInvariantSmall.system.build.toplevel.outPath != mvInvariantBig.system.build.toplevel.outPath)
+      ''
+        the guest toplevel changed with memory, cores or share source:
+          small (512MiB, 1 core): ${mvInvariantSmall.system.build.toplevel.outPath}
+          big (8192MiB, 8 cores): ${mvInvariantBig.system.build.toplevel.outPath}
+        the cache promise ("the first launch is a download") does not hold.''
+    ++ pkgs.lib.optional mvInvariantSmall.microvm.storeOnDisk "microvm.vms.vm.config.microvm.storeOnDisk is true at 512MiB; the host's /nix/store share should make an image build unnecessary."
+    ++ pkgs.lib.optional mvInvariantBig.microvm.storeOnDisk "microvm.vms.vm.config.microvm.storeOnDisk is true at 8192MiB; the host's /nix/store share should make an image build unnecessary.";
+
   # ---- a bundled service yields to a user who already configured it ----
   #
   # This is the Mode A hazard in one assertion. Someone adds nixarchy to a
@@ -691,6 +896,7 @@ pkgs.runCommand "nixarchy-options"
     mapped = pkgs.lib.concatStringsSep " " mappedRows;
     serviceProblems = pkgs.lib.concatStringsSep "\n" serviceProblems;
     flatpakProblems = pkgs.lib.concatStringsSep "\n" flatpakProblems;
+    microvmProblems = pkgs.lib.concatStringsSep "\n" microvmProblems;
     flatpakCount = builtins.toString (builtins.length (builtins.attrNames flatpaks));
     flatpakRemotes = pkgs.lib.concatStringsSep " " flatpakRemotes;
     fleetOff = pkgs.lib.boolToString fleet.offByDefault;
@@ -776,6 +982,12 @@ pkgs.runCommand "nixarchy-options"
       ''
         echo "data/services.nix has entries the generator cannot use:" >&2
         echo "$serviceProblems" >&2
+        exit 1
+      ''
+    else if microvmProblems != [ ] then
+      ''
+        echo "the microvm closure invariant does not hold:" >&2
+        echo "$microvmProblems" >&2
         exit 1
       ''
     else if broken == { } then


### PR DESCRIPTION
## Stacks on #255 (feat/microvm-222)

#255 is still OPEN at the time of this PR, so this branch is based on
`origin/feat/microvm-222`, not `main`, and its base is set accordingly. Once
#255 merges this should be retargeted/rebased onto `main` by whoever merges
it, or GitHub will do it automatically once #255 lands.

## What this changes, and why

Implements #223 (part of the #221 epic): `programs.nixarchy.services.microvm`
(`modules/services/microvm.nix`) — the declarative half of the sandboxes
epic. A machine declares permanent MicroVMs under
`programs.nixarchy.services.microvm.machines.<name>`; each becomes a
`microvm@<name>.service`, template-resolved (a typo in `template` fails at
evaluation, not at boot), with an optional forwarded SSH port compiled into
that machine's own closure.

The module imports `inputs.microvm.nixosModules.host`, whose own default is
`microvm.host.enable = true` the instant it's imported — carrying with it a
system user, memlock limits, the `tap`/`vhost_net` kernel modules, a setuid
`qemu-bridge-helper`, KSM, and a `microvm` CLI that drags Nix into the host
closure (measured in #221's table). So:

```nix
microvm.host.enable = lib.mkDefault (wanted && svc.machines != { });
```

sits **outside** this module's own `mkIf`, because everything upstream's
host module adds lives inside *its own* `mkIf config.microvm.host.enable` —
this one line is the entire gate, and a machine that never declares a
sandbox gets none of it.

Also: the `microvm` row in `data/services.nix` (bundled — there is no
upstream line to copy, the module isn't in nixpkgs), and ten `tests/options.nix`
cases plus one invariant, covering #221's measured inertness table.

## How I proved the check fails

Broke the gate exactly as #223 describes — deleted the
`microvm.host.enable = lib.mkDefault (...)` line, leaving the import:

```
nixarchy-options>   microvmCommand: on=1 off=1
nixarchy-options>   microvmHostUser: on=1 off=1
nixarchy-options>   microvmStateDir: on=1 off=1
nixarchy-options>   microvmUnits: on=1 off=1
nixarchy-options> these options do not take effect both ways: microvmCommand microvmHostUser microvmStateDir microvmUnits
nixarchy-options> an option that cannot be turned off is not an option.
```

Matches #223's predicted failing set exactly. Restored the fix and reran —
green:

```
nixarchy-options>   microvmAutostart: on=1 off=
nixarchy-options>   microvmCommand: on=1 off=
nixarchy-options>   microvmCores: on=1 off=
nixarchy-options>   microvmHostUser: on=1 off=
nixarchy-options>   microvmKvmGroup: on=1 off=
nixarchy-options>   microvmMemory: on=1 off=
nixarchy-options>   microvmShare: on=1 off=
nixarchy-options>   microvmStateDir: on=1 off=
nixarchy-options>   microvmTemplate: on=1 off=
nixarchy-options>   microvmUnits: on=1 off=
```

`microvmProblems` (the closure invariant) is a separate list-based check,
same pattern as `serviceProblems`/`flatpakProblems`: it compares
`system.build.toplevel.outPath` for two evaluations of the *same* machine
name with the *same* template, varying only memory (512 vs 8192 MiB), cores
(1 vs 8) and share **source** (holding tag/mountPoint fixed) — outPaths
matched, `storeOnDisk` was `false` in both. (First draft of this test used
two differently-*named* machines and it correctly failed, for the wrong
reason: upstream defaults `networking.hostName` from the machine name, which
is baked into the toplevel derivation's own name — that's a real difference,
not a broken invariant. Fixed by holding the name constant across the two
evaluations.)

## Checks run locally

- [x] `nix build .#checks.x86_64-linux.options --print-build-logs` — green
- [x] `nix fmt -- --ci` — clean
- [x] `nix run nixpkgs#statix -- check .` — clean
- [x] `nix run nixpkgs#deadnix -- --fail .` — clean
- [x] New files are `git add`ed
- [x] Adds options: `tests/options.nix` covers both states for every new
      option (10 pairs + 1 invariant)
- [ ] No new `checks.*` entry — cases were added to the existing `options`
      check, so no workflow change is needed

No large block was reindented; `git diff -w --stat` against the merge-base
is byte-identical to the plain `git diff --stat` (471 insertions, 3
deletions, all four files touched are new content).

## What I could not verify

- The KVM runner path and anything requiring a booted VM — out of scope for
  #223 (that's `checks.microvm-boot` in #228, and `pkgs/verify.sh` in #229
  for the real-hardware KVM path per #221).
- `nixarchy-vm` / `checks.microvm-template` (#224) don't exist yet on this
  branch, so the disposable-template CLI referenced in `sshPort`'s doc
  comment ("`microvm -s <name>` shells into it") is upstream's own `microvm`
  CLI, not yet nixarchy's wrapper.