### PR TITLE
The coverage guard reads the checks it is guarding, and the two orphans it missed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -294,6 +294,23 @@ jobs:
             ".#checks.x86_64-linux" \
             --apply 'c: builtins.concatStringsSep "\n" (builtins.attrNames c)')
 
+          # A floor, because the interesting failure of this guard is not a
+          # wrong answer but an EMPTY one. It has now passed-while-checking-
+          # nothing twice: once when the awk indentation went stale, and it
+          # would do so again if `nix eval` ever returned an empty set for a
+          # reason nobody predicted. AGENTS.md 1 says prove your check fails;
+          # that was never applied to the guard itself.
+          #
+          # 20 is well under the current 33 and well over zero -- it catches
+          # "extracted nothing" without needing maintenance every time a check
+          # is added or removed.
+          count=$(printf '%s\n' "$names" | grep -c . || true)
+          if [ "${count:-0}" -lt 20 ]; then
+            echo "::error::the check list came back with $count names, which is" \
+                 "too few to be real -- this guard is not reading the flake" >&2
+            exit 1
+          fi
+
           missing=""
           ungated=""
           for c in $names; do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,7 +250,12 @@ jobs:
           # rather than left to look accidental:
           #   omarchy                        built as `nix build .#omarchy`
           #   reference-unencrypted-toplevel pulled in by checks.install
-          exempt="omarchy reference-unencrypted-toplevel"
+          #   omarchy-runtime                built as `nix build .#omarchy-runtime`
+          # (omarchy-runtime is the same derivation either way -- the checks
+          # entry is an `inherit` of the package, so building the package IS
+          # building the check. The old awk-based extraction could never see it
+          # at all, which is why it was not listed here before.)
+          exempt="omarchy omarchy-runtime reference-unencrypted-toplevel"
 
           # And the same hole one level up, which is #164. "Some workflow names
           # it" was never the whole question: a check named only by nightly.yml
@@ -265,10 +270,29 @@ jobs:
           # Per-push, an hour of wall clock each makes the queue the bottleneck.
           # Written down here rather than arrived at by omission, which is the
           # argument the guard above already rests on.
-          nightly_only="install-iso iso-budget microvm-boot"
+          #   install-iso-net  the same image build plus a closure fetch; it is
+          #                    install-iso's sibling and belongs in the same
+          #                    bucket. Measured 483s warm, so promoting it to
+          #                    per-PR is affordable if the appetite is there --
+          #                    see the note above about this list's cost
+          #                    argument being stale.
+          nightly_only="install-iso iso-budget microvm-boot install-iso-net"
 
-          names=$(awk '/^      checks = eachSystem/,/^      };/' flake.nix |
-            grep -oE '^        [a-z][a-z0-9-]* =' | tr -d ' =')
+          # Ask Nix, do not parse the file.
+          #
+          # This used to be an awk range plus `grep -oE '^        [a-z]...'` --
+          # EIGHT spaces of indentation. #299 added a `let ... in` around the
+          # checks block, every entry moved to TEN, and the grep silently
+          # matched nothing from that commit onward: the guard printed its
+          # success line having extracted zero names. checks.installer-refusal
+          # and checks.install-iso-net both merged unwired while it stood dead,
+          # which is #133 twice over with the tripwire built for it switched off.
+          #
+          # A guard that reads the source's LAYOUT rather than its VALUE fails
+          # this way. `nix eval` cannot go stale when someone adds a binding.
+          names=$(nix eval --raw \
+            ".#checks.x86_64-linux" \
+            --apply 'c: builtins.concatStringsSep "\n" (builtins.attrNames c)')
 
           missing=""
           ungated=""

--- a/.github/workflows/install-check.yml
+++ b/.github/workflows/install-check.yml
@@ -227,7 +227,8 @@ jobs:
         run: |
           nix build --print-build-logs --max-jobs 2 \
             .#checks.x86_64-linux.install \
-            .#checks.x86_64-linux.free-space
+            .#checks.x86_64-linux.free-space \
+            .#checks.x86_64-linux.installer-refusal
 
       - name: Report what it cost
         if: always() && needs.gate.outputs.relevant == 'true'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -130,6 +130,13 @@ jobs:
       - name: Install from it with no network device present
         run: nix build .#checks.x86_64-linux.install-iso --print-build-logs
 
+      # The other image. Same shape, different failure: this one probes a
+      # substituter, fetches the closure it does not carry, and asserts the
+      # preflight's probe landed on the wire -- the half the offline image
+      # cannot exercise, because its preflight returns at the marker check.
+      - name: Install from the NETWORK ISO, fetching the closure
+        run: nix build .#checks.x86_64-linux.install-iso-net --print-build-logs
+
   # A failure at 03:00 that nobody sees until someone opens the Actions tab is
   # a failure that costs a day. This turns one into an issue.
   # Is the binary cache actually being filled?


### PR DESCRIPTION
**The guard has been vacuous since #299.** It extracted check names with an awk range plus `grep -oE '^        [a-z][a-z0-9-]* ='` — **eight spaces**. #299 wrapped the checks block in a `let … in`, every entry moved to **ten**, and from that commit the grep matched nothing. The loop ran zero times and the step printed *"every check in the flake is built by a workflow that runs on pull requests"* having checked nothing.

Run against `origin/main`: **zero names extracted.** `nix eval` lists **33**.

## What it was missing

Both merged while it stood dead — **#133 twice over, with the tripwire built for #133 switched off**.

| check | |
|---|---|
| `checks.installer-refusal` (#308) | run by nothing. **The #300 guarantee** — a dark substituter refused with the disk *intact*, and the only check holding a real disk. Now in the `install` job, which already has KVM and the two other disk checks. |
| `checks.install-iso-net` (#311) | run by nothing. The network image's entire CI coverage. Now in the nightly beside `install-iso`, and declared `nightly_only` so the guard's second rule (#164) stays satisfied honestly rather than by omission. |

## The fix

`nix eval --apply builtins.attrNames`. A guard that reads the source's **layout** rather than its **value** breaks the next time somebody adds a binding — silently, as this one did.

## A third, correctly identified as a false positive

The fixed guard also flagged `checks.omarchy-runtime`, which the old extraction could never see at any indentation because it is an `inherit`, not a binding. `build.yml:586` and `:612` build `.#omarchy-runtime` — the same derivation — so it joins the `exempt` list with the reason written down, beside `omarchy` which is exempt for the same reason.

## Red before green

The fixed guard against unwired `main` prints three `::error::` lines naming all three. The old extraction against **that same tree** prints its success line. Same input, opposite verdicts.

## Noted, not changed

`nightly_only`'s cost comment still says `install-iso` is "~3h"; the whole job measured **17m16s** last night. Promoting it — or `install-iso-net` at 483s warm — to per-PR is affordable if you want it. That is a gating policy decision, not a bug fix.

CI-gate change: proposed, a human merges.