### PR TITLE
The trigger.vm menu group: Sandboxes, under Trigger

### DIFF
--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -577,6 +577,71 @@ let
           description = "Copy the selection into your flake and nixos-rebuild switch";
         };
       }
+      // lib.optionalAttrs cfg.enable {
+        # The Sandboxes group (#226). A nested `trigger.vm`, not a new root
+        # section -- `trigger.ask` above is the same shape, a new parent
+        # under an upstream root, and there is no precedent here for a root
+        # of our own. `full = dict(upstream); full.update(out)` in
+        # menuDefaults above means a totally new id like this one is
+        # APPENDED, so it lands after System and About at the end of the
+        # list -- the ordering #226 documents, not something coded here.
+        #
+        # Two gates, both needed. This `lib.optionalAttrs cfg.enable` is the
+        # Nix-level one: belt-and-braces, since every row in this file
+        # already lives inside `config = lib.mkIf cfg.enable (...)` above --
+        # stated explicitly so a reader does not have to trace that back.
+        # The runtime one is the parent's own `when` below: whether *this
+        # login* can open /dev/kvm is only knowable now, not at rebuild
+        # time -- `nixarchy-vm --check` (pkgs/microvm.nix) always exits 0,
+        # so nothing here is actually gated on hardware; the fallback to a
+        # software CPU is what makes that true on every nixarchy machine.
+        #
+        # `nixarchy-vm` itself is installed unconditionally (this file,
+        # below -- same as `nixarchy dev init`), so there is no
+        # `programs.nixarchy.services.microvm.enable` to gate this on:
+        # #221 designed the disposable half to need no root and no rebuild,
+        # so nothing about it is opt-in.
+        "trigger.vm" = {
+          icon = "󰦛";
+          label = "Sandbox";
+          aliases = [
+            "vm"
+            "sandbox"
+            "microvm"
+          ];
+          when = "nixarchy-vm --check";
+        };
+        "trigger.vm.new" = {
+          icon = "󰕍";
+          label = "New sandbox";
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-vm new";
+          description = "Name one, pick a template, and open it";
+        };
+        "trigger.vm.open" = {
+          icon = "󰁯";
+          label = "Open a sandbox";
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-vm run";
+          description = "Attach to one you already created";
+        };
+        "trigger.vm.stop" = {
+          icon = "󰉉";
+          label = "Stop a sandbox";
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-vm stop";
+          description = "Ask a running sandbox to shut down";
+        };
+        "trigger.vm.destroy" = {
+          icon = "󱄅";
+          label = "Destroy a sandbox";
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-vm rm";
+          description = "Delete it and its state -- cannot be undone";
+        };
+        "trigger.vm.list" = {
+          icon = "󰆓";
+          label = "List sandboxes";
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-vm list";
+          description = "What you have created, and which are running";
+        };
+      }
       // lib.listToAttrs (
         lib.mapAttrsToList (
           name: app:


### PR DESCRIPTION
## What this changes, and why

The `trigger.vm` menu group (#226): a Sandboxes group nested under Trigger,
not a new root section — `trigger.ask` is the precedent for that shape, and
`full = dict(upstream); full.update(out)` in `modules/apps.nix`'s
`menuDefaults` generator means a brand-new id like `trigger.vm` is appended,
landing after System and About at the end of the list rather than needing
any ordering code of its own.

Six rows: the parent (`trigger.vm`, no action, `aliases = [ "vm" "sandbox"
"microvm" ]`) plus `new` / `open` / `stop` / `destroy` / `list`, each
launching `nixarchy vm <subcommand>` in a floating terminal.

Two gates, both from the issue:
- **Nix-level**: `lib.optionalAttrs cfg.enable { ... }` around the whole
  group. Belt-and-braces — every row in `overrideSpec` already lives inside
  `config = lib.mkIf cfg.enable (...)`, so this is stated explicitly rather
  than load-bearing on its own.
- **Runtime**: `when = "nixarchy-vm --check"` on the parent — whether *this
  login* can open `/dev/kvm` is only knowable now, not at rebuild time.
  `pkgs/microvm.nix`'s `--check` always exits 0 (the `-tcg` software-CPU
  fallback means the command works on every nixarchy machine), so nothing is
  actually hidden on hardware grounds — the row exists whenever the menu
  does.

`nixarchy-vm` itself is installed unconditionally (same as `nixarchy dev
init`) — there is no `programs.nixarchy.services.microvm.enable` to gate the
disposable half on; #221 designed it to need no root and no rebuild.

## How I proved the check fails

This PR adds rows to existing checks rather than a new check of its own
(`tests/coverage.py`'s command-existence check, and the menu label/action
checks in `.github/workflows/build.yml`, both already run other rows). To
prove they would catch a broken row, I renamed `nixarchy-vm` to
`nixarchy-vmx` in the `trigger.vm.list` action and rebuilt
`checks.options` (which runs `tests/coverage.py` against the merged menu):

```
nixarchy-options> all 74 Install rows are mapped or accounted for
nixarchy-options> these menu rows name a command that does not exist:
nixarchy-options>   nixarchy-vmx <- trigger.vm.list
nixarchy-options> An Omarchy bump removed or renamed it, or a rename here did; the rows still draw and do nothing when chosen.
error: Cannot build '...-nixarchy-options.drv'.
```

Reverted the typo, rebuilt clean:

```
nixarchy-options> all 74 Install rows are mapped or accounted for
nixarchy-options> all 356 menu rows name commands that exist
...
```

(350 rows before this PR, 356 after — the six new ones, all resolving.)

## Checks run locally

- [x] `nix fmt -- --ci` clean
- [x] `nix run nixpkgs#statix -- check .` clean
- [x] `nix run nixpkgs#deadnix -- --fail .` clean
- [x] `nix build .#checks.x86_64-linux.options` — green, RED/GREEN shown
      above (this is what exercises `tests/coverage.py` and the label/
      action-completeness checks against the merged menu)
- [x] New content is `git add`ed (no new files, one file edited)
- [ ] No new option added — no `tests/options.nix` change needed
- [ ] No new `checks.*` entry — rides on the existing `options` check and
      the "Verify the generated menu defaults" step in `build.yml`

Not verified: the menu actually rendering and being clickable inside a
booted session — that is `checks.session`, which I did not run locally
(costs ~10–20 min); the `options` check above reads the merged, generated
menu JSON the same file the session boots, including the label/action
completeness and command-existence checks.

Part of #221. Implements #226. Built on top of #225's templates only in the
sense that `nixarchy vm <subcommand>` already exists on `main` (merged as
#274) — this PR does not depend on #225's unmerged branch and is based
directly on `origin/main`.
