### PR TITLE
checks.box-template pins the debian image it now has to check

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1344,6 +1344,12 @@
               tag = "latest";
               sha256 = "sha256-XqDfBl6Ehkzgw/3LPVd+nrQnV3CxDCqyynqBOfTFZDs=";
             };
+            debian = {
+              imageName = "debian";
+              imageDigest = "sha256:f324c7ff54321e8d9c588493a20244965938ce0aa50bbd1022d38010e9ffc4b1";
+              tag = "trixie";
+              sha256 = "sha256-iL1J4Iro9wW+yL7dHgGlaMpoTxCU5XzuEgKkWAar4yA=";
+            };
           };
         };
 


### PR DESCRIPTION
**`main` is red.** `checks.box-template: no imagePins entry for: debian`

## How two green PRs broke each other

#288 added `checks.box-template`, whose `imagePins` table must name every
catalogue template. #289 added the `debian` template.

- #288's branch had no `debian`, so the check passed.
- #289's branch had no check, so it passed too.

Neither branch could see the other. Merged separately, they produce a failure
that had never run anywhere.

**This is the cost of the no-stacking rule I gave those agents.** It avoided the
rebuild-and-lose-work trap that cost three PRs earlier today — #266 and #274
would have silently deleted merged work if taken as stacked branches — and
bought this instead. Worth naming the trade rather than treating it as an
agent's mistake: neither of them could have caught it from their own branch.

## The pin

Taken from the registry with `nix-prefetch-docker` against
`docker.io/library/debian:trixie`, the same way the `archlinux` pin above it
was. That is the point of the table — a pin is what makes reading a template
reproducible without pulling the image.

```
imageDigest = "sha256:f324c7ff54321e8d9c588493a20244965938ce0aa50bbd1022d38010e9ffc4b1";
sha256      = "sha256-iL1J4Iro9wW+yL7dHgGlaMpoTxCU5XzuEgKkWAar4yA=";
```

## Verified

`nix build .#checks.x86_64-linux.box-template` passes on this branch and fails
on `main`.