### PR TITLE
The microvm boot check moves to the nightly, where its hardware lives

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,7 +265,7 @@ jobs:
           # Per-push, an hour of wall clock each makes the queue the bottleneck.
           # Written down here rather than arrived at by omission, which is the
           # argument the guard above already rests on.
-          nightly_only="install-iso iso-budget"
+          nightly_only="install-iso iso-budget microvm-boot"
 
           names=$(awk '/^      checks = eachSystem/,/^      };/' flake.nix |
             grep -oE '^        [a-z][a-z0-9-]* =' | tr -d ' =')
@@ -847,49 +847,3 @@ jobs:
         # answer to the epic's open first-start question, asserted as
         # observed. See tests/box-boot.nix.
         run: nix build .#checks.x86_64-linux.box-boot --print-build-logs
-
-  # Boots a declared MicroVM inside a NixOS test VM -- see
-  # tests/microvm-boot.nix. Its own job rather than a step in `system`: the
-  # boot is minutes of wall clock against that job's 30-minute budget, and it
-  # needs /dev/kvm arranged first, which no other step there does.
-  microvm:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: cachix/cachix-action@v17
-        # A cache upload failing must not fail a build that succeeded (#235).
-        continue-on-error: true
-        with:
-          name: nixarchy
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-
-      - name: /dev/kvm is real and writable, or fail here
-        # ubuntu-latest runners have had /dev/kvm since 2023, but it arrives
-        # root:kvm 0660 and the nix build users are not in `kvm`. The udev
-        # rule is GitHub's own documented fix (static_node keeps it across
-        # re-triggers).
-        #
-        # The preflight is deliberately LOUD. The test node (L1) must run
-        # accelerated; only the MicroVM inside it (L2) is the -tcg runner --
-        # a shipped artifact for hosts without KVM, not a test-only variant.
-        # If /dev/kvm quietly stopped being usable, the NixOS test driver
-        # would fall back to TCG at L1 too and this job would measure a
-        # different runner while staying green -- exactly the "green light"
-        # AGENTS.md 1 warns about. So: fail here, on day one, instead.
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
-            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-          grep -Eq 'vmx|svm' /proc/cpuinfo || { echo "::error::no vmx/svm in /proc/cpuinfo"; exit 1; }
-          test -w /dev/kvm || { echo "::error::/dev/kvm is not writable"; exit 1; }
-          ls -l /dev/kvm
-
-      - name: Boot a MicroVM on the -tcg runner
-        # checks.microvm-boot: microvm@sandbox.service reaches active, ssh
-        # over the forwarded SLiRP port answers, and `ro-store on
-        # /nix/.ro-store type 9p` is read from the guest's own mount table --
-        # the shared-store claim, verified from inside a running guest.
-        run: nix build .#checks.x86_64-linux.microvm-boot --print-build-logs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,6 +77,22 @@ jobs:
             | grep -E '^(driver|install)_seconds=' \
             | tee -a "$GITHUB_STEP_SUMMARY" || echo "no timing recorded"
 
+  microvm:
+    name: boot a MicroVM on the -tcg runner
+    # Moved here from build.yml after two per-PR attempts on ubuntu-latest
+    # (runs 33940632899 and 33941923132): genuine TCG at L2 on a 4-core
+    # runner did not reach sshd inside 600s and then not inside 1200s, and a
+    # third rung would need the job cap raised for a check that takes 113
+    # SECONDS on hardware with KVM at L1 -- which is exactly what this
+    # runner is. Here it is fast AND honest: L2 is still the pinned
+    # accel=tcg artifact (#304), only L1 stops being emulated.
+    runs-on: [self-hosted, nixos, kvm, big]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+      - name: Boot a MicroVM on the -tcg runner
+        run: nix build .#checks.x86_64-linux.microvm-boot --print-build-logs
+
   install-iso:
     name: install from the ISO, with no network
     runs-on: [self-hosted, nixos, kvm, big]
@@ -212,7 +228,7 @@ jobs:
   report:
     name: report a failure
     runs-on: ubuntu-latest
-    needs: [install, install-iso, cache]
+    needs: [install, install-iso, microvm, cache]
     # cancelled() too. On 2026-09-02 install-iso hit its 180-minute timeout,
     # which GitHub records as cancelled rather than failed, and this job --
     # the one whose whole purpose is that a 03:00 failure does not cost a day

--- a/tests/microvm-boot.nix
+++ b/tests/microvm-boot.nix
@@ -29,8 +29,15 @@
 #     ro-store share away, which builds an erofs and still boots: ssh
 #     succeeds, this grep fails.
 #
-# A TCG guest reaches a login prompt in about 2-3 minutes; the timeouts below
-# are sized to that, not to a KVM boot.
+# Timeout sizing, measured on the machine that matters this time. The first
+# real CI execution of this check (run 33940632899, the #309 repair run --
+# every earlier "run" died at workflow startup) showed the guest kernel at
+# 13.2 guest-seconds after 74.8 host-seconds: a ~5.7x TCG slowdown in KERNEL
+# boot on a 4-core runner, and syscall-heavy userspace init runs far slower
+# than that under TCG. The old 600s wait was reasoned from a 70.8s ssh wait
+# observed on a 128-core dev box with KVM at L1 -- the wrong machine. 1200s
+# fits the job's 30-minute budget beside the ~5 minutes of setup the failed
+# run measured, with margin.
 { inputs, pkgs }:
 let
   # nixpkgs' own test-only snakeoil keypair (RFC 9500) -- reused rather than
@@ -82,7 +89,9 @@ pkgs.testers.runNixOSTest {
     # Room for a 1 GiB guest plus the host itself, and a second core so the
     # emulated guest does not starve the node running it.
     virtualisation.memorySize = 4096;
-    virtualisation.cores = 2;
+    # All four of the runner's cores: the single TCG vCPU thread, qemu's
+    # I/O threads and the host's own userspace were sharing two.
+    virtualisation.cores = 4;
   };
 
   testScript = ''
@@ -99,7 +108,7 @@ pkgs.testers.runNixOSTest {
     # A TCG guest boots in minutes, not seconds. sshd is one of the last
     # things multi-user brings up, so this wait covers the whole guest boot.
     machine.succeed("install -m 600 ${keys.snakeOilEd25519PrivateKey} /root/snakeoil")
-    machine.wait_until_succeeds("${ssh} true", timeout=600)
+    machine.wait_until_succeeds("${ssh} true", timeout=1200)
 
     # The store is shared, not imaged -- asserted from inside the guest.
     mounts = machine.succeed("${ssh} mount")

--- a/tests/microvm-boot.nix
+++ b/tests/microvm-boot.nix
@@ -29,15 +29,16 @@
 #     ro-store share away, which builds an erofs and still boots: ssh
 #     succeeds, this grep fails.
 #
-# Timeout sizing, measured on the machine that matters this time. The first
-# real CI execution of this check (run 33940632899, the #309 repair run --
-# every earlier "run" died at workflow startup) showed the guest kernel at
-# 13.2 guest-seconds after 74.8 host-seconds: a ~5.7x TCG slowdown in KERNEL
-# boot on a 4-core runner, and syscall-heavy userspace init runs far slower
-# than that under TCG. The old 600s wait was reasoned from a 70.8s ssh wait
-# observed on a 128-core dev box with KVM at L1 -- the wrong machine. 1200s
-# fits the job's 30-minute budget beside the ~5 minutes of setup the failed
-# run measured, with margin.
+# Timeout provenance, and where this check now runs. Its first two real CI
+# executions -- runs 33940632899 and 33941923132; everything earlier died at
+# workflow startup, so this check and #304's fixed artifact had never met --
+# measured genuine TCG at L2 on a 4-core ubuntu-latest runner: the guest
+# kernel at 13.2 guest-seconds after 74.8 host-seconds (~5.7x, before
+# userspace init pays its 20-40x), sshd unreached at 600s and then at 1200s.
+# The same check reaches "sandbox login: dev" in 113s where L1 has KVM. That
+# ratio is why the job moved to nightly.yml's self-hosted KVM runners: L2 is
+# still the pinned accel=tcg artifact, only L1 stops being emulated. The
+# 1200s below is a generous ceiling for that home, not a hosted-runner hope.
 { inputs, pkgs }:
 let
   # nixpkgs' own test-only snakeoil keypair (RFC 9500) -- reused rather than


### PR DESCRIPTION
**CI GATE CHANGE (AGENTS.md §10): a human merges this.** Supersedes this PR's first shape (a timeout raise) — its own CI run was the experiment, and the experiment answered.

## The two datapoints (this PR's runs)

- run 33940632899: sshd unreached at **600s**, guest kernel at 13.2 guest-seconds after 74.8 host-seconds (~5.7× TCG slowdown in kernel boot, before userspace init pays its 20–40×).
- run 33941923132: sshd unreached at **1200s** — 25 of the job's 30 minutes spent waiting.

Against: **113 seconds** to `sandbox login: dev` wherever L1 has KVM (measured on the dev box, twice, independently). Two orders of magnitude across hardware — the ratio is the argument, not the timeout, and a third rung would mean raising the job cap for it.

## The change

- `build.yml`: the `microvm` job is removed; the every-check guard's `nightly_only` list gains `microvm-boot` beside `install-iso`/`iso-budget`, cost written down the way that list already does.
- `nightly.yml`: gains the job on `[self-hosted, nixos, kvm, big]` — where it is fast **and honest**: L2 remains the pinned `accel=tcg` artifact from #304 (the shipped runner for KVM-less hosts), only L1 stops being emulated. The nightly reporter's `needs` learns the job, so a red microvm files/wakes the issue rather than failing silently.
- `tests/microvm-boot.nix`: provenance comment records both CI datapoints and the new home; the 1200s wait stays as a generous ceiling for KVM-L1 hardware, not a hosted-runner hope.

Verified: `actionlint` clean across all five workflows using CI's exact invocation (`-ignore 'SC[0-9]+:(info|style):'` + `.github/actionlint.yaml`), guard list updated in the same commit as the job move so the every-check guard stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNg5aptS2JtfeeN3vTxbR3