### PR TITLE
Four error messages stop lying about why they failed

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -381,6 +381,10 @@
             # pkgs/box.nix's hazard. distrobox itself is deliberately NOT
             # here: it is looked up by bare name (`command -v distrobox`),
             # the same wrapper-only rule that command's own header explains.
+            # hyprctl is deliberately not here either -- the client has to
+            # match the RUNNING compositor, which the session's PATH carries
+            # and this list cannot; the Graphics section's comment in
+            # verify.sh makes the argument.
             podman
             # nix-store, for the MicroVM guests section's GC-root check
             # (#229): `--print-roots` reads the store, never `--gc`. Pinning

--- a/modules/services/microvm.nix
+++ b/modules/services/microvm.nix
@@ -123,6 +123,14 @@ in
                 declarative half and not the disposable templates, which
                 share one closure across every VM of a template and so
                 cannot each carry a different port.
+
+                A forwarded port is not yet a login: the guest's only user
+                (`dev`, modules/microvm/guest.nix) has no password, and
+                sshd's default `PermitEmptyPasswords no` refuses exactly
+                that. Until this machine's `modules` add an authorized key
+                (`users.users.dev.openssh.authorizedKeys.keys`), the port
+                reaches a daemon that will let nobody in -- the console
+                still works either way.
               '';
             };
 

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -76,12 +76,24 @@ in
           dataDir = lib.mkDefault "/home/${svc.user}";
           configDir = lib.mkDefault "/home/${svc.user}/.config/syncthing";
 
-          # NOT mkDefault. Upstream's default is true, and true here means
-          # "delete any folder or device the Nix configuration does not mention"
-          # -- which silently discards everything added through the web
-          # interface, the way most people actually use Syncthing.
-          overrideFolders = false;
-          overrideDevices = false;
+          # The VALUE is the decision here: upstream defaults these to true,
+          # and true means "delete any folder or device the Nix configuration
+          # does not mention" -- which silently discards everything added
+          # through the web interface, the way most people actually use
+          # Syncthing.
+          #
+          # mkDefault, though this once said "NOT mkDefault" -- that comment
+          # conflated the value with the priority. mkDefault (1000) still
+          # outranks the option's own default (1500), so everyone who writes
+          # nothing keeps the protection; what plain assignment added on top
+          # was a "defined multiple times" error for the user who explicitly
+          # asks for upstream's declarative mode, whose only exit was
+          # mkForce -- the one-way door this directory's header forbids.
+          # Someone who writes `overrideFolders = true` themselves has
+          # accepted the deletion; the shield is only for those who didn't
+          # choose.
+          overrideFolders = lib.mkDefault false;
+          overrideDevices = lib.mkDefault false;
         };
       }
 

--- a/pkgs/box.nix
+++ b/pkgs/box.nix
@@ -180,6 +180,18 @@ writeShellApplication {
     promote_box() {
       name="''${1:?usage: nixarchy box promote <name>}"
       require_distrobox
+      # podman by bare name, and NOT in runtimeInputs, even though this call
+      # only reads. runtimeInputs is one PATH for the whole script, so a
+      # podman pinned for this line would also be the podman distrobox's own
+      # calls in create_box inherit -- container creation handed to this
+      # flake's podman instead of the system's, which is the header's hazard
+      # by another road. (verify.sh pins podman because it only ever reads.)
+      # Bare means absent is possible, and absent must not be reported as
+      # "no box named ..." -- check first.
+      if ! command -v podman >/dev/null 2>&1; then
+        echo "nixarchy-box: podman is not on PATH -- cannot inspect '$name'." >&2
+        exit 1
+      fi
       image=$(podman inspect --type container --format '{{.Config.Image}}' "$name" 2>/dev/null) || true
       if [ -z "$image" ]; then
         echo "nixarchy-box: no box named '$name' (podman inspect found nothing)." >&2

--- a/pkgs/verify.sh
+++ b/pkgs/verify.sh
@@ -172,9 +172,26 @@ renderer=$(
 # The lspci lines are still worth printing -- they name the hardware, which the
 # renderer string does not on a hybrid machine. Strip the PCI address, the
 # vendor:device ids and the (rev ..) noise; keep the model.
+#
+# hyprctl by BARE NAME, deliberately not in runtimeInputs -- the same
+# wrapper-only rule as distrobox in pkgs/box.nix, for a different reason.
+# hyprctl speaks to the compositor over its instance socket, and the client
+# that matches the running Hyprland is the one the session put on PATH
+# (0.56, from flake.nix's pinned input); pinning nixpkgs' hyprctl here would
+# be a client one protocol behind the server it questions. The cost of bare
+# is that an absent hyprctl and an empty answer look identical downstream,
+# so tell them apart first: "no GPU listed" must never be this report's
+# spelling of "the tool was missing" -- that is the vainfo trap the
+# runtimeInputs list in flake.nix exists to prevent.
+if command -v hyprctl >/dev/null 2>&1; then
+  have_hyprctl=1
+else
+  have_hyprctl=0
+fi
 gpus=$(
   {
-    timeout 5 hyprctl systeminfo 2>/dev/null |
+    [ "$have_hyprctl" = 1 ] &&
+      timeout 5 hyprctl systeminfo 2>/dev/null |
       sed -n 's/^[0-9a-f]\{2\}:[0-9a-f.]* \(VGA compatible controller\|3D controller\|Display controller\)[^:]*: //p' |
       sed -e 's/ \[[0-9a-f]\{4\}:[0-9a-f]\{4\}\].*$//' -e 's/ Corporation / /' -e 's/ Inc\. / /'
   } || true
@@ -195,6 +212,8 @@ case "$renderer" in
 esac
 if [ -n "$gpus" ]; then
   while IFS= read -r gpu; do say_dim "$gpu"; done <<<"$gpus"
+elif [ "$have_hyprctl" = 0 ]; then
+  hmm "could not list GPUs" "hyprctl is not on PATH -- is this a Hyprland session?"
 else
   hmm "no GPU listed" "hyprctl systeminfo named no display controller"
 fi


### PR DESCRIPTION
## Theme

Every item here is code whose behaviour was defensible but whose ERROR MESSAGE lied about why it failed — a tool's absence reported as a hardware finding, a missing binary diagnosed as a missing container, an option description promising a door that will not open, and a protective default whose only escape hatch was the one this repo's own module rules forbid.

## Changes

1. **pkgs/verify.sh — bare `hyprctl`, now with the argument written down and the absence told apart.** Bare stays correct: the client has to match the *running* compositor (0.56, from the pinned input on the session's PATH), and pinning nixpkgs' 0.54 here would be a client one protocol behind the server it questions. That argument now lives in a distrobox-style comment at the call site, with a matching "deliberately not here" note in flake.nix's `runtimeInputs` list. And a missing hyprctl now reports as `could not list GPUs — hyprctl is not on PATH`, instead of `no GPU listed — hyprctl systeminfo named no display controller`, which was the vainfo trap verbatim.

2. **pkgs/box.nix — `promote_box`'s `podman inspect`, guarded rather than pinned.** `image=$(podman inspect ...) || true` swallowed command-not-found and then said "no box named '<name>'" — a wrong diagnosis exactly when someone is confused. Deliberately NOT pinned, though verify.sh pins podman: `runtimeInputs` is one PATH for the whole script, so a podman pinned for this read-only line would also be the podman distrobox's own calls in `create_box` inherit — container creation handed to this flake's podman instead of the system's, the header's hazard by another road. verify.sh can pin because it only ever reads; this script creates. So: `command -v podman` first, with its own honest message, and the comment states the trade-off.

3. **modules/services/microvm.nix — `sshPort`'s description stops promising a login.** It called the port "the only door in besides the console", but the guest's only user (`dev`) has no password and sshd's default `PermitEmptyPasswords no` refuses exactly that — a declared port forwards to a daemon nobody can authenticate to until the machine's `modules` add an authorized key. The description now says so, and names where the key goes. Behaviour unchanged.

4. **modules/services/syncthing.nix — `overrideFolders`/`overrideDevices` from plain priority to `mkDefault`.** The old "NOT mkDefault" comment conflated the value with the priority: `mkDefault` (1000) still outranks the option's own default (1500), so every user who writes nothing keeps the delete-nothing protection. What plain assignment added on top was a "defined multiple times" error for the user who explicitly asks for upstream's declarative mode, whose only exit was `mkForce` — the one-way door modules/services/default.nix's header forbids, and the exact failure shape (disko #441, home-manager #5870) that header cites. Someone who writes `overrideFolders = true` themselves has accepted the deletion; the shield is only for those who didn't choose. The rewritten comment makes both halves explicit.

## Verification

- `nix build .#verify .#nixarchy-box` — both build; writeShellApplication's shellcheck gate passes
- `nix build .#checks.x86_64-linux.options` — passes (covers the option-description changes; per repo practice this is the check that runs locally)
- `nix eval .#nixosConfigurations.vm.config.system.build.toplevel.drvPath` — evaluates
- `nix fmt -- --ci` — 0 changed

No workflow files touched; installer/, pkgs/microvm.nix and modules/apps.nix untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8RoHBbPBxfJKnjZDBx2b7
