### PR TITLE
A stalled install looks stalled: the bar freezes, then the dashboard says so

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1288,6 +1288,7 @@
           installer-store-space = import ./tests/installer-store-space.nix {
             pkgs = pkgsFor.${system};
             installScript = ./installer/install.sh;
+            dashboardScript = ./installer/lib/dashboard.sh;
           };
 
           # The bus redaction hook blocks what a pattern can decide, and only

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -88,6 +88,7 @@ SUBSTITUTE_FLAGS=(--option always-allow-substitutes true)
 
 dry_run=false
 answers_file=""
+answers_fetched=""
 
 # --from <url> and --host <name>: install this machine from a configuration
 # repository that already exists, instead of generating a fresh flake.
@@ -832,6 +833,11 @@ resolve_answers() {
     exit 1
   }
   answers_file=$tmp
+  # Remembered so main() can remove it the moment read_answers has taken what
+  # it needs. The file's whole content is secrets -- a password and a LUKS
+  # passphrase in clear -- and it used to sit in /tmp for the rest of the
+  # session, including inside the shell the failure screen offers.
+  answers_fetched=$tmp
 }
 
 read_answers() {
@@ -1948,6 +1954,10 @@ main() {
   if [ -n "$answers_file" ]; then
     resolve_answers
     read_answers "$answers_file"
+    # The fetched copy has just been read, and that read is the only thing it
+    # ever exists for. Gone now, not at exit: everything after this line can
+    # take an hour, fail, and offer a shell.
+    [ -n "$answers_fetched" ] && rm -f "$answers_fetched"
     # --host names the machine, and clone_repo has already chosen $hostdir from
     # it. A hostname in the answers file cannot also name it: leaving both to
     # fight would give a machine whose directory and hostName disagree, which
@@ -2046,9 +2056,17 @@ main() {
   # there -- and the log, which is the only thing worth having at that point,
   # unmentioned. The EXIT trap ui_dashboard_start sets restores the cursor;
   # this adds the part that says what happened and where to read about it.
-  trap 'ui_dashboard_stop; ui_failed "$log" 130; exit 130' INT TERM
+  #
+  # The rm first: format_disk removes the passphrase file itself, but an
+  # interrupt between writing it and that rm used to leave the LUKS
+  # passphrase sitting in /tmp -- world-invisible, but readable from the
+  # "Open a shell" option on the very screen this trap draws.
+  trap 'rm -f /tmp/nixarchy-luks.key; ui_dashboard_stop; ui_failed "$log" 130; exit 130' INT TERM
 
-  ui_dashboard_start
+  # Handed the log so the drawer can tell "still working" from "stopped":
+  # the phases below write only to this file, so a log that stops growing is
+  # the one observable sign that the install has too.
+  ui_dashboard_start "$log"
   # `&&` between the phases, not newlines, and it is load-bearing.
   #
   # This group's status is tested by `|| rc=$?`, and the comment on run_install

--- a/installer/lib/dashboard.sh
+++ b/installer/lib/dashboard.sh
@@ -9,6 +9,16 @@
 
 UI_BAR_CELLS=34
 
+# How long the log may sit still before the bar stops advancing, and before
+# the dashboard says so out loud. Two thresholds because they answer two
+# different questions: 30 seconds of silence is ordinary (one large
+# derivation, one slow disk sync) and only means the curve should stop
+# guessing; three minutes is when a person watching starts wondering whether
+# to reboot, and rebooting mid-install is how a recoverable stall becomes an
+# unrecoverable one.
+UI_STALL_FREEZE=30
+UI_STALL_SAY=180
+
 # Progress has two sources and takes whichever is further along.
 #
 # The honest one counts store paths under the target as nixos-install copies
@@ -18,11 +28,24 @@ UI_BAR_CELLS=34
 # moves during partitioning and bootloader installation, when nothing is being
 # copied and a frozen bar reads as a hung install.
 ui_progress() {
-  local elapsed=$1 copied=0 by_paths=0 by_time
+  local elapsed=$1 stall=${2:-0} copied=0 by_paths=0 by_time
 
   if [ -d /mnt/nix/store ]; then
     copied=$(find /mnt/nix/store -maxdepth 1 -mindepth 1 -printf . 2>/dev/null | wc -c)
     [ "$UI_EXPECTED_PATHS" -gt 0 ] && by_paths=$((copied * 100 / UI_EXPECTED_PATHS))
+  fi
+
+  # The time curve only advances while the log does. It exists so the bar
+  # moves through phases that copy nothing -- but that assumes the install is
+  # doing SOMETHING. The phases write only to the log by construction, so a
+  # log that has stopped growing is an install that has stopped doing
+  # observable work, and a percentage that keeps creeping toward 95 over a
+  # stopped log is a lie with a progress bar on it: the person watching 87%
+  # has no basis for choosing between "slow" and "wedged". Stalled time is
+  # subtracted, so the bar freezes where the log stopped -- a frozen bar is
+  # at least not a claim of progress.
+  if [ "$stall" -gt "$UI_STALL_FREEZE" ]; then
+    elapsed=$((elapsed - stall + UI_STALL_FREEZE))
   fi
 
   # Approaches but never reaches 95 -- a bar that sits at 100 while the install
@@ -45,8 +68,8 @@ ui_bar() {
 }
 
 ui_dashboard_draw() {
-  local elapsed=$1 pct tip n idx
-  pct=$(ui_progress "$elapsed")
+  local elapsed=$1 stall=${2:-0} pct tip n idx
+  pct=$(ui_progress "$elapsed" "$stall")
 
   # A tip every eight seconds, as upstream does. Long enough to read, short
   # enough that a slow install is not one sentence for ten minutes.
@@ -62,11 +85,52 @@ ui_dashboard_draw() {
   echo
   ui_centre "\e[32m$(ui_bar "$pct")\e[0m  ${pct}%" $((UI_BAR_CELLS + 6))
   echo
-  ui_centre "\e[90m$tip\e[0m" "${#tip}"
+  if [ "$stall" -ge "$UI_STALL_SAY" ]; then
+    # Said out loud, in the tip's place, because the tip is the one line a
+    # person watching actually reads. What they most need to hear is that
+    # waiting is safe and rebooting is not: a stall this long is usually a
+    # slow download, and 20-minute cache stalls that ended fine have been
+    # watched from the outside, indistinguishable from a hang.
+    local said
+    said="Nothing has reached the log in $(ui_elapsed "$stall")."
+    ui_centre "\e[33m$said\e[0m" "${#said}"
+    said="Usually a slow download; waiting is safe. Ctrl-C stops and shows the log."
+    ui_centre "\e[90m$said\e[0m" "${#said}"
+  else
+    ui_centre "\e[90m$tip\e[0m" "${#tip}"
+  fi
+}
+
+# One frame: measure the log, then draw. Split from the redraw loop so the
+# measurement -- the part that tells "still working" from "stopped" -- can be
+# driven by a test one tick at a time, without an infinite loop on a timer.
+#
+# The log is the right thing to watch because it is the ONLY thing the
+# install phases write to: main() redirects the whole chain into it, and the
+# dashboard deliberately hides it. So the drawer, the one process watching
+# from outside, is the one that can notice it has stopped.
+ui_dashboard_tick() {
+  local now size
+  now=$(date +%s)
+  if [ -n "${UI_DASH_LOG:-}" ]; then
+    size=$(wc -c 2>/dev/null <"$UI_DASH_LOG") || size=-1
+    if [ "$size" != "$UI_DASH_SIZE" ]; then
+      UI_DASH_SIZE=$size
+      UI_DASH_CHANGED=$now
+    fi
+  else
+    # Nothing to measure. Claiming a stall over a log nobody named would be
+    # the same lie in the other direction.
+    UI_DASH_CHANGED=$now
+  fi
+  ui_dashboard_draw $((now - UI_DASH_START)) $((now - UI_DASH_CHANGED))
 }
 
 ui_dashboard_start() {
   UI_DASH_START=$(date +%s)
+  UI_DASH_LOG=${1:-}
+  UI_DASH_SIZE=""
+  UI_DASH_CHANGED=$UI_DASH_START
   # No cursor while the dashboard owns the screen. It has nowhere sensible to
   # sit -- the screen is redrawn every second -- so it ends up parked in a
   # corner blinking at nothing.
@@ -74,7 +138,7 @@ ui_dashboard_start() {
   trap 'printf "\e[?25h"' EXIT
   (
     while :; do
-      ui_dashboard_draw $(($(date +%s) - UI_DASH_START))
+      ui_dashboard_tick
       sleep 1
     done
   ) &

--- a/tests/installer-store-space.nix
+++ b/tests/installer-store-space.nix
@@ -1,4 +1,8 @@
-{ pkgs, installScript }:
+{
+  pkgs,
+  installScript,
+  dashboardScript,
+}:
 # check_store_space, driven with plans nix really prints and a df that lies.
 #
 # Its answer selects a build store rather than refusing an install: non-zero
@@ -106,6 +110,179 @@ pkgs.runCommand "nixarchy-installer-store-space" { } ''
   }
 
   echo "check_store_space refuses what will not fit and nothing else"
+
+  # ------------------------------------------------------------------------
+  # The dashboard must not impersonate progress over a stopped install.
+  #
+  # The phase chain prints nothing to the screen by construction, and the
+  # bar's time curve used to keep creeping toward 95% whatever the install
+  # was doing -- so a stalled install looked exactly like a slow one. Watched
+  # happening: twenty minutes of total silence behind a moving bar, and the
+  # three states finished-and-slow, finished-and-hung, and wedged were
+  # indistinguishable without a process table. A person watching 87% has no
+  # basis for choosing between waiting and rebooting, and rebooting
+  # mid-install turns a recoverable stall into an unrecoverable one.
+  #
+  # The property under test: the bar stops when the log stops, and the
+  # dashboard eventually says so in words.
+  # ------------------------------------------------------------------------
+  sed -n '/^ui_progress()/,/^}/p' ${dashboardScript} > prog.sh
+  test -s prog.sh || { echo "ui_progress is not in dashboard.sh any more" >&2; exit 1; }
+  grep '^UI_STALL' ${dashboardScript} >> prog.sh || true
+
+  cat > progt.sh <<'EOF'
+  UI_EXPECTED_PATHS=0
+  . ./prog.sh
+  fails=0
+  # Ten minutes in, of which the last five wrote nothing to the log: the bar
+  # must sit where the log stopped, not where the clock got to.
+  working=$(ui_progress 600 0)
+  stalled=$(ui_progress 600 300)
+  [ "$stalled" -lt "$working" ] || {
+    echo "  FAILED  a stalled install reports the same progress as a working one ($stalled)"
+    fails=$((fails + 1))
+  }
+  # And it stays sat: another 100 seconds of stall moves nothing.
+  later=$(ui_progress 700 400)
+  [ "$later" = "$stalled" ] || {
+    echo "  FAILED  the bar keeps creeping while the log is stopped ($stalled -> $later)"
+    fails=$((fails + 1))
+  }
+  [ "$fails" = 0 ] && echo "  ok      the bar freezes where the log stopped"
+  exit $fails
+  EOF
+  bash progt.sh
+
+  # The words. After UI_STALL_SAY seconds of silence the tip line becomes a
+  # statement that the log has stopped and that waiting beats rebooting.
+  {
+    echo 'ui_init() { :; }'
+    echo 'ui_clear() { :; }'
+    echo 'ui_logo() { :; }'
+    echo 'ui_centre() { printf "%b\n" "$1"; }'
+    echo 'UI_EXPECTED_PATHS=0'
+    sed -n '/^UI_BAR_CELLS=/p;/^UI_STALL/p' ${dashboardScript}
+    sed -n '/^ui_progress()/,/^}/p' ${dashboardScript}
+    sed -n '/^ui_bar()/,/^}/p' ${dashboardScript}
+    sed -n '/^ui_elapsed()/,/^}/p' ${dashboardScript}
+    sed -n '/^ui_dashboard_draw()/,/^}/p' ${dashboardScript}
+  } > draw.sh
+  cat > drawt.sh <<'EOF'
+  . ./draw.sh
+  printf 'a tip about keybindings\n' > tips; UI_TIPS=tips
+  fails=0
+  ui_dashboard_draw 600 400 > out 2>&1
+  grep -q 'reached the log' out || {
+    echo "  FAILED  six minutes of silence and the dashboard says nothing about it"
+    fails=$((fails + 1))
+  }
+  grep -q 'aiting is safe' out || {
+    echo "  FAILED  the stall notice does not tell the person what to do"
+    fails=$((fails + 1))
+  }
+  ui_dashboard_draw 600 5 > out 2>&1
+  grep -q 'a tip about keybindings' out || {
+    echo "  FAILED  a working install lost its tip line"
+    fails=$((fails + 1))
+  }
+  grep -q 'reached the log' out && {
+    echo "  FAILED  five seconds of quiet is reported as a stall"
+    fails=$((fails + 1))
+  }
+  [ "$fails" = 0 ] && echo "  ok      a long stall is said in words, a short one is not"
+  exit $fails
+  EOF
+  bash drawt.sh
+
+  # The measurement itself, one tick at a time with a clock that lies.
+  # ui_dashboard_tick is the frame the redraw loop runs: measure the log,
+  # then draw with (elapsed, stall).
+  sed -n '/^ui_dashboard_tick()/,/^}/p' ${dashboardScript} > tick.sh
+  test -s tick.sh || { echo "ui_dashboard_tick is not in dashboard.sh: the drawer does not measure the log" >&2; exit 1; }
+  cat > tickt.sh <<'EOF'
+  . ./tick.sh
+  date() { echo "$NOW"; }
+  ui_dashboard_draw() { echo "draw elapsed=$1 stall=$2"; }
+  UI_DASH_LOG=log UI_DASH_SIZE="" UI_DASH_START=1000 UI_DASH_CHANGED=1000
+  fails=0
+  t() {
+    now=$1 want=$2 name=$3
+    # Not $(NOW=... ui_dashboard_tick): a subshell would lose the size and
+    # timestamp state the tick keeps between frames.
+    NOW=$now; ui_dashboard_tick > out; got=$(cat out)
+    if [ "$got" = "$want" ]; then
+      echo "  ok      $name"
+    else
+      echo "  FAILED  $name: wanted '$want', got '$got'"
+      fails=$((fails + 1))
+    fi
+  }
+  echo grow > log
+  t 1010 "draw elapsed=10 stall=0"    "a growing log is not a stall"
+  t 1200 "draw elapsed=200 stall=190" "an unchanged log counts as stalled from its last write"
+  echo more >> log
+  t 1300 "draw elapsed=300 stall=0"   "the log growing again resets the stall"
+  exit $fails
+  EOF
+  bash tickt.sh
+
+  # And that main() hands the drawer the log at all -- the function tests
+  # stay green with the call site never wired, which would be #133 again.
+  grep -q 'ui_dashboard_start "$log"' ${installScript} || {
+    echo "main() does not hand the log to the dashboard; the drawer cannot" >&2
+    echo "tell a stalled install from a slow one without it" >&2
+    exit 1
+  }
+
+  echo "a stalled install looks stalled: frozen bar, then words"
+
+  # ------------------------------------------------------------------------
+  # Two files of secrets that outlived their use.
+  # ------------------------------------------------------------------------
+  # An interrupt during the install phase lands in the INT/TERM trap, which
+  # used to exit without the rm that format_disk's own success path runs --
+  # leaving the LUKS passphrase in /tmp, readable from the "Open a shell"
+  # option on the failure screen the same trap draws.
+  grep -q "trap 'rm -f /tmp/nixarchy-luks.key" ${installScript} || {
+    echo "the INT/TERM trap does not remove the LUKS passphrase file;" >&2
+    echo "Ctrl-C during the install leaves it in /tmp for the failure" >&2
+    echo "screen's shell to read" >&2
+    exit 1
+  }
+
+  # The fetched answers file is a password and a LUKS passphrase in clear.
+  # resolve_answers must mark the copy for cleanup, and main() must remove it
+  # once read_answers has taken what it needs -- after the read, not before.
+  sed -n '/^resolve_answers()/,/^}/p' ${installScript} > ra.sh
+  test -s ra.sh || { echo "resolve_answers is not in install.sh any more" >&2; exit 1; }
+  cat > rat.sh <<'EOF'
+  . ./ra.sh
+  curl() {
+    while [ "$1" != -o ]; do shift; done
+    echo "password=secret" > "$2"
+  }
+  answers_file=https://example.invalid/answers
+  resolve_answers
+  [ -f "$answers_file" ] || { echo "  FAILED  the fetched file is gone before it was read"; exit 1; }
+  [ -n "$answers_fetched" ] || {
+    echo "  FAILED  resolve_answers does not mark the fetched copy for cleanup,"
+    echo "          so the plaintext password outlives its one read"
+    exit 1
+  }
+  rm -f "$answers_fetched"
+  echo "  ok      the fetched copy is marked for cleanup"
+  EOF
+  bash rat.sh
+  # The rm has to come after the read. Same line-order doctrine as the
+  # preflight/format_disk assertion above.
+  read_line=$(grep -n 'read_answers "$answers_file"' ${installScript} | cut -d: -f1 | head -1 || true)
+  rm_line=$(grep -n 'rm -f "$answers_fetched"' ${installScript} | cut -d: -f1 | head -1 || true)
+  [ -n "$rm_line" ] || { echo "main() never removes the fetched answers file" >&2; exit 1; }
+  [ -n "$read_line" ] && [ "$read_line" -lt "$rm_line" ] || {
+    echo "the fetched answers file is removed before read_answers reads it" >&2; exit 1;
+  }
+
+  echo "the passphrase file and the fetched answers do not outlive their use"
 
   # ------------------------------------------------------------------------
   # preflight_build (#300): the disk must not be wiped before anything proves


### PR DESCRIPTION
The unmitigated finding from the #326 review round: a hang in the install phase actively impersonated progress. The phase chain prints nothing by construction and the dashboard's time curve crept toward 95% regardless, so finished-and-slow, finished-and-hung and wedged were indistinguishable without a process table — and the observed 20-minute silent stall and the 21–24-minute cache.nixos.org stalls are exactly the shape that makes someone reboot a machine mid-install.

**Design** — the phases write only to the log (main() redirects the whole chain into it), so the log is the one observable signal. The drawer measures it every frame, factored as `ui_dashboard_tick` so a test can drive frames with a stubbed clock:

- **30s of silence**: the time curve stops advancing — stalled time is subtracted, the bar freezes where the log stopped. The store-path-counting half of `ui_progress` is genuinely honest and keeps running.
- **3min of silence**: the tip line is replaced with words: *"Nothing has reached the log in 4m 10s." / "Usually a slow download; waiting is safe. Ctrl-C stops and shows the log."* Ctrl-C lands in the INT trap, which draws the failure screen with the log tail — the right place to end up.
- No log handed to the drawer (defensive) → stall stays 0: claiming a stall over a log nobody named would be the same lie in the other direction.

This also covers the preflight cache-probe blind spot at the point it bites: a substituter that accepts connections but stalls transfers passes any single HEAD probe, and now the stall is named on screen with the disk already wiped, rather than the probe getting cleverer.

**The two small things** — both taken:
- The INT/TERM trap now removes `/tmp/nixarchy-luks.key` before drawing the failure screen (whose "Open a shell" could read it).
- `resolve_answers` marks the fetched copy (`answers_fetched`) and main() removes it the moment `read_answers` has consumed it — after the read, asserted by line order.

**Verification** — red before green in `tests/installer-store-space.nix` (new sections inserted mid-file, deliberately away from the lines #326 appends at the tail, so the two PRs should merge cleanly in either order; `dashboardScript` is wired through the check's args in flake.nix). Verbatim red against origin/main:

```
FAILED  a stalled install reports the same progress as a working one (67)
FAILED  the bar keeps creeping while the log is stopped (67 -> 70)
FAILED  six minutes of silence and the dashboard says nothing about it
FAILED  the stall notice does not tell the person what to do
ui_dashboard_tick is not in dashboard.sh: the drawer does not measure the log
main() does not hand the log to the dashboard; the drawer cannot
tell a stalled install from a slow one without it
the INT/TERM trap does not remove the LUKS passphrase file;
Ctrl-C during the install leaves it in /tmp for the failure
screen's shell to read
FAILED  resolve_answers does not mark the fetched copy for cleanup,
        so the plaintext password outlives its one read
main() never removes the fetched answers file
```

Green: `nix build .#checks.x86_64-linux.installer-store-space` (all pre-existing sections included) and `checks.x86_64-linux.doctor-graphics` (the screens still draw); shellcheck clean on install.sh and dashboard.sh; `nix fmt` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YhPPfiA5VMpymwje4gQaZ