### PR TITLE
The system job survives a substituter blip, at 45 minutes not 30

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -648,7 +648,15 @@ jobs:
 
   system:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 45, not 30. The job's own work is ~20 minutes (see below), so 30 looked
+    # like ample headroom until 2026-09-04, when a cache.nixos.org stall of
+    # 21-24 minutes hit four independent runners inside the same wall-clock
+    # window -- three of them blocked on the identical obs-studio store path.
+    # Every one of those runs died at the cap with its builds already green,
+    # and four PRs sat unmergeable behind an outage in somebody else's CDN.
+    # This cap exists to fail a hung job in half an hour rather than six
+    # (411c6a4); 45 still does that, while surviving a substituter blip.
+    timeout-minutes: 45
     # Its own concurrency group, and NOT cancel-in-progress. This job builds
     # Hyprland from source and takes ~20 minutes, so under the workflow-level
     # cancel-in-progress it is killed by any push landing within that window


### PR DESCRIPTION
## What happened

On 2026-09-04 a `cache.nixos.org` stall of **21-24 minutes** hit four
independent runners inside the same wall-clock window, three of them blocked
on the identical `obs-studio-32.2.1` store path:

| run | stall | blocked on |
|---|---|---|
| 33924505354 (#296) | 1359s | obs-studio-32.2.1 |
| 33924562036 (#297) | 1316s | libreoffice-26.2.5.2-wrapped |
| 33924510447 (#298) | 1276s | obs-studio-32.2.1 |
| 33924511154 (#299) | 1469s | obs-studio-32.2.1 |

All four stalls start ~22:16-22:17 UTC and end ~22:37-22:41 UTC. Four
independent VMs, different store paths, same window, same substituter: an
upstream CDN incident, not anything in this repository.

"Build the VM system closure" normally takes 2m40s. It took 24-27 minutes,
ate the whole budget, and every `system` job was cancelled at the cap **with
its builds already green** — dying partway through "Drive a session and the
app-selection loop" with seven test steps never reached. Four PRs sat
unmergeable behind somebody else's outage.

## Why 45

The job's own work is **16-19 minutes**, measured across ten successful runs
that day (16,16,17,17,17,18,18,19,19,25). 30 was never tight for the work —
only for the work plus an external blip.

`411c6a4` set these caps to fail a hung job in half an hour rather than
GitHub's default six. 45 keeps that property: a genuine hang still fails in
well under an hour.

`devenv-presets` already sits at 45 for the same class of reason, and its
comment says why: without a usable substituter the run "stops being a CI job
and starts being an afternoon".

## What this is not

Not a fix for slowness in this repo. Three hypotheses were tested and
rejected before landing here — step accumulation (the job has ~11 minutes of
headroom), runner contention (hosted runners are independent VMs; the
simultaneity was the *fingerprint* of the shared outage, not competition),
and cachix push failure (`nixarchy.cachix.org` served fine in the same logs).
The correct response to the incident itself was re-running, which was done
and passed. This only stops the next blip from blocking merges.

CI-gate change: proposing, not merging.