### PR TITLE
The nightly gains a canary that runs tomorrow's flake update, because the weekly cron never did

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,20 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    # Upstream Omarchy and Hyprland both move fast. A weekly run catches a
-    # break before someone else's `nix flake update` does.
+    # A weekly re-run against the COMMITTED lock. This used to claim it
+    # caught a break "before someone else's `nix flake update` does", and it
+    # cannot: the lock pins every flake input, so on those it proves nothing
+    # the last merged PR did not already prove. #320 is the measurement --
+    # nixpkgs renamed ffmpeg_7 away, every downstream consumer broke, and
+    # this run stayed green because its lock still held the old nixpkgs.
+    # nightly.yml's canary job is the one that resolves the inputs the way a
+    # user's update would.
+    #
+    # What this run DOES watch is everything the checks reach past the lock
+    # for: the live issue list the roadmap check reads, the registry nixpkgs
+    # that "every mapped app still evaluates" asks, the fetched upstream
+    # artefacts. Those move on their own schedule, so a scheduled run is
+    # what notices.
     - cron: "0 6 * * 1"
 
 concurrency:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -225,10 +225,55 @@ jobs:
             exit 1
           fi
 
+  # Tomorrow's user. build.yml's weekly cron re-runs the checks against the
+  # COMMITTED lock, so on the flake inputs it proves nothing a merged PR did
+  # not already prove -- the break that reaches people arrives through their
+  # own `nix flake update`, resolving every input this repo leaves mobile:
+  # nixpkgs on nixos-unstable, disko on the moving `latest` tag. zen-browser
+  # tracked master the same way until #320, and that is the incident this job
+  # exists for: nixpkgs renamed ffmpeg_7 away, every downstream consumer's
+  # eval broke, and this repo's CI stayed green the whole time because its
+  # own lock still held the old nixpkgs.
+  #
+  # So: update the lock in a scratch checkout and evaluate what a user's
+  # machine would evaluate. Eval, not build -- the class of break this
+  # catches (a removed attribute, a renamed option, an input that stopped
+  # evaluating) lives entirely in evaluation, and eval needs no KVM, no
+  # binary cache and no disk games. Nothing is committed; the lock this repo
+  # ships is untouched.
+  #
+  # Non-gating by design. A red here means upstream moved, not that a PR
+  # broke something, so it blocks nobody -- the report job below files it as
+  # its own issue, and review.yml's `ci nightly.yml` line keeps the night
+  # from failing silently.
+  canary:
+    name: what a user's flake update gets
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Resolve every input the way a user would tomorrow
+        run: nix flake update
+
+      - name: Their machine still evaluates
+        run: |
+          # drvPath forces the full evaluation of the system closure --
+          # every module, every package in systemPackages, every input the
+          # flake reaches for -- which is exactly the surface #320 broke on.
+          # Both hosts, because they diverge: vm is what checks boot,
+          # reference is what the installer writes.
+          nix eval --raw .#checks.x86_64-linux.vm-toplevel.drvPath
+          echo
+          nix eval --raw .#checks.x86_64-linux.reference-toplevel.drvPath
+          echo
+          echo "both toplevels evaluate against tomorrow's inputs"
+
   report:
     name: report a failure
     runs-on: ubuntu-latest
-    needs: [install, install-iso, microvm, cache]
+    needs: [install, install-iso, microvm, cache, canary]
     # cancelled() too. On 2026-09-02 install-iso hit its 180-minute timeout,
     # which GitHub records as cancelled rather than failed, and this job --
     # the one whose whole purpose is that a 03:00 failure does not cost a day
@@ -256,6 +301,15 @@ jobs:
           # more than the bug did.
           if [ "${{ needs.cache.result }}" = "failure" ]; then
             title="nightly: nothing is reaching the binary cache"
+          elif [ "${{ needs.canary.result }}" = "failure" ] &&
+            [ "${{ needs.install.result }}" = "success" ] &&
+            [ "${{ needs.install-iso.result }}" = "success" ]; then
+            # Its own identity: a canary failure means UPSTREAM moved under
+            # a mobile input, and sending the reader at the install checks
+            # would hide it -- the #236 shape again. Only when the installs
+            # themselves are green, though; a night where both broke is an
+            # install problem first.
+            title="nightly: tomorrow's flake update breaks a user's eval"
           else
             title="nightly: the install checks are failing"
           fi


### PR DESCRIPTION
**CI-gate adjacent (AGENTS.md §10): adds a nightly job and a report-title branch; a human merges it. Non-gating — it blocks no PR.**

## The false coverage claim

`build.yml`'s weekly cron comment says a weekly run *"catches a break before someone else's `nix flake update` does."* It cannot: the scheduled run builds the **committed lock**, so on the flake inputs it proves exactly what the last merged PR already proved. #320 is the measurement — nixpkgs renamed `ffmpeg_7` away, `zen-browser` (an input with no ref, tracking master) stopped evaluating for every downstream consumer, and this repo's CI stayed green the whole time because its own lock still held the old nixpkgs. The exposure recurs: `disko` rides the moving `latest` tag, `nixpkgs` rides `nixos-unstable`.

## The canary

A `canary` job in `nightly.yml` that is the downstream user: `nix flake update` in a scratch checkout (nothing committed), then `nix eval` of both toplevels' `.drvPath` — the full system evaluation, which is the exact surface #320 broke on. Eval only: no KVM, no cache, no self-hosted runner — a hosted runner and a few minutes (~20 hosted-runner minutes/week at nightly cadence).

Reporting: wired into the existing `report` job's `needs`, with its own issue identity — *"nightly: tomorrow's flake update breaks a user's eval"* — claimed only when the install checks themselves are green, so a night where everything broke still reads as an install problem first (the #236 title-identity rule). `review.yml`'s `ci nightly.yml` line already watches the workflow, so no new watcher.

The weekly cron's comment is rewritten to claim only what it actually covers: the things checks reach **past** the lock for — the live issue list the roadmap check reads, the registry nixpkgs that "every mapped app still evaluates" asks, fetched upstream artefacts.

## What a red canary means

Upstream moved under a mobile input. The first move is usually pinning the input that broke (the #320 fix was exactly that), not touching this repo's own code — which is why it gates nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwTCPv3v9fKXYvPjjf5Qz9