### PR TITLE
programs.nixarchy.services.boxes.machines — the declarative half

### DIFF
--- a/modules/home.nix
+++ b/modules/home.nix
@@ -49,6 +49,19 @@ let
   }
   // (osConfig.programs.nixarchy.localAi or { });
 
+  # Same shape as localAi just above: declared on the NixOS side
+  # (modules/services/boxes.nix), because `machines` names containers that
+  # should exist regardless of which user's home-manager config is reading
+  # this file, and applied here because Home Manager's `programs.distrobox`
+  # is a per-user option with nowhere else to be set. `enable = false` when
+  # there is no osConfig, for the same reason localAi's does: a standalone
+  # home-manager user has no NixOS module to have turned this on.
+  boxes = {
+    enable = false;
+    machines = { };
+  }
+  // (osConfig.programs.nixarchy.services.boxes or { });
+
   # Through the overlay on *your* nixpkgs, for the same reason cfg.package's
   # default takes that route: inputs.self.packages is built from nixarchy's own
   # nixpkgs, and a second copy of anything in home.packages is a buildEnv
@@ -884,5 +897,48 @@ in
     # omarchy-launch-shell responds to that by exiting 0 -- see its
     # compositor_alive() guard. The unit therefore "succeeded" while starting
     # nothing, and duplicated a launch Hyprland was already doing correctly.
+
+    # The declared half of boxes (#257; the imperative half is `distrobox`
+    # itself, installed by modules/services/boxes.nix). `machines` came over
+    # from the NixOS side above; everything else here is what turns it into
+    # containers Home Manager's own module actually writes.
+    programs.distrobox = lib.mkIf boxes.enable {
+      # Scalars, so mkDefault throughout -- see the header of
+      # modules/services/default.nix. This is Home Manager's option, not
+      # ours, but the same Mode A reasoning holds: someone who already set
+      # programs.distrobox by hand in their own home-manager config keeps
+      # their definition, and this yields to it. `containers` is the one
+      # attrset here and stays plain assignment for the same reason -- see
+      # that file's header for why mkDefault on a merging type is a bug
+      # rather than a courtesy.
+      enable = lib.mkDefault true;
+      containers = boxes.machines;
+
+      # Never `pkgs.distrobox` -- that would go through the overlay/plain
+      # nixpkgs pkgs this file already has and add a SECOND profile entry for
+      # the same package modules/services/boxes.nix already put in
+      # environment.systemPackages. `null` here means Home Manager's module
+      # installs nothing: one copy of distrobox, reached the way its own
+      # comment requires -- by bare name, through
+      # /run/current-system/sw/bin, never a store path.
+      package = lib.mkDefault null;
+
+      # Left at Home Manager's own default everywhere else, which is
+      # `cfg.containers != { } && cfg.package != null` -- true the instant
+      # `machines` is non-empty, so leaving this unset would turn it on.
+      # Refused outright: its ExecStart is
+      # `${cfg.package}/bin/distrobox-assemble create --file ...`, a literal
+      # /nix/store/... path baked straight into the unit file -- the exact
+      # GC-survival hazard (nixpkgs#478154) modules/services/boxes.nix's own
+      # comment documents distrobox itself must never be reached through.
+      # `nix-collect-garbage` can delete that path out from under this unit
+      # the same way it can out from under a running box. It also hardcodes
+      # uid 1000 in the cleanup it runs first
+      # (`rm -rf /tmp/storage-run-1000/...`), a second, independent reason to
+      # leave it off. `nixarchy box` (a later issue) is how a machine picks
+      # up a declared container -- by calling `distrobox-assemble` itself,
+      # by bare name, the way the module comment already requires.
+      enableSystemdUnit = lib.mkDefault false;
+    };
   };
 }

--- a/modules/services/boxes.nix
+++ b/modules/services/boxes.nix
@@ -21,6 +21,17 @@
 let
   cfg = config.programs.nixarchy;
   svc = cfg.services.boxes;
+
+  # The exact type Home Manager's own `programs.distrobox.containers` uses --
+  # not a redeclaration, a reuse. distrobox-assemble's INI accepts a bool, a
+  # string or a list of strings per key (a list repeats the key), which is
+  # what `pkgs.formats.ini { listsAsDuplicateKeys = true; }` already encodes.
+  # Building it here rather than importing Home Manager's module for its type
+  # alone is the shape modules/local-ai.nix already uses for a value it hands
+  # to home-manager rather than applies itself: declare data, let the module
+  # that consumes it (modules/home.nix, via Home Manager's own module) own
+  # what "valid" means.
+  containerIniAtom = (pkgs.formats.ini { listsAsDuplicateKeys = true; }).lib.types.atom;
 in
 {
   options.programs.nixarchy.services.boxes = {
@@ -35,6 +46,36 @@ in
       in the menu next to Flatpak, which *is* a sandbox -- do not expect the
       same isolation
     '';
+
+    machines = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.attrsOf containerIniAtom);
+      default = { };
+      example = lib.literalExpression ''
+        {
+          dev = {
+            image = "archlinux:latest";
+            additional_packages = "git base-devel";
+          };
+        }
+      '';
+      description = ''
+        Boxes that come up the same way after every rebuild, instead of
+        living only in whatever was typed at a shell. Each attribute name is
+        a container; its value is passed straight through to Home Manager's
+        `programs.distrobox.containers`, which writes exactly the INI
+        `distrobox-assemble` reads -- see that option's own documentation and
+        upstream's distrobox-assemble manual for the available fields.
+
+        Read out to Home Manager, not applied here: this is a NixOS option,
+        and Home Manager's `containers` are per-user. `modules/home.nix`
+        reads this attrset back out of `osConfig` and hands it to
+        `programs.distrobox.containers` for the user
+        `programs.nixarchy.homeManagerModules.nixarchy` is imported for. An
+        empty attrset (the default) writes nothing -- Home Manager's own
+        module already gates its INI file and its systemd unit on
+        `containers != { }`.
+      '';
+    };
   };
 
   config = lib.mkIf (cfg.enable && svc.enable) {

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -377,6 +377,68 @@ let
   hasCache = cfg: builtins.elem "https://devenv.cachix.org" cfg.nix.settings.substituters;
   hookIn = text: pkgs.lib.hasInfix "devenv hook" text;
 
+  # ---- boxes, both halves (#257) --------------------------------------
+  #
+  # More reaches across than devenv does: turning services.boxes.enable on
+  # crosses into Home Manager, which nothing else in this file evaluates.
+  # Every effect the option has, measured both ways -- the shape #221 set
+  # for microvm.host.enable:
+  #
+  #   | | enable = false | enable = true, one machine |
+  #   |---|---|---|
+  #   | virtualisation.podman.enable | false | true |
+  #   | programs.distrobox.containers | { } | populated |
+  #   | distrobox-home-manager systemd unit | absent | absent (forced off) |
+  #   | distrobox in environment.systemPackages | absent | present |
+  #   | distrobox in home.packages | absent | absent (package = null) |
+  #
+  # The systemd-unit row is the one that matters most: Home Manager's own
+  # default for enableSystemdUnit is `containers != { } && package != null`,
+  # which is true the moment a machine is declared -- so "on" has to prove
+  # the unit is STILL absent, not just that "off" is quiet.
+  boxesUser = "tester";
+
+  boxesConfig =
+    enable:
+    (inputs.nixpkgs.lib.nixosSystem {
+      inherit system;
+      modules = [
+        inputs.self.nixosModules.nixarchy
+        inputs.home-manager.nixosModules.home-manager
+        {
+          programs.nixarchy = {
+            enable = true;
+            services.boxes = {
+              inherit enable;
+            }
+            // pkgs.lib.optionalAttrs enable {
+              machines.dev.image = "archlinux:latest";
+            };
+          };
+          users.users.${boxesUser}.isNormalUser = true;
+          home-manager.users.${boxesUser} = {
+            imports = [ inputs.self.homeManagerModules.nixarchy ];
+            home.stateVersion = "25.05";
+            programs.nixarchy.enable = true;
+          };
+        }
+        {
+          boot.loader.grub.device = "/dev/sda";
+          fileSystems."/" = {
+            device = "/dev/sda1";
+            fsType = "ext4";
+          };
+          system.stateVersion = "25.05";
+        }
+      ];
+    }).config;
+
+  boxesOff = boxesConfig false;
+  boxesOn = boxesConfig true;
+
+  homeOfBoxes = cfg: cfg.home-manager.users.${boxesUser};
+  hasDistrobox = list: builtins.any (p: (p.pname or "") == "distrobox") list;
+
   # ---- sops-nix, imported by everyone and doing nothing --------------
   #
   # #155 adopted a declarative secrets mechanism for one concrete reason:
@@ -746,6 +808,25 @@ pkgs.runCommand "nixarchy-options"
     sopsOnActive = pkgs.lib.boolToString (hasSops sopsOn);
     devenvNoCacheCache = pkgs.lib.boolToString (hasCache devenvNoCache);
     devenvNoCachePackage = pkgs.lib.boolToString (hasDevenv devenvNoCache);
+    boxesOffPodman = pkgs.lib.boolToString boxesOff.virtualisation.podman.enable;
+    boxesOffContainers = pkgs.lib.boolToString (
+      (homeOfBoxes boxesOff).programs.distrobox.containers == { }
+    );
+    boxesOffUnit = pkgs.lib.boolToString (
+      (homeOfBoxes boxesOff).systemd.user.services ? distrobox-home-manager
+    );
+    boxesOffSystemPkg = pkgs.lib.boolToString (hasDistrobox boxesOff.environment.systemPackages);
+    boxesOffHomePkg = pkgs.lib.boolToString (hasDistrobox (homeOfBoxes boxesOff).home.packages);
+    boxesOnPodman = pkgs.lib.boolToString boxesOn.virtualisation.podman.enable;
+    boxesOnContainers = pkgs.lib.boolToString (
+      (homeOfBoxes boxesOn).programs.distrobox.containers ? dev
+    );
+    boxesOnImage = (homeOfBoxes boxesOn).programs.distrobox.containers.dev.image or "";
+    boxesOnUnit = pkgs.lib.boolToString (
+      (homeOfBoxes boxesOn).systemd.user.services ? distrobox-home-manager
+    );
+    boxesOnSystemPkg = pkgs.lib.boolToString (hasDistrobox boxesOn.environment.systemPackages);
+    boxesOnHomePkg = pkgs.lib.boolToString (hasDistrobox (homeOfBoxes boxesOn).home.packages);
     # The home-backup script, run rather than read. Its gate and its allowlist
     # are the two things this issue actually promises, and both are answerable
     # by executing it -- --check and --list exist partly for that reason and
@@ -1175,6 +1256,59 @@ pkgs.runCommand "nixarchy-options"
             exit 1
           }
           echo "devenv respects binaryCaches = false and still installs"
+
+          # ---- boxes: off adds nothing, anywhere ---------------------------
+          for pair in "podman:$boxesOffPodman" "distrobox containers:$boxesOffContainers" \
+            "distrobox unit:$boxesOffUnit" "distrobox in systemPackages:$boxesOffSystemPkg" \
+            "distrobox in home.packages:$boxesOffHomePkg"; do
+            case "''${pair%%:*}" in
+              "distrobox containers") want=true ;;
+              *) want=false ;;
+            esac
+            if [ "''${pair#*:}" != "$want" ]; then
+              echo "services.boxes is off, but its ''${pair%%:*} says otherwise on the machine anyway." >&2
+              echo "A configuration that never selects boxes must gain nothing -- neither on the" >&2
+              echo "NixOS side (podman, distrobox in systemPackages) nor across into Home Manager" >&2
+              echo "(distrobox.containers, its systemd unit, or a second copy in home.packages)." >&2
+              exit 1
+            fi
+          done
+          echo "boxes adds no podman, no distrobox and nothing in Home Manager until selected"
+
+          # ---- boxes: on reaches Home Manager, and still refuses the unit --
+          for pair in "podman:$boxesOnPodman" "distrobox containers:$boxesOnContainers" \
+            "distrobox in systemPackages:$boxesOnSystemPkg"; do
+            if [ "''${pair#*:}" != "true" ]; then
+              echo "services.boxes is enabled with a machine declared, but its ''${pair%%:*} is missing." >&2
+              exit 1
+            fi
+          done
+          [ "$boxesOnImage" = "archlinux:latest" ] || {
+            echo "the declared machine's image did not reach programs.distrobox.containers.dev:" >&2
+            echo "got '$boxesOnImage'" >&2
+            exit 1
+          }
+          echo "boxes on with one machine: podman, the package, and the container all land"
+
+          # This is the row that matters most. Home Manager's OWN default for
+          # enableSystemdUnit is `containers != { } && package != null` -- true
+          # the instant a machine is declared -- so this has to prove the unit
+          # is STILL absent, not merely that "off" produced nothing. Its
+          # ExecStart bakes a literal /nix/store/... path
+          # (the distrobox package's own /bin/distrobox-assemble) straight
+          # into the unit file, the same
+          # GC-survival hazard nixpkgs#478154 describes and modules/services/
+          # boxes.nix already refuses for distrobox itself.
+          for pair in "distrobox unit:$boxesOnUnit" "distrobox in home.packages:$boxesOnHomePkg"; do
+            if [ "''${pair#*:}" != "false" ]; then
+              echo "services.boxes is enabled, but its ''${pair%%:*} is present anyway." >&2
+              echo "enableSystemdUnit must stay refused: its ExecStart bakes a literal" >&2
+              echo "/nix/store/... path into the unit, the same hazard distrobox itself is" >&2
+              echo "never allowed to be reached through (nixpkgs#478154)." >&2
+              exit 1
+            fi
+          done
+          echo "boxes on still refuses Home Manager's own systemd unit, and installs distrobox once"
 
           # ---- sops-nix: imported by everyone, inert until asked --------
           for pair in "systemd unit:$sopsOffUnit" "activation script:$sopsOffActivation"; do


### PR DESCRIPTION
## What this changes, and why

Closes the declarative half of epic #230 — issue #257. Adds
`programs.nixarchy.services.boxes.machines`, an attrset of Home Manager's own
`programs.distrobox.containers` fields, following the shape
`modules/services/default.nix` already sets for its siblings (`enable` plus
data). `modules/home.nix` reads it back off `osConfig` and wires it to Home
Manager's `programs.distrobox`, so a box declared in `machines` comes up the
same way after every rebuild and rolls back with a generation, instead of
living only in whatever a shell typed by hand created (#256, merged as PR
#265, is the imperative half this builds on: rootless podman and the
`distrobox` package itself).

Two decisions worth being explicit about:

- **`programs.distrobox.package = null`.** Home Manager's own default installs
  `pkgs.distrobox` into `home.packages`, which would be a second profile
  carrying the exact package `modules/services/boxes.nix` already put in
  `environment.systemPackages`. `null` means one copy, reached the way that
  module's own comment already requires — by bare name, through
  `/run/current-system/sw/bin`, never a store path.
- **`programs.distrobox.enableSystemdUnit` forced to `false`.** Home
  Manager's own default for it is `containers != { } && package != null` —
  true the instant a machine is declared, if `package` were left at its
  default. Its `ExecStart` bakes a literal `${package}/bin/distrobox-assemble`
  `/nix/store/...` path straight into the unit file — the same GC-survival
  hazard nixpkgs#478154 describes and #256 already refuses everywhere else
  distrobox is reached from this repo. (It also hardcodes uid 1000 in its
  cleanup step, a second, independent reason.)

**A framing correction to #257 itself, before writing any code**, matching
the note in the task that #256 had already corrected the same wrong framing
on #230 and #258: the issue's `enableSystemdUnit` bullet blamed "the exact
hyphenated-binary problem" — the actual hazard is the literal `/nix/store/...`
path baked into the unit's `ExecStart`, not which binary name is called (a
call through the dispatcher via a store path would be exactly as broken).
Also corrected "deliberately not set" to "must be set to `false`" — Home
Manager's own default computes `true` the moment `machines` is non-empty
*and* `package` is non-null, so "not set" would silently turn the unit on.
Edited https://github.com/olafkfreund/nixarchy/issues/257 and left a comment
explaining the correction before implementing against it.

**Stacks on #256 (PR #265, merged).** Branched from `origin/main`, which
already includes it.

## How I proved the check fails

Broke the two guardrails together — removed both `package = lib.mkDefault
null;` and `enableSystemdUnit = lib.mkDefault false;` from
`modules/home.nix`, the realistic version of this regression (someone deletes
what looks like redundant lines) — and reran
`nix build .#checks.x86_64-linux.options`:

```
nixarchy-options> boxes adds no podman, no distrobox and nothing in Home Manager until selected
nixarchy-options> boxes on with one machine: podman, the package, and the container all land
nixarchy-options> services.boxes is enabled, but its distrobox unit is present anyway.
nixarchy-options> enableSystemdUnit must stay refused: its ExecStart bakes a literal
nixarchy-options> /nix/store/... path into the unit, the same hazard distrobox itself is
nixarchy-options> never allowed to be reached through (nixpkgs#478154).
error: Cannot build '/nix/store/hrk18qh5s67gcri758ib8bddyxqzp080-nixarchy-options.drv'.
       Reason: builder failed with exit code 1.
```

Restored both lines and reran — green, naming all three new lines:

```
nixarchy-options> boxes adds no podman, no distrobox and nothing in Home Manager until selected
nixarchy-options> boxes on with one machine: podman, the package, and the container all land
nixarchy-options> boxes on still refuses Home Manager's own systemd unit, and installs distrobox once
```

This closes the gap #256 documented and deliberately left open: that agent
broke `pkgs.distrobox` → `pkgs.distroboxx` and reran `checks.options`, and it
stayed green, because nothing in the suite ever set
`services.boxes.enable = true`. The new cases build a real
`home-manager.nixosModules.home-manager` + `home-manager.users.tester`
alongside the NixOS module (nothing else in `tests/options.nix` does this)
and assert every effect the option has in both states — mirroring the
inertness-table shape the task described for #223 (not present in this repo's
history at the time of writing; built directly from #257's own Mode A table
instead):

| | `enable = false` | `= true`, one machine |
|---|---|---|
| `virtualisation.podman.enable` | false | true |
| `programs.distrobox.containers` | `{ }` | populated (`dev.image` reaches it) |
| `distrobox-home-manager` systemd unit | absent | **absent** (Home Manager's own default would turn it on) |
| `distrobox` in `environment.systemPackages` | absent | present |
| `distrobox` in `home.packages` | absent | **absent** (`package = null` — no second copy) |

Both new cases go into the existing `options` check — no `checks.*` entry
added, so no `build.yml` workflow edit is needed.

## Checks run locally

- [x] `nix fmt -- --ci` clean
- [x] `nix run nixpkgs#statix -- check .` clean
- [x] `nix run nixpkgs#deadnix -- --fail .` clean
- [x] `nix build .#checks.x86_64-linux.options` — green (see above for the
      broken/restored cycle)
- [x] New/changed files `git add`ed and committed before every build
- [x] `tests/options.nix` covers both states of
      `programs.nixarchy.services.boxes.machines`
- [x] No `checks.*` entry added, so no workflow wiring needed

Not run: `checks.session` (does not run locally, per this repo's own note),
`checks.install`/`free-space` (self-hosted-runner only, no option-surface
change here that would touch them).

## What I could NOT verify

No real `podman`/`distrobox` commands were run for this PR — #256 already did
the live verification (`distrobox create`/`enter`, `podman inspect`) for the
package and rootless-podman half; this PR only adds a NixOS option and a
Home Manager wiring, both eval-only in nature, and I did not create or touch
any containers on this machine. Nothing to clean up.

Not built: an actual `nixos-rebuild` onto a real Home Manager user with
`services.boxes.machines.dev` set, followed by `distrobox list` showing it
with no manual `distrobox create` — the issue's own "done when" criterion.
`tests/options.nix` proves the wiring evaluates correctly (containers reach
Home Manager, the systemd unit stays off, no duplicate package), but does not
boot a VM or run `distrobox-assemble` against the generated INI — that is
`checks.box-template` (#258) and `checks.box-boot` (#262), both later issues.

## Diff honesty

```
modules/home.nix           |  56 +++++++++++++++++++
modules/services/boxes.nix |  41 ++++++++++++++
tests/options.nix          | 134 +++++++++++++++++++++++++++++++++++++++++++++
3 files changed, 231 insertions(+)
```

`git diff -w origin/main` reports the same counts — no reindenting.

Part of #230. Closes #257.
