### PR TITLE
actionlint, so a dead CI gate cannot look like "checks pending"

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,12 @@
+# The self-hosted runners this repository actually has. actionlint cannot
+# know them -- they are labels on machines, not GitHub-provided images -- and
+# without this it reports every `runs-on: [self-hosted, nixos, kvm, big]` in
+# nightly.yml, release.yml and install.yml as an unknown label.
+#
+# Keep this in step with the runners registered on the repository; a label
+# here that no runner carries is a job that queues forever.
+self-hosted-runner:
+  labels:
+    - nixos
+    - kvm
+    - big

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,31 @@ jobs:
       # and then copied a command that filed into somebody else's tracker --
       # people who cannot act on a NixOS store or rebuild problem. Cheap enough
       # to sit here: a runCommand over the already-built package, no VM.
+      # The workflow files themselves, against GitHub's own schema.
+      #
+      # Added because build.yml shipped BROKEN and nothing caught it: a bad
+      # conflict resolution left `box:` with no body, GitHub rejected the
+      # whole workflow at startup, and every run produced ZERO JOBS. No job
+      # meant no check, so the four required contexts never reported and
+      # branch protection blocked every merge -- a dead CI gate that looked
+      # from the outside like "checks pending", for hours.
+      #
+      # `yq` parses that file happily, which is why local validation passed.
+      # actionlint uses GitHub's schema and says exactly what is wrong:
+      #
+      #   "runs-on" section is missing in job "box"
+      #   "steps" section is missing in job "box"
+      #   "box" job should not be empty
+      #
+      # -ignore drops shellcheck's info level only, matching the -S warning
+      # this repo already uses for its own scripts. Errors and warnings still
+      # fail. Without it the four pre-existing info notes (SC2012/2013/2016)
+      # would fail a workflow file that is fine.
+      - name: The workflow files are valid GitHub Actions
+        run: |
+          nix shell nixpkgs#actionlint -c \
+            actionlint -ignore 'SC[0-9]+:info:'
+
       - name: Crash reports route to the repository the rule names
         run: nix build .#checks.x86_64-linux.crash-report-repo --print-build-logs
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
       - name: The workflow files are valid GitHub Actions
         run: |
           nix shell nixpkgs#actionlint -c \
-            actionlint -ignore 'SC[0-9]+:info:'
+            actionlint -ignore 'SC[0-9]+:(info|style):'
 
       - name: Crash reports route to the repository the rule names
         run: nix build .#checks.x86_64-linux.crash-report-repo --print-build-logs


### PR DESCRIPTION
Follow-up to #309, which repairs the breakage this would have prevented.
**Merge #309 first** — until it lands, this PR's own `actionlint` step
correctly fails, on the very bug it exists to catch.

## What went wrong, and why nothing saw it

A bad conflict resolution left `box:` with no body in `build.yml`. GitHub
rejects a workflow containing an empty job, so every run since produced
**zero jobs**. No job means no check reported; the four required contexts
never appeared, and branch protection blocked every merge. For hours that
was indistinguishable from "checks still running" — including to someone
reading the API directly.

`yq` parses the broken file happily. It tolerates the exact shape GitHub
rejects, which is why local validation passed.

## What actionlint says instead

```
build.yml:812:3: "runs-on" section is missing in job "box"   [syntax-check]
build.yml:812:3: "steps" section is missing in job "box"     [syntax-check]
build.yml:812:7: "box" job should not be empty               [syntax-check]
```

Red before green, both measured on this branch:

| tree | result |
|---|---|
| current `main` (broken) | `rc=1`, exactly those three findings, nothing else |
| `main` + #309's fix | `rc=0` |

## Two decisions the step embeds

**`.github/actionlint.yaml` declares `nixos`, `kvm`, `big`.** Without it,
every `runs-on: [self-hosted, nixos, kvm, big]` in `nightly.yml`,
`release.yml` and `install.yml` is reported as an unknown label — twelve
findings for three correct lines. They are labels on machines; actionlint
cannot discover them.

**`-ignore 'SC[0-9]+:(info|style):'`** matches the `-S warning` this repo
already uses for its own scripts. Four pre-existing info notes and one style
note would otherwise fail workflow files that are fine. Errors and warnings
still fail.

## Scope

The whole `.github/workflows` directory, not `build.yml` alone. The first
version of this check scanned `build.yml` only, passed, and would have missed
that the other four workflows had findings of their own — which is the same
mistake in miniature as validating with a tool that checks a weaker property
than the one that matters.

CI-gate change: proposed, a human merges.