### PR TITLE
The doctor and verify are installed, so the commands that name them work

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -264,6 +264,103 @@
     in
     {
       overlays.default = final: _prev: {
+
+        # nixarchy-doctor and nixarchy-verify live here rather than only under
+        # `packages` so the module can install them. A module cannot take them
+        # from inputs.self.packages -- see the note on programs.nixarchy.package
+        # in modules/nixos.nix: those are built from NIXARCHY's nixpkgs, and
+        # mixing instances makes buildEnv refuse the profile with two builds of
+        # the same version. The overlay is how this repo hands a package to a
+        # configuration, and `packages.doctor` now just names the overlay's.
+        nixarchy-doctor = final.writeShellApplication {
+          name = "nixarchy-doctor";
+          runtimeInputs = with final; [
+            systemd
+            gnused
+            gnugrep
+            gawk
+            coreutils
+          ];
+          # @apps@ is the app-to-command table, generated here for the same
+          # reason the menu's is: the doctor has to answer "which of these do
+          # you already have" on a machine that has never had nixarchy, so it
+          # cannot ask the running system and cannot be handed a list by it.
+          #
+          # meta.mainProgram where nixpkgs states one -- it is right where the
+          # attribute name is wrong, and vscode putting `code` on PATH is not a
+          # guess anyone would make. tryEval because unfree packages throw at
+          # evaluation when allowUnfree is off.
+          text =
+            builtins.replaceStrings
+              [ "@apps@" ]
+              [
+                (
+                  let
+                    pkgs = final;
+                    apps = import ./data/apps.nix;
+                    usable = final.lib.filterAttrs (_: a: !(a ? unavailable)) apps;
+                    binaryOf =
+                      name: app:
+                      let
+                        probe = builtins.tryEval (
+                          let
+                            # nixarchy-apps first, then the top level. Apps
+                            # this repo packages live under nixarchy-apps, so
+                            # probing only the top level returned null for every
+                            # one of them and the fallback answered with the
+                            # attribute name. That is right by luck when the
+                            # attribute matches the binary -- once, omacut,
+                            # ttfx -- and wrong when it does not: `zen` for a
+                            # package installing bin/zen-beta, `hey-cli` for one
+                            # installing bin/hey. Both were reported as absent
+                            # on machines that had them.
+                            path = final.lib.splitString "." (app.attr or name);
+                            p = final.lib.attrByPath path (final.lib.attrByPath path null pkgs) pkgs.nixarchy-apps;
+                          in
+                          if p == null then null else (p.meta.mainProgram or null)
+                        );
+                      in
+                      if probe.success && probe.value != null then probe.value else name;
+                  in
+                  final.lib.concatStringsSep "\n" (
+                    final.lib.mapAttrsToList (n: a: "${binaryOf n a}\t${a.label or n}") usable
+                  )
+                )
+              ]
+              (builtins.readFile ./pkgs/doctor.sh);
+        };
+
+        nixarchy-verify = final.writeShellApplication {
+          name = "nixarchy-verify";
+          runtimeInputs = with final; [
+            systemd
+            gnugrep
+            gnused
+            coreutils
+            findutils
+            glib
+            bluez
+            # pgrep and ps. The Session and Screen sharing probes both look for
+            # a running process by name, and writeShellApplication's PATH does
+            # not carry the caller's -- an undeclared pgrep here is a probe that
+            # reports "not running" for everything.
+            procps
+            # awk, in the Session section's quickshell match. Undeclared until
+            # the Fails-in-silence probes went in and the list was read again.
+            gawk
+            # wpctl. "pipewire is running" and "there is a sink" are different
+            # questions and only wireplumber answers the second.
+            wireplumber
+            # The menu-row probe. The menu is JSONC -- comments and trailing
+            # commas -- and the shell's own parser is three lines of Python
+            # that build.yml and both VM tests already share. A fourth
+            # spelling of it in sed would be a parser that disagrees with the
+            # shell, reporting on a menu nobody has.
+            python3
+          ];
+          text = builtins.readFile ./pkgs/verify.sh;
+        };
+
         # Apps Omarchy offers that nixpkgs does not carry. Packaged here so a
         # NixOS user gets the same menu Arch users do, rather than a menu with
         # holes in it.
@@ -538,36 +635,7 @@
           # reasoning as `verify` and `doctor` just below.
           nixarchy-vm = pkgsFor.${system}.callPackage ./pkgs/microvm.nix { inherit self; };
 
-          verify = pkgsFor.${system}.writeShellApplication {
-            name = "nixarchy-verify";
-            runtimeInputs = with pkgsFor.${system}; [
-              systemd
-              gnugrep
-              gnused
-              coreutils
-              findutils
-              glib
-              bluez
-              # pgrep and ps. The Session and Screen sharing probes both look for
-              # a running process by name, and writeShellApplication's PATH does
-              # not carry the caller's -- an undeclared pgrep here is a probe that
-              # reports "not running" for everything.
-              procps
-              # awk, in the Session section's quickshell match. Undeclared until
-              # the Fails-in-silence probes went in and the list was read again.
-              gawk
-              # wpctl. "pipewire is running" and "there is a sink" are different
-              # questions and only wireplumber answers the second.
-              wireplumber
-              # The menu-row probe. The menu is JSONC -- comments and trailing
-              # commas -- and the shell's own parser is three lines of Python
-              # that build.yml and both VM tests already share. A fourth
-              # spelling of it in sed would be a parser that disagrees with the
-              # shell, reporting on a menu nobody has.
-              python3
-            ];
-            text = builtins.readFile ./pkgs/verify.sh;
-          };
+          verify = pkgsFor.${system}.nixarchy-verify;
 
           # `nix run .#review` -- what needs updating, and what is quietly
           # broken. An app rather than a check because it asks GitHub what
@@ -622,63 +690,7 @@
           # system and prints the configuration it would need. Runnable before
           # nixarchy is an input anywhere, which is the only entry point someone
           # deciding whether to adopt it actually has.
-          doctor = pkgsFor.${system}.writeShellApplication {
-            name = "nixarchy-doctor";
-            runtimeInputs = with pkgsFor.${system}; [
-              systemd
-              gnused
-              gnugrep
-              gawk
-              coreutils
-            ];
-            # @apps@ is the app-to-command table, generated here for the same
-            # reason the menu's is: the doctor has to answer "which of these do
-            # you already have" on a machine that has never had nixarchy, so it
-            # cannot ask the running system and cannot be handed a list by it.
-            #
-            # meta.mainProgram where nixpkgs states one -- it is right where the
-            # attribute name is wrong, and vscode putting `code` on PATH is not a
-            # guess anyone would make. tryEval because unfree packages throw at
-            # evaluation when allowUnfree is off.
-            text =
-              builtins.replaceStrings
-                [ "@apps@" ]
-                [
-                  (
-                    let
-                      pkgs = pkgsFor.${system};
-                      apps = import ./data/apps.nix;
-                      usable = nixpkgs.lib.filterAttrs (_: a: !(a ? unavailable)) apps;
-                      binaryOf =
-                        name: app:
-                        let
-                          probe = builtins.tryEval (
-                            let
-                              # nixarchy-apps first, then the top level. Apps
-                              # this repo packages live under nixarchy-apps, so
-                              # probing only the top level returned null for every
-                              # one of them and the fallback answered with the
-                              # attribute name. That is right by luck when the
-                              # attribute matches the binary -- once, omacut,
-                              # ttfx -- and wrong when it does not: `zen` for a
-                              # package installing bin/zen-beta, `hey-cli` for one
-                              # installing bin/hey. Both were reported as absent
-                              # on machines that had them.
-                              path = nixpkgs.lib.splitString "." (app.attr or name);
-                              p = nixpkgs.lib.attrByPath path (nixpkgs.lib.attrByPath path null pkgs) pkgs.nixarchy-apps;
-                            in
-                            if p == null then null else (p.meta.mainProgram or null)
-                          );
-                        in
-                        if probe.success && probe.value != null then probe.value else name;
-                    in
-                    nixpkgs.lib.concatStringsSep "\n" (
-                      nixpkgs.lib.mapAttrsToList (n: a: "${binaryOf n a}\t${a.label or n}") usable
-                    )
-                  )
-                ]
-                (builtins.readFile ./pkgs/doctor.sh);
-          };
+          doctor = pkgsFor.${system}.nixarchy-doctor;
 
           # `nix run .#devenv-presets` -- scaffolds every preset in
           # data/devenv-presets.nix with the real `nixarchy dev init`, then asks a

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -887,6 +887,24 @@ in
         };
 
         environment.systemPackages = [
+          # The doctor and verify, which until now were flake apps only.
+          #
+          # `nixarchy doctor` has always been an advertised subcommand, and on
+          # every machine where you can type `nixarchy` it answered "The doctor
+          # is not installed". The dispatcher below already has
+          # `if command -v nixarchy-doctor` and routes to it -- a branch nothing
+          # could take, because nothing installed it.
+          #
+          # Running from the flake is unchanged: that entry point exists so the
+          # doctor can be run BEFORE nixarchy is an input anywhere, and
+          # installing it does not take that away.
+          #
+          # Through the overlay on the user's own pkgs, never
+          # inputs.self.packages -- see the note on programs.nixarchy.package in
+          # modules/nixos.nix for what mixing nixpkgs instances does to buildEnv.
+          (pkgs.extend inputs.self.overlays.default).nixarchy-doctor
+          (pkgs.extend inputs.self.overlays.default).nixarchy-verify
+
           # Uncomments one app in ~/.config/nixarchy/apps.nix. Matching is on
           # the `#@ <id>` marker, not a line number or a label, so the file
           # survives being reformatted, reordered or annotated by hand.
@@ -1766,6 +1784,7 @@ in
                 # the only entry point someone deciding whether to adopt it
                 # actually has. Route to the command that works rather than to
                 # a binary that is not there.
+                verify)   shift; exec nixarchy-verify "$@" ;;
                 doctor)
                   if command -v nixarchy-doctor >/dev/null 2>&1; then
                     shift; exec nixarchy-doctor "$@"


### PR DESCRIPTION
A user ran `nixarchy doctor` and got:

```
The doctor is not installed -- it runs from the flake, so that it
works on a machine that has not adopted nixarchy yet:

  nix run github:olafkfreund/nixarchy#doctor
```

## The dispatcher already knew better

```bash
doctor)
  if command -v nixarchy-doctor >/dev/null 2>&1; then
    shift; exec nixarchy-doctor "$@"
  fi
```

**A branch nothing could ever take**, because nothing installed the binary.
`systemPackages` carried twelve `nixarchy-*` commands; `nixarchy-doctor` and
`nixarchy-verify` were the only two missing, and `nixarchy verify` was not
reachable from the dispatcher at all.

## Running from the flake is unchanged

That message was not wrong about *why* — `nix run …#doctor` exists so the doctor
can be run **before** nixarchy is an input anywhere, which is the only entry
point someone deciding whether to adopt it has. It just was not the whole story.
The two answer different questions and both should work.

## Through the overlay, not `inputs.self.packages`

This is why the diff is bigger than "add two names to a list": both definitions
moved from `packages` into `overlays.default`, and `packages.doctor` now names
the overlay's.

The note on `programs.nixarchy.package` in `modules/nixos.nix` explains why that
is not cosmetic — `inputs.self.packages` is built from **nixarchy's** nixpkgs, so
every runtime dependency comes from a different instance than the rest of the
user's system, and the first package they also install themselves makes
`buildEnv` refuse the profile:

> two given paths contain a conflicting subpath:
>   …/tesseract-5.5.3/bin/tesseract and …/tesseract-5.5.3/bin/tesseract

Two builds of the same version. That was found by building a real config; this
avoids repeating it.

## Verified

On the reference host: both are in `sw/bin`, `nixarchy verify` routes, the
doctor's previously-dead branch is live and runs, and `nix build .#doctor
.#verify` still works from the flake.

## Not in this PR

The **`gpu` subcommand does not exist** — a user asked for `nixarchy doctor gpu`
and there is no such thing. That is the graphics probe from the approved plan and
it is separate work. This PR only makes the doctor reachable; it adds no new
diagnosis.