### PR TITLE
Two probes that lied: the VM pin GitHub cannot fetch, and the Install row that never dims

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -409,18 +409,20 @@
           hey-cli = final.callPackage ./pkgs/apps/hey-cli.nix { };
 
           # Not built here -- upstream's own flake, re-exported into the overlay
-          # so nixarchy-doctor and the Install menu can find it.
+          # so nixarchy-doctor can find it.
           #
-          # Both ask pkgs for an app's meta.mainProgram to learn which command it
-          # puts on PATH, and fall back to the attribute name when the lookup
-          # fails. zen-browser lived only in packages.<system>, so the lookup
-          # returned null and the fallback answered "zen" -- a command that does
-          # not exist, because this package installs bin/zen-beta. The doctor
-          # could never report Zen as present and the menu never dimmed its row.
+          # The doctor asks pkgs for an app's meta.mainProgram to learn which
+          # command it puts on PATH, and falls back to the attribute name when
+          # the lookup fails. zen-browser lived only in packages.<system>, so
+          # the lookup returned null and the fallback answered "zen" -- a
+          # command that does not exist, because this package installs
+          # bin/zen-beta. The doctor could never report Zen as present.
           #
           # Exactly the vscode/code trap the doctor was written to avoid, reached
           # by a different road: not a wrong mainProgram, but a package the probe
-          # could not see.
+          # could not see. The Install menu's copy of the probe had the same bug
+          # for longer -- it reads cfg.apps.<name>.package instead of this
+          # overlay; see appBinary in modules/apps.nix.
           zen-browser = zen-browser.packages.${final.stdenv.hostPlatform.system}.default;
 
           # Two of the four applications Omarchy writes itself. nixpkgs has

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -28,13 +28,24 @@ let
   # would have broken evaluation for everyone who has not opted into unfree --
   # a far worse outcome than the dim row it is here to draw. Falling back to
   # the app's own name is the same guess omarchy-pkg-present already makes.
+  #
+  # `ours` apps are answered by cfg.apps.<name>.package -- the very derivation
+  # the row would install, including any override the user put on it -- and
+  # NOT by a lookup in `pkgs`, which cannot see them: this module's pkgs
+  # carries no nixarchy overlay (modules/services/default.nix says why), so
+  # the lookup returned null for every app this repo packages and the
+  # fallback answered with the app id. That was `command -v zen` for a
+  # package whose only binary is zen-beta, so the row never dimmed on a
+  # machine that HAS Zen. nixarchy-doctor hit the same trap and fixed its
+  # copy first, by probing final.nixarchy-apps (flake.nix); this is the
+  # menu's half, asserted by tests/coverage.py against the flake's packages.
   appBinary =
     name: app:
     let
       path = lib.splitString "." (app.attr or name);
       probe = builtins.tryEval (
         let
-          p = lib.attrByPath path null pkgs;
+          p = if app.ours or false then cfg.apps.${name}.package or null else lib.attrByPath path null pkgs;
         in
         if p == null then null else (p.meta.mainProgram or null)
       );

--- a/pkgs/microvm.nix
+++ b/pkgs/microvm.nix
@@ -43,15 +43,25 @@ let
 
   # `self.rev` is what mkFlake.nix uses to pin the generated installer flake,
   # and it throws on a dirty tree because that pin has to survive forever on
-  # an installed machine. This is not that: worst case here is a `nix build`
-  # against `main` instead of the exact commit, so `self.dirtyRev` (present
-  # once this tree has ANY commit, dirty or not) and a plain "main" fallback
-  # both keep evaluation working -- which matters because, unlike
-  # mkFlake.nix, this package is evaluated by every ordinary
-  # `nixosModules.nixarchy` consumer, including every check in this repo's
-  # own flake, not only the installer image.
-  rev = self.rev or self.dirtyRev or "main";
+  # an installed machine. This is not that -- unlike mkFlake.nix, this
+  # package is evaluated by every ordinary `nixosModules.nixarchy` consumer,
+  # including every check in this repo's own flake, so evaluation has to keep
+  # working with no rev at all, dirty tree included.
+  #
+  # On a dirty tree there is no `self.rev`, only `self.dirtyRev`: the
+  # underlying commit with "-dirty" appended, which is NOT a ref GitHub can
+  # resolve -- handed to `nix build github:...` verbatim it 404s at `run`
+  # time, with nix's fetch error as the only word on why. So the suffix is
+  # stripped and the underlying commit pinned instead. Even a clean rev is a
+  # promise rather than a guarantee -- a commit never pushed resolves no
+  # better -- which is why run_vm below falls back to `main`, out loud, when
+  # the pinned rev cannot be fetched. Worst case is therefore a `nix build`
+  # against `main` instead of the exact commit, and the user is told so.
+  # checks.microvm-template asserts both halves, on a pinned fake dirtyRev
+  # rather than whatever state CI's checkout happens to be in.
+  rev = lib.removeSuffix "-dirty" (self.rev or self.dirtyRev or "main");
   flakeUrl = "github:olafkfreund/nixarchy/${rev}";
+  fallbackUrl = "github:olafkfreund/nixarchy/main";
 
   # One file per template plus a tab-separated index -- same shape as
   # pkgs/dev-init.nix's presetDir, and for the same reason: the script then
@@ -83,6 +93,7 @@ writeShellApplication {
         stateDir="''${XDG_STATE_HOME:-$HOME/.local/state}/nixarchy/microvm"
         templates=${templateDir}
         flakeUrl=${lib.escapeShellArg flakeUrl}
+        fallbackUrl=${lib.escapeShellArg fallbackUrl}
 
         list_templates() {
           echo "Templates:"
@@ -217,7 +228,21 @@ writeShellApplication {
 
           # Never `nix run`: see the header comment on why that would leave this
           # guest's store share unprotected from garbage collection.
-          nix build "$flakeUrl#$attr" --out-link "$dir/current"
+          #
+          # The pinned rev is this system's own commit, but only a commit
+          # GitHub actually has can be fetched -- a dirty checkout's stripped
+          # rev and an unpushed local commit both fail here. Falling back to
+          # main, with a word about it, beats nix's bare fetch error, which
+          # says nothing a user can act on.
+          if ! nix build "$flakeUrl#$attr" --out-link "$dir/current"; then
+            [ "$flakeUrl" != "$fallbackUrl" ] || exit 1
+            echo "nixarchy-vm: could not build $flakeUrl#$attr." >&2
+            echo "This machine was built from a commit GitHub does not have" >&2
+            echo "(a dirty checkout, or one never pushed). Falling back to" >&2
+            echo "$fallbackUrl -- the template may differ from the commit" >&2
+            echo "this system was built from." >&2
+            nix build "$fallbackUrl#$attr" --out-link "$dir/current"
+          fi
 
           echo "$name" > "$dir/hostname"
           cd "$dir"

--- a/tests/coverage.py
+++ b/tests/coverage.py
@@ -97,3 +97,30 @@ if missing:
     )
 print(f"all {len(menu)} menu rows name commands that exist")
 
+# ---- packaged apps dim on the command their package installs --------------
+# An Install row dims when its `disabled` probe's `command -v <binary>`
+# succeeds, and <binary> is supposed to be the app package's meta.mainProgram.
+# For `ours` apps that package is not in plain nixpkgs, so a probe that asks
+# only pkgs finds nothing and falls back to the app id -- `command -v zen`
+# for a package whose only binary is zen-beta -- and the row never dims on a
+# machine that HAS the app. $oursBinaries (tests/options.nix) carries the
+# binary each `ours` package really installs, read off the flake's own
+# packages, so this compares what the menu probes against ground truth.
+wrong = []
+for pair in os.environ["oursBinaries"].split():
+    row_id, binary = pair.split("=", 1)
+    disabled = str(menu.get(row_id, {}).get("disabled", ""))
+    if f"command -v {binary} >" not in disabled:
+        probed = re.search(r"command -v (\S+)", disabled)
+        wrong.append(
+            f"{row_id}: dims on `{probed.group(1) if probed else '(nothing)'}`, "
+            f"but its package installs `{binary}`"
+        )
+if wrong:
+    sys.exit(
+        "these Install rows dim on a command their package does not install, "
+        "so they never dim on a machine that has the app:\n  "
+        + "\n  ".join(wrong)
+    )
+print(f"all {len(os.environ['oursBinaries'].split())} packaged apps' rows dim on the command they install")
+

--- a/tests/microvm-template.nix
+++ b/tests/microvm-template.nix
@@ -36,6 +36,21 @@ let
     podman = "var-lib-containers.img";
     persistent = "home.img";
   };
+
+  # The CLI as a machine built from a DIRTY checkout evaluates it: no
+  # `self.rev`, only `self.dirtyRev` -- the underlying commit with "-dirty"
+  # appended, which is not a ref GitHub can resolve. `nixarchyVm` above is
+  # built from whatever state CI's own checkout happens to be in, so the
+  # dirty case has to be pinned here or it is only ever tested by accident --
+  # and it shipped broken exactly that way: `run` handed
+  # `github:olafkfreund/nixarchy/<rev>-dirty` to `nix build`, which 404s with
+  # nothing to say why.
+  dirtyRev = "0000000000000000000000000000000000000000";
+  dirtyVm = pkgs.callPackage ../pkgs/microvm.nix {
+    self = {
+      dirtyRev = "${dirtyRev}-dirty";
+    };
+  };
 in
 pkgs.runCommand "nixarchy-microvm-template"
   {
@@ -269,6 +284,72 @@ pkgs.runCommand "nixarchy-microvm-template"
 
     kill "$first" 2>/dev/null || true
     wait "$first" 2>/dev/null || true
+
+    echo "== nixarchy vm: a machine built from a dirty or unpushed commit =="
+
+    # The URL baked into the dirty-checkout CLI. "<rev>-dirty" is what
+    # self.dirtyRev holds, and github:owner/repo/<rev>-dirty is a ref GitHub
+    # cannot resolve -- `nixarchy vm run` on any machine built from a dirty
+    # tree 404s at build time, with nix's fetch error as the only word on it.
+    if grep -q -- '-dirty' ${dirtyVm}/bin/nixarchy-vm; then
+      echo "the dirty-checkout CLI embeds a flake URL ending in -dirty:" >&2
+      grep -o 'github:[^"]*' ${dirtyVm}/bin/nixarchy-vm | sort -u >&2
+      echo "GitHub has no such ref, so 'nixarchy vm run' can never build" >&2
+      fail=1
+    fi
+
+    # And the pinned commit itself is only a promise: a stripped dirty rev or
+    # a clean but unpushed commit resolves no better. A second stub `nix`
+    # that refuses everything except .../main -- exactly what GitHub does for
+    # a commit it does not have -- so `run` has to fall back to main, out
+    # loud, instead of dying on the fetch.
+    mkdir -p bin2
+    calls2=$PWD/nix-calls2.log
+    cat > bin2/nix <<STUB2
+    #!${pkgs.bash}/bin/bash
+    echo "\$*" >> $calls2
+    case "\$2" in
+      */main#*) exec $PWD/bin/nix "\$@" ;;
+      *) echo "stub nix: cannot find flake reference '\$2' (no such ref)" >&2; exit 1 ;;
+    esac
+    STUB2
+    chmod +x bin2/nix
+    export PATH="$PWD/bin2:$PATH"
+    export HOME=$PWD/home2
+    export XDG_STATE_HOME=$HOME/.local/state
+    mkdir -p "$HOME"
+
+    ${dirtyVm}/bin/nixarchy-vm create pinned
+    ( ${dirtyVm}/bin/nixarchy-vm run pinned > run3.log 2>&1; echo $? > run3.status ) &
+    third=$!
+    for _ in $(seq 1 50); do
+      [ -f "$XDG_STATE_HOME/nixarchy/microvm/pinned/run.marker" ] && break
+      sleep 0.2
+    done
+    if [ ! -f "$XDG_STATE_HOME/nixarchy/microvm/pinned/run.marker" ]; then
+      echo "'run' did not fall back to main after the pinned commit failed to resolve:" >&2
+      echo "a machine built from an unpushed (or dirty) commit cannot run a VM at all" >&2
+      echo "-- see run3.log:" >&2
+      cat run3.log >&2
+      fail=1
+    else
+      # The pin was still tried first -- falling straight to main would throw
+      # away the exact-commit match every pushed machine is entitled to.
+      if ! grep -q -- "/${dirtyRev}#" "$calls2"; then
+        echo "the fallback skipped the pinned commit entirely:" >&2
+        cat "$calls2" >&2
+        fail=1
+      fi
+      # And the switch to main was said out loud, not done silently.
+      if ! grep -qi 'falling back' run3.log; then
+        echo "the fallback to main happened without a word to the user:" >&2
+        cat run3.log >&2
+        fail=1
+      fi
+      echo "the pinned commit was tried, refused, and main took over audibly"
+    fi
+    kill "$third" 2>/dev/null || true
+    wait "$third" 2>/dev/null || true
 
     [ "$fail" -eq 0 ] || exit 1
     echo "every template's runner is qemu, shares the host store read-only," \

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -306,6 +306,28 @@ let
     )
     ++ pkgs.lib.mapAttrsToList (_: s: s.menuId) (pkgs.lib.filterAttrs (_: s: s ? menuId) services);
 
+  # menuId=binary, for every `ours` app with an Install row. The binary is
+  # read off the flake's own package -- meta.mainProgram, falling back to the
+  # app id the way modules/apps.nix does -- so this is ground truth for the
+  # row's "already installed" dim probe: the command the package actually
+  # puts on PATH, not whatever a lookup in plain nixpkgs answers. Plain
+  # nixpkgs cannot answer for these at all (the module's pkgs carries no
+  # nixarchy overlay), which is exactly the bug this feeds coverage.py to
+  # catch: a probe that falls back to `command -v zen` for a package whose
+  # only binary is zen-beta, so the row never dims on a machine that has it.
+  oursBinaries =
+    pkgs.lib.mapAttrsToList
+      (
+        name: app:
+        let
+          probe = builtins.tryEval (inputs.self.packages.${system}.${app.attr}.meta.mainProgram or name);
+        in
+        "${app.menuId}=${if probe.success then probe.value else name}"
+      )
+      (
+        pkgs.lib.filterAttrs (_: a: (a.ours or false) && a ? menuId && a ? attr) (import ../data/apps.nix)
+      );
+
   # Rows that are actions rather than applications, plus the gaps the README
   # names. Fonts go through omarchy-install-font and the Arch-name map; the
   # four gaming rows and three frameworks are documented as needing a hand.
@@ -956,6 +978,7 @@ pkgs.runCommand "nixarchy-options"
     # command check pointed at the package's menu could never see one of them.
     treeMenu = "${inputs.self.nixosConfigurations.vm.config.programs.nixarchy.tree}/default/omarchy/omarchy-menu.jsonc";
     mapped = pkgs.lib.concatStringsSep " " mappedRows;
+    oursBinaries = pkgs.lib.concatStringsSep " " oursBinaries;
     serviceProblems = pkgs.lib.concatStringsSep "\n" serviceProblems;
     flatpakProblems = pkgs.lib.concatStringsSep "\n" flatpakProblems;
     microvmProblems = pkgs.lib.concatStringsSep "\n" microvmProblems;


### PR DESCRIPTION
## What this changes, and why

Two user-visible bugs, each with a comment in the tree claiming the opposite of what the code did. Neither breaks on Arch — both are in nixarchy's own plumbing.

**`nixarchy vm run` was broken on any machine built from a dirty checkout.** `pkgs/microvm.nix` pinned `self.rev or self.dirtyRev or "main"` into the flake URL, and `self.dirtyRev` is `<rev>-dirty` — not a ref GitHub can resolve, so `run` 404ed with nix's fetch error as the only explanation. The comment claimed "worst case here is a nix build against main"; the dirtyRev branch sat *before* the main fallback and was strictly worse than both. Now the `-dirty` suffix is stripped so the underlying commit is pinned, and — because even a clean rev only resolves once pushed — `run` falls back to `main` out loud when the pin cannot be fetched.

**The Install menu's "already installed" probe could not see nixarchy's own apps.** `modules/apps.nix` probed plain `pkgs`, which carries no nixarchy overlay, so every `ours` app answered null and the probe fell back to the app id: the Zen row dimmed on `command -v zen` while the package installs `bin/zen-beta`, so the row never dimmed on a machine that HAS Zen. This is the exact bug flake.nix's overlay comment describes as fixed — but only the doctor's copy of the probe was fixed. `ours` apps are now answered by `cfg.apps.<name>.package` (the very derivation the row would install, user overrides included), and both stale comments now match the code.

## How I proved the check fails

Bug 2 — `checks.options` (new assertion in tests/coverage.py, fed ground truth from the flake's own packages by tests/options.nix), red on the unfixed module:

```
> these Install rows dim on a command their package does not install, so they never dim on a machine that has the app:
>   install.browser.zen: dims on `zen`, but its package installs `zen-beta`
```

Green after: `all 4 packaged apps' rows dim on the command they install`

Bug 1 — `checks.microvm-template` (new section, on a pinned fake `dirtyRev` rather than whatever state CI's checkout is in). Red on the unfixed rev expression:

```
> the dirty-checkout CLI embeds a flake URL ending in -dirty:
> github:olafkfreund/nixarchy/0000000000000000000000000000000000000000-dirty
> GitHub has no such ref, so 'nixarchy vm run' can never build
```

and, with the strip but no runtime fallback (a stub `nix` that refuses everything but `.../main`, which is what GitHub does for a commit it does not have):

```
> 'run' did not fall back to main after the pinned commit failed to resolve:
> a machine built from an unpushed (or dirty) commit cannot run a VM at all
> -- see run3.log:
> stub nix: cannot find flake reference 'github:olafkfreund/nixarchy/0000000000000000000000000000000000000000#microvm-shell' (no such ref)
```

Green after: `the pinned commit was tried, refused, and main took over audibly`

## Checks run locally

- `nix build .#checks.x86_64-linux.options` — green (red first, above)
- `nix build .#checks.x86_64-linux.microvm-template` — green (red first, above)
- `nix eval .#checks.x86_64-linux.session.drvPath` — evaluates (the boot half is CI's)

- [x] `nix fmt` / statix / deadnix are clean (`nix fmt -- --ci`: 0 changed)
- [x] New files are `git add`ed (none added — both checks extend existing files)
- [x] No new option; no new `checks.*` entry, so no workflow change needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Np8BCQrdT7rhyxnN4jcDkg