### PR TITLE
The hypr-rdp module records what to delete when upstream gains a password file

### DIFF
--- a/modules/services/hypr-rdp.nix
+++ b/modules/services/hypr-rdp.nix
@@ -348,6 +348,25 @@ in
         # /proc/*/cmdline is world-readable, so `-p` would publish it to every
         # process on the machine. 0400 and owned by the user whose session it
         # is; the rendered path is under /run, never the store and never git.
+        #
+        # WHAT TO DELETE WHEN UPSTREAM GAINS A PASSWORD FILE (#157). Asked for
+        # in MuNeNiCK/hypr-rdp#80; the maintainer answered on 2026-09-02 with
+        # the shape they want, so the semantics below are theirs, not a guess:
+        # `--password-file` plus a `password_file` config key, conflicting with
+        # the inline `password` rather than overriding it, and a hard startup
+        # failure when the named file is missing, unreadable or empty. Nothing
+        # is merged and no PR is open; the check is whether a release past
+        # v0.1.5 (the input's pin in flake.nix) has `password_file` in
+        # src/config.rs.
+        #
+        # When it lands: this template becomes a plain `sops.secrets.<name>`
+        # file (no rendering, no placeholder, no restart-on-change caveat), the
+        # config file becomes store-safe and can be a `writeText`, and the
+        # `password = ".+"` arm of the guard below moves to checking the secret
+        # file is non-empty. The username arm and the assertions stay -- an
+        # upstream hard failure still leaves the "no credentials at all serves
+        # the desktop unauthenticated" default in place for anyone who
+        # configures neither.
         sops.templates."hypr-rdp.toml" = {
           owner = svc.user;
           mode = "0400";


### PR DESCRIPTION
## What this changes, and why

Comment only, in `modules/services/hypr-rdp.nix`. #157's remaining "done when"
bullet on our side is a follow-up note saying what to delete when upstream
takes a password file. That note did not exist; the module explains at length
why the password must be rendered *into* the config file today, and nothing
recorded what would collapse when it no longer has to be.

Upstream now has an answer to record. [MuNeNiCK/hypr-rdp#80](https://github.com/MuNeNiCK/hypr-rdp/issues/80)
was filed on 2026-09-02 and the maintainer replied ten minutes later with the
shape they want: `--password-file` and a `password_file` config key, which
**conflict** with the inline `password` rather than overriding it, and a hard
startup failure when the named file is missing, unreadable or empty. That
answers the design question #157 was deliberately waiting on before offering
the PR, so it is worth writing down where the code it affects lives rather than
only in an issue thread.

Nothing is merged and no PR is open upstream, so no behaviour changes here.
Verified today: `password_file` still returns 0 code results across
`MuNeNiCK/hypr-rdp`, and the newest release is still v0.1.5 (2026-08-18), which
is what the flake input pins (`cf3fbd8`, the commit `v0.1.5` resolves to).

## How I proved the check fails

This PR needs no check: it adds nine lines of comment and no expression. AGENTS
§1's contract applies to checks, and there is no property here that could vary.

## Checks run locally

- `nix build .#checks.x86_64-linux.options` — green (nothing evaluable changed,
  run as a floor rather than as evidence).

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [x] If this adds an option: `tests/options.nix` covers both states — n/a
- [x] If this adds a `checks.*` entry: a PR-triggered workflow builds it — n/a
