### PR TITLE
The roadmap says sandboxes and boxes are done, because they are

### DIFF
--- a/README.md
+++ b/README.md
@@ -1644,11 +1644,21 @@ is the shape.
 | epic | what it is for | |
 | --- | --- | --- |
 | [#159](https://github.com/olafkfreund/nixarchy/issues/159) | **remote desktop** — reaching the Hyprland session from elsewhere | 4 of 5 done |
-| [#221](https://github.com/olafkfreund/nixarchy/issues/221) | **sandboxes** — a throwaway NixOS machine from a template, in seconds, with no root and no rebuild | planned, 8 issues |
-| [#230](https://github.com/olafkfreund/nixarchy/issues/230) | **boxes** — an Arch or Debian userland for software NixOS will not run, and its apps in your launcher | planned, 8 issues |
 | [#268](https://github.com/olafkfreund/nixarchy/issues/268) | **agent bus** — a public room where agents working on this repo leave each other notes, and the setup to join it | room live, kit landed, 3 issues |
 
 **Recently finished:**
+[sandboxes](https://github.com/olafkfreund/nixarchy/issues/221)
+— a throwaway NixOS MicroVM from a template, in seconds, with no root and no
+rebuild: the catalogue and guest module, the declarative service, `nixarchy
+vm`, four templates, a menu group, the manual page, a boot check in the
+nightly, and the `verify.sh` section for what only real hardware can answer.
+Also
+[boxes](https://github.com/olafkfreund/nixarchy/issues/230)
+— an Arch or Debian userland for software NixOS will not run: rootless podman
+and distrobox, the declarative half through Home Manager, `nixarchy box` with
+`promote` to turn a hand-made container into config, a menu group, the manual
+page, and an offline check that creates and enters one for real.
+
 [bare metal to a desktop](https://github.com/olafkfreund/nixarchy/issues/6)
 — all 22 of it: disko layout, generated flake, interactive and unattended
 install, a bootable ISO that autostarts it, release automation, free-space


### PR DESCRIPTION
Unblocks #316, #317 and #318 — all three are failing `omarchy` on this, not on anything of their own.

#221 and #230 closed with all sixteen children complete, but the README's Roadmap still listed both as "planned, 8 issues". `build.yml`'s guard catches precisely that ("epic #N is closed but the Roadmap still lists it as planned") and has been failing every open PR since. **That is the guard working**, not a fault in it.

Both moved to **Recently finished** with what actually shipped, rather than deleted — the section's existing convention, and more useful to a reader than a silent removal.

`#268` stays in the table and is correct there: no `epic` label, so the guard treats it as context, which its own comment allows.

Verified with the guard's own comparison: open epics `{159}`, roadmap rows `{159, 268}` — nothing missing, nothing closed still listed.