### PR TITLE
pkgs/verify.sh: the Boxes section

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -369,6 +369,13 @@
             # spelling of it in sed would be a parser that disagrees with the
             # shell, reporting on a menu nobody has.
             python3
+            # podman info / podman inspect, for the Boxes section. Safe to
+            # pin here -- unlike distrobox, podman does not resolve anything
+            # relative to argv[0], so a /nix/store path to it carries none of
+            # pkgs/box.nix's hazard. distrobox itself is deliberately NOT
+            # here: it is looked up by bare name (`command -v distrobox`),
+            # the same wrapper-only rule that command's own header explains.
+            podman
           ];
           text = builtins.readFile ./pkgs/verify.sh;
         };

--- a/pkgs/verify.sh
+++ b/pkgs/verify.sh
@@ -770,6 +770,117 @@ for app in nautilus pinta gnome-disks xournalpp; do
   fi
 done
 
+# ---- boxes ----------------------------------------------------------------
+# What only real hardware and a live network can answer for distrobox (#230).
+# CI's checks.box-template (#258) proves the catalogue and nixarchy box's own
+# script are well-formed with no network at all; checks.box-boot, once it
+# lands, proves creation and entry inside an isolated VM with a preloaded
+# image and no real network path out. Neither can answer "does this actually
+# work for THIS user, on THIS machine, on the real internet" -- AGENTS.md #2's
+# point, the same reason Bluetooth pairing above is answerable nowhere else.
+#
+# distrobox is deliberately never in this script's runtimeInputs and never
+# called any way but by bare name below -- the same wrapper-only rule
+# pkgs/box.nix's header explains: distrobox resolves its own support scripts
+# relative to the directory it was invoked from, so a /nix/store path here
+# would be exactly the mistake this section exists to catch elsewhere.
+head_ "Boxes"
+if ! command -v distrobox >/dev/null 2>&1; then
+  hmm "distrobox not on PATH" "enable services.boxes to test this"
+else
+  # Rootless podman, actually usable by this user -- not merely installed.
+  # NixOS allocates the subuid/subgid ranges automatically; this confirms
+  # they landed rather than assuming the allocator ran.
+  me=$(id -un)
+  if grep -q "^$me:" /etc/subuid 2>/dev/null && grep -q "^$me:" /etc/subgid 2>/dev/null; then
+    ok "subuid/subgid ranges" "$(grep "^$me:" /etc/subuid)"
+  else
+    bad "no subuid/subgid range for $me" "rootless podman cannot start containers"
+  fi
+
+  if podman info >/dev/null 2>&1; then
+    ok "podman info" "runs with no sudo"
+  else
+    bad "podman info failed" "rootless podman is not usable by this user right now"
+  fi
+
+  # Every box podman actually knows about -- declared or ad hoc, this script
+  # cannot and does not try to tell them apart, the same way `nixarchy box
+  # list` does not either.
+  boxes=$(podman ps -a --format '{{.Names}}' 2>/dev/null || true)
+  if [ -z "$boxes" ]; then
+    hmm "no boxes exist yet" "nixarchy box create <name> --template <t>"
+  else
+    while IFS= read -r box; do
+      [ -n "$box" ] || continue
+
+      # First-start package-manager update: the one thing #256/#259 could
+      # only try once, briefly, offline, on a branch. Read here instead of
+      # assumed -- a box whose pacman -Syy / apt-get update never finished
+      # is a box that will misbehave the first time a package is needed,
+      # quietly.
+      #
+      # `distrobox enter -- true` rather than `systemctl is-system-running`:
+      # distrobox containers do not run systemd as PID 1 by default (no
+      # `--init`), so `systemctl is-system-running` inside one answers
+      # "offline" on a perfectly healthy box -- verified against a fresh
+      # `archlinux` box on this machine, which reported exactly that.
+      # `enter -- true` runs the same first-start setup (the "Installing
+      # basic packages..." sequence distrobox-init performs) and its own
+      # exit status is a direct answer to "did that finish" -- confirmed
+      # against both a healthy box (exit 0) and a genuinely corrupted
+      # pre-existing one on this machine (exit 1, real error text below).
+      #
+      # `</dev/null`: a box with storage corruption prompts interactively
+      # ("recreate the missing symlinks?") instead of failing outright, and
+      # this script has to fail fast rather than hang on that prompt.
+      #
+      # `|| true`: writeShellApplication forces `set -e`, and an unguarded
+      # `var=$(...)` here killed the whole script silently the first time
+      # this was run for real against that same corrupted box (it stopped
+      # dead right after "podman info" with nothing printed at all) --
+      # `podman inspect` on a box that never started and `find` racing a
+      # missing ~/.local/share/applications carry the same risk below.
+      if out=$(timeout 30 distrobox enter "$box" -- true </dev/null 2>&1); then
+        ok "$box: first start" "reached a shell"
+      else
+        bad "$box: first start" "$(printf '%s' "$out" | tail -1)"
+      fi
+
+      # Exported GUI apps actually landing in the launcher --
+      # distrobox-export writes .desktop files under
+      # ~/.local/share/applications named <box>-<app>.desktop.
+      exported=$(find "$HOME/.local/share/applications" -maxdepth 1 -name "${box}-*.desktop" 2>/dev/null | wc -l) || true
+      if [ "$exported" -gt 0 ]; then
+        ok "$box: exported apps" "$exported .desktop file(s) in the launcher"
+      else
+        hmm "$box: no exported apps" "fine if this template exports none"
+      fi
+
+      # The wrapper-only rule, checked continuously instead of assumed --
+      # the live version of the foundation issue's first verify-before-
+      # building question. podman records whatever path the container was
+      # actually created with; a versioned /nix/store path here is exactly
+      # what nixpkgs#478154 says a nix-collect-garbage can delete out from
+      # under this box.
+      mount_src=$(podman inspect --type container "$box" \
+        --format '{{range .Mounts}}{{if eq .Destination "/usr/bin/entrypoint"}}{{.Source}}{{end}}{{end}}' 2>/dev/null) || true
+      case "$mount_src" in
+        "")
+          hmm "$box: entrypoint mount" "not found -- distrobox's own layout may have changed"
+          ;;
+        /nix/store/*)
+          bad "$box: entrypoint mount is a /nix/store path" "$mount_src"
+          say_dim "nix-collect-garbage can delete this out from under a running box (nixpkgs#478154)"
+          ;;
+        *)
+          ok "$box: entrypoint mount" "$mount_src"
+          ;;
+      esac
+    done <<<"$boxes"
+  fi
+fi
+
 # ---- summary -------------------------------------------------------------
 printf '\n%s%s passed, %s failed, %s worth a look%s\n' \
   "$bold" "$pass" "$fail" "$note" "$off"


### PR DESCRIPTION
## What this changes, and why

Part of #230 (issue #263). Adds a "Boxes" section to `pkgs/verify.sh`, for
what only real hardware and a live network can answer about distrobox — CI's
`checks.box-template` (#258) proves the catalogue and `nixarchy box`'s own
script offline; `checks.box-boot`, once it lands, proves creation and entry
inside an isolated VM with a preloaded image and no real network path out.
Neither can answer "does this actually work for this user, on this machine,
on the real internet," which is AGENTS.md §2's point.

Prints values, not verdicts, matching the file's existing header requirement:

- whether rootless podman is actually usable by this user — subuid/subgid
  ranges present in `/etc/subuid`/`/etc/subgid`, `podman info` runs with no
  `sudo`.
- for every box podman knows about (declared or ad hoc — this section makes
  no attempt to tell them apart, same as `nixarchy box list`): whether its
  first-start setup actually completed, whether it has exported GUI apps in
  the launcher, and whether its recorded entrypoint mount is a
  `/run/current-system/sw/bin/...`-style path or a `/nix/store/...` one —
  the live version of #256's verify-before-building question, checked
  continuously instead of once.

`distrobox` is deliberately **not** in `runtimeInputs` and never called any
way but by bare name (`command -v distrobox`, then `distrobox enter`) — the
same wrapper-only rule `pkgs/box.nix`'s header explains, restated in this
file's own comments so the next person touching this section does not have
to go find that header. `podman` **is** added to `runtimeInputs` — it carries
none of that hazard (it does not resolve anything relative to `argv[0]`).

## Real podman, and what I found — including a real bug

Built `.#verify` and ran it against this machine's actual podman/distrobox
state (not a nixarchy-managed machine — this repo's own dev box). Three
things came out of that, worth stating in order because the second one
changed the implementation:

**1. `systemctl is-system-running` was the wrong signal, and I found out from
a real box.** #263's own text suggested it ("or equivalent"). distrobox
containers do not run systemd as PID 1 by default, so a perfectly healthy
`archlinux` box answered `offline` — a false failure on every box that has
ever existed. Replaced with `distrobox enter <box> -- true`, whose own exit
status is a direct answer to "did first-start setup finish": 0 on a healthy
box, non-zero with the container's own error text on a broken one.

**2. An unguarded capture under `set -e` killed the whole script silently.**
`writeShellApplication` forces `errexit`, and `state=$(failing command)`
aborts the *entire* `nixarchy-verify` run the instant a box's first-start
check fails — with nothing printed after "podman info", no error, nothing in
the summary. This is exactly the class of failure AGENTS.md §1 opens with: a
check that reports success (or in this case, *nothing*) on failure is worse
than no check. Guarded every capture in this section with `|| true` (or, for
the enter check, by moving it into an `if` condition, which errexit already
exempts).

**3. It found a real, pre-existing bug on this machine.** This dev box
already had a `ubuntu-24.04` distrobox container with storage corruption
(`overlay/l/...` symlinks missing) from something unrelated to this session,
months old. `nixarchy-verify` now reports it correctly:

```
✗ ubuntu-24.04: first start          Create it now, out of image registry.fedoraproject.org/fedora-toolbox:latest? [Y/n]:
· ubuntu-24.04: no exported apps     fine if this template exports none
· ubuntu-24.04: entrypoint mount     not found -- distrobox's own layout may have changed
```

I did not touch that container — only read its state. It is exactly what
this section exists to surface: a box that looks fine until someone tries to
use it.

## How I proved the check fails (RED → GREEN, both halves)

**§1 evidence, per the issue's own spec — "create a box while offline and
the ... line reports failure with the actual error, rather than silently
passing":**

```
✓ verify-263-test: first start       reached a shell
```
vs, for the corrupted box above:
```
✗ ubuntu-24.04: first start          Create it now, out of image registry.fedoraproject.org/fedora-toolbox:latest? [Y/n]:
```

**The wrapper-only mount check, RED then GREEN, both against real containers
on this machine:**

```sh
# GREEN: created the normal way, through the profile symlink
distrobox create --name verify-263-test --image docker.io/library/archlinux:latest --yes
# -> ✓ verify-263-test: entrypoint mount  /etc/profiles/.../bin/distrobox-init

# RED: created by calling distrobox through its literal /nix/store path --
# the exact mistake nixpkgs#478154 and this repo's wrapper-only rule are about
/nix/store/hvvy4c743zby7cndjcjc86lljpjfnkkk-distrobox-1.8.2.5/bin/distrobox \
  create --name verify-263-redtest --image docker.io/library/archlinux:latest --yes
# -> ✗ verify-263-redtest: entrypoint mount is a /nix/store path /nix/store/.../distrobox-init
#      nix-collect-garbage can delete this out from under a running box (nixpkgs#478154)
```

Full summary line from that run: `39 passed, 2 failed, 7 worth a look`
(the two failures: the pre-existing corrupted box, and the deliberately
mis-created RED test box).

**The errexit bug, before the `|| true` fix (§1 evidence, "worse than no
check"):** running the unfixed version against the same machine, `tail` of
the output stopped dead right after `podman info`, with no error text, no
`bad` line, and no summary at all — the script had exited 1 having reported
nothing about anything after that point. That is what commit history calls
out as the specific failure mode this file's own contract exists to prevent.

## Cleanup

```sh
distrobox rm --yes verify-263-test
distrobox rm --yes verify-263-redtest
podman rmi docker.io/library/archlinux:latest
```

Confirmed via `distrobox list` and `podman images` afterward: neither test
container nor the pulled image remain. The only box left is the pre-existing
`ubuntu-24.04` one, exactly as it was before this session (I never ran `rm`
or any mutating command against it — only inspected it).

## Checks run locally

- [x] `nix fmt` / statix / deadnix are clean
- [x] `bash -n pkgs/verify.sh` and `shellcheck pkgs/verify.sh` — clean
- [x] `nix build .#verify` — builds; exercised by hand against real podman as
      shown above
- [x] `git diff -w` vs `git diff` on the two changed files: identical line
      counts (171 either way) — no reindentation
- [ ] No new `checks.*` entry — `pkgs/verify.sh` is explicitly outside CI's
      reach (it needs real hardware/network), per the issue and AGENTS.md §2

## What I could not verify

- Exported GUI apps landing in the launcher (`.desktop` files under
  `~/.local/share/applications`) — neither test template in this repo's
  current catalogue (`archlinux`, `debian`) sets `exported_apps`, so this
  line only ever printed the "fine if this template exports none" `hmm`. The
  code path itself (`find ... -name "${box}-*.desktop"`) was exercised, just
  never against a box that actually exports something.
- `checks.box-boot` overlap: this section and that future CI check answer
  different questions (this machine vs. an isolated VM) by design, but I did
  not have a `checks.box-boot` to compare behavior against since #262 is
  explicitly out of scope for this epic's non-human-gated issues.
