### PR TITLE
nixarchy vm, and a check that reads a runner without booting it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -689,6 +689,15 @@ jobs:
         # cannot rot unnoticed between releases.
         run: nix build .#checks.x86_64-linux.reference-toplevel --print-build-logs
 
+      - name: Read a MicroVM runner without booting it
+        # checks.microvm-template: what hypervisor, whether the store is
+        # shared or imaged, whether the network needs root -- read off the
+        # built package and qemu command line, plus nixarchy-vm's launch and
+        # locking behaviour against a stub `nix`. Also how the templates
+        # reach nixarchy.cachix.org: cachix-action above pushes what this
+        # job builds.
+        run: nix build .#checks.x86_64-linux.microvm-template --print-build-logs
+
       - name: Drive a session and the app-selection loop
         # Boots a machine, picks two apps through nixarchy-app-enable, checks
         # the file still parses, and checks nixarchy-apply copies the

--- a/flake.nix
+++ b/flake.nix
@@ -532,6 +532,12 @@
           # Requires a committed tree -- it pins nixarchy by commit.
           flake-template = pkgsFor.${system}.callPackage ./installer/mkFlake.nix { inherit self; };
 
+          # Exposed at top level, rather than only reachable through
+          # modules/apps.nix's callPackage, so checks.microvm-template can
+          # build and read the exact command `nixarchy vm` execs -- same
+          # reasoning as `verify` and `doctor` just below.
+          nixarchy-vm = pkgsFor.${system}.callPackage ./pkgs/microvm.nix { inherit self; };
+
           verify = pkgsFor.${system}.writeShellApplication {
             name = "nixarchy-verify";
             runtimeInputs = with pkgsFor.${system}; [
@@ -1265,6 +1271,21 @@
         # bootloader, disko-provided filesystems, nothing faked. If this builds
         # and vm-toplevel builds, the extraction has not let the two drift.
         reference-toplevel = self.nixosConfigurations.reference.config.system.build.toplevel;
+
+        # Builds a runner and reads it. Boots nothing -- see tests/microvm-template.nix
+        # for what that can and cannot prove. Costs about what reference-toplevel
+        # above does: a runCommand plus a ~1-1.5 GB guest closure from
+        # cache.nixos.org. This step is also how the templates reach
+        # nixarchy.cachix.org: cachix-action pushes what this job builds.
+        microvm-template = import ./tests/microvm-template.nix {
+          pkgs = pkgsFor.${system};
+          inherit lib;
+          templates = lib.mapAttrs (name: _: {
+            kvm = self.packages.${system}."microvm-${name}";
+            tcg = self.packages.${system}."microvm-${name}-tcg";
+          }) (import ./data/microvm-templates.nix);
+          nixarchyVm = self.packages.${system}.nixarchy-vm;
+        };
 
         # The other disk mode, built so the cache has it: installer/cd.nix
         # bakes both onto the ISO, and an image built on a runner that has

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -1726,6 +1726,11 @@ in
           # machine that has not enabled it yet.
           (pkgs.callPackage ../pkgs/dev-init.nix { })
 
+          # `nixarchy vm <subcommand>`. Its own file for the same reason as
+          # dev-init.nix above: `checks.microvm-template` (#224) has to run
+          # the real command. See pkgs/microvm.nix for what it does and why.
+          (pkgs.callPackage ../pkgs/microvm.nix { inherit (inputs) self; })
+
           # One name for the commands this repo adds, and a way through to
           # the 431 it vendors.
           #
@@ -1788,6 +1793,7 @@ in
                     init) shift 2; exec nixarchy-dev-init "$@" ;;
                   esac
                   ;;
+                vm) shift; exec nixarchy-vm "$@" ;;
                 ""|--help|-h|help)
                   cat <<'USAGE'
               nixarchy -- the Omarchy desktop, vendored for NixOS.
@@ -1801,6 +1807,7 @@ in
                 nixarchy app remove         Pick what to deselect, interactively
                 nixarchy apply              Copy the selection into your flake and rebuild
                 nixarchy dev init <preset>  Scaffold a devenv project here (no argument lists them)
+                nixarchy vm <subcommand>    Disposable NixOS MicroVMs -- 'nixarchy vm help'
                 nixarchy doctor             What this machine needs to run nixarchy
 
               Everything else is Omarchy's own, and reaches it unchanged:

--- a/pkgs/microvm.nix
+++ b/pkgs/microvm.nix
@@ -1,0 +1,291 @@
+# `nixarchy vm <subcommand>` -- disposable MicroVM sandboxes, the user-scoped
+# half of #221's "two halves, both wanted". No root, no rebuild:
+# `~/.local/state/nixarchy/microvm/<name>/` is the whole state a VM has, and
+# creating or destroying one touches nothing this repo's modules manage. The
+# declarative half -- machines that autostart at boot -- is
+# `programs.nixarchy.services.microvm` (modules/services/microvm.nix, #223).
+#
+# Its own file rather than another entry in modules/apps.nix's package list,
+# same reason as pkgs/dev-init.nix: `checks.microvm-template` has to exercise
+# the real command, not a copy of it.
+#
+# Two behaviours here are load-bearing, both from #221 and both asserted by
+# `checks.microvm-template` rather than trusted:
+#
+#   * `nix build --out-link`, never `nix run`. `nix run` registers no GC
+#     root, and a `nix-collect-garbage` while a guest is running takes the
+#     store it is 9p-mounted on out from under it -- reads start returning
+#     ENOENT for anything not already in page cache. `--out-link` is an
+#     indirect root under /nix/var/nix/gcroots/auto, which is what lets `rm`
+#     make the root go away simply by removing the link.
+#   * A `flock` on the VM's own directory for the life of the qemu process,
+#     so a second `run` of the same name refuses instead of two qemus racing
+#     over the same 9p-shared hostdir.
+#
+# The name is never a Nix argument (#221): `run` builds ONE closure per
+# template (from this flake, at the revision this system was built from) and
+# `exec`s it from inside `~/.local/state/nixarchy/microvm/<name>/` -- that
+# directory, not a Nix parameter, is what makes it "alice's shell" instead of
+# "bob's". modules/microvm/guest.nix reads the runtime hostname from a file
+# dropped there for exactly this reason.
+{
+  lib,
+  writeShellApplication,
+  writeText,
+  runCommandLocal,
+  coreutils,
+  gnugrep,
+  util-linux,
+  self,
+}:
+let
+  templates = import ../data/microvm-templates.nix;
+
+  # `self.rev` is what mkFlake.nix uses to pin the generated installer flake,
+  # and it throws on a dirty tree because that pin has to survive forever on
+  # an installed machine. This is not that: worst case here is a `nix build`
+  # against `main` instead of the exact commit, so `self.dirtyRev` (present
+  # once this tree has ANY commit, dirty or not) and a plain "main" fallback
+  # both keep evaluation working -- which matters because, unlike
+  # mkFlake.nix, this package is evaluated by every ordinary
+  # `nixosModules.nixarchy` consumer, including every check in this repo's
+  # own flake, not only the installer image.
+  rev = self.rev or self.dirtyRev or "main";
+  flakeUrl = "github:olafkfreund/nixarchy/${rev}";
+
+  # One file per template plus a tab-separated index -- same shape as
+  # pkgs/dev-init.nix's presetDir, and for the same reason: the script then
+  # knows nothing about the catalogue beyond "read this directory", so a new
+  # template is a change to data/microvm-templates.nix and nothing else.
+  templateDir = runCommandLocal "nixarchy-vm-templates" { } ''
+    mkdir -p $out
+    cp ${
+      writeText "index.tsv" (
+        lib.concatMapStrings (n: "${n}\t${templates.${n}.label}\t${templates.${n}.note}\n") (
+          lib.attrNames templates
+        )
+      )
+    } $out/index.tsv
+  '';
+in
+writeShellApplication {
+  name = "nixarchy-vm";
+  runtimeInputs = [
+    coreutils
+    gnugrep
+    util-linux # flock
+  ];
+  # `nix` itself is deliberately not in runtimeInputs: it is the system's
+  # own nix, already first on PATH, and pinning a second copy here would be
+  # a second place for its version to drift from the one everything else on
+  # the machine uses.
+  text = ''
+        stateDir="''${XDG_STATE_HOME:-$HOME/.local/state}/nixarchy/microvm"
+        templates=${templateDir}
+        flakeUrl=${lib.escapeShellArg flakeUrl}
+
+        list_templates() {
+          echo "Templates:"
+          while IFS=$'\t' read -r name label note; do
+            printf '  %-10s %s\n' "$name" "$label"
+            printf '  %-10s   %s\n' "" "$note"
+          done < "$templates/index.tsv"
+        }
+
+        template_exists() {
+          grep -q "^$1	" "$templates/index.tsv"
+        }
+
+        # KVM present and writable -> the real thing. Absent or not (yet) writable
+        # -> the -tcg (software CPU) variant, which is slower but boots anywhere,
+        # including nixarchy running inside a VM without nested virtualisation.
+        # Preflight rather than letting qemu fail: its own message for a missing
+        # /dev/kvm ("Could not access KVM kernel module: No such file or
+        # directory") reads like a broken install, not an unavailable feature.
+        variant() {
+          if [ ! -e /dev/kvm ]; then
+            cat >&2 <<'EOF'
+    nixarchy-vm: /dev/kvm does not exist on this machine.
+
+    Either virtualisation is off in firmware (Intel VT-x / AMD-V), or this is
+    itself a VM without nested virtualisation exposed to it. Falling back to
+    the software-emulated CPU runner, which works here but is slower.
+    EOF
+            echo "tcg"
+            return
+          fi
+          if [ ! -w /dev/kvm ]; then
+            cat >&2 <<'EOF'
+    nixarchy-vm: /dev/kvm exists but is not writable by you.
+
+    You were likely just added to the kvm group -- group membership is read at
+    login, so this needs a logout/login (or reboot) to take effect. Falling
+    back to the software-emulated CPU runner for this run.
+    EOF
+            echo "tcg"
+            return
+          fi
+          echo "kvm"
+        }
+
+        list_vms() {
+          if [ ! -d "$stateDir" ] || [ -z "$(ls -A "$stateDir" 2>/dev/null)" ]; then
+            echo "No VMs yet. 'nixarchy vm create <name>' to make one."
+            return
+          fi
+          echo "VMs:"
+          for dir in "$stateDir"/*/; do
+            [ -d "$dir" ] || continue
+            name=$(basename "$dir")
+            tmpl=$(cat "$dir/template" 2>/dev/null || echo "?")
+            status=stopped
+            if [ -e "$dir/.lock" ]; then
+              exec 8>"$dir/.lock"
+              flock -n 8 || status=running
+              exec 8>&-
+            fi
+            printf '  %-16s template=%-10s %s\n' "$name" "$tmpl" "$status"
+          done
+        }
+
+        create_vm() {
+          name="''${1:?usage: nixarchy vm create <name> [--template t]}"
+          shift
+          template=shell
+          while [ $# -gt 0 ]; do
+            case "$1" in
+              --template)
+                template="''${2:?--template needs a value}"
+                shift 2
+                ;;
+              *)
+                echo "nixarchy-vm: unknown argument '$1'" >&2
+                exit 1
+                ;;
+            esac
+          done
+
+          case "$name" in
+            *[!a-zA-Z0-9_-]*|"")
+              echo "nixarchy-vm: name must be letters, digits, '-' or '_'." >&2
+              exit 1
+              ;;
+          esac
+
+          if ! template_exists "$template"; then
+            echo "nixarchy-vm: no template '$template'." >&2
+            list_templates >&2
+            exit 1
+          fi
+
+          dir="$stateDir/$name"
+          if [ -e "$dir" ]; then
+            echo "nixarchy-vm: '$name' already exists." >&2
+            exit 1
+          fi
+
+          mkdir -p "$dir"
+          echo "$template" > "$dir/template"
+          echo "$name" > "$dir/hostname"
+
+          echo "Created '$name' from the '$template' template."
+          echo "  nixarchy vm run $name"
+        }
+
+        run_vm() {
+          name="''${1:?usage: nixarchy vm run <name>}"
+          dir="$stateDir/$name"
+          if [ ! -d "$dir" ]; then
+            echo "nixarchy-vm: no VM named '$name'. 'nixarchy vm create $name' first." >&2
+            exit 1
+          fi
+          template=$(cat "$dir/template")
+
+          # Held for the life of this process -- including across the exec below,
+          # since a plain `exec N>file` redirection is not close-on-exec. A second
+          # `run` of the same name hits this while the first is still attached to
+          # the terminal, and refuses instead of two qemus racing over one 9p
+          # share and one volume image.
+          exec 9>"$dir/.lock"
+          if ! flock -n 9; then
+            echo "nixarchy-vm: '$name' is already running." >&2
+            exit 1
+          fi
+
+          attr="microvm-$template"
+          [ "$(variant)" = "tcg" ] && attr="$attr-tcg"
+
+          # Never `nix run`: see the header comment on why that would leave this
+          # guest's store share unprotected from garbage collection.
+          nix build "$flakeUrl#$attr" --out-link "$dir/current"
+
+          echo "$name" > "$dir/hostname"
+          cd "$dir"
+          exec ./current/bin/microvm-run
+        }
+
+        stop_vm() {
+          name="''${1:?usage: nixarchy vm stop <name>}"
+          dir="$stateDir/$name"
+          if [ ! -d "$dir" ] || [ ! -e "$dir/current" ]; then
+            echo "nixarchy-vm: no VM named '$name'." >&2
+            exit 1
+          fi
+          ( cd "$dir" && ./current/bin/microvm-shutdown )
+        }
+
+        rm_vm() {
+          name="''${1:?usage: nixarchy vm rm <name>}"
+          dir="$stateDir/$name"
+          if [ ! -d "$dir" ]; then
+            echo "nixarchy-vm: no VM named '$name'." >&2
+            exit 1
+          fi
+          if [ -e "$dir/.lock" ]; then
+            exec 9>"$dir/.lock"
+            if ! flock -n 9; then
+              echo "nixarchy-vm: '$name' is running -- 'nixarchy vm stop $name' first." >&2
+              exit 1
+            fi
+          fi
+          # Removing the directory removes the out-link with it, which is how the
+          # GC root goes away -- there is nothing else to clean up.
+          rm -rf "$dir"
+          echo "Removed '$name'."
+        }
+
+        case "''${1:-}" in
+          # Always 0: the -tcg fallback in `variant` above means this works on
+          # every nixarchy machine, KVM or not, so #226's menu group has
+          # nothing to gate on beyond "this command exists".
+          --check) exit 0 ;;
+          templates|"") list_templates ;;
+          list) list_vms ;;
+          create) shift; create_vm "$@" ;;
+          run) shift; run_vm "$@" ;;
+          stop) shift; stop_vm "$@" ;;
+          rm) shift; rm_vm "$@" ;;
+          -h|--help|help)
+            cat <<'USAGE'
+    nixarchy vm -- disposable NixOS MicroVMs. No root, no rebuild.
+
+      nixarchy vm templates          List what's available
+      nixarchy vm list                List VMs you have created
+      nixarchy vm create <name> [--template t]
+                                      Make one (default template: shell)
+      nixarchy vm run <name>          Build (if needed) and attach -- Ctrl-A X to
+                                       leave the console without stopping the VM
+      nixarchy vm stop <name>         Ask a running VM to shut down
+      nixarchy vm rm <name>           Delete a VM and its state
+
+    A permanent, boot-time machine is a different thing:
+      programs.nixarchy.services.microvm.machines.<name> in your own flake.
+    USAGE
+            ;;
+          *)
+            echo "nixarchy-vm: unknown subcommand '$1'" >&2
+            exit 1
+            ;;
+        esac
+  '';
+}

--- a/tests/microvm-template.nix
+++ b/tests/microvm-template.nix
@@ -1,0 +1,212 @@
+# Builds a runner and reads it. Boots nothing.
+#
+# What a runner *is* -- which hypervisor, whether the store is shared or
+# imaged, whether the network needs root -- is written into the package and
+# the qemu command line, and those decide whether `nixarchy vm run` works as
+# the desktop user with no rebuild and nothing that needs `/dev/kvm`. #221's
+# whole argument rests on properties that never boot a kernel to see: this
+# check reads them off the built derivation instead.
+#
+# Two things are read here. `templates` is every entry of
+# data/microvm-templates.nix, built both ways (KVM and -tcg) by
+# `lib.mkMicrovm` -- the runner itself. `nixarchyVm` is the CLI built over it
+# (pkgs/microvm.nix) -- the two behaviours #221 calls load-bearing,
+# `nix build --out-link` and the per-name flock, neither of which the runner
+# package alone can prove.
+{
+  pkgs,
+  lib,
+  templates,
+  nixarchyVm,
+}:
+let
+  # One template is enough to prove the runner's shape -- data/microvm-templates.nix
+  # carries only `shell` until #225. Every template gets asserted, so a new
+  # one is covered for free.
+  names = builtins.attrNames templates;
+in
+pkgs.runCommand "nixarchy-microvm-template"
+  {
+    nativeBuildInputs = with pkgs; [
+      gnugrep
+      coreutils
+      util-linux # flock, for the CLI half below
+      bash
+    ];
+  }
+  ''
+    fail=0
+
+    ${lib.concatMapStrings (name: ''
+      echo "== template: ${name} =="
+      kvm=${templates.${name}.kvm}
+      tcg=${templates.${name}.tcg}
+      run=$kvm/bin/microvm-run
+
+      # bin/microvm-run and bin/microvm-shutdown exist. Breaking this looks
+      # like pointing the package at the toplevel instead of declaredRunner.
+      for bin in microvm-run microvm-shutdown; do
+        for variant in "$kvm" "$tcg"; do
+          if [ ! -x "$variant/bin/$bin" ]; then
+            echo "${name}: $variant/bin/$bin is missing or not executable" >&2
+            fail=1
+          fi
+        done
+      done
+
+      # share/microvm/hypervisor is qemu. Breaking this looks like setting
+      # hypervisor = "cloud-hypervisor", which cannot do user networking.
+      for variant in "$kvm" "$tcg"; do
+        hv=$(cat "$variant/share/microvm/hypervisor" 2>/dev/null || echo "MISSING")
+        if [ "$hv" != qemu ]; then
+          echo "${name}: $variant/share/microvm/hypervisor is '$hv', not qemu" >&2
+          fail=1
+        fi
+      done
+
+      # No store disk on the command line, and mount_tag=ro-store IS present.
+      # Breaking this looks like removing the /nix/store share -- an erofs
+      # build would appear in the closure, which is the cost this catches.
+      if grep -oE -- "-drive '[^']*'" "$run" | grep -q store; then
+        echo "${name}: bin/microvm-run has a -drive mentioning a store image -- an image was built for it" >&2
+        fail=1
+      fi
+      if ! grep -q 'mount_tag=ro-store' "$run"; then
+        echo "${name}: bin/microvm-run has no ro-store 9p share -- the host store is not shared" >&2
+        fail=1
+      fi
+
+      # -netdev user, is present (SLiRP -- no root needed), and nothing here
+      # asks for a tap interface, which does.
+      if ! grep -q -- "-netdev 'user," "$run"; then
+        echo "${name}: bin/microvm-run has no SLiRP user networking" >&2
+        fail=1
+      fi
+      if [ -s "$kvm/share/microvm/tap-interfaces" ]; then
+        echo "${name}: share/microvm/tap-interfaces is non-empty -- this needs root to run" >&2
+        fail=1
+      fi
+
+      # The KVM and -tcg runners share one share/microvm/system: the guest
+      # closure the -cpu flag differs, not the guest itself. Breaking this
+      # looks like a -tcg build that quietly diverged into a second guest.
+      kvmSys=$(readlink -f "$kvm/share/microvm/system")
+      tcgSys=$(readlink -f "$tcg/share/microvm/system")
+      if [ "$kvmSys" != "$tcgSys" ]; then
+        echo "${name}: KVM and -tcg runners do not share one guest system:" >&2
+        echo "  kvm: $kvmSys" >&2
+        echo "  tcg: $tcgSys" >&2
+        fail=1
+      fi
+
+      # -enable-kvm only on the KVM runner, -cpu max only on -tcg -- the one
+      # option that removes -enable-kvm on the pinned microvm.nix commit.
+      if ! grep -q -- '-enable-kvm' "$kvm/bin/microvm-run"; then
+        echo "${name}: KVM runner has no -enable-kvm" >&2
+        fail=1
+      fi
+      if grep -q -- '-enable-kvm' "$tcg/bin/microvm-run"; then
+        echo "${name}: -tcg runner still passes -enable-kvm" >&2
+        fail=1
+      fi
+    '') names}
+
+    echo "== nixarchy vm: launch and locking =="
+
+    # A stub `nix` that logs its own argv and then fakes the build: it writes
+    # the out-link the real caller asked for, pointing at a stub runner. This
+    # is what proves `nix build --out-link` rather than `nix run` without
+    # paying for an actual guest build -- checks.microvm-template already
+    # does that above, on the real packages.
+    mkdir -p bin
+    calls=$PWD/nix-calls.log
+    cat > bin/nix <<STUB
+    #!${pkgs.bash}/bin/bash
+    echo "\$*" >> $calls
+    if [ "\$1" = build ]; then
+      out=""
+      prev=""
+      for a in "\$@"; do
+        if [ "\$prev" = --out-link ]; then out="\$a"; fi
+        prev="\$a"
+      done
+      if [ -z "\$out" ]; then echo "stub nix build: no --out-link seen" >&2; exit 1; fi
+      mkdir -p "\$out/bin"
+      cat > "\$out/bin/microvm-run" <<'RUNNER'
+    #!${pkgs.bash}/bin/bash
+    echo "stub guest running" > run.marker
+    sleep 30
+    RUNNER
+      chmod +x "\$out/bin/microvm-run"
+      cat > "\$out/bin/microvm-shutdown" <<'SHUT'
+    #!${pkgs.bash}/bin/bash
+    true
+    SHUT
+      chmod +x "\$out/bin/microvm-shutdown"
+      exit 0
+    fi
+    echo "stub nix: unexpected subcommand '\$1'" >&2
+    exit 1
+    STUB
+    chmod +x bin/nix
+    export PATH="$PWD/bin:$PATH"
+    export HOME=$PWD/home
+    export XDG_STATE_HOME=$HOME/.local/state
+    mkdir -p "$HOME"
+
+    ${nixarchyVm}/bin/nixarchy-vm create sandbox
+
+    # First run: builds via the stub, then execs the stub runner, which
+    # sleeps -- backgrounded so the check can also try a second run while
+    # the first is still "up".
+    ( ${nixarchyVm}/bin/nixarchy-vm run sandbox > run1.log 2>&1; echo $? > run1.status ) &
+    first=$!
+
+    # Wait for the stub runner to actually be attached, rather than timing:
+    # the marker file only appears once bin/microvm-run itself is running.
+    for _ in $(seq 1 50); do
+      [ -f "$HOME/.local/state/nixarchy/microvm/sandbox/run.marker" ] && break
+      sleep 0.2
+    done
+    if [ ! -f "$HOME/.local/state/nixarchy/microvm/sandbox/run.marker" ]; then
+      echo "the first 'run' never reached the stub guest -- see run1.log:" >&2
+      cat run1.log >&2
+      fail=1
+    fi
+
+    if ! grep -q -- '^build ' "$calls"; then
+      echo "nix was never called with 'build' as its first argument:" >&2
+      cat "$calls" >&2
+      fail=1
+    fi
+    if grep -q '^run ' "$calls"; then
+      echo "nix was called with 'run' -- that registers no GC root:" >&2
+      cat "$calls" >&2
+      fail=1
+    fi
+    if ! grep -q -- '--out-link' "$calls"; then
+      echo "nix build was never given --out-link:" >&2
+      cat "$calls" >&2
+      fail=1
+    fi
+
+    # A second instance of the same name refuses instead of a second qemu
+    # racing the first over the same 9p share and volume image.
+    if ${nixarchyVm}/bin/nixarchy-vm run sandbox > run2.log 2>&1; then
+      echo "a second 'run sandbox' succeeded while the first was still up:" >&2
+      cat run2.log >&2
+      fail=1
+    else
+      echo "second run correctly refused:"
+      cat run2.log
+    fi
+
+    kill "$first" 2>/dev/null || true
+    wait "$first" 2>/dev/null || true
+
+    [ "$fail" -eq 0 ] || exit 1
+    echo "every template's runner is qemu, shares the host store read-only," \
+         "uses user networking, and the KVM/-tcg pair share one guest --" \
+         "and nixarchy-vm launches it with an out-link, under a flock."
+    touch $out
+  ''


### PR DESCRIPTION
## Summary

Implements #224 (part of the #221 epic). Stacked on #266 (#223) — **base branch is `feat/microvm-223`, not `main`**, because #223 was still open when this started; rebase target once #266 merges.

- `pkgs/microvm.nix` → `nixarchy-vm`, a `writeShellApplication` in its own file (same shape as `pkgs/dev-init.nix`), `callPackage`d from `modules/apps.nix` and routed by a `vm)` arm in the `nixarchy` dispatcher. Subcommands: `templates`, `list`, `create <name> [--template t]`, `run <name>`, `stop <name>`, `rm <name>`, plus `--check` (unconditionally 0 — the `-tcg` fallback means this works on every nixarchy machine, so #226's menu group has nothing else to gate on).
- Two load-bearing behaviours from #221, both asserted by the new check rather than trusted:
  - `run` launches with `nix build "$flakeUrl#$attr" --out-link "$dir/current"`, never `nix run`.
  - `run` and `rm` take a `flock` on the VM's own directory (`exec 9>"$dir/.lock"; flock -n 9`), held for the life of the qemu process (a plain `exec N>file` redirect is not close-on-exec).
- Preflight (`variant()`): missing `/dev/kvm` or a present-but-unwritable one falls back to the `-tcg` template with a message naming the cause (firmware/nested-virt, or "log out and back in" for the kvm-group case) — never lets qemu's own opaque error surface.
- `flakeUrl` is `github:olafkfreund/nixarchy/${self.rev or self.dirtyRev or "main"}` — deliberately NOT `self.rev or throw` like `installer/mkFlake.nix`. This package is evaluated by every ordinary `nixosModules.nixarchy` consumer (every check in this repo's own flake included), not only the installer image, and I did not want every check to start requiring a committed tree the way the installer already does. Worst case on a dirty/uncommitted `self` is a build against `main` instead of the exact pinned commit.
- `packages.<system>.nixarchy-vm` exposed at flake top level (next to `verify`/`doctor`) so the check below builds the exact command, not a copy.
- `tests/microvm-template.nix` → `checks.microvm-template`. Builds a runner and reads it — boots nothing. Per template (KVM + `-tcg`): `bin/microvm-run`/`bin/microvm-shutdown` exist and are executable; `share/microvm/hypervisor` is `qemu`; no `-drive` mentions a store image and `mount_tag=ro-store` is present; `-netdev 'user,` is present and `share/microvm/tap-interfaces` is empty/absent; the KVM and `-tcg` runners share one `share/microvm/system` (`readlink -f` compared); `-enable-kvm` only on the KVM runner. Then exercises `nixarchy-vm` itself against a stub `nix` that logs its argv and fakes the build (writes the out-link, points it at a stub `bin/microvm-run` that just sleeps): asserts `nix` was called with `build` (never `run`) and `--out-link`, and that a second `run` of the same name while the first is still up refuses.
- Wired into `.github/workflows/build.yml`'s `system` job, right after `reference-toplevel` (same cost band per #224's own note — a `runCommand` plus a ~1–1.5 GB guest closure from `cache.nixos.org`; this step is also how the templates reach `nixarchy.cachix.org`, since that job already pushes via cachix-action).

## Empirical basis for the assertions

Built `packages.x86_64-linux.microvm-shell` and `microvm-shell-tcg` by hand before writing the check, to read the real `bin/microvm-run` command line and `share/microvm/` layout rather than guessing at microvm.nix's output shape. Confirmed: no `-drive` at all for the shared-store shell template (only `-fsdev local,...,path=/nix/store,...` + `mount_tag=ro-store`), `-netdev 'user,id=vmnet'` with no `tap-interfaces` file at all, `-enable-kvm -cpu host,...` on the KVM variant vs `-cpu max` (no `-enable-kvm`) on `-tcg`, and both variants' `share/microvm/system` symlinks resolve to the byte-identical `nixos-system-...` store path.

## Check proven RED then GREEN (AGENTS.md §1)

Two separate breaks, each reverted after capturing the failure:

**1. `nix run` instead of `nix build --out-link`:**
```
nixarchy-microvm-template> the first 'run' never reached the stub guest -- see run1.log:
nixarchy-microvm-template> stub nix: unexpected subcommand 'run'
nixarchy-microvm-template> nix was never called with 'build' as its first argument:
nixarchy-microvm-template> run github:olafkfreund/nixarchy/e5e4cd2...#microvm-shell -- --out-link /build/home/.local/state/nixarchy/microvm/sandbox/current
nixarchy-microvm-template> nix was called with 'run' -- that registers no GC root:
nixarchy-microvm-template> run github:olafkfreund/nixarchy/e5e4cd2...#microvm-shell -- --out-link /build/home/.local/state/nixarchy/microvm/sandbox/current
error: Cannot build '...-nixarchy-microvm-template.drv'.
```

**2. Dropped the flock entirely:**
```
nixarchy-microvm-template> Created 'sandbox' from the 'shell' template.
nixarchy-microvm-template>   nixarchy vm run sandbox
nixarchy-microvm-template> a second 'run sandbox' succeeded while the first was still up:
error: Cannot build '...-nixarchy-microvm-template.drv'.
```

**Restored, GREEN:**
```
nixarchy-microvm-template> == template: shell ==
nixarchy-microvm-template> == nixarchy vm: launch and locking ==
nixarchy-microvm-template> Created 'sandbox' from the 'shell' template.
nixarchy-microvm-template>   nixarchy vm run sandbox
nixarchy-microvm-template> second run correctly refused:
nixarchy-microvm-template> nixarchy-vm: 'sandbox' is already running.
nixarchy-microvm-template> every template's runner is qemu, shares the host store read-only, uses user networking, and the KVM/-tcg pair share one guest -- and nixarchy-vm launches it with an out-link, under a flock.
```

I did not separately red/green each of the seven static package-shape assertions (hypervisor, ro-store share, netdev/tap, KVM↔-tcg shared system, `-enable-kvm`) — those were validated by direct empirical inspection of the built derivation (see above) rather than a break/restore cycle, in the interest of time. Flagging that rather than implying full per-assertion RED/GREEN coverage.

## Also ran

- `nix build .#checks.x86_64-linux.options --print-build-logs` — still green (350 menu rows, no coverage regression; no menu row was added, that's #226).
- `nix fmt -- --ci`, `nix run nixpkgs#statix -- check .`, `nix run nixpkgs#deadnix -- --fail .` — all clean.
- `git diff -w` against the merge-base for `modules/apps.nix`, `flake.nix`, `.github/workflows/build.yml`: identical line count with and without `-w` (91 both ways) — no reindentation.
- Confirmed `checks.microvm-template` is named by a `nix build` step in `build.yml`'s `system` job (which triggers on `pull_request`), satisfying the "every check is run by some workflow" guard.

## What I could NOT verify

- The KVM runner actually booting — #221 says outright this is not provable in CI without nested virtualisation (`pkgs/verify.sh`'s job, #229, out of scope here).
- Real cachix push of the templates to `nixarchy.cachix.org` — the mechanism (this check builds the packages in a job with cachix-action already wired) is unchanged from how `reference-toplevel` already does it, but I didn't have push credentials to observe it land.
- The CI runner actually executing `checks.microvm-template` end-to-end (I ran it locally; have not seen a green Actions run).
- `nixarchy-vm`'s menu integration (`--check` as `trigger.vm`'s `when`) — that's #226, explicitly out of scope.

## Test plan

- [x] `nix build .#checks.x86_64-linux.microvm-template --print-build-logs` — green locally
- [x] Proven RED (2 separate breaks) then GREEN, output above
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5