### PR TITLE
The four coding agents people actually asked for are installable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the parts that assume Arch, rather than reimplementing it in Nix.
 Tracking an upstream release is a source bump, not a re-port.
 
 What that buys you: the Install menu writes to a Nix config instead of running
-pacman, **56 applications** are selectable that way, **every other package and
+pacman, **60 applications** are selectable that way, **every other package and
 NixOS option is one `Install ▸ Search` away**, plugins and themes still install
 from a git URL at runtime the way upstream intends, and every command that
 assumed `/usr` either points at what NixOS uses or says why it cannot.
@@ -44,7 +44,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | **`nixarchy` command** | this port's own commands, and a way through to Omarchy's 431 |
 | **Remove menu** | deselects apps, never touches your own config |
 | **Update menu** | `nh os switch --update <flake>` |
-| 55 apps in the selection | 41 from nixpkgs, 4 as NixOS modules, 8 built here, 2 with no equivalent |
+| 59 apps in the selection | 45 from nixpkgs, 4 as NixOS modules, 8 built here, 2 with no equivalent |
 | Learn menu | NixOS wiki, `search.nixos.org` packages and options |
 | Shell functions | bash and zsh source the chain; fish derives it from the same files |
 | RetroArch | 13 libretro cores, resolved from the store rather than `/usr/lib` |
@@ -387,7 +387,7 @@ The notification is clickable and runs the rebuild.
 
 ### Anything the menu does not offer
 
-The 55 apps are the ones Omarchy's own menu lists. Everything else in nixpkgs —
+The 59 apps are the ones Omarchy's own menu lists. Everything else in nixpkgs —
 and every NixOS option — is behind **`Install ▸ Search`**, or `nixarchy-search`
 from a terminal:
 
@@ -410,7 +410,7 @@ from a terminal:
   enter to select · tab for several · esc to cancel
 ```
 
-**137,599 rows: 25,102 NixOS options, 112,443 packages, and 53 of the 55 apps
+**137,599 rows: 25,102 NixOS options, 112,443 packages, and 57 of the 59 apps
 (the two with no nixpkgs equivalent cannot be indexed).** Three kinds,
 one picker, because you should not have to know which kind you want before you
 can look. They are not interchangeable and the rows say so — picking Tailscale
@@ -1250,7 +1250,7 @@ done
 
 Almost nothing here waits on a maintainer.
 
-**45 of the 55 apps never touch this repo.** Brave, VSCode, Signal and the rest
+**49 of the 59 apps never touch this repo.** Brave, VSCode, Signal and the rest
 are installed as `pkgs.<name>` from **your** nixpkgs, and the five
 module-backed ones (Steam, 1Password, Tailscale, Firefox, Xbox controllers)
 come from there too — the module is NixOS', not this repo's. Your own
@@ -1309,7 +1309,7 @@ Most of it is not our job, and should not be:
 
 | where the app comes from | who updates it |
 |---|---|
-| nixpkgs (45 of 55 apps) | **nobody** — your own `nix flake update` |
+| nixpkgs (49 of 59 apps) | **nobody** — your own `nix flake update` |
 | pinned in this repo (2) | a weekly bot, opening a PR |
 | `zen` | upstream's own flake |
 | `retroarch` | nixpkgs, via this flake's own pin — it is a rebuild with cores |

--- a/data/apps.nix
+++ b/data/apps.nix
@@ -328,6 +328,57 @@
     unfree = true;
     arch = "openai-codex-desktop";
   };
+  # The terminal coding agents. Four entries that share one shape, so the
+  # reasoning is here once rather than repeated four times.
+  #
+  # NO menuId, deliberately, following t3-code above: Omarchy v4.0.2's menu
+  # ships exactly five install.ai.* rows -- chatgpt, dictation, grok-bot,
+  # lm-studio, ollama -- and the row generator FAILS on a menuId upstream does
+  # not have. These are reachable as programs.nixarchy.apps.<name> and through
+  # `nixarchy-app-enable`, and each gains a menu row for free if upstream ever
+  # adds one.
+  #
+  # NO arch, also deliberately. That field maps an Arch package name onto our
+  # app id so the generator can rewrite upstream's `remove.*` rows, which
+  # identify their target with `omarchy-pkg-present <arch>`. Upstream has no
+  # rows for these, so there is no name to match -- and inventing a plausible
+  # AUR name would create a mapping that fires on somebody else's package.
+  # `archMap` filters on `a ? arch` (modules/apps.nix:787), so omitting it is
+  # supported rather than merely tolerated.
+  claude-code = {
+    label = "Claude Code";
+    category = "AI";
+    attr = "claude-code";
+    # Anthropic's licence is not a free-software licence; nixpkgs marks the
+    # package unfree, and an entry without this flag fails to evaluate for a
+    # user who has not set allowUnfree.
+    unfree = true;
+  };
+  codex = {
+    label = "Codex";
+    category = "AI";
+    attr = "codex";
+    # Apache-2.0. Not unfree, unlike the ChatGPT desktop app above, which is a
+    # different piece of software from the same vendor.
+  };
+  gemini-cli = {
+    label = "Gemini CLI";
+    category = "AI";
+    attr = "gemini-cli";
+    # Apache-2.0.
+    #
+    # Worth knowing before you rely on this one: nixpkgs is a long way behind
+    # upstream here. On 2026-09-05 both the old and the new nixpkgs pin carried
+    # 0.47.0 while upstream had shipped 0.58.0 -- eleven minor versions, and a
+    # gap no pin bump closes, because it is nixpkgs itself that is stale. The
+    # other three track upstream within days.
+  };
+  antigravity = {
+    label = "Antigravity";
+    category = "AI";
+    attr = "antigravity";
+    unfree = true;
+  };
   dictation = {
     menuId = "install.ai.dictation";
     label = "Dictation";


### PR DESCRIPTION
## What was missing

nixarchy's AI category offered ChatGPT Desktop, LM Studio, Dictation, Grok Bot, T3 Code and HEY CLI — and **not one terminal coding agent**. Meanwhile the repo's own skills reference `claude` and `agy` as commands the user is simply assumed to already have.

All four are in nixpkgs today, and were one file away from being installable:

| app | attr | version on the current pin | licence |
|---|---|---|---|
| Claude Code | `claude-code` | 2.1.238 | unfree |
| Codex | `codex` | 0.149.0 | Apache-2.0 |
| Gemini CLI | `gemini-cli` | 0.47.0 | Apache-2.0 |
| Antigravity | `antigravity` | 2.5.5 | unfree |

## Two fields deliberately omitted, and why

**No `menuId`**, following `t3-code` three entries up. Omarchy v4.0.2's menu ships exactly five `install.ai.*` rows — `chatgpt`, `dictation`, `grok-bot`, `lm-studio`, `ollama` — and **the row generator fails on a `menuId` upstream does not ship**. That is how `t3-code`'s absence was originally caught, and it is a real failure, not a warning.

These are reachable as `programs.nixarchy.apps.<name>` and via `nixarchy-app-enable`, and each gains a menu row for free if upstream adds one.

**No `arch`**, for a sharper reason than "upstream has no row". That field maps an Arch package name onto our app id so the generator can rewrite upstream's `remove.*` rows, which identify their target with `omarchy-pkg-present <arch>`. A plausible-looking AUR name invented here would not be inert — **it would create a mapping that fires on somebody else's package.** `archMap` filters on `a ? arch` (`modules/apps.nix:787`), so omitting it is supported rather than merely tolerated.

## Licences checked, not assumed

Read from nixpkgs metadata. Getting this wrong breaks evaluation for anyone who has not set `allowUnfree`, so it is not a detail: `claude-code` and `antigravity` are unfree; `codex` and `gemini-cli` are Apache-2.0.

Worth noting that `codex` is free while the ChatGPT desktop app directly above it is unfree — they are different software from the same vendor, and the inconsistency is correct.

## One caveat recorded in the file

**nixpkgs is eleven minor versions behind upstream on `gemini-cli`** — 0.47.0 against 0.58.0, on *both* the old and new pin. That gap is nixpkgs' own and no pin bump closes it; it would need an overlay or an upstream nixpkgs PR.

The other three track upstream within days, which is exactly what makes the nightly pin bump in #335 the right mechanism for keeping them current rather than per-package rewrite scripts.

## Verified

- the catalogue evaluates; the AI category now lists ten entries
- all four attrs resolve against the locked nixpkgs
- **`checks.options` builds green (2m49s)** — this is the check that fails on a `menuId` upstream does not ship, so it is the one that matters for this change

## Not included

`claude-desktop` is **absent from nixpkgs entirely**, so it cannot be added this way. It is the one app of the four originally asked about that needs packaging from scratch — and the one place the version+hash rewrite shape of `update.yml` and `pkgs/apps/` genuinely applies.
