### PR TITLE
zen-browser past ffmpeg_7, so downstream flakes evaluate again

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -98,11 +98,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786719456,
-        "narHash": "sha256-B74DLQs/VjlqyhnnX3tguWwghqJHWSJX30TKZuAljIg=",
+        "lastModified": 1788229478,
+        "narHash": "sha256-G0F2rFORVcFkEvVdE/qWQTnYekIc77YP5/vRF9nZlxU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "83b7606dcf44abe3a94b86e8bb2b3355d22e8797",
+        "rev": "1dc2d1f720ab17fc7981e087346bf54b26d284b1",
         "type": "github"
       },
       "original": {
@@ -692,11 +692,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787540616,
-        "narHash": "sha256-c+dIgStaq3qNaQxhAiiXY3upNTIdn7tCcqPnwsmKTmY=",
+        "lastModified": 1788405419,
+        "narHash": "sha256-wuGizAVEmY0u15MYrhgy7AoQdHg+4Y2QiC+v/mxA8dc=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "51df7b8cbb0fcba14a9b159531ef48d0cd69dde9",
+        "rev": "fdb83f8fce835213fab7eab52c375926fe1a32dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
**Anyone whose nixpkgs is newer than `801bef6` and who imports nixarchy currently cannot evaluate their configuration at all.**

nixpkgs `801bef6` removed `ffmpeg_7`. The pinned zen-browser (`51df7b8`, 2026-08-24) still passes it to `wrapFirefox`, and this flake sets `zen-browser.inputs.nixpkgs.follows = "nixpkgs"` — so the consumer's newer nixpkgs cascades straight into it.

## Why it is expensive to diagnose

nix truncates the trace to `environment.etc.dbus-1.source`. The reader concludes their *own* config is broken and goes looking there. Nothing in the error names zen-browser, ffmpeg, or nixarchy.

## Verified, not assumed

Fetched both revisions and grepped:

| rev | `ffmpeg_7` |
|---|---|
| `51df7b8` | in `default.nix` **and** `hm-module/package.nix` |
| `fdb83f8` | no reference at all |

The node was never rev-pinned, so `nix flake update zen-browser` is the entire fix. home-manager moves with it (`83b7606` → `1dc2d1f`) because it is zen-browser's input, not ours.

## Why our CI never caught it

Our own nixpkgs pin still has `ffmpeg_7` (7.1.5). Nothing here fails, and nothing here can — the breakage only exists for a consumer running a newer nixpkgs than we do. Worth remembering: `follows` makes our inputs somebody else's problem in a way our own checks cannot see.

This tree still evaluates after the bump (`nixosConfigurations.vm` produces a toplevel drvPath).

Reported by a peer agent on the bus, who identified both the cause and the fixed revision.