### PR TITLE
nightly: stop archiving the ISO to a disk the runners will not write to

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,10 +9,19 @@ name: nightly
 # all, and installs a 15.3 GB closure into a qcow2. That is about an hour and
 # roughly 16 GB of build directory, on a machine with /dev/kvm.
 #
-# So they run here, nightly, on p510 -- 40 cores, 94 GB, KVM, and room for the
-# images: builds land in /home (its own disk, 829 GB free) and the ISO copies
-# below go on /mnt/img_pool (840 GB free). See hosts/p510/nixos/github-runner.nix
-# in the NixOS config repo for the runner itself.
+# So they run here, nightly, on the self-hosted runners -- p510 (40 cores,
+# 94 GB, KVM) and p620 -- where builds land on each host's own build-dir
+# (`/home/nix-build` on p510, `/mnt/games/nix-build` on p620) with hundreds of
+# gigabytes free. See hosts/*/nixos/github-runner.nix in the NixOS config repo
+# for the runners themselves.
+#
+# Nothing here writes outside the Nix store. An earlier version archived each
+# night's ISO to /mnt/img_pool on p510; that never once succeeded (the runner
+# units are ProtectSystem=strict with an empty ReadWritePaths) and it was aimed
+# at the wrong disk anyway -- /mnt/img_pool is p510's SMR drive, which the host
+# deliberately avoids writing to, and it does not exist as a filesystem on p620
+# at all. The ISO's store path is printed in the job summary instead; anyone who
+# wants a copy of a particular night's image can pin it by hand from there.
 #
 # Nightly rather than per-push on purpose. An hour of wall clock per push would
 # make the queue the bottleneck, and what these protect against -- a package
@@ -89,8 +98,8 @@ jobs:
           # had built perfectly well. Bash can split two fields by itself.
           read -r _ closure < <(nix path-info -Sh \
             .#nixosConfigurations.reference.config.system.build.toplevel)
-          printf '| | |\n|---|---|\n| ISO | %s |\n| closure | %s |\n' \
-            "$size" "$closure" | tee -a "$GITHUB_STEP_SUMMARY"
+          printf '| | |\n|---|---|\n| ISO | %s |\n| closure | %s |\n| store path | %s |\n' \
+            "$size" "$closure" "$iso" | tee -a "$GITHUB_STEP_SUMMARY"
 
       # The number the size report prints is only useful if something acts on
       # it. This is that. It builds the network image too, which is the one
@@ -104,33 +113,6 @@ jobs:
 
       - name: Install from it with no network device present
         run: nix build .#checks.x86_64-linux.install-iso --print-build-logs
-
-      - name: Keep a date-stamped copy
-        run: |
-          # On the pool, not as a workflow artifact. A 5.6 GB upload every
-          # night would pass GitHub's free artifact storage in two days and
-          # cost money on the third, to produce a file that already exists on
-          # the machine that built it. Publishing belongs to a tag, which is
-          # what the release workflow is for.
-          #
-          # A symlink into the store rather than a copy: the store path is
-          # already immutable and already there, so this costs nothing until
-          # the store is garbage collected, and `nix-store --add-root` is what
-          # stops that happening.
-          out=$(nix build .#iso --no-link --print-out-paths)
-          iso=$(echo "$out"/iso/*.iso)
-          stamp=$(date -u +%Y-%m-%d)
-          dir=/mnt/img_pool/nixarchy-iso
-          mkdir -p "$dir"
-          nix-store --add-root "$dir/nixarchy-$stamp.iso" --indirect -r "$out" >/dev/null
-          ln -sfn "$iso" "$dir/nixarchy-latest.iso"
-
-          # Fourteen nights. Enough to bisect "it worked last week" without
-          # letting a nightly build fill 840 GB over a year.
-          find "$dir" -maxdepth 1 -name 'nixarchy-????-??-??.iso' -mtime +14 -delete
-
-          printf '| nightly ISO | `%s` |\n' "$dir/nixarchy-$stamp.iso" \
-            | tee -a "$GITHUB_STEP_SUMMARY"
 
   # A failure at 03:00 that nobody sees until someone opens the Actions tab is
   # a failure that costs a day. This turns one into an issue.
@@ -240,10 +222,11 @@ jobs:
           body="The nightly $what: $RUN"
           body="$body
 
-          Both jobs run on the self-hosted runner on p510. If the failure is
-          'no space left', check both /home -- where the nix daemon builds --
-          and /mnt/img_pool, where the nightly ISO copies go. A VM test that
-          runs out of room does not fail cleanly, it wedges."
+          Both jobs run on a self-hosted runner (p510 or p620). If the
+          failure is 'no space left', check that host's nix build-dir and its
+          store -- /home/nix-build and / on p510, /mnt/games/nix-build and /
+          on p620. A VM test that runs out of room does not fail cleanly, it
+          wedges."
           existing=$(gh issue list --state open --search "$title in:title" \
             --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then


### PR DESCRIPTION
**This is a CI-gate change (AGENTS.md §10): a human merges it. I have not merged it and will not.**

Closes the last thing keeping the nightly red in #236.

## What this changes, and why

The ISO job's last step, `Keep a date-stamped copy`, has never once succeeded. It archived each night's ISO to `/mnt/img_pool/nixarchy-iso` on p510. That target was wrong in three independent ways, and I checked each on the machines rather than reasoning about it:

1. **The runners cannot write there.** Both units are sandboxed with an empty `ReadWritePaths`:
   ```
   $ systemctl show github-runner-nixarchy.service -p ProtectSystem -p ReadWritePaths
   ProtectSystem=strict
   ReadWritePaths=
   ```
   Identical on p510 and p620.

2. **It is the wrong disk.** `/mnt/img_pool` on p510 is `sda`, a `ST1000LM035-1RK172` — a DM-SMR drive the host deliberately avoids writing to. The healthy large disk on p510 is `/home` (`sdc`, WDC WD10EZEX, 809 GB free), which is already where nix builds: `build-dir = /home/nix-build`.

3. **It does not exist on the other runner.** Both jobs say `runs-on: [self-hosted, nixos, kvm, big]`, and p620 carries that label too. On p620 `/mnt/img_pool` is not a mount at all — just an empty root-owned `drwx--x--x` stub on `/`. `findmnt /mnt/img_pool` returns nothing; `stat -c %m` says `/`. p620's build-dir is `/mnt/games/nix-build`.

So my earlier suggestion on #236 — add `ReadWritePaths = [ "/mnt/img_pool" ]` to the runner units — was wrong, and I withdraw it. It would have pointed a nightly write loop at the one disk both hosts avoid, and it would still have failed on p620.

**The retention design was unsafe too, independently of the path.** Fourteen nightly `nix-store --add-root` GC roots pin fourteen ISO closures. p510's Nix store is on `/` (`sdb1`, 226 GB, **51 GB free**), with `min-free = 10 GB` / `max-free = 50 GB`, so nix auto-GCs to keep room to build. Fourteen pinned ~5.6 GB ISOs plus their closures would have fought the collector for the disk the job needs. Whatever we did about the write path, this loop should not run on p510 as written.

**Nothing consumes these copies.** `grep -rn 'img_pool\|nixarchy-latest'` matches only `nightly.yml` itself, and `/mnt/img_pool/nixarchy-iso` exists on neither host, so there is no history to lose. Publishing an ISO is `release.yml`'s job, as the step's own comment said.

The step is therefore **removed** rather than repointed (YAGNI: it has produced nothing in its lifetime and has no reader). The only genuinely useful thing it emitted — which ISO was built tonight — is kept by adding the store path to the size table already in the job summary, using the `$iso` variable that step already computes. One row, no new commands.

Two comments that sent readers to the wrong disk are corrected: the file header, and the auto-filed issue body that says "check … `/mnt/img_pool`, where the nightly ISO copies go". Both now name each host's real build-dir.

Also worth flagging for a reviewer, though **not** changed here: the header, the concurrency comment and the reporter all say "the runner on p510", but the label set matches p620 as well and jobs do land there. That's a factual drift in prose that this PR only partly fixes; the rest is out of scope.

## How I proved the check fails

There is no repo `checks.*` here — this is a workflow-only change, so the "check" is the step itself. I reproduced the exact failure on p510 under the same sandbox settings the runner unit uses:

```
$ ssh p510 sudo systemd-run --pipe --quiet \
    -p ProtectSystem=strict -p ReadWritePaths= \
    mkdir -p /mnt/img_pool/nixarchy-iso
mkdir: cannot create directory ‘/mnt/img_pool/nixarchy-iso’: Read-only file system
rc=1
```

Character-for-character the message in the failing nightly (run 33883083132, `Keep a date-stamped copy`). The fix is deletion, so "green with the fix" is "the step is no longer there" — the remaining steps are untouched, and the last one, `Install from it with no network device present`, has been passing since #238.

I did **not** run a nightly against this branch: `nightly.yml` has no `pull_request` trigger, so the change cannot be exercised until it is on `main` and the 03:00 run fires (or someone dispatches it). That is the one thing I could not verify end to end, and a reviewer should know it.

## Checks run locally

`actionlint` (which CI does not run) on the file, before and after: the change introduces no new finding, and removes the one `SC2016` shellcheck note the deleted step carried.

- [x] `nix fmt` / statix / deadnix are clean — no `.nix` file is touched
- [x] New files are `git add`ed — no new files
- [x] If this adds an option: `tests/options.nix` covers both states — n/a
- [x] If this adds a `checks.*` entry: n/a — no `checks` entry added or removed, so the coverage guard is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
