### PR TITLE
The remaining three MicroVM templates: python, podman, persistent

### DIFF
--- a/data/microvm-templates.nix
+++ b/data/microvm-templates.nix
@@ -48,16 +48,28 @@
 #   note     What the template gives you and what it costs, same job as the
 #            `note` field in every other catalogue here.
 #
-# ## What is not here
-#
-# Only `shell` exists yet -- #222 is the issue that proves the shape works at
-# all, and one template is enough to prove it. `python`, `podman` and
-# `persistent` are #225, once #223 and #224 have given them something to be
-# checked and launched by.
 {
   shell = {
     label = "Shell";
     module = ../modules/microvm/templates/shell.nix;
     note = "A bare NixOS shell with nothing added beyond modules/microvm/guest.nix -- the fastest way to a throwaway prompt, and the template every other one starts from.";
+  };
+
+  python = {
+    label = "Python";
+    module = ../modules/microvm/templates/python.nix;
+    note = "python3 and uv, 3 GiB of RAM. Ephemeral like Shell -- run 'uv venv /mnt/host/.venv' if the venv should outlive the VM.";
+  };
+
+  podman = {
+    label = "Podman";
+    module = ../modules/microvm/templates/podman.nix;
+    note = "Rootless-capable podman with Docker compatibility. /var/lib/containers is a 20 GiB volume that survives a restart; the rest of the root filesystem does not.";
+  };
+
+  persistent = {
+    label = "Persistent";
+    module = ../modules/microvm/templates/persistent.nix;
+    note = "Shell, plus /home on a 10 GiB volume. The volume goes when the VM does ('nixarchy vm rm'); the root filesystem is still thrown away every boot.";
   };
 }

--- a/modules/microvm/templates/persistent.nix
+++ b/modules/microvm/templates/persistent.nix
@@ -1,0 +1,24 @@
+# The `persistent` template: `shell` plus a `/home` that survives a restart.
+#
+# The volume goes in the VM's own directory (a RELATIVE image path, same rule
+# as `podman`'s), so `nixarchy vm rm <name>` deleting that directory is what
+# makes the image go too -- there is no separate cleanup step, and no image
+# left behind for a template this repo later drops.
+#
+# The root filesystem is NOT part of that promise: modules/microvm/guest.nix
+# gives every template a tmpfs root, and this template does not change that.
+# Everything outside /home is thrown away at every boot, exactly as it is on
+# `shell`.
+{
+  imports = [ ./shell.nix ];
+
+  microvm.volumes = [
+    {
+      image = "home.img";
+      mountPoint = "/home";
+      size = 10 * 1024;
+      fsType = "ext4";
+      autoCreate = true;
+    }
+  ];
+}

--- a/modules/microvm/templates/podman.nix
+++ b/modules/microvm/templates/podman.nix
@@ -1,0 +1,29 @@
+# The `podman` template. Root is still tmpfs -- like every other template,
+# it is thrown away every boot -- but pulled images are the expensive part of
+# a container workflow, and losing those on every restart would make this
+# template worse than useless. So `/var/lib/containers` gets its own 20 GiB
+# volume, a RELATIVE image path in the VM's own directory
+# (data/microvm-templates.nix's rule: this is what lets one closure serve
+# every VM of this template, each with its own image).
+#
+# Containers inside a MicroVM is the case that justifies a kernel of your
+# own: podman's own rootless mode already gets you most of an isolated
+# container without one, but a MicroVM boundary is a real one -- podman
+# inside it can be handed CAP_SYS_ADMIN, `--privileged`, or a kernel module
+# nobody would grant on the host.
+{
+  virtualisation.podman = {
+    enable = true;
+    dockerCompat = true;
+  };
+
+  microvm.volumes = [
+    {
+      image = "var-lib-containers.img";
+      mountPoint = "/var/lib/containers";
+      size = 20 * 1024;
+      fsType = "ext4";
+      autoCreate = true;
+    }
+  ];
+}

--- a/modules/microvm/templates/python.nix
+++ b/modules/microvm/templates/python.nix
@@ -1,0 +1,22 @@
+# The `python` template. Ephemeral like `shell` -- modules/microvm/guest.nix's
+# tmpfs root is thrown away every boot, same as it is there -- and the only
+# two things this adds beyond that are `python3` and `uv` on PATH, plus more
+# memory than the 1 GiB default, since resolving a venv routinely wants it.
+#
+# `uv venv` writes into the guest's own tmpfs root by default, and that venv
+# is gone at the next boot along with everything else outside /mnt/host --
+# `uv venv /mnt/host/.venv` is what makes one outlive the VM, onto the same
+# host directory `nixarchy vm run` shares in.
+{ pkgs, ... }:
+{
+  environment.systemPackages = [
+    pkgs.python3
+    pkgs.uv
+  ];
+
+  # microvm.nix's own default (nixos-modules/microvm/options.nix) is 512;
+  # modules/microvm/guest.nix does not raise it, so a template that wants
+  # more says so itself. 3072 is enough headroom to resolve a
+  # dependency-heavy lockfile without swapping on a share as slow as 9p.
+  microvm.mem = 3072;
+}

--- a/tests/microvm-template.nix
+++ b/tests/microvm-template.nix
@@ -24,6 +24,18 @@ let
   # carries only `shell` until #225. Every template gets asserted, so a new
   # one is covered for free.
   names = builtins.attrNames templates;
+
+  # #225: "checks.microvm-template should cover at least one template with a
+  # volume, since autoCreate and the relative path are exactly what a rename
+  # would break silently." The image basename each volume-carrying template
+  # writes into `microvm.volumes` -- lib/runners/qemu.nix (the pinned commit,
+  # read above) puts this string into `-drive ...,file=${image},...`
+  # VERBATIM, with no path resolution of its own, so a template that grew an
+  # absolute path here would only fail at boot, on real hardware, never here.
+  volumeImages = {
+    podman = "var-lib-containers.img";
+    persistent = "home.img";
+  };
 in
 pkgs.runCommand "nixarchy-microvm-template"
   {
@@ -86,6 +98,25 @@ pkgs.runCommand "nixarchy-microvm-template"
         echo "${name}: share/microvm/tap-interfaces is non-empty -- this needs root to run" >&2
         fail=1
       fi
+
+      ${lib.optionalString (volumeImages ? ${name}) ''
+        # A volume's `file=` is the RELATIVE image path this template
+        # declared, not an absolute one. Breaking this looks like a template
+        # writing `microvm.volumes[].image` as
+        # "/var/lib/nixarchy/${volumeImages.${name}}" instead of a bare
+        # filename -- the whole promise of one closure serving every VM of
+        # this template, each with its own disk in its own directory
+        # (data/microvm-templates.nix's rule), depends on this staying
+        # relative.
+        if ! grep -qE -- "file=${volumeImages.${name}}(,|')" "$run"; then
+          echo "${name}: bin/microvm-run has no -drive for ${volumeImages.${name}}" >&2
+          fail=1
+        fi
+        if grep -qE -- "file=/[^,']*${volumeImages.${name}}" "$run"; then
+          echo "${name}: ${volumeImages.${name}} is on the drive line with an absolute path" >&2
+          fail=1
+        fi
+      ''}
 
       # The KVM and -tcg runners share one share/microvm/system: the guest
       # closure the -cpu flag differs, not the guest itself. Breaking this


### PR DESCRIPTION
## What this changes, and why

Adds the three remaining MicroVM templates #221 promised beyond `shell`:
`python` (python3 + uv, 3 GiB RAM), `podman` (rootless-capable podman with
Docker compat, `/var/lib/containers` on its own 20 GiB volume), and
`persistent` (`shell` plus `/home` on a 10 GiB volume). Each is a plain
NixOS module imported alongside `modules/microvm/guest.nix` — no nixarchy
vocabulary, per `data/microvm-templates.nix`'s own bar.

`tests/microvm-template.nix` gains a volume-specific assertion (issue's own
ask: "cover at least one template with a volume, since autoCreate and the
relative path are exactly what a rename would break silently"). For
`podman` and `persistent` it greps the built runner's `-drive ...,file=...`
argument and asserts the image is the bare relative filename the template
declared, not an absolute path — `lib/runners/qemu.nix` in the pinned
microvm.nix commit puts that string on the qemu command line verbatim, with
no path resolution of its own, so a template that grew an absolute path
would only fail at boot, on real hardware, never in CI.

## How I proved the check fails

Changed `podman.nix`'s volume image to an absolute path
(`/var/lib/nixarchy/var-lib-containers.img`) and rebuilt
`checks.microvm-template`:

```
nixarchy-microvm-template> == template: persistent ==
nixarchy-microvm-template> == template: podman ==
nixarchy-microvm-template> podman: bin/microvm-run has no -drive for var-lib-containers.img
nixarchy-microvm-template> podman: var-lib-containers.img is on the drive line with an absolute path
error: Cannot build '...-nixarchy-microvm-template.drv'.
       Reason: builder failed with exit code 1.
```

Reverted, rebuilt clean:

```
nixarchy-microvm-template> == template: persistent ==
nixarchy-microvm-template> == template: podman ==
nixarchy-microvm-template> == template: python ==
nixarchy-microvm-template> == template: shell ==
nixarchy-microvm-template> == nixarchy vm: launch and locking ==
nixarchy-microvm-template> ...
nixarchy-microvm-template> every template's runner is qemu, shares the host store read-only,
                            uses user networking, and the KVM/-tcg pair share one guest --
                            and nixarchy-vm launches it with an out-link, under a flock.
```

## Checks run locally

- [x] `nix fmt -- --ci` clean (statix flagged an empty `{ ... }:` head on
      `podman.nix`/`persistent.nix` — neither uses its arguments, so it's
      dropped the way `shell.nix` already does; fixed before commit)
- [x] `nix run nixpkgs#statix -- check .` clean
- [x] `nix run nixpkgs#deadnix -- --fail .` clean
- [x] `nix build .#checks.x86_64-linux.options` — green
- [x] `nix build .#checks.x86_64-linux.microvm-template` — green, RED/GREEN
      shown above
- [x] New files are `git add`ed
- [ ] No new option added (templates are plain NixOS modules, per
      `data/microvm-templates.nix`'s bar) — `tests/options.nix` untouched
- [ ] No new `checks.*` entry — extends the existing `microvm-template` check

Not verified: real boot of `podman`/`persistent` on KVM hardware (this
check reads the built runner, per `checks.microvm-template`'s own header
comment — actually booting is `pkgs/verify.sh`'s job, issue #229, not yet
open for this).

Part of #221. Implements #225.
