### PR TITLE
free-space settles the filesystem it just made before mounting it

### DIFF
--- a/tests/free-space.nix
+++ b/tests/free-space.nix
@@ -477,6 +477,21 @@ pkgs.testers.runNixOSTest {
     # unmount -- and then never touch it again, so that the hash taken in a
     # moment is the hash of a filesystem nobody has opened since.
     installer.succeed("mkfs.vfat -n SYSTEM /dev/vdb1")
+    # Between the mkfs and the mount, because the two are not as ordered as
+    # they read. mkfs.vfat returning does not mean the kernel and udev have
+    # seen the new signature, and the mount then fails with
+    #
+    #   mount: /win: wrong fs type, bad option, bad superblock on /dev/vdb1
+    #
+    # 58 seconds into a run, before the installer has done anything at all.
+    #
+    # Latent until #232, which puts checks.install and checks.free-space in one
+    # nix invocation so the two VMs run at the same time. The extra I/O on the
+    # runner is what widened a window that had always been there -- the same
+    # `udevadm settle` already guards the partition table twelve lines up and
+    # the raw write eight lines down, so this was the one step in the sequence
+    # trusting a return code to mean the device was ready.
+    installer.succeed("sync && udevadm settle")
     installer.succeed("mkdir -p /win && mount /dev/vdb1 /win")
     installer.succeed("mkdir -p /win/EFI/Microsoft/Boot")
     installer.succeed("head -c 65536 /dev/urandom > /win/EFI/Microsoft/Boot/bootmgfw.efi")


### PR DESCRIPTION
`checks.free-space` failed on #275:

```
mount: /win: wrong fs type, bad option, bad superblock on /dev/vdb1
```

**58 seconds in, before the installer had done anything.** The step immediately
before is `mkfs.vfat -n SYSTEM /dev/vdb1`, which succeeded.

## Why

mkfs returning does not mean the kernel and udev have seen the new signature.
The surrounding code already knows this — there is a `udevadm settle` twelve
lines above guarding the partition table, and another eight lines below guarding
the raw write. The mkfs was the one step in the sequence trusting a return code
to mean the device was ready.

## Why now

It was latent until #232, which puts `checks.install` and `checks.free-space`
in one `nix` invocation so both VMs run at the same time. The extra I/O on the
runner widened a window that had always been there.

**Worth saying plainly:** when I rewrote #232 I argued it was a convenience
rather than a fix, and that its only cost was losing the ordered failure
reporting. That was incomplete. Running the two in parallel also changes the
timing *inside* each of them, and this is the first thing it shook loose. It may
not be the last.

## What this is not

**Not reproduced locally.** A race that needs a loaded runner is not one this
machine will show on demand. So this is the fix the surrounding code already
applies to the same hazard — not a fix proven against the failure. If
`free-space` fails this way again, that is the evidence this was the wrong
cause, and the next place to look is the parallelism itself rather than the
mkfs.