### PR TITLE
The doctor reads the GPU and says what it needs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,11 @@ jobs:
       # checks.install cannot see this: it installs onto a machine whose store
       # fits, which is the only shape that does not fail. So the decision is
       # unit-tested here instead, in seconds.
+      # The doctor's GPU rules, against fixture machines. checks.install's VM
+      # has no PCI display controller, so nothing else can reach these branches.
+      - name: The doctor reads a GPU correctly
+        run: nix build .#checks.x86_64-linux.doctor-graphics --print-build-logs
+
       - name: The installer refuses a build the live store cannot hold
         run: nix build .#checks.x86_64-linux.installer-store-space --print-build-logs
 

--- a/flake.nix
+++ b/flake.nix
@@ -280,6 +280,18 @@
             gnugrep
             gawk
             coreutils
+            # vainfo, for the Graphics section. Declared because
+            # writeShellApplication builds a strict PATH, and an undeclared
+            # vainfo does not read as "vainfo is missing" -- it reads as "no
+            # VAAPI driver answered", which is a different and much worse
+            # answer to hand someone. It ran anyway while this was being
+            # written, from the developer's own PATH, which is exactly how
+            # that goes unnoticed.
+            #
+            # No pciutils: the GPUs come from /sys/bus/pci, the same way the
+            # Bluetooth check reads /sys/class/bluetooth, and sysfs hands over
+            # the PCI address already in the form the bus IDs need.
+            libva-utils
           ];
           # @apps@ is the app-to-command table, generated here for the same
           # reason the menu's is: the doctor has to answer "which of these do
@@ -1149,6 +1161,11 @@
         # The installer's interactive screens, at every width worth caring
         # about. Nothing else draws them: every other harness passes
         # --answers, which is exactly how #133 shipped.
+        doctor-graphics = import ./tests/doctor-graphics.nix {
+          pkgs = pkgsFor.${system};
+          inherit (self.packages.${system}) doctor;
+        };
+
         installer-store-space = import ./tests/installer-store-space.nix {
           pkgs = pkgsFor.${system};
           installScript = ./installer/install.sh;

--- a/pkgs/doctor.sh
+++ b/pkgs/doctor.sh
@@ -466,6 +466,110 @@ fi
 # Unit names as systemd spells them, not lowercased: NetworkManager.service is
 # capitalised, and lowercasing it returned not-found -- which this reported as
 # "NetworkManager is off here" on a machine where it was enabled.
+# ---- graphics ------------------------------------------------------------
+# Three faults on one laptop in one day, all from nothing here looking at the
+# GPU: a recorder that cannot encode, an environment variable pinning libva to
+# a decode-only driver, and an unconfigured hybrid.
+#
+# sysfs rather than lspci, for the same reason the Bluetooth check below reads
+# /sys/class/bluetooth: it is already there, needs no package, and works on a
+# machine that has adopted nothing. It also hands over the PCI address in the
+# form the conversion needs -- lspci would have to be parsed back out of.
+say "${bold}Graphics${off}"
+
+igpu="" igpu_addr="" dgpu="" dgpu_addr=""
+# The path is a variable so the check can point it at fixtures. sysfs is the
+# one input here that cannot be faked any other way, and a GPU rule nobody can
+# test is a GPU rule nobody should trust -- checks.install's VM has no GPU at
+# all, so this is the only way these branches are ever exercised.
+: "${NIXARCHY_SYSFS_PCI:=/sys/bus/pci/devices}"
+for d in "$NIXARCHY_SYSFS_PCI"/*/; do
+  [ -r "$d/class" ] && [ -r "$d/vendor" ] || continue
+  # 0x03xxxx is a display controller. Anything else is not a GPU.
+  case "$(cat "$d/class")" in 0x03*) ;; *) continue ;; esac
+  case "$(cat "$d/vendor")" in
+    0x10de) dgpu="NVIDIA" dgpu_addr=$(basename "$d") ;;
+    0x8086) igpu="Intel"  igpu_addr=$(basename "$d") ;;
+    0x1002) [ -n "$igpu" ] || { igpu="AMD" igpu_addr=$(basename "$d"); } ;;
+  esac
+done
+
+# 0000:01:00.0 -> PCI:1:0:0. Hexadecimal in sysfs and in lspci, DECIMAL in Nix,
+# which nixos-gpu/SKILL.md flags as a trap because it is one -- and is the whole
+# argument for a tool doing this instead of a person reading it off a screen.
+# printf %d on an 0x-prefixed string is bash's own hex conversion.
+pci_nix() {
+  local rest=${1#*:} bus dev fn
+  bus=${rest%%:*} rest=${rest#*:} dev=${rest%%.*} fn=${rest#*.}
+  printf 'PCI:%d:%d:%d' "0x$bus" "0x$dev" "0x$fn"
+}
+
+# Can it ENCODE, which is a different question from whether VAAPI works.
+#
+# A driver that opens and returns 0 still cannot record if every profile it
+# reports is VAEntrypointVLD -- VLD is decode. nvidia-vaapi-driver is an NVDEC
+# wrapper and is decode-only by design, so `va_openDriver() returns 0` was the
+# reassuring half of a report from a machine that could not record at all.
+# Overridable for the same reason NIXARCHY_SYSFS_PCI is: writeShellApplication
+# PREPENDS its runtimeInputs to PATH, so a stub earlier in PATH never wins and
+# the check silently measured libva-utils' own vainfo finding no driver. Every
+# fixture then looked "decode only", including the one that can encode.
+: "${NIXARCHY_VAINFO:=vainfo}"
+va=$("$NIXARCHY_VAINFO" 2>/dev/null) || true
+va_driver=$(printf '%s' "$va" | sed -n 's/.*Driver version: //p') || true
+enc=$(printf '%s' "$va" | grep -c 'VAEntrypointEncSlice' 2>/dev/null) || enc=0
+
+if [ -z "$igpu$dgpu" ]; then
+  say "  ${dim}No PCI display controller here -- a VM, or a framebuffer.${off}"
+elif [ -z "$va" ]; then
+  finding "No VAAPI driver answered" "$warn" "video will decode and encode on the CPU"
+  snippet+=("  hardware.graphics.extraPackages = with pkgs; [ intel-media-driver ];")
+  notes+=("Nothing answered vainfo. On Intel that is usually intel-media-driver, which mesa does not ship; AMD gets one from mesa already.")
+elif [ "$enc" -gt 0 ]; then
+  finding "Video encoding available" "$ok" "${va_driver:-a VAAPI driver}"
+else
+  finding "This driver cannot encode" "$warn" "${va_driver:-VAAPI}, decode only"
+  notes+=("vainfo reports no VAEntrypointEncSlice, so screen recording and any encoder that wants the GPU will fail. nvidia-vaapi-driver is decode-only by design; Intel's iHD, from intel-media-driver, does encode.")
+  snippet+=("  hardware.graphics.extraPackages = with pkgs; [ intel-media-driver ];")
+fi
+
+# And the variable that hides all of the above. Set to a decode-only driver, it
+# stops libva ever trying the one that could encode -- which is exactly what
+# happened on the machine this section was written for.
+if [ -n "${LIBVA_DRIVER_NAME:-}" ]; then
+  if [ "$enc" -eq 0 ] && [ -n "$va" ]; then
+    finding "LIBVA_DRIVER_NAME is pinning libva" "$warn" "to '$LIBVA_DRIVER_NAME', which cannot encode"
+    notes+=("LIBVA_DRIVER_NAME='$LIBVA_DRIVER_NAME' stops libva trying any other driver. Unset it and run vainfo again before adding packages -- the encoder may already be installed and simply never reached.")
+  else
+    finding "LIBVA_DRIVER_NAME is set" "$ok" "'$LIBVA_DRIVER_NAME'"
+  fi
+fi
+
+# Hybrid. Both GPUs present and no prime configuration is the browser-crashing,
+# battery-eating default, and the bus IDs are the part nobody gets right by hand.
+if [ -n "$igpu" ] && [ -n "$dgpu" ]; then
+  finding "Hybrid graphics" "$warn" "$igpu + $dgpu, no PRIME configuration read"
+  ibus=$(pci_nix "$igpu_addr") nbus=$(pci_nix "$dgpu_addr")
+  snippet+=("")
+  snippet+=("  # $igpu + $dgpu. Bus IDs read from sysfs and converted to decimal.")
+  snippet+=("  hardware.nvidia.prime = {")
+  snippet+=("    offload.enable = true;")
+  snippet+=("    offload.enableOffloadCmd = true;   # gives you \`nvidia-offload <cmd>\`")
+  if [ "$igpu" = Intel ]; then
+    snippet+=("    intelBusId = \"$ibus\";")
+  else
+    snippet+=("    amdgpuBusId = \"$ibus\";")
+  fi
+  snippet+=("    nvidiaBusId = \"$nbus\";")
+  snippet+=("  };")
+  snippet+=("  # Or sync mode instead -- dGPU drives everything: best performance,")
+  snippet+=("  # worst battery. The two are mutually exclusive; pick one.")
+  snippet+=("  #   hardware.nvidia.prime.sync.enable = true;")
+  notes+=("offload is written above because it is the better default on a laptop, but it IS a choice: offload for battery, sync for performance. Read both before rebuilding.")
+elif [ -n "$dgpu" ]; then
+  finding "Discrete $dgpu only" "$ok" "no hybrid setup needed"
+fi
+
 # ---- what a laptop or a shared machine will want to know ----------------
 say "${bold}Worth turning on${off}"
 if [ -d /sys/class/bluetooth ] && [ -n "$(ls -A /sys/class/bluetooth 2>/dev/null)" ]; then
@@ -483,21 +587,21 @@ else
   finding "You are not in the input group" "$warn" ""
   say "     Omarchy's dictation tools and controllers need it. nixarchy adds"
   say "     it for the user you name:"
-  say "       programs.nixarchy.user = \"$USER\";"
+  say "       programs.nixarchy.user = \"${USER:-$(id -un)}\";"
 fi
 say ""
 
-say "  ${dim}programs.nixarchy.browserThemeUser = \"$USER\" tints Chromium with"
+say "  ${dim}programs.nixarchy.browserThemeUser = \"${USER:-$(id -un)}\" tints Chromium with"
 say "  the current theme. Off by default: it hands that user the browsers'"
 say "  policy directories, which on a shared machine is policy for everyone."
 say "  Light and dark already follow the theme without it.${off}"
 
-case "${SHELL##*/}" in
+case "$(basename "${SHELL:-unknown}")" in
   bash | zsh | fish)
-    finding "Omarchy's shell chain covers ${SHELL##*/}" "$ok" ""
+    finding "Omarchy's shell chain covers $(basename "${SHELL:-unknown}")" "$ok" ""
     ;;
   *)
-    finding "Your shell is ${SHELL##*/}" "$warn" ""
+    finding "Your shell is $(basename "${SHELL:-unknown}")" "$warn" ""
     say "     The chain reaches bash, zsh and fish. You would keep the menus"
     say "     and the desktop, and lose the aliases and functions."
     ;;
@@ -515,14 +619,14 @@ esac
 # disagrees: the rc the current system installed, against the PATH this
 # session inherited.
 devenv_rc=""
-case "${SHELL##*/}" in
+case "$(basename "${SHELL:-unknown}")" in
   bash) devenv_rc=/etc/bashrc ;;
   zsh) devenv_rc=/etc/zshrc ;;
   fish) devenv_rc=/etc/fish/config.fish ;;
 esac
 if [ -n "$devenv_rc" ] && [ -r "$devenv_rc" ] && grep -q 'devenv hook' "$devenv_rc"; then
   if command -v devenv >/dev/null 2>&1; then
-    finding "devenv activates in ${SHELL##*/}" "$ok" "cd into a devenv allow'ed project"
+    finding "devenv activates in ${SHELL:-unknown}" "$ok" "cd into a devenv allow'ed project"
   else
     finding "devenv is selected but not on this session's PATH" "$warn" ""
     say "     ${devenv_rc} has the activation hook, so the rebuild landed."

--- a/tests/doctor-graphics.nix
+++ b/tests/doctor-graphics.nix
@@ -1,0 +1,86 @@
+{ pkgs, doctor }:
+# The doctor's Graphics section, driven against fixture machines.
+#
+# checks.install's VM runs llvmpipe and has no PCI display controller at all,
+# so it can never reach any branch of this. The rules would be untested in a
+# repo full of tests, which is the shape that let #251 ship broken and green.
+#
+# So: a fake /sys/bus/pci (NIXARCHY_SYSFS_PCI) and a stub vainfo on PATH. Both
+# are the only inputs the section has, which is why it was written to take them
+# from one variable and one command rather than from lspci.
+#
+# The fixtures are real. The decode-only vainfo is the shape a reporter's
+# NVIDIA laptop actually printed -- eighteen profiles, every one VLD -- and the
+# hybrid addresses are an ordinary Intel iGPU at 00:02.0 with a dGPU at 01:00.0.
+pkgs.runCommand "nixarchy-doctor-graphics" { nativeBuildInputs = [ pkgs.gnugrep ]; } ''
+  mk() { mkdir -p "$1/$2"; echo 0x030000 > "$1/$2/class"; echo "$3" > "$1/$2/vendor"; }
+  mkdir -p fix/bin
+  mk fix/hybrid "0000:00:02.0" 0x8086
+  mk fix/hybrid "0000:01:00.0" 0x10de
+  mk fix/amd    "0000:e3:00.0" 0x1002
+
+  # Decode only: a driver that opens, returns 0, and cannot record a thing.
+  printf '#!/bin/sh\necho "vainfo: Driver version: VA-API NVDEC driver"\necho "  VAProfileH264Main : VAEntrypointVLD"\n' > fix/bin/vainfo
+  # And one that can.
+  printf '#!/bin/sh\necho "vainfo: Driver version: Mesa Gallium radeonsi"\necho "  VAProfileH264Main : VAEntrypointEncSlice"\n' > fix/bin/vainfo-enc
+  chmod +x fix/bin/vainfo fix/bin/vainfo-enc
+
+  # HOME and USER because the doctor reads ~/.config and names the user in its
+  # snippet, and a build sandbox has neither -- without them it dies on line 24
+  # under `set -u` and prints nothing at all, which reads exactly like a rule
+  # that found nothing. That cost a debugging round; it is what the empty-output
+  # guard below is for.
+  export HOME=$PWD/home USER=tester
+  mkdir -p "$HOME"
+
+  run() { # run <sysfs> <vainfo> [LIBVA_DRIVER_NAME]
+    ( export NIXARCHY_VAINFO="$PWD/fix/bin/$2" NIXARCHY_SYSFS_PCI="$PWD/fix/$1"
+      # export, not a `VAR=val cmd` prefix built by expansion: a word coming out
+      # of ''${3:+...} is a COMMAND to bash, not an assignment, and it failed with
+      # "LIBVA_DRIVER_NAME=nvidia: command not found".
+      # `if`, not `&&`: the builder runs under `set -e`, so a test that is false
+      # is a non-zero last status and kills the subshell before the doctor runs.
+      # The case with no third argument produced no output at all because of it.
+      if [ -n "''${3-}" ]; then export LIBVA_DRIVER_NAME="$3"; fi
+      ${doctor}/bin/nixarchy-doctor 2>&1 ) || true
+  }
+
+  fails=0
+  want() { # want <name> <output> <pattern>
+    if printf '%s' "$2" | grep -q "$3"; then echo "  ok      $1"
+    else echo "  FAILED  $1: no /$3/ in the output"; fails=$((fails + 1)); fi
+  }
+  wantnot() {
+    if printf '%s' "$2" | grep -q "$3"; then
+      echo "  FAILED  $1: /$3/ present and should not be"; fails=$((fails + 1))
+    else echo "  ok      $1"; fi
+  }
+
+  h=$(run hybrid vainfo nvidia)
+  # Every `want` below fails identically when the doctor produced nothing, which
+  # is indistinguishable from every rule being wrong. Say which it is.
+  printf '%s' "$h" | grep -q 'Graphics' || {
+    echo "the doctor printed no Graphics section at all:"; printf '%s\n' "$h"; exit 1; }
+  want "hybrid is detected"          "$h" 'Hybrid graphics'
+  want "decode-only driver is named" "$h" 'cannot encode'
+  want "the libva pin is named"      "$h" 'pinning libva'
+  # The conversion is the load-bearing arithmetic: sysfs and lspci print these
+  # in hex, Nix wants decimal, and nixos-gpu/SKILL.md flags it as a trap. A
+  # wrong answer here is a machine that will not start a desktop.
+  want "intel bus id, hex->decimal"  "$h" 'intelBusId = "PCI:0:2:0"'
+  want "nvidia bus id, hex->decimal" "$h" 'nvidiaBusId = "PCI:1:0:0"'
+  # offload is written; sync is offered, never chosen for them.
+  want "offload is written"          "$h" 'offload.enable = true'
+  want "sync is offered as a choice" "$h" 'prime.sync.enable'
+
+  a=$(run amd vainfo-enc)
+  want    "encode is recognised"     "$a" 'Video encoding available'
+  wantnot "single GPU is not hybrid" "$a" 'Hybrid graphics'
+  # e3 is the case that makes the conversion undeniable: read as decimal it is
+  # nonsense, and this machine really has a GPU there.
+  wantnot "no prime for one GPU"     "$a" 'nvidiaBusId'
+
+  [ "$fails" = 0 ] || { echo "$fails case(s) failed"; exit 1; }
+  echo "the doctor reads a GPU correctly"
+  touch $out
+''


### PR DESCRIPTION
Stacked on #283 (which installs the doctor). Retarget to `main` once that merges.

Three faults on one Intel + NVIDIA laptop in a day, all from nothing looking at
the GPU. The doctor now answers all three.

## What it prints

Against a synthetic hybrid machine with the reporter's real `vainfo` shape:

```
Graphics
  · This driver cannot encode              VAAPI, decode only
  · LIBVA_DRIVER_NAME is pinning libva     to 'nvidia', which cannot encode
  · Hybrid graphics                        Intel + NVIDIA, no PRIME configuration read
```

and under **Add this to your configuration**:

```nix
hardware.nvidia.prime = {
  offload.enable = true;
  offload.enableOffloadCmd = true;   # gives you `nvidia-offload <cmd>`
  intelBusId  = "PCI:0:2:0";
  nvidiaBusId = "PCI:1:0:0";
};
# Or sync mode instead -- dGPU drives everything: best performance,
# worst battery. The two are mutually exclusive; pick one.
#   hardware.nvidia.prime.sync.enable = true;
```

That is a diagnosis that took an afternoon, printed in a second.

## Decisions

**sysfs, not lspci** — the same way the Bluetooth check reads
`/sys/class/bluetooth`. No package, works on a machine that has adopted nothing,
and hands over the PCI address already in the form the bus IDs need.

**Bus IDs are converted.** Hex in sysfs and lspci, decimal in Nix;
`nixos-gpu/SKILL.md` calls it a trap. This machine's GPU is at `e3` — 227.

**`offload` written, `sync` offered.** A real choice between battery and
performance. Same policy as `nixarchy-search`'s `add_option`: write a value only
when the type makes it finite, otherwise scaffold it with the reasoning.

## Two testability hooks, both found by being wrong

`NIXARCHY_SYSFS_PCI` and `NIXARCHY_VAINFO`. The second matters:
**`writeShellApplication` PREPENDS `runtimeInputs` to PATH**, so a stub earlier
in PATH never wins — the check was silently measuring `libva-utils`' own
`vainfo` finding no driver, and *every* fixture looked "decode only", including
the one that can encode. A passing test of a broken rule.

`libva-utils` is declared for the same class of reason: an undeclared `vainfo`
reads as "no VAAPI driver answered", not "vainfo is missing". It ran anyway
while I was writing this, from my own PATH, which is how that goes unnoticed.

## Also fixed

`$USER` and `$SHELL` were unguarded under `set -u` — the doctor died partway and
printed a truncated report with nothing saying why.

## The check

`checks.install`'s VM has no PCI display controller, so nothing else can reach
these branches. `checks.doctor-graphics` drives the section against fixtures —
the reporter's decode-only `vainfo`, an encoding one, a hybrid, a single GPU.

Each rule proved by breaking it and watching it fail by name:

```
break the hex conversion  -> FAILED intel bus id, hex->decimal
                             FAILED nvidia bus id, hex->decimal
break the encode test     -> FAILED decode-only driver is named
                             FAILED the libva pin is named
break the vendor match    -> FAILED hybrid is detected
```

All ten green with them restored.

## Not here

The `gpu` subcommand, writing to `advanced.nix`, and install-time configuration.
The rules have been right on one real machine and a set of fixtures. That is not
enough to start writing into someone's configuration unasked.