### PR TITLE
First-run can finish, so the welcome notification stops coming back

### DIFF
--- a/pkgs/omarchy/default.nix
+++ b/pkgs/omarchy/default.nix
@@ -1442,6 +1442,41 @@ stdenvNoCC.mkDerivation {
                 # Omarchy's shell for zsh. Upstream has a bash rc chain and nothing else,
                 # so a zsh user got none of the aliases or functions the manual documents.
                 # See the file for what is sourced as-is and what had to be rewritten.
+
+                # install/user/first-run/enable-user-units.sh enables six user units in ONE
+                # `systemctl --user enable --now` under `set -euo pipefail`, so one absent
+                # unit fails the whole command:
+                #
+                #   Failed to enable unit: Unit omarchy-migrate-notify.service does not exist
+                #
+                # Two of them are deliberately absent -- modules/nixos.nix explains that
+                # omarchy-migrate-notify and omarchy-tailscale-receive can never satisfy their
+                # ConditionPath* on NixOS. What was missed is that upstream's first-run still
+                # NAMES them.
+                #
+                # omarchy-provision-first-run marks itself done only when EVERY step
+                # succeeded, so that one failure meant the marker was never written and
+                # first-run ran again at every login -- re-showing the welcome notification
+                # for the life of the machine. Reported as "this appears after each reboot";
+                # the log had been saying so all along:
+                #
+                #   Failed: enable user systemd units (exit code: 1)
+                #   One or more first-run steps failed; first-run will retry next login
+                #
+                # Replaced wholesale rather than patched: the unit list is a
+                # continuation-line command, and a whitespace-exact multi-line
+                # --replace-fail is the kind of patch an upstream reindent breaks. The grep
+                # is the drift detector --replace-fail would otherwise have given for free.
+                for u in bt-agent omarchy-recover-internal-monitor omarchy-sleep-lock \
+                  omarchy-migrate-notify omarchy-fcitx5 omarchy-crash-watch; do
+                  grep -q "$u.service" install/user/first-run/enable-user-units.sh || {
+                    echo "enable-user-units.sh no longer names $u.service -- upstream changed" >&2
+                    echo "the set; read it against pkgs/omarchy/enable-user-units.sh." >&2
+                    exit 1
+                  }
+                done
+                install -Dm755 ${./enable-user-units.sh} \
+                  $out/share/omarchy/install/user/first-run/enable-user-units.sh
                 install -Dm644 ${./zsh-rc} $out/share/omarchy/default/zsh/rc
 
                 # And fish, which cannot source any of it -- see the file for why nothing

--- a/pkgs/omarchy/enable-user-units.sh
+++ b/pkgs/omarchy/enable-user-units.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Enable the user units this machine actually has.
+#
+# Upstream enables six in one `systemctl --user enable --now` under
+# `set -euo pipefail`, so one absent unit fails the whole command:
+#
+#   Failed to enable unit: Unit omarchy-migrate-notify.service does not exist
+#
+# Two are deliberately absent here. modules/nixos.nix explains that
+# omarchy-migrate-notify and omarchy-tailscale-receive can never satisfy their
+# ConditionPath* on NixOS, and that both jobs belong elsewhere -- migrations
+# arrive with a rebuild, Taildrop with services.tailscale. What was missed is
+# that upstream's first-run still NAMES them.
+#
+# The cost was out of all proportion to the cause. omarchy-provision-first-run
+# marks itself done only when EVERY step succeeded, so one absent unit meant
+# the marker was never written and first-run ran again at every login -- which
+# is a welcome notification on every boot, for the life of the machine.
+#
+# Filtered at runtime rather than trimmed to a shorter fixed list:
+# omarchy-fcitx5 is absent too on a machine with no input method configured,
+# and a hardcoded list would need editing every time the module's set changes.
+# Units that DO exist still report their own failures, which is the half worth
+# keeping -- this makes a MISSING unit non-fatal, not a broken one.
+set -euo pipefail
+
+systemctl --user daemon-reload
+
+want=()
+for u in \
+  bt-agent.service \
+  omarchy-recover-internal-monitor.service \
+  omarchy-sleep-lock.service \
+  omarchy-migrate-notify.service \
+  omarchy-fcitx5.service \
+  omarchy-crash-watch.service; do
+  if systemctl --user cat "$u" >/dev/null 2>&1; then
+    want+=("$u")
+  fi
+done
+
+if [ ${#want[@]} -gt 0 ]; then
+  systemctl --user enable --now "${want[@]}"
+fi


### PR DESCRIPTION
Reported as *"this appears after each reboot"* — the Update System / Learn
Keybindings cards, every login.

The notification is not the bug. **First-run never completes**, so it runs again
every login and re-shows it. The log had been saying so since the machine was
installed:

```
Failed: enable user systemd units (exit code: 1)
One or more first-run steps failed; first-run will retry next login
```

## Cause

`install/user/first-run/enable-user-units.sh` enables six user units in **one**
`systemctl --user enable --now`, under `set -euo pipefail`. One absent unit
fails the whole command:

```
Failed to enable unit: Unit omarchy-migrate-notify.service does not exist
```

On this machine two of the six do not exist:

```
bt-agent.service                          present
omarchy-recover-internal-monitor.service  present
omarchy-sleep-lock.service                present
omarchy-migrate-notify.service            MISSING
omarchy-fcitx5.service                    MISSING
omarchy-crash-watch.service               present
```

Their absence is **deliberate**, and `modules/nixos.nix` already says why:

> `omarchy-migrate-notify` and `omarchy-tailscale-receive` are deliberately
> absent. Their conditions … can never hold here, and both jobs belong elsewhere
> on NixOS: migrations arrive with a rebuild, and Taildrop with
> `services.tailscale`.

That reasoning is right. What was missed is that upstream's first-run still
**names** them — and `omarchy-provision-first-run` marks itself done only when
*every* step succeeded.

## Fix

Filtered at runtime, not trimmed to a shorter fixed list. `omarchy-fcitx5` is
absent too on a machine with no input method, so a hardcoded list would need
editing every time the module's set changes — and the next divergence would cost
another machine another forever-loop.

A **missing** unit is skipped. A **broken** one still fails, which is the half
worth keeping.

## Verified

On this machine, where two units are missing — upstream's exits 1, this exits 0
and enables the four that exist:

```
Created symlink …/bt-agent.service
Created symlink …/omarchy-recover-internal-monitor.service
Created symlink …/omarchy-sleep-lock.service
Created symlink …/omarchy-crash-watch.service
exit=0
```

Drift detector proved by renaming a unit:

```
enable-user-units.sh no longer names omarchy-NOT-A-UNIT.service -- upstream changed
```

## A near miss worth recording

My first attempt replaced the script with a heredoc whose terminator was
indented. It never terminated, swallowed the **rest of the install phase**, and
produced a package silently missing the plymouth and SDDM themes — **and the
build succeeded.** So this PR asserts both are still present after the change,
and the replacement is an installed file rather than an inline heredoc.