### PR TITLE
Nothing irreversible happens before the thing that can fail is proven

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -254,6 +254,24 @@ network_ready() {
   curl -sfI --max-time 8 https://cache.nixos.org/nix-cache-info >/dev/null 2>&1
 }
 
+# The way out of any question, said out loud.
+#
+# Every prompt in the flow is a `var=$(... gum ...)` assignment, and the flow
+# runs at top level where errexit and pipefail are both live. gum exits
+# non-zero on Escape, pipefail hands that status to the assignment, and
+# errexit exits on it -- BEFORE any `[ -n "$var" ] || exit` guard on the next
+# line can run. The result was the exact failure ask_encrypt's comment and
+# #240 set out to eliminate: a black screen with nothing running and no word
+# of what happened. So every prompt catches its own status with `|| ui_abort`,
+# and the abort says what the person most needs to hear.
+ui_abort() {
+  ui_left ""
+  ui_left "\e[1mStopped before anything was written.\e[0m"
+  ui_left "\e[90mNo disk has been changed. Power off, or reboot to try again.\e[0m"
+  ui_left ""
+  exit 1
+}
+
 connect_wifi() {
   ui_screen "Let's get you on Wi-Fi..."
   nmcli radio wifi on >/dev/null 2>&1 || true
@@ -325,7 +343,7 @@ ask_network() {
 
     local choice
     choice=$(printf '%s\n' "Wi-Fi" "Try again" |
-      gum choose --height "$(ui_widget_height)" --padding "$(ui_gum_pad)" --header "No network yet")
+      gum choose --height "$(ui_widget_height)" --padding "$(ui_gum_pad)" --header "No network yet") || choice=""
 
     case $choice in
       "Wi-Fi") connect_wifi || true ;;
@@ -334,7 +352,7 @@ ask_network() {
       "Try again") ;;
       # gum returns nothing on an interrupt. Leave, rather than loop forever
       # on a screen someone is trying to escape.
-      *) exit 1 ;;
+      *) ui_abort ;;
     esac
 
     if network_ready; then
@@ -346,8 +364,8 @@ ask_network() {
 ask_keymap() {
   ui_screen "Let's set up your keyboard..."
   local choice
-  choice=$(cut -f1 "$UI_KEYMAPS" | gum choose --height "$(ui_widget_height)" --padding "$(ui_gum_pad)" --header "Select keyboard layout")
-  [ -n "$choice" ] || exit 1
+  choice=$(cut -f1 "$UI_KEYMAPS" | gum choose --height "$(ui_widget_height)" --padding "$(ui_gum_pad)" --header "Select keyboard layout") || ui_abort
+  [ -n "$choice" ] || ui_abort
   keymap=$(grep -F "$choice"$'\t' "$UI_KEYMAPS" | cut -f2)
   loadkeys "$keymap" 2>/dev/null || true
 }
@@ -386,8 +404,8 @@ validate_hostname() {
 ask_password() {
   while :; do
     local pw pw2
-    pw=$(gum input --padding "$(ui_gum_pad)" --password --prompt "Password> ")
-    pw2=$(gum input --padding "$(ui_gum_pad)" --password --prompt "Confirm> ")
+    pw=$(gum input --padding "$(ui_gum_pad)" --password --prompt "Password> ") || ui_abort
+    pw2=$(gum input --padding "$(ui_gum_pad)" --password --prompt "Confirm> ") || ui_abort
     if [ "$pw" != "$pw2" ]; then
       ui_left "\e[31mThose do not match.\e[0m"
       continue
@@ -436,12 +454,12 @@ ask_recovery() {
   ui_left "different from your password. Press enter to skip."
   while :; do
     local pw pw2
-    pw=$(gum input --padding "$(ui_gum_pad)" --password --prompt "Recovery> ")
+    pw=$(gum input --padding "$(ui_gum_pad)" --password --prompt "Recovery> ") || ui_abort
     if [ -z "$pw" ]; then
       recovery_hash=""
       break
     fi
-    pw2=$(gum input --padding "$(ui_gum_pad)" --password --prompt "Confirm> ")
+    pw2=$(gum input --padding "$(ui_gum_pad)" --password --prompt "Confirm> ") || ui_abort
     if [ "$pw" != "$pw2" ]; then
       ui_left "\e[31mThose do not match.\e[0m"
       continue
@@ -460,7 +478,7 @@ ask_identity() {
   ui_screen "Let's set up your user account..."
   local why
   while :; do
-    username=$(gum input --padding "$(ui_gum_pad)" --placeholder "Alphanumeric, no spaces (like dhh)" --prompt "Username> ")
+    username=$(gum input --padding "$(ui_gum_pad)" --placeholder "Alphanumeric, no spaces (like dhh)" --prompt "Username> ") || ui_abort
     why=$(validate_username "$username") && break
     gum style --foreground 1 "$why"
   done
@@ -469,7 +487,7 @@ ask_identity() {
   ask_recovery
 
   while :; do
-    hostname=$(gum input --padding "$(ui_gum_pad)" --placeholder "nixarchy" --prompt "Hostname> ")
+    hostname=$(gum input --padding "$(ui_gum_pad)" --placeholder "nixarchy" --prompt "Hostname> ") || ui_abort
     hostname=${hostname:-nixarchy}
     why=$(validate_hostname "$hostname") && break
     gum style --foreground 1 "$why"
@@ -479,14 +497,32 @@ ask_identity() {
     find "$TZDIR" -type f -not -path '*/posix/*' -not -path '*/right/*' |
       sed "s#.*/zoneinfo/##" | grep '/' | sort |
       gum filter --height "$(ui_widget_height)" --padding "$(ui_gum_pad)" --placeholder "Type to search" --value "UTC"
-  )
+  ) || ui_abort
   timezone=${timezone:-UTC}
 }
 
 # The medium we booted from must never be in the list. An installer that offers
 # to format itself is a bug, not an edge case.
+#
+# The parent disk comes from lsblk's PKNAME, not from trimming digits off the
+# partition name. `sed 's/[0-9]*$//'` turns /dev/sdb1 into /dev/sdb and
+# looks finished -- and turns /dev/nvme0n1p1 into "/dev/nvme0n1p" and
+# /dev/mmcblk0p1 into "/dev/mmcblk0p", which match no disk, so the exclusion
+# excluded nothing and an ISO written to an internal NVMe or an SD reader was
+# offered as its own install target. The kernel already knows the parent;
+# ask it.
 boot_medium() {
-  findmnt -no SOURCE /iso 2>/dev/null | sed 's/[0-9]*$//' || true
+  local src parent
+  src=$(findmnt -no SOURCE /iso 2>/dev/null) || return 0
+  [ -n "$src" ] || return 0
+  parent=$(lsblk -no PKNAME "$src" 2>/dev/null | head -1) || parent=""
+  if [ -n "$parent" ]; then
+    printf '/dev/%s\n' "$parent"
+  else
+    # Already a whole device: an ISO dd'd to a disk and booted without a
+    # partition table has no parent, and is itself the thing to exclude.
+    printf '%s\n' "$src"
+  fi
 }
 
 ask_device() {
@@ -524,8 +560,8 @@ ask_device() {
     echo "nixarchy needs at least 8 GiB; nothing attached qualifies." >&2
     exit 1
   fi
-  device=$(printf '%s\n' "$list" | gum choose --height "$(ui_widget_height)" --padding "$(ui_gum_pad)" --header "Select install disk" | awk '{print $1}')
-  [ -n "$device" ] || exit 1
+  device=$(printf '%s\n' "$list" | gum choose --height "$(ui_widget_height)" --padding "$(ui_gum_pad)" --header "Select install disk" | awk '{print $1}') || ui_abort
+  [ -n "$device" ] || ui_abort
 }
 
 # ---------------------------------------------------------------------------
@@ -717,13 +753,13 @@ ask_disk_mode() {
   choice=$(printf '%s\n' \
     "Free space install -- keep what is on $device, use the $(free_region_human) free" \
     "Full disk install -- erase $device and everything on it" |
-    gum choose --height "$(ui_widget_height)" --padding "$(ui_gum_pad)" --header "How should nixarchy use $device?")
+    gum choose --height "$(ui_widget_height)" --padding "$(ui_gum_pad)" --header "How should nixarchy use $device?") || choice=""
   case $choice in
     "Free space install"*) disk_mode=free ;;
     "Full disk install"*) disk_mode=whole ;;
     # Escape, or a gum that could not draw. Neither is consent to format a
     # disk with an operating system on it.
-    *) exit 1 ;;
+    *) ui_abort ;;
   esac
 }
 
@@ -759,11 +795,7 @@ ask_encrypt() {
       # "do it anyway, differently" -- but it used to refuse in silence, and on
       # the ISO a silent exit leaves a terminal with nothing on it. Say what
       # happened, and say the thing the person most needs to hear.
-      ui_left ""
-      ui_left "\e[1mStopped before anything was written.\e[0m"
-      ui_left "\e[90mNo disk has been changed. Power off, or reboot to try again.\e[0m"
-      ui_left ""
-      exit 1
+      ui_abort
       ;;
   esac
 }
@@ -1191,10 +1223,24 @@ partition_free_space() {
   root_type=8300
   [ "$encrypt" = true ] && root_type=8309
 
+  # Checked by hand: this runs inside main()'s `|| rc=$?` chain, where bash
+  # suppresses errexit. Unchecked, a failed sgdisk fell through to the settle
+  # loop below, which timed out and printed "The partitions were created" --
+  # asserting a creation that never happened, in free-space mode, on the one
+  # disk that has somebody else's OS on it.
   sgdisk --new=0:"$free_start":"$esp_end" \
-    --typecode=0:EF00 --change-name=0:nixarchy-esp "$dev"
+    --typecode=0:EF00 --change-name=0:nixarchy-esp "$dev" || {
+    echo "nixarchy-install: sgdisk could not create the ESP on $dev (exit $?)." >&2
+    echo "  Nothing was formatted. Check the partition table before retrying." >&2
+    exit 1
+  }
   sgdisk --new=0:"$root_start":"$free_end" \
-    --typecode=0:"$root_type" --change-name=0:nixarchy-root "$dev"
+    --typecode=0:"$root_type" --change-name=0:nixarchy-root "$dev" || {
+    echo "nixarchy-install: sgdisk could not create the root partition on $dev (exit $?)." >&2
+    echo "  The ESP entry was created; nothing was formatted. Check the" >&2
+    echo "  partition table before retrying." >&2
+    exit 1
+  }
 
   # sgdisk asks the kernel to re-read the table itself; partx is the fallback
   # for when it cannot, which is any disk that has a partition mounted.
@@ -1274,12 +1320,30 @@ format_disk() {
   # Built and then executed, rather than `nix run`: diskoScript's output IS the
   # script, and `nix run` looks for $out/bin/<name> inside it, which fails with
   # "Not a directory".
-  local script
+  # Both the build and the run are checked by hand, because errexit cannot do
+  # it here: main() tests this whole chain's status with `|| rc=$?`, and bash
+  # suppresses errexit inside any compound whose status is tested. Unchecked,
+  # a failed build handed `""` to the exec line (exit 127, ignored), a partial
+  # disko run was ignored too, and format_disk's status was that of its last
+  # command -- the rm, which always succeeds. The failure then surfaced half
+  # an hour later at the bootloader step, naming bootctl instead of disko, on
+  # a disk that was erased in the first minute.
+  local script rc=0
   script=$(nix "${NIX_FLAGS[@]}" build --no-link --print-out-paths \
-    "$work#nixosConfigurations.$hostname.config.system.build.diskoScript")
-  "$script"
-
+    "$work#nixosConfigurations.$hostname.config.system.build.diskoScript") || rc=$?
+  if [ "$rc" -ne 0 ] || [ -z "$script" ]; then
+    rm -f /tmp/nixarchy-luks.key
+    echo "nixarchy-install: the disko script did not build (exit $rc)." >&2
+    echo "  Nothing was formatted; the error above this is the one to read." >&2
+    return 1
+  fi
+  "$script" || rc=$?
   rm -f /tmp/nixarchy-luks.key
+  if [ "$rc" -ne 0 ]; then
+    echo "nixarchy-install: disko exited $rc; the disk may be partly formatted." >&2
+    echo "  Nothing was installed. This is disko failing, not the bootloader." >&2
+    return 1
+  fi
 }
 
 # Prove disko mounted what the layout asked for.
@@ -1294,8 +1358,13 @@ format_disk() {
 # `findmnt --mountpoint` matches only a real mountpoint, so a plain
 # directory inside `@` does not satisfy it.
 verify_subvolume_mounts() {
+  # /mnt/boot is in the list because it is the one mountpoint whose absence
+  # this check used to let through: a disko run that mounted the four btrfs
+  # subvolumes but left the ESP unformatted sailed past here, and the failure
+  # surfaced ~30 minutes later when bootctl refused -- with an error naming
+  # the bootloader, on a disk erased at minute one.
   local mp missing=""
-  for mp in /mnt /mnt/nix /mnt/home /mnt/var/log; do
+  for mp in /mnt /mnt/boot /mnt/nix /mnt/home /mnt/var/log; do
     findmnt -rno TARGET --mountpoint "$mp" >/dev/null 2>&1 || missing="$missing $mp"
   done
   if [ -n "$missing" ]; then

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -462,7 +462,10 @@ in
           + "kdenlive gnome-disk-utility sushi cliamp.";
       }
       {
-        assertion = config.programs.hyprland.package.version or "0" >= "0.55";
+        # versionAtLeast, not string >=: Nix compares strings lexicographically,
+        # so "0.100.0" >= "0.55" is false and the day Hyprland reaches 0.100
+        # this assertion would fire wrongly on every machine at once.
+        assertion = lib.versionAtLeast (config.programs.hyprland.package.version or "0") "0.55";
         message = ''
           Nixarchy needs Hyprland >= 0.55 for the Lua config API that
           Omarchy 4.x is written against (hl.bind / hl.window_rule / hl.on).

--- a/tests/installer-store-space.nix
+++ b/tests/installer-store-space.nix
@@ -186,5 +186,205 @@ pkgs.runCommand "nixarchy-installer-store-space" { } ''
   }
 
   echo "preflight_build refuses before the wipe, and main runs it there"
+
+  # ------------------------------------------------------------------------
+  # format_disk must hand out the diskoScript's status, not the rm's.
+  #
+  # It runs inside main()'s `|| rc=$?` chain, where bash suppresses errexit,
+  # so nothing implicit checks the build or the run. Unchecked, a failed
+  # build executed "" (127, ignored), a partial disko run was ignored too,
+  # and the function returned the status of `rm -f` -- always 0. The failure
+  # then surfaced ~30 minutes later at bootctl, on a disk erased at minute
+  # one, with an error naming the bootloader instead of disko.
+  # ------------------------------------------------------------------------
+  sed -n '/^format_disk()/,/^}/p' ${installScript} > fd.sh
+  test -s fd.sh || { echo "format_disk is not in install.sh any more" >&2; exit 1; }
+
+  cat > fdt.sh <<'EOF'
+  NIX_FLAGS=() work=/nonexistent hostname=h
+  disk_mode=whole luks_passphrase=pw
+  . ./fd.sh
+  findmnt() { return 1; }   # nothing mounted at /mnt
+  fails=0
+  t() {
+    want=$1 name=$2
+    if format_disk >out 2>&1; then got=proceed; else got=refuse; fi
+    if [ "$got" = "$want" ]; then
+      echo "  ok      $name ($got)"
+    else
+      echo "  FAILED  $name: wanted $want, got $got"; sed 's/^/            /' out
+      fails=$((fails + 1))
+    fi
+  }
+
+  # The build fails: nothing to execute, and the status must say so.
+  nix() { echo "error: builder failed" >&2; return 1; }
+  t refuse "diskoScript build fails -> format_disk fails"
+  grep -qi disko out || { echo "  FAILED  build refusal does not name disko"; fails=$((fails+1)); }
+
+  # The build succeeds and disko itself dies partway.
+  printf '#!/bin/sh\nexit 3\n' > fake-disko-bad; chmod +x fake-disko-bad
+  nix() { echo "$PWD/fake-disko-bad"; }
+  t refuse "diskoScript exits 3 -> format_disk fails"
+  grep -qi disko out || { echo "  FAILED  disko refusal does not name disko"; fails=$((fails+1)); }
+
+  # And a run that works still works.
+  printf '#!/bin/sh\nexit 0\n' > fake-disko-ok; chmod +x fake-disko-ok
+  nix() { echo "$PWD/fake-disko-ok"; }
+  t proceed "diskoScript succeeds -> format_disk succeeds"
+  exit $fails
+  EOF
+  bash fdt.sh
+
+  # verify_subvolume_mounts is format_disk's backstop, and /mnt/boot has to
+  # be in it: a disko run that mounted the four btrfs subvolumes and left the
+  # ESP alone used to sail through, and the failure surfaced at bootctl.
+  sed -n '/^verify_subvolume_mounts()/,/^}/p' ${installScript} > vs.sh
+  test -s vs.sh || { echo "verify_subvolume_mounts is not in install.sh any more" >&2; exit 1; }
+  cat > vst.sh <<'EOF'
+  . ./vs.sh
+  findmnt() {
+    case "$*" in
+      *--mountpoint\ /mnt/boot*) return 1 ;;  # everything mounted but the ESP
+      *) return 0 ;;
+    esac
+  }
+  if verify_subvolume_mounts >out 2>&1; then
+    echo "  FAILED  an unmounted /mnt/boot was let through"
+    exit 1
+  fi
+  grep -q '/mnt/boot' out || { echo "  FAILED  refusal does not name /mnt/boot"; exit 1; }
+  echo "  ok      unmounted /mnt/boot is refused by name"
+  findmnt() { return 0; }
+  verify_subvolume_mounts >out 2>&1 || { echo "  FAILED  a fully mounted target was refused"; exit 1; }
+  echo "  ok      fully mounted target proceeds"
+  EOF
+  bash vst.sh
+
+  echo "format_disk fails when disko does, and the backstop checks the ESP"
+
+  # ------------------------------------------------------------------------
+  # boot_medium must resolve the parent disk for every naming convention.
+  #
+  # The old sed 's/[0-9]*$//' turned /dev/nvme0n1p1 into "/dev/nvme0n1p",
+  # which matches no disk, so the exclusion excluded nothing and the
+  # installer offered to format the medium it booted from. The file's own
+  # comment calls that a bug, not an edge case.
+  # ------------------------------------------------------------------------
+  sed -n '/^boot_medium()/,/^}/p' ${installScript} > bm.sh
+  test -s bm.sh || { echo "boot_medium is not in install.sh any more" >&2; exit 1; }
+  cat > bmt.sh <<'EOF'
+  . ./bm.sh
+  findmnt() { printf '%s\n' "$SRC"; }
+  lsblk() { printf '%s\n' "$PARENT"; }
+  fails=0
+  t() {
+    src=$1 parent=$2 want=$3
+    got=$(SRC=$src PARENT=$parent boot_medium)
+    if [ "$got" = "$want" ]; then
+      echo "  ok      $src -> $got"
+    else
+      echo "  FAILED  $src: wanted $want, got '$got'"
+      fails=$((fails + 1))
+    fi
+  }
+  t /dev/sdb1      sdb      /dev/sdb
+  t /dev/nvme0n1p1 nvme0n1  /dev/nvme0n1
+  t /dev/mmcblk0p1 mmcblk0  /dev/mmcblk0
+  # An image dd'd to the whole device: no parent, the device is the medium.
+  t /dev/sdb       ""       /dev/sdb
+  exit $fails
+  EOF
+  bash bmt.sh
+  echo "boot_medium excludes the right disk for sd, nvme and mmcblk names"
+
+  # ------------------------------------------------------------------------
+  # partition_free_space: a failed sgdisk must be named, not narrated over.
+  #
+  # errexit is dead here too (same chain), so an unchecked sgdisk failure
+  # fell through to the settle loop, which timed out and printed "The
+  # partitions were created" -- asserting a creation that never happened, in
+  # free-space mode, on the one disk with somebody else's OS on it.
+  # ------------------------------------------------------------------------
+  sed -n '/^partition_free_space()/,/^}/p' ${installScript} > pfs.sh
+  test -s pfs.sh || { echo "partition_free_space is not in install.sh any more" >&2; exit 1; }
+  cat > pfst.sh <<'EOF'
+  device=/dev/vdz free_start=2048 free_end=20000000 free_why=""
+  encrypt=false FREE_ESP_MIB=2048
+  . ./pfs.sh
+  free_space_possible() { return 0; }
+  blockdev() { echo 512; }
+  partx() { :; }
+  udevadm() { :; }
+  sleep() { :; }               # the settle loop must not cost 15 real seconds
+  wipefs() { touch wipefs-called; }
+  sgdisk() { return 1; }
+  fails=0
+  if ( partition_free_space ) >out 2>&1; then
+    echo "  FAILED  a failed sgdisk was treated as success"; fails=$((fails+1))
+  fi
+  grep -q sgdisk out || { echo "  FAILED  the refusal does not name sgdisk"; sed 's/^/            /' out | head -4; fails=$((fails+1)); }
+  ! grep -q 'were created' out || { echo "  FAILED  the message claims partitions were created"; fails=$((fails+1)); }
+  [ ! -e wipefs-called ] || { echo "  FAILED  wipefs ran after sgdisk failed"; fails=$((fails+1)); }
+  [ "$fails" = 0 ] && echo "  ok      failed sgdisk is refused by name, nothing wiped"
+  exit $fails
+  EOF
+  bash pfst.sh
+  echo "partition_free_space names sgdisk when sgdisk is what failed"
+
+  # ------------------------------------------------------------------------
+  # Escape at a prompt must say what happened, not black-screen (#240).
+  #
+  # The question flow runs at top level where errexit and pipefail are LIVE:
+  # gum exits non-zero on Escape, the `var=$(... gum ...)` assignment carries
+  # that status, and errexit killed the script before any guard on the next
+  # line could run. Run the real functions in a fresh `set -euo pipefail`
+  # process -- the same regime install.sh runs under -- and demand words on
+  # the way out. Driven as a process, not a function, because errexit
+  # suppression does not cross the process boundary.
+  # ------------------------------------------------------------------------
+  {
+    echo 'set -euo pipefail'
+    echo 'ui_screen() { :; }'
+    echo 'ui_left() { printf "%b\n" "$1"; }'
+    echo 'ui_indent() { cat; }'
+    echo 'ui_widget_height() { echo 10; }'
+    echo 'ui_gum_pad() { echo 0; }'
+    echo 'gum() { return 130; }   # Escape, at every prompt'
+    echo 'loadkeys() { :; }'
+    sed -n '/^ui_abort()/,/^}/p' ${installScript}
+    sed -n '/^validate_username()/,/^}/p' ${installScript}
+    sed -n '/^ask_keymap()/,/^}/p' ${installScript}
+    sed -n '/^ask_identity()/,/^}/p' ${installScript}
+    sed -n '/^ask_disk_mode()/,/^}/p' ${installScript}
+  } > esc-common.sh
+  cat > esct.sh <<'EOF'
+  fails=0
+  t() {
+    name=$1; shift
+    { cat esc-common.sh; printf '%s\n' "$@"; } > esc-run.sh
+    if bash esc-run.sh >out 2>&1; then
+      echo "  FAILED  $name: escape was treated as an answer"; fails=$((fails+1)); return
+    fi
+    if grep -q 'Stopped before anything was written' out; then
+      echo "  ok      $name says it stopped"
+    else
+      echo "  FAILED  $name: died with no word of what happened"
+      sed 's/^/            /' out | head -3
+      fails=$((fails + 1))
+    fi
+  }
+  printf 'us\tus\n' > keymaps
+  t "escape at the keymap"    'UI_KEYMAPS=keymaps' 'ask_keymap'
+  t "escape at the username"  'ask_identity'
+  t "escape at the disk mode" 'device=/dev/vda' \
+    'free_space_possible() { return 0; }' \
+    'free_region_human() { echo 10G; }' \
+    'lsblk() { echo part; }' \
+    'ask_disk_mode'
+  exit $fails
+  EOF
+  bash esct.sh
+  echo "escape at a prompt stops with words on the screen, not a black one"
     touch $out
 ''


### PR DESCRIPTION
Five confirmed robustness findings of the #300 class — something irreversible (or a silent death) sitting in front of the check that would have caught it. Each is independent; all five landed.

**1. Hyprland version assertion used string comparison** (`modules/nixos.nix`)
Nix `>=` on strings is lexicographic, so `"0.100.0" >= "0.55"` is `false` — the day Hyprland reaches 0.100 the assertion fires wrongly, with a misleading message, on every machine at once. Now `lib.versionAtLeast`. (`nix eval`: string `>=` → `false`, `versionAtLeast` → `true`.)

**2. format_disk swallowed the diskoScript's exit status** (`installer/install.sh`)
It runs inside main()'s `|| rc=$?` chain where bash suppresses errexit, and returned the status of its last command — `rm -f` of the passphrase file, always 0. A failed build executed `""` (127, ignored); a partial disko run was ignored too; the failure surfaced ~30 minutes later at bootctl, naming the bootloader, on a disk erased at minute one. Both the build and the run are checked explicitly now, and `verify_subvolume_mounts` checks `/mnt/boot` — the one mountpoint whose absence it used to let through.

**3. boot_medium's self-exclusion failed for nvme/mmcblk**
`sed 's/[0-9]*$//'` turns `/dev/nvme0n1p1` into `/dev/nvme0n1p` — a name matching no disk, so the exclusion excluded nothing and the installer offered to format the medium it booted from. Now `lsblk -no PKNAME`, with the whole-device (no parent) case handled.

**4. Both sgdisk calls in partition_free_space were unchecked**
Same dead errexit: a failed sgdisk fell through to the settle loop, which timed out and printed "The partitions were created" — asserting a creation that never happened, in free-space mode, on the one disk with somebody else's OS on it. Checked; the refusal names sgdisk; the timeout message is now only reachable when the creation really happened.

**5. Escape at a gum prompt killed the installer silently**
The question flow runs at top level where errexit and pipefail ARE live, so gum's nonzero status on ESC exited on the assignment — before any `[ -n "$var" ] || exit` guard could run. The black screen #240 set out to eliminate survived at every prompt but ask_encrypt's. Every prompt (keymap, username, password, recovery, hostname, timezone, device, disk mode, network menu) now lands in `ui_abort`, which prints ask_encrypt's "Stopped before anything was written" wording.

**Verification** — red before green, red failing by name, in `tests/installer-store-space.nix` (the established stub-driven home; no new check, no workflow change). Against the old install.sh the new assertions fail with:

```
FAILED  diskoScript build fails -> format_disk fails: wanted refuse, got proceed
FAILED  diskoScript exits 3 -> format_disk fails: wanted refuse, got proceed
FAILED  an unmounted /mnt/boot was let through
FAILED  /dev/nvme0n1p1: wanted /dev/nvme0n1, got '/dev/nvme0n1p'
FAILED  /dev/mmcblk0p1: wanted /dev/mmcblk0, got '/dev/mmcblk0p'
FAILED  the refusal does not name sgdisk
FAILED  the message claims partitions were created
FAILED  escape at the keymap: died with no word of what happened
FAILED  escape at the username: died with no word of what happened
FAILED  escape at the disk mode: died with no word of what happened
```

With the fixes: `nix build .#checks.x86_64-linux.installer-store-space` is green (all pre-existing sections included), `checks.options` builds, shellcheck clean, `nix fmt` run.

Item 1 has no dedicated check: there is no natural stub-driven home for a module assertion, and adding one would be a new check needing a workflow line. Demonstrated by eval instead (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YhPPfiA5VMpymwje4gQaZ