### PR TITLE
The network image proves the build can start before it wipes the disk

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1647,10 +1647,16 @@ preflight_build() {
 
   echo "nixarchy-install: the system cannot be planned, so no install was started." >&2
   echo >&2
-  printf '%s\n' "$plan" | grep -m1 'error:' | sed 's/^ */  /' >&2
+  # Herestrings, not printf pipes -- the #273 shape, again. `grep -m1` and
+  # `grep -q` both close the read end the moment they match, printf dies on
+  # EPIPE, and "printf: Broken pipe" lands immediately above the refusal this
+  # function exists to print. A full closure dry-run is long enough to make
+  # that likely rather than theoretical.
+  grep -m1 'error:' <<<"$plan" | sed 's/^ */  /' >&2
   echo >&2
-  if printf '%s' "$plan" | grep -qiE \
-    'unable to download|could not resolve|network is unreachable|couldn.t connect|connection timed out'; then
+  if grep -qiE \
+    'unable to download|could not resolve|network is unreachable|couldn.t connect|connection timed out' \
+    <<<"$plan"; then
     echo "  That is the network: evaluating the flake fetches its inputs, and" >&2
     echo "  the fetch failed. Check the connection, then run nixarchy-install" >&2
     echo "  again." >&2

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1586,6 +1586,80 @@ check_store_space() {
   return 1
 }
 
+# One line so the store-space check can extract it with a grep; the test stubs
+# it to say "network image" without an /etc to write a marker into.
+on_net_image() { [ -f /etc/nixarchy-iso-net ]; }
+
+# Prove the build could start BEFORE the disk is wiped (#300).
+#
+# main() chains format_disk five phases ahead of the build, and that order is
+# load-bearing: the build lands in the live store, a RAM-backed overlay at
+# half the machine's memory (the check_store_space comment above), and when
+# it does not fit the only store big enough is the disk format_disk creates
+# -- run_install's `--store /mnt` fallback. So the build itself cannot move
+# ahead of the wipe. The QUESTION "would this build even start" can, and on
+# the network image the answer is usually about the network.
+#
+# Two probes, both cheap, both while refusal still costs nothing:
+#
+#   - the caches. `nix build --dry-run` does NOT fail on a dark substituter:
+#     nix disables it with a warning and plans a from-source build instead,
+#     which on this image means compiling a desktop into a tmpfs that cannot
+#     hold it. So each cache is asked for its nix-cache-info directly -- the
+#     same test network_ready already applies to cache.nixos.org, extended to
+#     the extra substituters the build actually fetches from.
+#
+#   - the plan. Evaluating the flake fetches its inputs, so this is what
+#     fails when the network died after ask_network let it through --
+#     "unable to download ...tar.gz" -- and what fails on a broken input.
+#     run_install repeats this dry-run after the wipe; by then evaluation is
+#     cached and the repeat is close to free.
+#
+# Only the network image. The offline image carries the closure and has no
+# substituters to probe, and checks.install runs with no network, no marker
+# of either kind and a seeded store -- keying on anything but the net image's
+# own marker would make a passing check demand a network and fail, which is
+# the trap the ask_network comment already names.
+preflight_build() {
+  on_net_image || return 0
+
+  local sub
+  for sub in https://cache.nixos.org $SUBSTITUTERS; do
+    curl -sfI --max-time 8 "$sub/nix-cache-info" >/dev/null 2>&1 && continue
+    echo "nixarchy-install: cannot reach $sub." >&2
+    echo >&2
+    echo "  This image downloads the desktop from that cache as it installs," >&2
+    echo "  and it is not answering. Check the network connection, then run" >&2
+    echo "  nixarchy-install again." >&2
+    echo >&2
+    echo "  Nothing was written: the disk has not been touched." >&2
+    return 1
+  done
+
+  # The flake in a git worktree sees only tracked or staged files
+  # (install_flake_dir says why), and install_flake_dir's later `git init`
+  # on this repository is a no-op.
+  git -C "$work" init -q
+  git -C "$work" add -A
+  local plan
+  plan=$(nix "${NIX_FLAGS[@]}" build --dry-run "${SUBSTITUTE_FLAGS[@]}" \
+    "$work#nixosConfigurations.$hostname.config.system.build.toplevel" 2>&1) && return 0
+
+  echo "nixarchy-install: the system cannot be planned, so no install was started." >&2
+  echo >&2
+  printf '%s\n' "$plan" | grep -m1 'error:' | sed 's/^ */  /' >&2
+  echo >&2
+  if printf '%s' "$plan" | grep -qiE \
+    'unable to download|could not resolve|network is unreachable|couldn.t connect|connection timed out'; then
+    echo "  That is the network: evaluating the flake fetches its inputs, and" >&2
+    echo "  the fetch failed. Check the connection, then run nixarchy-install" >&2
+    echo "  again." >&2
+    echo >&2
+  fi
+  echo "  Nothing was written: the disk has not been touched." >&2
+  return 1
+}
+
 run_install() {
   # What would have to be built, printed before doing it. On a machine with no
   # network an unseeded build input is the difference between an install and a
@@ -1921,6 +1995,12 @@ main() {
     echo "$work"
     exit 0
   fi
+
+  # Refusal is free until format_disk runs; after it there is no OS to go
+  # back to. So what can prove the install would die says so here, on the
+  # screen, instead of five phases deep in a log under a "1 dependency
+  # failed" cascade (#300).
+  preflight_build || exit 1
 
   # From here the screen belongs to the dashboard and every phase writes to the
   # log instead. A wall of store paths tells nobody anything they can act on,

--- a/tests/installer-store-space.nix
+++ b/tests/installer-store-space.nix
@@ -127,7 +127,12 @@ pkgs.runCommand "nixarchy-installer-store-space" { } ''
   curl() { [ "$CURL_OK" = 1 ]; }
   nix() {
     if [ "$NIX_OK" = 1 ]; then echo 'these 0 derivations will be built'; else
+      # Long on purpose: a real dry-run of a desktop closure is thousands of
+      # lines, which is what makes an early-exiting reader (`grep -m1`, `grep
+      # -q`) kill its producer with EPIPE -- the #273 shape. A short plan
+      # cannot reproduce that race; this one does.
       echo "error: unable to download 'https://github.com/x/archive/r.tar.gz'"
+      seq 1 200000 | sed 's/^/error: cascade line /'
       return 1
     fi
   }
@@ -154,6 +159,10 @@ pkgs.runCommand "nixarchy-installer-store-space" { } ''
   # The network died after ask_network let it through: evaluation fails.
   t refuse  "net image, flake input unreachable" net  1 0
   grep -qi 'network' out || { echo "  FAILED  eval refusal does not name the network"; fails=$((fails+1)); }
+  # The #273 regression, which reached a user: an early-exiting grep killing
+  # its producer puts "printf: Broken pipe" immediately above the refusal, on
+  # the one screen where noise costs the most.
+  ! grep -qi 'broken pipe' out || { echo "  FAILED  refusal is preceded by Broken pipe noise"; fails=$((fails+1)); }
   # And a network that works installs as before.
   t proceed "net image, everything answers"      net  1 1
 

--- a/tests/installer-store-space.nix
+++ b/tests/installer-store-space.nix
@@ -106,5 +106,76 @@ pkgs.runCommand "nixarchy-installer-store-space" { } ''
   }
 
   echo "check_store_space refuses what will not fit and nothing else"
+
+  # ------------------------------------------------------------------------
+  # preflight_build (#300): the disk must not be wiped before anything proves
+  # the build could start. Same doctrine as above -- the function on its own,
+  # driven with stubs that lie.
+  # ------------------------------------------------------------------------
+  sed -n '/^preflight_build()/,/^}/p' ${installScript} > pf.sh
+  test -s pf.sh || { echo "preflight_build is not in install.sh any more" >&2; exit 1; }
+  grep '^on_net_image()' ${installScript} >> pf.sh
+
+  cat > pt.sh <<'EOF'
+  NIX_FLAGS=() SUBSTITUTE_FLAGS=()
+  SUBSTITUTERS="https://nixarchy.cachix.org"
+  work=/nonexistent hostname=h
+  . ./pf.sh
+  # The one thing that must never happen before the probes pass.
+  wipefs() { touch wipefs-called; }
+  git() { :; }
+  curl() { [ "$CURL_OK" = 1 ]; }
+  nix() {
+    if [ "$NIX_OK" = 1 ]; then echo 'these 0 derivations will be built'; else
+      echo "error: unable to download 'https://github.com/x/archive/r.tar.gz'"
+      return 1
+    fi
+  }
+  fails=0
+  t() {
+    want=$1 name=$2 img=$3 curlok=$4 nixok=$5
+    if [ "$img" = net ]; then on_net_image() { return 0; }; else on_net_image() { return 1; }; fi
+    if CURL_OK=$curlok NIX_OK=$nixok preflight_build >out 2>&1; then got=proceed; else got=refuse; fi
+    if [ "$got" = "$want" ]; then
+      echo "  ok      $name ($got)"
+    else
+      echo "  FAILED  $name: wanted $want, got $got"; sed 's/^/            /' out
+      fails=$((fails + 1))
+    fi
+  }
+
+  # No marker: checks.install's shape -- no network, seeded store. Probing
+  # here would fail a passing check, so nothing may be probed at all.
+  t proceed "no image marker, network dead"      none 0 0
+  # The filed case: net image, cache dark. Refused, and the message names
+  # the network rather than emitting a dependency cascade.
+  t refuse  "net image, substituter unreachable" net  0 1
+  grep -qi 'network' out || { echo "  FAILED  refusal does not name the network"; fails=$((fails+1)); }
+  # The network died after ask_network let it through: evaluation fails.
+  t refuse  "net image, flake input unreachable" net  1 0
+  grep -qi 'network' out || { echo "  FAILED  eval refusal does not name the network"; fails=$((fails+1)); }
+  # And a network that works installs as before.
+  t proceed "net image, everything answers"      net  1 1
+
+  # (c) of #300: across every scenario, including the refusals, the disk was
+  # never touched.
+  [ ! -e wipefs-called ] || { echo "  FAILED  preflight called wipefs"; fails=$((fails+1)); }
+  exit $fails
+  EOF
+  bash pt.sh
+
+  # And that main() actually runs it ahead of the wipe. The function tests
+  # above stay green with the call site deleted, which would be #133 again:
+  # written, extracted, asserted, and run by nothing.
+  # `|| true` because stdenv sets pipefail, and a grep with no match must
+  # reach the named refusal below rather than kill the script mid-pipe.
+  pf_line=$(grep -n 'preflight_build || exit 1' ${installScript} | cut -d: -f1 | head -1 || true)
+  fmt_line=$(grep -n '^    format_disk &&' ${installScript} | cut -d: -f1 | head -1 || true)
+  [ -n "$pf_line" ] || { echo "main() no longer calls preflight_build" >&2; exit 1; }
+  [ -n "$fmt_line" ] && [ "$pf_line" -lt "$fmt_line" ] || {
+    echo "preflight_build does not run before format_disk; #300 is back" >&2; exit 1;
+  }
+
+  echo "preflight_build refuses before the wipe, and main runs it there"
     touch $out
 ''


### PR DESCRIPTION
Fixes #300.

The installer erased the disk in `format_disk`, five phases before anything proved the system could be built. A tester on NIXARCHY_4_0_2 met a build failure as a stop screen full of "Reason: 1 dependency failed" on a machine with no OS left on it.

**What this does not do:** move the build ahead of the wipe. That order is load-bearing — the build lands in the live store, a RAM-backed overlay at half system memory, and `run_install`'s escape hatch for closures that do not fit is `--store /mnt`, the disk `format_disk` just created. Confirmed from `check_store_space`'s own comments before designing anything.

**What it does:** `preflight_build`, run in `main()` after the questions and before the dashboard/wipe chain, on the network image only:

- probes each substituter (`cache.nixos.org` + `$SUBSTITUTERS`) for `nix-cache-info` — the same test `network_ready` already applies at question time, re-applied at the moment of commitment. A dry-run alone cannot catch this: nix disables an unreachable cache with a warning and plans a from-source build, which on this image means compiling a desktop into a tmpfs that cannot hold it.
- evaluates the build plan (`nix build --dry-run` from `$work`) — this is what fails when the network died after `ask_network` let it through, and what fails on a broken input. `run_install`'s later dry-run repeats it against a warm eval cache.

Refusals print what is wrong, name the network when it is the network, and say "Nothing was written: the disk has not been touched" — on screen, not five phases deep in the log.

**Skipped outright** on the offline image, and on anything with no net-image marker: `checks.install` runs with no network, no marker, and a seeded store, so keying on anything but `/etc/nixarchy-iso-net` would fail a passing check (the trap `ask_network`'s comment names).

**Guard:** extended `tests/installer-store-space.nix` in its own doctrine — the function extracted alone, driven by a `curl`/`nix` that lie, plus a line-order assertion that `main()` calls it ahead of `format_disk`. Asserts (a) unreachable substituter → non-zero, (b) the refusal names the network, (c) `wipefs` never called, and that the no-marker sandbox shape still proceeds. Each assertion broken in turn and confirmed to fail by name (call site deleted → "main() no longer calls preflight_build"; refusal made non-fatal → "wanted refuse, got proceed"; wording changed → "refusal does not name the network"; wipefs injected → "preflight called wipefs").

Rides in the existing `installer-store-space` check rather than a new one, because the build.yml guard requires every flake check to be wired into a PR workflow and the CI gate is out of scope here.

Not tagged for release: installer changes need a local VM install first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNg5aptS2JtfeeN3vTxbR3