### PR TITLE
The target-store build asks for a store that will accept what it hands over

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1625,12 +1625,34 @@ run_install() {
   # (its own `sub="auto?trusted=1"`). Combined with always-allow-substitutes in
   # SUBSTITUTE_FLAGS -- see the comment on it, which is about precisely this
   # arrangement -- the closure is copied rather than rebuilt.
+  #
+  # require-sigs=false on the TARGET, and this is the half #251 shipped without.
+  # A path built on this machine carries no signature, and a fresh store refuses
+  # unsigned paths:
+  #
+  #   error: cannot add path '/nix/store/...-update-users-groups.pl' because it
+  #   lacks a signature by a trusted key
+  #
+  # `auto?trusted=1` does not cover it -- that marks the SOURCE trusted to fetch
+  # from; the destination still validates on add. Those two paths are NixOS'
+  # own assembly derivations, the allowSubstitutes = false ones SUBSTITUTE_FLAGS
+  # is about, so they are always built rather than fetched and always unsigned.
+  #
+  # tests/install.nix already knew. It sets require-sigs = false inside the test
+  # VM and says why -- "with require-sigs on, /mnt refuses all of them ... the
+  # whole source bootstrap from stage0-posix appears and the install dies
+  # fetching bash's tarball". Which means the checks CANNOT see this, and every
+  # real install walks into it. The ISO does not set it; only the test VMs do.
+  #
+  # Safe because the target store is one this script just created, on a disk
+  # this script just formatted, populated from this machine's own store, as
+  # root. There is nothing here for a signature to protect against.
   local build_store=()
   case ${build_store_choice:-auto} in
-    target) build_store=(--store /mnt --eval-store auto --extra-substituters "auto?trusted=1") ;;
+    target) build_store=(--store "/mnt?require-sigs=false" --eval-store auto --extra-substituters "auto?trusted=1") ;;
     live) ;;
     *) check_store_space "$plan" ||
-      build_store=(--store /mnt --eval-store auto --extra-substituters "auto?trusted=1") ;;
+      build_store=(--store "/mnt?require-sigs=false" --eval-store auto --extra-substituters "auto?trusted=1") ;;
   esac
 
   # Build here, then install what was built. NOT `nixos-install --flake`.

--- a/tests/installer-store-space.nix
+++ b/tests/installer-store-space.nix
@@ -70,6 +70,41 @@ pkgs.runCommand "nixarchy-installer-store-space" { } ''
   EOF
     bash t.sh
 
-    echo "check_store_space refuses what will not fit and nothing else"
+    # And that the target-store fallback asks for a store that will ACCEPT what
+  # it is handed.
+  #
+  # A path built on the installing machine has no signature, and a fresh store
+  # refuses unsigned paths -- "cannot add path ... because it lacks a signature
+  # by a trusted key". NixOS' own assembly derivations are allowSubstitutes =
+  # false, so they are always built and always unsigned; the fallback therefore
+  # fails on every real machine without this.
+  #
+  # Asserted here because nothing else can. tests/install.nix and
+  # tests/free-space.nix both set require-sigs = false INSIDE the test VM -- and
+  # say why -- so an install check passes whether or not the installer asks for
+  # it. The ISO does not set it. That gap is exactly how #251 shipped broken and
+  # went green.
+  # The URI form, not the bare setting -- the comment above it in install.sh
+  # says "require-sigs=false" too, so a looser pattern matches the explanation
+  # and stays green with the flag deleted. Found by breaking it.
+  grep -q '/mnt?require-sigs=false' ${installScript} || {
+    echo "" >&2
+    echo "the target-store build does not pass require-sigs=false." >&2
+    echo "" >&2
+    echo "Paths built on the installing machine are unsigned, and a fresh" >&2
+    echo "store rejects them:" >&2
+    echo "" >&2
+    echo "  cannot add path '...' because it lacks a signature by a trusted key" >&2
+    echo "" >&2
+    echo "No install check can catch this: they set require-sigs = false in" >&2
+    echo "the test VM, so /mnt accepts unsigned paths there regardless." >&2
+    exit 1
+  }
+  grep -q 'eval-store auto' ${installScript} || {
+    echo "the target-store build no longer splits the evaluation store; see #249" >&2
+    exit 1
+  }
+
+  echo "check_store_space refuses what will not fit and nothing else"
     touch $out
 ''


### PR DESCRIPTION
#251 shipped without this, and **every net install fails on it.** Found by
installing the released `v4.0.2-4` net ISO in a VM:

```
error (ignored): cannot add path '/nix/store/…-update-users-groups.pl'
  because it lacks a signature by a trusted key
error: cannot add path '/nix/store/…-lib.sh' because it lacks a signature by a trusted key
nixarchy-install: the system did not build; nothing was installed.
```

## Why

A path built on the installing machine has no signature, and a fresh store
refuses unsigned paths. `auto?trusted=1` does **not** cover it — that marks the
*source* trusted to fetch from; the destination still validates on add.

Reproduced directly:

```
$ nix copy --to /scratch  $unsigned_path
error: cannot add path '…' because it lacks a signature by a trusted key

$ nix copy --to '/scratch?require-sigs=false'  $unsigned_path
copying path '…' to 'local://'      present: yes
```

The two paths named are NixOS' own assembly derivations — the
`allowSubstitutes = false` ones `SUBSTITUTE_FLAGS`' comment is about — so they
are always built rather than fetched, and therefore always unsigned. **There is
no machine on which this does not happen.**

## The part that matters more than the fix

`tests/install.nix:305` already knew, and says so at length:

> Every path this test seeded … carries no signature, so with require-sigs on,
> /mnt refuses all of them — "cannot add path … because it lacks a signature by
> a trusted key" — and falls back to building what it cannot copy … the whole
> source bootstrap from stage0-posix appears and the install dies fetching
> bash's tarball.

It sets `require-sigs = false` **inside the test VM**. The ISO does not set it.
So the install checks pass whether or not the installer asks for it — which is
exactly how #251 went green while being broken on every real machine.

Same shape as the RAM-backed store overlay earlier today: the condition was
understood, fixed where it was cheap, and left exposed where a user meets it.

## The check, and the one I got wrong first

`checks.installer-store-space` asserts it, because no install check can.

My first version grepped for `require-sigs=false` — which **also matches the
comment explaining it**, so deleting the flag left the check green. A check that
cannot fail is the thing this PR is complaining about, so that was worth
catching. Found by breaking it. It now matches the URI form:

```
the target-store build does not pass require-sigs=false.
  cannot add path '...' because it lacks a signature by a trusted key
```

## Safety

The target store is one this script created, on a disk it formatted, populated
from this machine's own store, as root. There is nothing here for a signature to
protect against.