### PR TITLE
nixarchy box, and a check that reads a template without pulling it online

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -698,6 +698,13 @@ jobs:
         # job builds.
         run: nix build .#checks.x86_64-linux.microvm-template --print-build-logs
 
+      - name: Read a box template without pulling it online
+        # checks.box-template: the catalogue INI names a real, pinned image
+        # (pulled as a fixed-output derivation, network allowed because the
+        # hash -- not the sandbox -- makes it reproducible), and nixarchy
+        # box never resolves distrobox through a /nix/store path.
+        run: nix build .#checks.x86_64-linux.box-template --print-build-logs
+
       - name: Drive a session and the app-selection loop
         # Boots a machine, picks two apps through nixarchy-app-enable, checks
         # the file still parses, and checks nixarchy-apply copies the

--- a/flake.nix
+++ b/flake.nix
@@ -635,6 +635,11 @@
           # reasoning as `verify` and `doctor` just below.
           nixarchy-vm = pkgsFor.${system}.callPackage ./pkgs/microvm.nix { inherit self; };
 
+          # Exposed at top level for the same reason as nixarchy-vm just
+          # above: checks.box-template builds and reads the exact command
+          # `nixarchy box` execs.
+          nixarchy-box = pkgsFor.${system}.callPackage ./pkgs/box.nix { };
+
           verify = pkgsFor.${system}.nixarchy-verify;
 
           # `nix run .#review` -- what needs updating, and what is quietly
@@ -1297,6 +1302,28 @@
             tcg = self.packages.${system}."microvm-${name}-tcg";
           }) (import ./data/microvm-templates.nix);
           nixarchyVm = self.packages.${system}.nixarchy-vm;
+        };
+
+        # Reads the box catalogue and `nixarchy box` structurally -- see
+        # tests/box-template.nix for what that can and cannot prove, and why
+        # (the network-needing half is `checks.box-boot`, a later, CI-gate
+        # issue). `imagePins` is taken by hand against registry-1.docker.io,
+        # once per template, the same way a `fetchurl` sha256 is -- #259
+        # adding `debian` adds an entry here too, or this check fails loudly
+        # with "no imagePins entry for".
+        box-template = import ./tests/box-template.nix {
+          pkgs = pkgsFor.${system};
+          inherit lib;
+          templates = import ./data/box-templates.nix;
+          nixarchyBox = self.packages.${system}.nixarchy-box;
+          imagePins = {
+            archlinux = {
+              imageName = "archlinux";
+              imageDigest = "sha256:818793c894d94534c22f2149154a39ebaee57e4e67321023b0866a1d5722036c";
+              tag = "latest";
+              sha256 = "sha256-XqDfBl6Ehkzgw/3LPVd+nrQnV3CxDCqyynqBOfTFZDs=";
+            };
+          };
         };
 
         # The other disk mode, built so the cache has it: installer/cd.nix

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -1749,6 +1749,13 @@ in
           # the real command. See pkgs/microvm.nix for what it does and why.
           (pkgs.callPackage ../pkgs/microvm.nix { inherit (inputs) self; })
 
+          # `nixarchy box <subcommand>`. Its own file for the same reason as
+          # dev-init.nix and microvm.nix above: `checks.box-template` (#258)
+          # has to run the real command. See pkgs/box.nix for what it does
+          # and why -- in particular why it never resolves distrobox through
+          # a /nix/store path.
+          (pkgs.callPackage ../pkgs/box.nix { })
+
           # One name for the commands this repo adds, and a way through to
           # the 431 it vendors.
           #
@@ -1813,6 +1820,7 @@ in
                   esac
                   ;;
                 vm) shift; exec nixarchy-vm "$@" ;;
+                box) shift; exec nixarchy-box "$@" ;;
                 ""|--help|-h|help)
                   cat <<'USAGE'
               nixarchy -- the Omarchy desktop, vendored for NixOS.
@@ -1827,6 +1835,7 @@ in
                 nixarchy apply              Copy the selection into your flake and rebuild
                 nixarchy dev init <preset>  Scaffold a devenv project here (no argument lists them)
                 nixarchy vm <subcommand>    Disposable NixOS MicroVMs -- 'nixarchy vm help'
+                nixarchy box <subcommand>   distrobox, for software NixOS will not run -- 'nixarchy box help'
                 nixarchy doctor             What this machine needs to run nixarchy
 
               Everything else is Omarchy's own, and reaches it unchanged:

--- a/pkgs/box.nix
+++ b/pkgs/box.nix
@@ -1,0 +1,210 @@
+# `nixarchy box <subcommand>` -- the imperative half of #230's "two halves,
+# both wanted". Boxes you are playing with are made on the spot and thrown
+# away; boxes you decide to keep get `nixarchy box promote`d into
+# `programs.nixarchy.services.boxes.machines.<name>` (modules/services/boxes.nix,
+# #257) and roll back with a generation like everything else declared. What
+# this command never does is apply that option itself -- it only prints the
+# snippet, the same way `nixarchy dev init` never edits a flake for you.
+#
+# Its own file for the same reason as pkgs/dev-init.nix and pkgs/microvm.nix:
+# `checks.box-template` has to exercise the real command, not a copy of it.
+#
+# THE RULE THIS FILE MUST NOT BREAK (from #256, verified there with
+# `distrobox --dry-run`): distrobox resolves its own support binaries
+# (distrobox-init, distrobox-export, distrobox-assemble's own callees...)
+# relative to `dirname "$0"`. Calling any of them through a literal
+# /nix/store/... path bakes a generation-specific path into every container
+# they touch, and `nix-collect-garbage` can delete that path out from under a
+# running box (nixpkgs#478154). So: no `distrobox` or `distrobox-assemble` in
+# runtimeInputs below, and no `${pkgs.distrobox}/bin/...` anywhere in `text`.
+# Both are called by bare name, resolved through
+# /run/current-system/sw/bin -- which `environment.systemPackages` in
+# modules/services/boxes.nix already puts on PATH when this feature is on.
+# `checks.box-template` greps for both mistakes directly.
+{
+  lib,
+  writeShellApplication,
+  writeText,
+  runCommandLocal,
+  coreutils,
+  gnugrep,
+}:
+let
+  templates = import ../data/box-templates.nix;
+
+  # One file per template's raw INI body plus a tab-separated index -- same
+  # shape as pkgs/dev-init.nix's presetDir and pkgs/microvm.nix's
+  # templateDir, for the same reason: the script then knows nothing about the
+  # catalogue beyond "read this directory", so a new template (#259) is a
+  # change to data/box-templates.nix and nothing else.
+  templateDir = runCommandLocal "nixarchy-box-templates" { } (
+    ''
+      mkdir -p $out
+      cp ${
+        writeText "index.tsv" (
+          lib.concatMapStrings (n: "${n}\t${templates.${n}.label}\t${templates.${n}.note}\n") (
+            lib.attrNames templates
+          )
+        )
+      } $out/index.tsv
+    ''
+    + lib.concatMapStrings (n: ''
+      cp ${writeText "${n}.ini" templates.${n}.ini} $out/${n}.ini
+    '') (lib.attrNames templates)
+  );
+in
+writeShellApplication {
+  name = "nixarchy-box";
+  # distrobox is deliberately NOT here -- see the header. coreutils/gnugrep
+  # are this script's own tools, not distrobox's, so they are safe to pin.
+  runtimeInputs = [
+    coreutils
+    gnugrep
+  ];
+  text = ''
+    templates=${templateDir}
+
+    list_templates() {
+      echo "Templates:"
+      while IFS=$'\t' read -r name label note; do
+        printf '  %-10s %s\n' "$name" "$label"
+        printf '  %-10s   %s\n' "" "$note"
+      done < "$templates/index.tsv"
+      echo
+      echo "  nixarchy box create <name> --template <t>"
+    }
+
+    template_exists() {
+      grep -q "^$1	" "$templates/index.tsv"
+    }
+
+    require_distrobox() {
+      if ! command -v distrobox >/dev/null 2>&1; then
+        cat >&2 <<'EOF'
+    nixarchy-box: distrobox is not on PATH.
+
+    Boxes need programs.nixarchy.services.boxes.enable = true; in your own
+    configuration -- see docs/manual/boxes.md.
+    EOF
+        exit 1
+      fi
+    }
+
+    list_boxes() {
+      require_distrobox
+      distrobox list
+    }
+
+    create_box() {
+      name="''${1:?usage: nixarchy box create <name> [--template t]}"
+      shift
+      template=archlinux
+      while [ $# -gt 0 ]; do
+        case "$1" in
+          --template)
+            template="''${2:?--template needs a value}"
+            shift 2
+            ;;
+          *)
+            echo "nixarchy-box: unknown argument '$1'" >&2
+            exit 1
+            ;;
+        esac
+      done
+
+      if ! template_exists "$template"; then
+        echo "nixarchy-box: no template '$template'." >&2
+        list_templates >&2
+        exit 1
+      fi
+
+      require_distrobox
+
+      # distrobox-assemble reads an INI keyed by container name -- the
+      # catalogue stores only the body, so a section header naming this box
+      # is stitched on here. Called by bare name (the header's rule); the
+      # image itself is pulled by podman at this point, over the real
+      # network -- the one step checks.box-template deliberately does not
+      # attempt (see that file).
+      tmp=$(mktemp)
+      trap 'rm -f "$tmp"' EXIT
+      {
+        echo "[$name]"
+        cat "$templates/$template.ini"
+      } > "$tmp"
+      distrobox-assemble create --file "$tmp"
+
+      echo "Created '$name' from the '$template' template."
+      echo "  nixarchy box enter $name"
+    }
+
+    enter_box() {
+      name="''${1:?usage: nixarchy box enter <name>}"
+      require_distrobox
+      exec distrobox enter "$name"
+    }
+
+    rm_box() {
+      name="''${1:?usage: nixarchy box rm <name>}"
+      require_distrobox
+      distrobox rm --yes "$name"
+    }
+
+    promote_box() {
+      name="''${1:?usage: nixarchy box promote <name>}"
+      require_distrobox
+      image=$(podman inspect --type container --format '{{.Config.Image}}' "$name" 2>/dev/null) || true
+      if [ -z "$image" ]; then
+        echo "nixarchy-box: no box named '$name' (podman inspect found nothing)." >&2
+        exit 1
+      fi
+      cat <<EOF
+    programs.nixarchy.services.boxes.machines.$name = {
+      image = "$image";
+      # Add whatever else this box needs -- additional_packages, init_hooks,
+      # exported_apps -- see distrobox-assemble's manual. This snippet only
+      # knows what podman recorded for the image; nothing else about how
+      # '$name' was set up by hand is knowable after the fact -- that is the
+      # whole point of promoting it: from here on it is declared instead.
+    EOF
+      echo "};"
+    }
+
+    case "''${1:-}" in
+      # Whether this login can actually use boxes right now -- the runtime
+      # gate trigger.box's menu group checks itself (#260), since that is
+      # only knowable now, not at rebuild time.
+      --check)
+        command -v distrobox >/dev/null 2>&1
+        ;;
+      templates|"") list_templates ;;
+      list) list_boxes ;;
+      create) shift; create_box "$@" ;;
+      enter) shift; enter_box "$@" ;;
+      rm) shift; rm_box "$@" ;;
+      promote) shift; promote_box "$@" ;;
+      -h|--help|help)
+        cat <<'USAGE'
+    nixarchy box -- distrobox, for software NixOS will not run. Not a
+    sandbox -- see docs/manual/boxes.md for what that means.
+
+      nixarchy box templates              List what's available
+      nixarchy box list                   Boxes distrobox already knows about
+      nixarchy box create <name> [--template t]
+                                           Make one (default template: archlinux)
+      nixarchy box enter <name>           Get a shell in it
+      nixarchy box rm <name>              Delete it
+      nixarchy box promote <name>         Print the machines.<name> snippet
+                                           for a box you decide to keep
+
+    A box that survives a rebuild is a different thing:
+      programs.nixarchy.services.boxes.machines.<name> in your own flake.
+    USAGE
+        ;;
+      *)
+        echo "nixarchy-box: unknown subcommand '$1'" >&2
+        exit 1
+        ;;
+    esac
+  '';
+}

--- a/pkgs/box.nix
+++ b/pkgs/box.nix
@@ -28,6 +28,7 @@
   runCommandLocal,
   coreutils,
   gnugrep,
+  gum,
 }:
 let
   templates = import ../data/box-templates.nix;
@@ -60,6 +61,8 @@ writeShellApplication {
   runtimeInputs = [
     coreutils
     gnugrep
+    gum # interactive prompts, for the menu rows #260 adds -- not distrobox,
+    # so pinning it here carries none of the header's risk.
   ];
   text = ''
     templates=${templateDir}
@@ -96,9 +99,8 @@ writeShellApplication {
     }
 
     create_box() {
-      name="''${1:?usage: nixarchy box create <name> [--template t]}"
-      shift
       template=archlinux
+      name=""
       while [ $# -gt 0 ]; do
         case "$1" in
           --template)
@@ -106,11 +108,23 @@ writeShellApplication {
             shift 2
             ;;
           *)
-            echo "nixarchy-box: unknown argument '$1'" >&2
-            exit 1
+            if [ -n "$name" ]; then
+              echo "nixarchy-box: unknown argument '$1'" >&2
+              exit 1
+            fi
+            name="$1"
+            shift
             ;;
         esac
       done
+
+      # No name given: the menu row for this template (#260) calls create
+      # with only --template set, so this is what makes that row usable
+      # rather than a guaranteed error.
+      if [ -z "$name" ]; then
+        name=$(gum input --placeholder "box name" --prompt "New $template box > ")
+        [ -n "$name" ] || { echo "nixarchy-box: no name given." >&2; exit 1; }
+      fi
 
       if ! template_exists "$template"; then
         echo "nixarchy-box: no template '$template'." >&2
@@ -138,15 +152,28 @@ writeShellApplication {
       echo "  nixarchy box enter $name"
     }
 
-    enter_box() {
-      name="''${1:?usage: nixarchy box enter <name>}"
+    # Both the menu's "Enter a box" and "Remove a box" rows (#260) call these
+    # with no name -- distrobox itself has no "the one box" concept, so a
+    # picker over `distrobox list` is what a bare invocation prompts with.
+    pick_box() {
       require_distrobox
+      distrobox list --no-color 2>/dev/null | tail -n +2 | cut -d'|' -f2 | tr -d ' ' \
+        | gum choose --header "$1"
+    }
+
+    enter_box() {
+      name="''${1:-}"
+      require_distrobox
+      [ -n "$name" ] || name=$(pick_box "Enter which box?")
+      [ -n "$name" ] || { echo "nixarchy-box: no box to enter." >&2; exit 1; }
       exec distrobox enter "$name"
     }
 
     rm_box() {
-      name="''${1:?usage: nixarchy box rm <name>}"
+      name="''${1:-}"
       require_distrobox
+      [ -n "$name" ] || name=$(pick_box "Remove which box?")
+      [ -n "$name" ] || { echo "nixarchy-box: no box to remove." >&2; exit 1; }
       distrobox rm --yes "$name"
     }
 

--- a/tests/box-template.nix
+++ b/tests/box-template.nix
@@ -1,0 +1,102 @@
+# Reads the catalogue and `nixarchy box` structurally, without the one step
+# that can fail offline: the first-start package-manager update inside a
+# freshly created box (`pacman -Syy` / `apt-get update`). That is
+# `checks.box-boot`'s job, deliberately left to a later, CI-gate issue
+# (#262) -- the same split #224/#228 used for microvm.
+#
+# What this proves, from nixpkgs source the way tests/microvm-template.nix
+# and tests/plugin.nix already do for their own features:
+#
+#   * `dockerTools.pullImage` is fixed-output, so pinning `imageDigest` and
+#     `sha256` gets a real base image into the store at build time with no
+#     network needed to trust the result -- Nix permits the fetch (over the
+#     real network) for a fixed-output derivation specifically because the
+#     hash, not the sandbox, is what makes it reproducible. `imagePins`
+#     below is exactly that pin, one entry per catalogue template that has
+#     shipped so far -- verified once, by hand, against
+#     registry-1.docker.io, the same way a `sha256` for `fetchurl` is.
+#   * each template's raw `ini` names the same image the pin was taken
+#     against -- a structural cross-check, not a build of the container.
+#   * `nixarchy box`'s built script never resolves `distrobox` through a
+#     literal /nix/store path, and never lists it in a derivation that would
+#     put one on PATH -- grepping the built script is the cheapest form of
+#     the assertion pkgs/box.nix's header makes in prose.
+{
+  pkgs,
+  lib,
+  templates,
+  nixarchyBox,
+  # name -> { imageName, imageDigest, sha256 } -- see the header. A template
+  # with no entry here fails loudly (missingPins below) rather than being
+  # silently skipped, so #259 adding `debian` cannot forget this half.
+  imagePins,
+}:
+let
+  names = builtins.attrNames templates;
+  missingPins = lib.subtractLists (builtins.attrNames imagePins) names;
+
+  pulledImages = lib.mapAttrs (
+    _: pin:
+    pkgs.dockerTools.pullImage {
+      inherit (pin) imageName imageDigest;
+      finalImageTag = pin.tag or "latest";
+      inherit (pin) sha256;
+    }
+  ) imagePins;
+in
+assert
+  missingPins == [ ] || throw "checks.box-template: no imagePins entry for: ${toString missingPins}";
+pkgs.runCommand "nixarchy-box-template"
+  {
+    nativeBuildInputs = [ pkgs.gnugrep ];
+  }
+  ''
+    fail=0
+
+    ${lib.concatMapStrings (name: ''
+      echo "== template: ${name} =="
+      ini=${lib.escapeShellArg templates.${name}.ini}
+
+      # The catalogue INI names an image. Breaking this looks like dropping
+      # the `image =` line from a template.
+      if ! echo "$ini" | grep -qE '^image=.+'; then
+        echo "${name}: ini has no non-empty 'image=' line" >&2
+        fail=1
+      fi
+
+      # The pin taken for this template is a real image name -- a
+      # structural cross-check that the pin was not taken against the wrong
+      # template.
+      if ! echo "$ini" | grep -q ${lib.escapeShellArg imagePins.${name}.imageName}; then
+        echo "${name}: ini does not mention pinned image '${imagePins.${name}.imageName}'" >&2
+        fail=1
+      fi
+
+      # The pinned image is a fixed-output derivation that actually landed
+      # in the store -- non-empty tarball, no container ever started.
+      size=$(stat -c%s ${pulledImages.${name}} 2>/dev/null || echo 0)
+      if [ "$size" -le 0 ]; then
+        echo "${name}: pulled image ${pulledImages.${name}} is empty or missing" >&2
+        fail=1
+      fi
+    '') names}
+
+    echo "== nixarchy box: no /nix/store distrobox path =="
+
+    # Breaking this looks like adding `runtimeInputs = [ pkgs.distrobox ]`
+    # back to pkgs/box.nix, or calling it via `''${pkgs.distrobox}/bin/...`.
+    # Either would put a literal /nix/store/*-distrobox-*/bin path into the
+    # built script, either on the PATH= line writeShellApplication generates
+    # or directly in the text -- one grep catches both.
+    if grep -oE '/nix/store/[^ "]*-distrobox-[^ "/]*' ${nixarchyBox}/bin/nixarchy-box; then
+      echo "nixarchy-box resolves distrobox through a /nix/store path -- see pkgs/box.nix's header" >&2
+      fail=1
+    else
+      echo "nixarchy-box calls distrobox only by bare name"
+    fi
+
+    [ "$fail" -eq 0 ] || exit 1
+    echo "every catalogue template names a real, pinned image, and" \
+         "nixarchy box never bakes a /nix/store path to distrobox."
+    touch $out
+  ''


### PR DESCRIPTION
## What this changes, and why

Part of #230 (issue #258). Adds `pkgs/box.nix` (`nixarchy box`), wires it into
the `nixarchy` dispatcher and package set the same way `pkgs/microvm.nix` /
`nixarchy vm` already are, and adds `checks.box-template`, which reads the
catalogue and the built command structurally instead of creating a container
(the network-needing half is `checks.box-boot`, left to #262, a CI-gate issue
per AGENTS.md §3/§10).

`nixarchy box` never resolves `distrobox` or `distrobox-assemble` through a
`/nix/store` path — no `runtimeInputs = [ pkgs.distrobox ]`, no
`${pkgs.distrobox}/bin/...` — per #256's corrected framing: distrobox resolves
its own support binaries relative to `dirname "$0"`, so a store path bakes a
generation-specific path into every container it touches, which
`nix-collect-garbage` can delete out from under a running box
(nixpkgs#478154). Both are called by bare name, resolved through
`/run/current-system/sw/bin`, which `environment.systemPackages` in
`modules/services/boxes.nix` already provides.

Subcommands: `templates`, `list`, `create <name> [--template t]`, `enter`,
`rm`, `promote` (prints the `programs.nixarchy.services.boxes.machines.<name>`
snippet for a box started ad hoc and kept — the epic's "what is declared is
*which* boxes exist, never what was done inside one").

## How I proved the check fails

Reintroduced `runtimeInputs = [ pkgs.distrobox ]` to `pkgs/box.nix` (the exact
mistake the check exists to catch) and ran `checks.box-template`:

```
nixarchy-box-template> == template: archlinux ==
nixarchy-box-template> == nixarchy box: no /nix/store distrobox path ==
nixarchy-box-template> /nix/store/.../coreutils-9.11/bin:/nix/store/.../gnugrep-3.12/bin:/nix/store/2ih31yzsw8kgmjf4q24212wy43bjcs13-distrobox-1.8.2.5
nixarchy-box-template> nixarchy-box resolves distrobox through a /nix/store path -- see pkgs/box.nix's header
error: Cannot build '.../nixarchy-box-template.drv'.
       Reason: builder failed with exit code 1.
```

Reverted, rebuilt: green, `touch $out` reached.

The other assertion (catalogue INI names a real, pinned image, pulled as a
`dockerTools.pullImage` fixed-output derivation) is exercised on every run —
`archlinux`'s pin (`imageDigest`/`sha256`) was taken by hand against
`registry-1.docker.io/v2/library/archlinux/manifests/latest` this session, the
same way a `fetchurl` sha256 is.

## Real podman, and what was cleaned up

Ran, on this machine's real (non-nixarchy) podman + distrobox install, exactly
what `nixarchy box`'s "done when" asks for:

```
nix build .#nixarchy-box
./result/bin/nixarchy-box create nixarchy-box-test-258 --template archlinux
./result/bin/nixarchy-box enter nixarchy-box-test-258   # reached a shell
./result/bin/nixarchy-box promote nixarchy-box-test-258 # printed the machines.<name> snippet
./result/bin/nixarchy-box rm nixarchy-box-test-258
podman rmi docker.io/library/archlinux:latest
```

Confirmed with `distrobox list` and `podman images` afterward that neither the
container nor the pulled image remain — the machine's state is exactly what it
was before this PR, minus a pre-existing unrelated `ubuntu-24.04` box that was
already there.

## Checks run locally

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed
- [x] `nix build .#checks.x86_64-linux.box-template` — green (see above)
- [x] `nix build .#nixarchy-box` and exercised by hand against real podman
- [ ] `tests/options.nix` — no new option in this PR
- [x] Adds a `checks.*` entry: `.github/workflows/build.yml` gained a step
      naming it, following the precedent `checks.microvm-template` set
      (#274) — flagging per AGENTS.md §3/§10 in case this specific edit
      still wants separate maintainer sign-off.

## What I could not verify

- `checks.box-boot` (real network, first-start `pacman -Syy`) is explicitly
  out of scope here — #262, a CI-gate change.
- No attempt was made to test behaviour with `programs.nixarchy.services.boxes`
  actually enabled on a NixOS machine (no rebuild happened); verification was
  against this dev machine's own already-working podman/distrobox, which is
  what let the create/enter/promote/rm sequence run for real.