### PR TITLE
The remaining templates: debian, and whatever else upstream's own examples justify

### DIFF
--- a/data/box-templates.nix
+++ b/data/box-templates.nix
@@ -41,4 +41,27 @@
       start_now=false
     '';
   };
+
+  # The other half of the README's "an Arch or Debian userland is one command
+  # away" -- .deb/apt software, an AUR package's opposite number. `trixie`
+  # rather than `stable`/`latest`: a moving alias would make the pinned
+  # `checks.box-template` image drift out from under this file with no diff
+  # to review, the same reason data/microvm-templates.nix names a release
+  # rather than tracking a channel.
+  #
+  # Verified against this template's own base image (#259's "verify before
+  # writing much"): entering a freshly created box with apt-get unable to
+  # reach the network still reaches a shell -- distrobox-init's first-start
+  # package-manager update warns rather than aborting on Debian too, the
+  # same answer #256 got for archlinux's pacman -Syy.
+  debian = {
+    label = "Debian";
+    note = "A .deb/apt userland -- AUR's opposite number. Software packaged for Debian and nothing else.";
+    ini = ''
+      image=docker.io/library/debian:trixie
+      pull=false
+      replace=false
+      start_now=false
+    '';
+  };
 }


### PR DESCRIPTION
## What this changes, and why

Part of #230 (issue #259). Adds `debian` to `data/box-templates.nix`, the
other half of the README's "an Arch or Debian userland is one command away."
Pinned to `docker.io/library/debian:trixie` rather than `stable`/`latest` —
same reason `data/microvm-templates.nix` names a release rather than tracking
a moving alias: a floating tag would let the pinned image
`checks.box-template` uses (once #258 merges) drift with no diff to review.

Branched from `origin/main` per the epic's own dependency note ("#259 through
#263 are independent once #258 lands") and this repo's "no stacking" rule —
this PR is the catalogue entry alone. #258's PR (#288, not yet merged) is
where `nixarchy box` and `checks.box-template` live; that check already
iterates every catalogue entry and requires an `imagePins` entry for each
name (fails loudly with "no imagePins entry for" if one is missing), so
`debian` will need one added there. For whoever merges these, the pin taken
by hand this session against `registry-1.docker.io`:

```nix
debian = {
  imageName = "debian";
  imageDigest = "sha256:6788062a1b42ac281f053ac876170b79a3eaed5d61383b8ed7eaca6c6965f3b1";
  tag = "trixie";
  sha256 = "sha256-iL1J4Iro9wW+yL7dHgGlaMpoTxCU5XzuEgKkWAar4yA=";
};
```

## Verify before writing much (#259's own requirement)

The foundation issue's "warns, does not abort" answer for archlinux's
`pacman -Syy` was confirmed to also hold for debian's `apt-get update`, on
this machine's real podman + distrobox:

```
distrobox create --name box-debian-verify-259 --image docker.io/library/debian:trixie --yes
env http_proxy=http://127.0.0.1:1 https_proxy=http://127.0.0.1:1 \
  distrobox enter box-debian-verify-259 -- bash -lc 'echo FIRSTSTART_SHELL_OK; id'
# -> first-start apt-get update fails against the broken proxy; the shell still comes up
distrobox enter box-debian-verify-259 -- bash -lc 'echo FIRSTSTART_SHELL_OK; cat /etc/os-release | head -2'
# -> FIRSTSTART_SHELL_OK
# -> PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
```

Cleaned up afterward: `distrobox rm --yes box-debian-verify-259`,
`podman rmi docker.io/library/debian:trixie`. Confirmed via `distrobox list`
and `podman images` that neither remains — machine state is back to what it
was before this PR, minus the same pre-existing unrelated `ubuntu-24.04` box
noted in #288.

## How I proved the check fails

No check lives in this PR (see above — `checks.box-template` is #258's, not
yet merged to `main`). `data/box-templates.nix` is plain data with no
evaluator of its own in this branch to break; I instead ran the existing
`checks.options` against the changed file to confirm nothing else on `main`
regressed, and evaluated the catalogue directly:

```
$ nix-instantiate --strict --json --eval -E 'builtins.attrNames (import ./data/box-templates.nix)'
["archlinux","debian"]
```

## Checks run locally

- [x] `nix fmt` / statix / deadnix are clean
- [x] New content is `git add`ed
- [x] `nix build .#checks.x86_64-linux.options` — green, unaffected by this change
- [ ] `checks.box-template` — does not exist on `main` yet (see above); the
      pin above is handed off for whichever merge order lands it

## What I could not verify

- `nixarchy box templates` listing `debian` — that command does not exist on
  `main` (it's #258/#288). Verified instead directly against distrobox/podman
  as shown above.
- Real network first-start with the network *actually* down (rather than a
  broken proxy) was not attempted — taking the machine off the network would
  disrupt other agents working on this host concurrently (confirmed on the
  shared agent bus before starting). The broken-proxy substitute produces the
  same class of failure `distrobox-init` has to tolerate (apt-get exits
  non-zero) and gets the same tolerant result.