### PR TITLE
Main keeps the verdict it paid for, instead of cancelling it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,13 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # On a PR branch, a newer push supersedes the older one and cancelling is
+  # right. On main it is data loss: every push here is a DIFFERENT merged
+  # commit, and cancelling discards the only verdict that commit will ever
+  # get -- nothing re-tests it. Five consecutive merges this morning left
+  # main with no `box` result at all, each run killed by the next merge.
+  # Same argument the `system` job already makes below, one scope up.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   lint:


### PR DESCRIPTION
## What

One line: `cancel-in-progress` becomes an expression, false on `main`.

```yaml
cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

## Why

On a PR branch, cancelling is right — a newer push supersedes the old one and the discarded result was about code that no longer exists.

**On `main` it is data loss.** Every push to main is a *different merged commit*, and nothing re-tests a commit that is already on main. The cancelled run was that commit's only verdict.

This is not theoretical. Five consecutive merges this morning each killed the run before it:

```
33957938424  (null)      The nightly gains a canary...
33957922115  cancelled   The Omarchy bump waits for the checks it advertises
33957890786  cancelled   The agent room's opt-in is enforced at the connect
33957845138  cancelled   Four error messages stop lying about why they fail
33957753472  cancelled   The coverage guard reads the checks it is guarding
```

`main` currently has **no `box` verdict at all** across that entire sequence. The UI says `cancelled`, which a human reads as "superseded" — not as "this commit was never checked".

Same shape as two bugs fixed today: the merge gate that inferred green from the absence of failures, and the coverage guard that printed success while extracting zero check names. **An absent bad signal is not a good signal.**

## Prior art in this same file

The `system` job already carries this argument for itself (line ~752), because building Hyprland from source took ~20 minutes and was "killed by any push landing within that window — which meant the most valuable check in this workflow routinely never completed." This lifts that reasoning one scope up, to the branch where a discarded result is unrecoverable.

## Cost

Runs on `main` now queue instead of cancelling. Since merges are the only pushes to main and they are not frequent, the queue depth is the merge rate — and the runner was going to do this work anyway if anyone wanted the answer.

## Verified

- `actionlint` clean (no errors; only pre-existing `info`-level shellcheck notices the lint job already ignores). **Not** `yq` — a workflow can parse perfectly and still be rejected by GitHub, which is how `main` produced zero jobs for hours while ten PRs merged blind.
- Job list byte-identical to `main`'s: `lint,devenv-presets,omarchy,system,box`.