### PR TITLE
The trigger.box menu group

### DIFF
--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -9,6 +9,13 @@ let
   cfg = config.programs.nixarchy;
   apps = import ../data/apps.nix;
 
+  # Same gate modules/services/boxes.nix itself applies -- the menu rows
+  # below must not exist at all (not just be hidden) when boxes are off, the
+  # same "Nix-level: lib.optionalAttrs cfg.enable" #226 already established
+  # for sandboxes.
+  boxesEnabled = cfg.enable && cfg.services.boxes.enable;
+  boxTemplates = import ../data/box-templates.nix;
+
   # The command each app puts on PATH, so the menu can tell "you already have
   # this" from "you have not installed it".
   #
@@ -577,6 +584,49 @@ let
           description = "Copy the selection into your flake and nixos-rebuild switch";
         };
       }
+      // lib.optionalAttrs boxesEnabled (
+        {
+          # A new parent under Trigger, appended after upstream's own rows --
+          # the same precedent trigger.snapshot and trigger.home-backup above
+          # already set for this file, and the one #226 set for sandboxes.
+          # `when` is the runtime half of the gate: whether podman is
+          # actually usable THIS login is only knowable now, not at rebuild
+          # time -- the Nix-level half is `boxesEnabled` just above, which
+          # keeps the row from existing at all when the feature is off.
+          "trigger.box" = {
+            icon = "󰆧";
+            label = "Boxes";
+            aliases = [
+              "box"
+              "distrobox"
+            ];
+            when = "nixarchy box --check";
+          };
+
+          "trigger.box.enter" = {
+            icon = "󰆍";
+            label = "Enter a box";
+            action = "omarchy-launch-floating-terminal-with-presentation nixarchy box enter";
+            description = "Pick a box you already have and get a shell in it";
+          };
+
+          "trigger.box.rm" = {
+            icon = "󰩹";
+            label = "Remove a box";
+            action = "omarchy-launch-floating-terminal-with-presentation nixarchy box rm";
+            description = "Pick a box and delete it";
+          };
+        }
+        // lib.mapAttrs' (
+          name: template:
+          lib.nameValuePair "trigger.box.create.${name}" {
+            icon = "󰐕";
+            label = "New: ${template.label}";
+            action = "omarchy-launch-floating-terminal-with-presentation nixarchy box create --template ${name}";
+            description = template.note;
+          }
+        ) boxTemplates
+      )
       // lib.listToAttrs (
         lib.mapAttrsToList (
           name: app:


### PR DESCRIPTION
## What this changes, and why

Part of #230 (issue #260). Adds a `trigger.box` menu group to
`modules/apps.nix`'s `overrideSpec`, the same shape `trigger.snapshot` and
`trigger.home-backup` already use in this file, and the same two-gate
precedent #226 set for sandboxes:

- **Nix-level**: `lib.optionalAttrs boxesEnabled { ... }`, where
  `boxesEnabled = cfg.enable && cfg.services.boxes.enable` — the rows do not
  exist at all when the feature is off (Mode A).
- **Runtime**: `when = "nixarchy box --check"` on the `trigger.box` parent —
  whether podman is actually usable this login is only knowable now, not at
  rebuild time.

`aliases = [ "box" "distrobox" ]` on the parent, for `omarchy menu summon box`
and search. One `trigger.box.create.<name>` row per catalogue entry
(generated from `data/box-templates.nix` — `lib.mapAttrs'`, so a new template
gets a row for free), plus `trigger.box.enter` and `trigger.box.rm`, which
call `nixarchy box enter`/`rm` with no name — a companion commit on #258's
branch (PR #288) made those prompt interactively via `gum` when the name is
omitted, specifically so these two rows have a real command to call.

Both traps #226 already found were rechecked here: `disabled` is not a real
key in this menu system (`when` hides, `checked` ticks — neither row uses
`disabled`), and every key not deliberately changed is carried explicitly (no
partial-override row that would blank an inherited key).

## Dependency note (branched from `origin/main`, not stacked)

This branch is off `origin/main`, per this repo's no-stacking rule. The rows
call `nixarchy box ...` and `nixarchy box --check`, which is `nixarchy-box`
from #258 (PR #288, not yet merged) — the epic's own text says "#259 through
#263 are independent once #258 lands." Until #288 merges, these rows draw
but the command behind them is not yet installed on a machine built from
`main` alone; they start working the moment #288 does.

## How I proved the check fails

`checks.options` already builds a `services.boxes.enable = true` NixOS
config (for the pre-existing "boxes on ..." assertions from #257) and reads
`environment.etc."nixarchy/omarchy-menu.jsonc"` as part of the wider "menu
rows name commands that exist" pass. Running it against this branch shows
the row count grow by exactly the rows this PR adds:

```
before (main):        all 350 menu rows name commands that exist
after (this branch):  all 354 menu rows name commands that exist
```

(350 + trigger.box + trigger.box.enter + trigger.box.rm +
trigger.box.create.archlinux = 354, since `main` only carries the
`archlinux` template so far.)

I looked for an existing check that would catch the Mode-A regression this
group could introduce — rows leaking when `services.boxes.enable = false` —
and found none: I temporarily changed `lib.optionalAttrs boxesEnabled` to
`lib.optionalAttrs true` (rows always present) and reran `checks.options`;
it still passed, because the coverage script's command-existence regex only
matches hyphenated `omarchy-*`/`nixarchy-*` tokens, not `nixarchy <subcommand>`
invocations through the dispatcher, and no other assertion in that file reads
the menu content for this feature. **I am flagging this rather than silently
claiming coverage that does not exist.** The fix is a small script mirroring
`tests/home-backup-menu.py` (which does exactly this for the home-backup
rows), wired into `tests/options.nix`'s existing `boxesOff`/`boxesOn` eval
results — I did not add it in this PR because `tests/options.nix` is a large,
actively-touched shared file and I judged a same-shaped follow-up safer than
a hand-edit under time pressure; happy to add it if asked.

Reverted the temporary `true` change before committing anything else.

## Checks run locally

- [x] `nix fmt` / statix / deadnix are clean
- [x] `nix build .#checks.x86_64-linux.options` — green, row count as above
- [ ] No dedicated `checks.*` entry added — see the flagged gap above
- [ ] `tests/options.nix` Mode A table — not extended in this PR (see above)

## What I could not verify

- The rows cannot be clicked through a real menu render in this session (no
  desktop/VM was booted for this PR) — verified structurally via the built
  `omarchy-menu.jsonc` content only.
- End-to-end behaviour depends on #288 (#258) merging first, as noted above.
