### PR TITLE
agent-bus-mcp as a flake output, and bus-peek.sh gains its test

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -557,6 +557,26 @@
           default = self.packages.${system}.omarchy;
           inherit (pkgsFor.${system}) omarchy nixarchy-plymouth;
 
+          # `nix run github:olafkfreund/nixarchy#agent-bus-mcp` -- the bus MCP
+          # server as a flake output (#268), so an outside agent's mcp.json can
+          # name a store path instead of `uv run --with mcp --with httpx` on a
+          # copy of the script. The script itself stays the single source in
+          # share/agent-bus/; this wraps it with its two dependencies from the
+          # locked nixpkgs. bus-peek.sh's AGENT_BUS_CMD accepts this binary
+          # verbatim.
+          agent-bus-mcp = pkgsFor.${system}.writeShellApplication {
+            name = "agent-bus-mcp";
+            runtimeInputs = [
+              (pkgsFor.${system}.python3.withPackages (p: [
+                p.mcp
+                p.httpx
+              ]))
+            ];
+            text = ''
+              exec python3 ${./share/agent-bus/agent_bus_mcp.py} "$@"
+            '';
+          };
+
           # `nix run github:olafkfreund/nixarchy#verify`, from inside a running
           # Omarchy session. Everything in checks/ runs in a machine with no GPU,
           # no Bluetooth radio, no network and no sound; this asks the questions
@@ -1276,6 +1296,7 @@
           bus-redact = import ./tests/bus-redact.nix {
             pkgs = pkgsFor.${system};
             hook = ./share/agent-bus/hooks/bus-redact.sh;
+            peekHook = ./share/agent-bus/hooks/bus-peek.sh;
           };
 
           installer-lock = import ./tests/installer-lock.nix {

--- a/tests/bus-redact.nix
+++ b/tests/bus-redact.nix
@@ -1,4 +1,8 @@
-{ pkgs, hook }:
+{
+  pkgs,
+  hook,
+  peekHook,
+}:
 # The redaction hook, driven with the payloads it will actually meet (#272).
 #
 # AGENTS.md §1 applies with unusual force here: a security hook that passes
@@ -89,7 +93,59 @@ pkgs.runCommand "nixarchy-bus-redact" { nativeBuildInputs = [ pkgs.jq ]; } ''
     fails=$((fails+1))
   fi
 
+  # ------------------------------------------------------------------------
+  # bus-peek.sh (#268): the Stop hook that decides exit 0 (let the turn end)
+  # vs exit 2 (hand pending messages back), from a JSON payload and its
+  # peek command's exit code -- and until now had no test at all. Same
+  # doctrine as above: the real script, driven by stubs that lie.
+  # ------------------------------------------------------------------------
+  cp ${peekHook} peek.sh
+  chmod +x peek.sh
+
+  # The stub peek command AGENT_BUS_CMD points at: rc and output from env.
+  cat > stubpeek.sh <<'EOF'
+  #!/bin/sh
+  printf '%s\n' "''${PEEK_OUT:-}"
+  exit "''${PEEK_RC:-0}"
+  EOF
+  chmod +x stubpeek.sh
+  export AGENT_BUS_CMD=$PWD/stubpeek.sh
+
+  pt() {
+    want=$1 name=$2 payload=$3
+    if printf '%s' "$payload" | bash peek.sh >out 2>err; then got=0; else got=$?; fi
+    if [ "$got" = "$want" ]; then
+      echo "  ok      $name (exit $got)"
+    else
+      echo "  FAILED  $name: wanted exit $want, got $got"
+      sed 's/^/            /' err
+      fails=$((fails + 1))
+    fi
+  }
+
+  # A Stop hook that fires while already continuing from a Stop hook is a
+  # loop; the payload says so and the hook must let the turn end, pending
+  # messages or not.
+  MATRIX_ACCESS_TOKEN=syt_test PEEK_RC=1 PEEK_OUT="you have mail"     pt 0 "stop_hook_active short-circuits" '{"stop_hook_active":true}'
+
+  # No token means not on the bus: get out of the way, never nag.
+  MATRIX_ACCESS_TOKEN= PEEK_RC=1 PEEK_OUT="you have mail"     pt 0 "no token, no wake" '{}'
+
+  # Nothing pending: the turn ends.
+  MATRIX_ACCESS_TOKEN=syt_test PEEK_RC=0     pt 0 "peek quiet" '{}'
+
+  # Something pending: exit 2, and the MESSAGE plus the reply guidance are
+  # what comes back -- an exit 2 with an empty stderr wakes an agent with
+  # nothing to act on.
+  MATRIX_ACCESS_TOKEN=syt_test PEEK_RC=1 PEEK_OUT="agent-x: are the boxes up?"     pt 2 "pending message wakes the agent" '{}'
+  grep -q "are the boxes up" err || { echo "  FAILED  the wake does not carry the message"; fails=$((fails+1)); }
+  grep -q "post(thread=" err || { echo "  FAILED  the wake does not say how to reply"; fails=$((fails+1)); }
+
+  # Garbage payload: jq errors, the case matches nothing, and the hook
+  # continues on its other gates rather than crashing the Stop.
+  MATRIX_ACCESS_TOKEN= PEEK_RC=0     pt 0 "malformed payload falls through" 'not json'
+
   [ "$fails" -eq 0 ] || exit 1
-  echo "bus-redact blocks the decidable leaks and only those"
+  echo "bus-redact blocks the decidable leaks and only those; bus-peek wakes exactly when something is pending"
   touch $out
 ''


### PR DESCRIPTION
Part of #268 — the two unticked boxes an agent can do; the other two (registration token, `#agents` fencing) touch live infrastructure and stay proposals on the epic.

## `packages.agent-bus-mcp`

Wraps `share/agent-bus/agent_bus_mcp.py` with `python3.withPackages (mcp, httpx)` — both in the locked nixpkgs (mcp 1.29.0). An outside agent's `.mcp.json` can now point at `nix run github:olafkfreund/nixarchy#agent-bus-mcp` instead of `uv run --with mcp --with httpx` on a hand-copied script; the script stays the single source in `share/`. `bus-peek.sh`'s `AGENT_BUS_CMD` accepts the binary verbatim.

Smoke-verified: builds; imports resolve; `--peek` with no credentials exits **0 silently** — exactly the contract the hook's comment leans on ("anything else means get out of the way").

## bus-peek.sh's first test

The Stop hook decides exit 0 vs exit 2 from a JSON payload and its peek command's exit code — logic with no test until now. Added to `checks.bus-redact` (the kit's hook test, already wired at build.yml:132 — **no new check, no guard dance**), same doctrine: the real script, stubs that lie.

Five scenarios: `stop_hook_active` short-circuits even with mail waiting; no token never nags; quiet peek ends the turn; a pending message exits 2 **carrying the message and the reply guidance** (an exit 2 with empty stderr wakes an agent with nothing to act on); garbage payload falls through rather than crashing the Stop.

Red before green, each by name:

```
exit 2 flattened to 0   ->  FAILED  pending message wakes the agent: wanted exit 2, got 0
guidance line deleted   ->  FAILED  the wake does not say how to reply
```

`nix fmt -- --ci` clean. No workflow files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNg5aptS2JtfeeN3vTxbR3