### PR TITLE
The -tcg MicroVM runner can now boot on the hosts it exists for

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -933,6 +933,36 @@
         # `/dev/kvm` (including nixarchy running inside a VM) can boot, and
         # the one CI builds. No separate "disable kvm" option exists to set;
         # there is only this one.
+        #
+        # machineOpts on the -tcg variant, and every entry is load-bearing:
+        #
+        #   - `pit = "on"`, `pic = "on"`. Upstream's default microvm machine
+        #     sets both off, which is correct under KVM -- kvmclock is the
+        #     guest's clock -- and fatal under TCG, which has no kvmclock:
+        #     with no PIT, no PIC and no HPET on this machine type, early
+        #     timer init has nothing to calibrate from, and the kernel
+        #     triple-faults or wedges right after "Poking KASLR", outcome
+        #     depending on where KASLR happened to land. Measured on a real
+        #     A/B: the shipped runner under forced TCG produced zero output
+        #     for five minutes; the same runner with pit/pic on booted to a
+        #     login prompt in 2m13s. `-cpu qemu64` wedged identically, so
+        #     the CPU model was ruled out.
+        #
+        #   - `accel = "tcg"`, PINNED -- not upstream's `kvm:tcg` fallback
+        #     chain. The fallback is how the wedge above shipped unnoticed:
+        #     qemu silently takes KVM wherever /dev/kvm exists (including
+        #     inside a test VM on a host with nested virtualisation), so
+        #     every local run of the "-tcg" artifact was measuring a KVM
+        #     boot, and the one environment that exercised real TCG was CI
+        #     -- at the moment something first tried to boot it. This
+        #     variant's entire reason to exist is hosts with no /dev/kvm; a
+        #     KVM host should run the normal runner. Do not "optimise" the
+        #     fallback back in: an artifact that never runs as what its
+        #     name promises is how this bug lived long enough to gate a PR.
+        #
+        #   - the rest reproduce upstream's x86 defaults (machineOpts
+        #     REPLACES the whole set, so omitting one is turning it off).
+        #     `pcie = "on"` because the 9p shares sit on virtio-pci.
         // lib.concatMapAttrs (
           name: template:
           let
@@ -945,7 +975,21 @@
           in
           {
             "microvm-${name}" = mkMicrovm [ ];
-            "microvm-${name}-tcg" = mkMicrovm [ { microvm.cpu = "max"; } ];
+            "microvm-${name}-tcg" = mkMicrovm [
+              {
+                microvm.cpu = "max";
+                microvm.qemu.machineOpts = {
+                  accel = "tcg";
+                  acpi = "on";
+                  "mem-merge" = "on";
+                  pcie = "on";
+                  pit = "on";
+                  pic = "on";
+                  rtc = "on";
+                  usb = "off";
+                };
+              }
+            ];
           }
         ) (import ./data/microvm-templates.nix)
       );

--- a/tests/microvm-template.nix
+++ b/tests/microvm-template.nix
@@ -140,6 +140,41 @@ pkgs.runCommand "nixarchy-microvm-template"
         echo "${name}: -tcg runner still passes -enable-kvm" >&2
         fail=1
       fi
+
+      # The -tcg runner's machine line, and each of these is a bug that
+      # already shipped or the door it came through.
+      #
+      # accel=tcg, PINNED. Upstream's default is the `kvm:tcg` fallback
+      # chain, under which qemu silently takes KVM wherever /dev/kvm exists
+      # -- so every local run of the "-tcg" artifact measured a KVM boot,
+      # and the artifact that cannot boot under real TCG went out measured
+      # as working. The flake.nix comment on machineOpts says the rest; this
+      # grep is what stops the fallback being "optimised" back in.
+      if ! grep -q -- 'accel=tcg[^:]' "$tcg/bin/microvm-run"; then
+        echo "${name}: -tcg runner does not pin accel=tcg -- the kvm:tcg fallback is back, and with it the unmeasured artifact" >&2
+        fail=1
+      fi
+      # pit=on and pic=on. The microvm machine's pit=off/pic=off default is
+      # correct under KVM (kvmclock) and fatal under TCG (no kvmclock, no
+      # HPET, nothing to calibrate early timers from): the guest kernel
+      # triple-faults or wedges right after "Poking KASLR". Proved by A/B:
+      # five minutes of silence with them off, a 2m13s boot to login with
+      # them on, `-cpu qemu64` ruling the CPU model out.
+      for knob in pit=on pic=on; do
+        if ! grep -q -- "$knob" "$tcg/bin/microvm-run"; then
+          echo "${name}: -tcg runner's machine line lacks $knob -- under TCG this guest wedges after 'Poking KASLR'" >&2
+          fail=1
+        fi
+      done
+      # And the KVM runner keeps upstream's defaults untouched: kvmclock
+      # makes pit=off/pic=off correct there, and this fix must not widen
+      # into the path every real user runs.
+      for knob in pit=off pic=off; do
+        if ! grep -q -- "$knob" "$kvm/bin/microvm-run"; then
+          echo "${name}: KVM runner's machine line lost $knob -- the -tcg fix leaked into the KVM path" >&2
+          fail=1
+        fi
+      done
     '') names}
 
     echo "== nixarchy vm: launch and locking =="


### PR DESCRIPTION
Root-cause fix for the `microvm` job failure gating #298. Diagnosis first, then the change.

## The defect

The shipped `microvm-*-tcg` artifact **cannot boot under actual TCG, at any timeout**. Upstream's `microvm` machine type sets `pit=off,pic=off` — correct under KVM, where kvmclock is the guest's clock, and fatal under TCG, which has no kvmclock: no PIT, no PIC, no HPET on that machine type leaves early timer init nothing to calibrate from. The kernel triple-faults or wedges right after `Poking KASLR using RDRAND RDTSC...`, outcome depending on where KASLR landed. In run 33924510447 the guest crash-looped (two SeaBIOS iterations visible in the stripped log) for 11 minutes while `ssh -p 2222` reset against a forward with nothing behind it.

## The measurements (the whole argument — no re-derivation needed)

All under **forced `accel=tcg`** on one 128-core machine, same guest closure:

| variant | result |
|---|---|
| shipped (`-cpu max`, pit=off, pic=off) | wedged after "Poking KASLR": **zero output for 5m16s** until killed |
| `-cpu qemu64`, pit=off, pic=off | wedged identically — **CPU model ruled out** |
| `-cpu max`, **pit=on, pic=on** | **SeaBIOS → login prompt in 2m13s** |
| this PR's artifact, as shipped, no forcing | **SeaBIOS → login prompt in 2m12s** |

## How it shipped measured-as-working

Upstream hardcodes `accel=kvm:tcg`, so qemu silently takes KVM wherever `/dev/kvm` exists — including inside a NixOS test VM on a host with nested virtualisation. Every local run of the "-tcg" artifact (the "2-3 minutes" comment in tests/microvm-boot.nix, and `checks.microvm-boot` passing locally in ~112–116s) was measuring a **KVM** boot. The first real TCG execution was CI's, at the moment something first tried to boot the artifact.

A detail that will otherwise mislead readers of tests/microvm-boot.nix: the -tcg variant *does* drop `-enable-kvm`, exactly as that test's comment claims — but dropping `-enable-kvm` while the machine line still says `accel=kvm:tcg` is a **no-op for acceleration**. qemu tries KVM first off the machine option regardless. The comment presents the removal as the mechanism that makes the variant TCG; it never was, which is why the artifact kept running under KVM.

Hence the second half of this change: **`accel=tcg` is PINNED** on the -tcg variant. Its entire reason to exist is hosts with no `/dev/kvm`; a KVM host should run the normal runner; and an artifact that never runs as what its name promises is exactly how this bug shipped. The flake.nix comment says so in place, so the fallback does not get "optimised" back in.

## Blast radius

- **The normal (KVM) runner is untouched and was never affected** — kvmclock makes `pit=off/pic=off` correct there, demonstrated by `checks.microvm-boot` passing wherever the fallback found KVM. `checks.microvm-template` now asserts `pit=off`/`pic=off` are still on the KVM runner's command line, so this fix cannot leak into the path every real user runs.
- **Deliberate behaviour change** (flagging for Olaf): anyone currently running `microvm-*-tcg` on a KVM host gets true emulation after this and will notice the speed difference. That is the honest reading of the artifact's name; a KVM host wants `microvm-*` instead.

## The guard, red before green

`checks.microvm-template` (already wired, boots nothing, reads the command line — it would have caught this at the point the artifact was defined) gains: `accel=tcg` pinned on -tcg, `pit=on`/`pic=on` present on -tcg, `pit=off`/`pic=off` still present on KVM. Broken in turn:

```
old flake against new checks  ->  "-tcg runner does not pin accel=tcg -- the kvm:tcg fallback is back, and with it the unmeasured artifact"
                                  "-tcg runner's machine line lacks pit=on -- under TCG this guest wedges after 'Poking KASLR'"
                                  "-tcg runner's machine line lacks pic=on -- ..."
machineOpts leaked onto KVM   ->  "KVM runner's machine line lost pit=off -- the -tcg fix leaked into the KVM path"
                                  "KVM runner's machine line lost pic=off -- ..."
```

Green with the fix; `nix fmt -- --ci` clean. No workflow files touched.

## Relation to #298

#298's boot check was right and its guest config was fine — it was booting a broken artifact. After this merges, #298 rebases and its `wait_until_succeeds` should be re-measured against a real CI TCG boot (2m12s here is a fast box; CI will be slower, and 600s may be tight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNg5aptS2JtfeeN3vTxbR3
