### PR TITLE
Encrypted installs pin the encrypted initrd modules, not the plain ones

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1360,7 +1360,14 @@ reuse_baked_initrd() {
   # The list depends on the answer to the encryption question: LUKS pulls a
   # dozen crypto modules into the initrd, so the two baked initrds have
   # different module sets and pinning to the wrong one matches neither.
-  if [ "$encrypt" = "yes" ]; then
+    # `true`, not "yes". validate_answers normalises the answers file's yes/no
+    # into true/false before any phase runs, and ask_encrypt sets true/false
+    # directly -- so comparing against "yes" made this branch UNREACHABLE and
+    # every ENCRYPTED install pinned the PLAIN module list. With mkForce, which
+    # then discarded luksroot.nix's dm_crypt and friends: the install succeeded
+    # and the machine could not unlock its root. Every other test of $encrypt in
+    # this file already says `= true`.
+  if [ "$encrypt" = true ]; then
     avail_src="@initrdmodules@"
     forced_src="@initrdforced@"
   else

--- a/tests/installer-store-space.nix
+++ b/tests/installer-store-space.nix
@@ -166,6 +166,36 @@ pkgs.runCommand "nixarchy-installer-store-space" { } ''
   # And a network that works installs as before.
   t proceed "net image, everything answers"      net  1 1
 
+  # An ENCRYPTED install must pin the ENCRYPTED module list.
+  #
+  # reuse_baked_initrd chose between two baked lists on `[ "$encrypt" = "yes" ]`
+  # while validate_answers normalises the answers file's yes/no into true/false
+  # before any phase runs -- so the encrypted branch was UNREACHABLE and every
+  # encrypted install pinned the PLAIN list with mkForce, discarding
+  # luksroot.nix's dm_crypt. Install succeeds; machine will not unlock its root.
+  # Nothing caught it because every install test in this repo uses encrypt=no.
+  #
+  # No nested heredoc here on purpose: this is inside a Nix indented string,
+  # where the terminator would itself be indented and so would not terminate --
+  # the same trap that once swallowed a theme install. (Writing the two-quote
+  # delimiter in this comment would also end the string, which is how the first
+  # attempt at this comment broke the file.)
+  sed -n '/^reuse_baked_initrd()/,/^}/p' ${installScript} > rb.sh
+  test -s rb.sh || { echo "reuse_baked_initrd is not in install.sh any more" >&2; exit 1; }
+  sed -i 's/@initrdmodules@/ENCRYPTEDLIST ahci/; s/@initrdforced@/ENCFORCED/' rb.sh
+  sed -i 's/@initrdmodulesplain@/PLAINLIST ahci/; s/@initrdforcedplain@/PLAINFORCED/' rb.sh
+
+  # Ends with a closing brace: reuse_baked_initrd refuses to touch a file whose
+  # last line is not `}`, because the pin has to go inside it.
+  printf '{\n  boot.initrd.availableKernelModules = [ "ahci" ];\n  boot.initrd.kernelModules = [ ];\n}\n' > hw.nix
+  ( . ./rb.sh; encrypt=true reuse_baked_initrd hw.nix )
+  if grep -q ENCRYPTEDLIST hw.nix; then
+    echo "  ok      encrypt=true pins the encrypted list"
+  else
+    echo "  FAILED  encrypt=true pinned the PLAIN list -- LUKS modules mkForce'd away"
+    fails=$((fails + 1))
+  fi
+
   # (c) of #300: across every scenario, including the refusals, the disk was
   # never touched.
   [ ! -e wipefs-called ] || { echo "  FAILED  preflight called wipefs"; fails=$((fails+1)); }


### PR DESCRIPTION
**An encrypted install currently produces a machine that may not unlock its root at first boot.** Encryption is the default answer to the interactive question.

## The bug

`reuse_baked_initrd` chose between the two baked module lists on `[ "$encrypt" = "yes" ]`. But:

| line | |
|---|---|
| `:1008` | `validate_answers` normalises the file's yes/no into **true/false** |
| `:755-756` | `ask_encrypt` sets **true/false** directly |
| `:1192` | correctly tests `[ "$encrypt" = true ]` |
| `:1370` | tested `= "yes"` — **unreachable** |

So every encrypted install took the `else` and pinned `@initrdmodulesplain@`.

## Why that is dangerous rather than untidy

The pin is `lib.mkForce`, deliberately, so an imported profile cannot add to it. That also discards nixpkgs `luksroot.nix`'s plain-priority `dm_mod`, `dm_crypt`, `cryptd` and the cipher modules. The initrd then cannot map the LUKS device.

**The install succeeds.** The failure appears at first boot, in stage 1, on a disk that was erased at minute one — #300's outcome by a different route.

It only bites when every detected module happens to be in the plain list, which is the common case: `nixos-generate-config` detects storage controllers, and those are in both. When something is missing, the function already refuses to pin and the install builds its own initrd — slow and correct. **So the failure is silent and hardware-dependent.**

The file's own comment two lines above says exactly what goes wrong: *"the two baked initrds have different module sets and pinning to the wrong one matches neither"*.

## Why nothing caught it

Every install test passes `encrypt=no` — `install.nix:325`, `install-iso.nix`, `install-iso-net.nix:100`, `free-space.nix:344`. There is no CI coverage of the encrypted path past evaluation.

## Guarded

`checks.installer-store-space` now drives `reuse_baked_initrd` directly with `encrypt=true` and asserts it selects the encrypted list.

**Red before green, by name.** With the fix reverted:

```
FAILED  encrypt=true pinned the PLAIN list -- LUKS modules mkForce'd away
```

Found by a code-review agent reading for #300-class ordering bugs; verified against the code before the fix was written.