### PR TITLE
verify.sh notices a soft-blocked radio and says how to clear it

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -357,6 +357,10 @@
             # spelling of it in sed would be a parser that disagrees with the
             # shell, reporting on a menu nobody has.
             python3
+            # rfkill, for the Radios section (#277). An undeclared rfkill
+            # reads as "no radios on this machine" rather than "rfkill is
+            # missing" -- the same trap the doctor's vainfo hit.
+            util-linux
           ];
           text = builtins.readFile ./pkgs/verify.sh;
         };

--- a/pkgs/verify.sh
+++ b/pkgs/verify.sh
@@ -420,6 +420,39 @@ else
   fi
 fi
 
+# ---- radios ---------------------------------------------------------------
+# #277: rfkill and nmcli are both on a stock machine, but nothing looks at
+# rfkill state, so a soft-blocked radio -- a hardware key, a stray `nmcli
+# radio wifi off`, a driver quirk during a bad boot -- is a dead end nobody
+# notices. systemd-rfkill saves that state at shutdown and restores it at
+# boot, so it comes back on every reboot after until something clears it.
+#
+# Soft and hard blocked are reported separately on purpose: soft is undone by
+# `rfkill unblock`, hard is a physical switch or BIOS setting that no command
+# here touches, and telling them apart is the point (see the issue).
+head_ "Radios"
+if ! command -v rfkill >/dev/null 2>&1; then
+  hmm "rfkill not on PATH" "nothing to check"
+else
+  radios=$(rfkill list -n -o TYPE,SOFT,HARD 2>/dev/null)
+  if [ -z "$radios" ]; then
+    hmm "no radios on this machine" "nothing to test"
+  else
+    while read -r type soft hard; do
+      [ -n "$type" ] || continue
+      if [ "$hard" = "blocked" ]; then
+        bad "$type is hard blocked" "a physical switch or BIOS setting -- software cannot clear this"
+      elif [ "$soft" = "blocked" ]; then
+        bad "$type is soft blocked" "will stay blocked across reboots until cleared"
+        say_dim "rfkill unblock all"
+        say_dim "sudo rm -f /var/lib/systemd/rfkill/*   # or it returns at the next boot"
+      else
+        ok "$type unblocked" ""
+      fi
+    done <<<"$radios"
+  fi
+fi
+
 # ---- theming -------------------------------------------------------------
 head_ "Theme"
 scheme=$(


### PR DESCRIPTION
## What this changes, and why

#277: `rfkill` and `nmcli` are both already on a stock nixarchy machine, but
nothing looks at rfkill state. A soft-blocked radio (a hardware key, a stray
`nmcli radio wifi off`, a driver quirk during a bad boot) is a dead end nobody
notices, and `systemd-rfkill` saves that state at shutdown and restores it at
boot, so it comes back on every reboot after until something clears it.

Adds a "Radios" section to `pkgs/verify.sh` — the tier of check reserved for
what only real hardware can answer (AGENTS.md §2) — that reports each radio's
soft/hard block state separately, and for a soft block prints the actual fix,
including the part nobody guesses:

```
rfkill unblock all
sudo rm -f /var/lib/systemd/rfkill/*   # or it returns at the next boot
```

Hard blocked (a physical switch or BIOS setting) gets a different message,
since nothing here can clear it and conflating the two sends people at the
wrong fix — that distinction was the issue's specific ask.

Not done, deliberately: masking `systemd-rfkill` by default. It does a
legitimate job — someone who turns a radio off on purpose expects it to stay
off — so disabling it for everyone to spare the people it surprises is the
wrong trade. The issue explains this and I agree with it.

Also not done: the menu row the issue mentions as a second, smaller
improvement. Scoped this PR to the verify.sh check, which is the part the
issue calls "worth more."

## How I proved the check fails

Real hardware (this machine's only radio, its Bluetooth adapter). RED:

```
$ rfkill block bluetooth
$ bash pkgs/verify.sh | grep -A6 Radios
Radios
  ✗ bluetooth is soft blocked          will stay blocked across reboots until cleared
    rfkill unblock all
    sudo rm -f /var/lib/systemd/rfkill/*   # or it returns at the next boot
```

GREEN:

```
$ rfkill unblock bluetooth
$ bash pkgs/verify.sh | grep -A3 Radios
Radios
  ✓ bluetooth unblocked
```

Radio state was restored before finishing (confirmed `rfkill list` shows
`unblocked` again); this machine has no Wi-Fi radio, so Bluetooth is the
verified case and Wi-Fi is the same code path, unverified on Wi-Fi hardware.

## Checks run locally

- [x] `nix fmt -- --ci` clean
- [x] `statix check .` clean
- [x] `deadnix --fail .` clean
- [x] `nix build .#verify --print-build-logs` — builds, `writeShellApplication`'s
      shellcheck pass is clean
- [x] Ran the built `nixarchy-verify` binary end-to-end, confirmed the new
      section prints correctly
- [x] New files are `git add`ed
- [ ] No new option added — `tests/options.nix` not touched
- [ ] No new `checks.*` entry — `verify.sh` is real-hardware-only by design
      (AGENTS.md §5/§2), like the existing Bluetooth section beside it; no
      workflow wiring needed

`util-linux` added to `nixarchy-verify`'s `runtimeInputs` in flake.nix for
`rfkill` — an undeclared `rfkill` reads as "no radios on this machine" rather
than "rfkill is missing," the same trap `nixarchy-doctor`'s `vainfo` hit
(see #284).

Closes #277.
