### PR TITLE
An installed machine can update itself

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,6 +284,18 @@ jobs:
             --discussion-category announcements \
             --prerelease
 
+      # Every installed machine points its flake at the `release` branch
+      # (installer/mkFlake.nix): `nix flake update nixarchy` resolves whatever
+      # this branch names, so moving it IS shipping the release to users --
+      # deliberately, when a human cuts a tag, not with every bot merge that
+      # moves main. Plain push, not force: a release branch that moved
+      # backwards would downgrade the next machine to update, so a non
+      # fast-forward here should fail loudly and be looked at.
+      - name: Move the release branch to this tag
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: git push origin "refs/tags/$TAG^{}:refs/heads/release"
+
       # 5.6 GB of parts on the runner's root filesystem, which is the small
       # one. The workspace is cleaned at the start of the next run, but a
       # failed release should not sit on the disk until then.

--- a/installer/mkFlake.nix
+++ b/installer/mkFlake.nix
@@ -7,10 +7,10 @@
 #
 # The template files carry @tokens@; the installer substitutes the answers it
 # collected. What cannot be a template file is the lock, so it is derived here.
-{ runCommand
-, jq
-, self
-,
+{
+  runCommand,
+  jq,
+  self,
 }:
 let
   # Building from a dirty tree gives no rev, and the generated flake pins
@@ -39,31 +39,31 @@ let
   refUrl = "github:olafkfreund/nixarchy/${ref}";
 in
 runCommand "nixarchy-flake-template"
-{
-  nativeBuildInputs = [ jq ];
-  inherit
-    rev
-    url
-    ref
-    refUrl
-    ;
-  inherit (self) narHash;
+  {
+    nativeBuildInputs = [ jq ];
+    inherit
+      rev
+      url
+      ref
+      refUrl
+      ;
+    inherit (self) narHash;
 
-  # And the timestamp, which nix writes into every lock node it produces and
-  # this one was leaving out (#208).
-  #
-  # An input node without it evaluates: `self.lastModified` is simply absent
-  # on the other side, so anything reading it takes its fallback. That made
-  # the omission invisible until something in the closure DEPENDED on it --
-  # nixarchy-version, which prints the build's date. This flake evaluates to
-  # a different omarchy than the one the installer seeded, the offline
-  # install cannot copy what it now has to build, and it walks back to the
-  # source bootstrap and dies fetching a Debian patch for libssh2. The rev
-  # was never the problem: shortRev is identical on both sides.
-  lastModified = toString self.lastModified;
+    # And the timestamp, which nix writes into every lock node it produces and
+    # this one was leaving out (#208).
+    #
+    # An input node without it evaluates: `self.lastModified` is simply absent
+    # on the other side, so anything reading it takes its fallback. That made
+    # the omission invisible until something in the closure DEPENDED on it --
+    # nixarchy-version, which prints the build's date. This flake evaluates to
+    # a different omarchy than the one the installer seeded, the offline
+    # install cannot copy what it now has to build, and it walks back to the
+    # source bootstrap and dies fetching a Debian patch for libssh2. The rev
+    # was never the problem: shortRev is identical on both sides.
+    lastModified = toString self.lastModified;
 
-  passthru = { inherit url rev refUrl; };
-}
+    passthru = { inherit url rev refUrl; };
+  }
   ''
     mkdir -p $out/host
     cp ${./template}/flake.nix           $out/flake.nix

--- a/installer/mkFlake.nix
+++ b/installer/mkFlake.nix
@@ -7,10 +7,10 @@
 #
 # The template files carry @tokens@; the installer substitutes the answers it
 # collected. What cannot be a template file is the lock, so it is derived here.
-{
-  runCommand,
-  jq,
-  self,
+{ runCommand
+, jq
+, self
+,
 }:
 let
   # Building from a dirty tree gives no rev, and the generated flake pins
@@ -23,28 +23,47 @@ let
       or (throw "flake-template: build from a committed tree; the generated flake pins nixarchy by commit");
 
   url = "github:olafkfreund/nixarchy/${rev}";
+
+  # What the machine ASKS for when it updates, as opposed to what it GOT
+  # (`url` above, which is provenance and stays rev-pinned). This goes into
+  # flake.nix and the lock's `original`; the rev goes into `locked`. Nix never
+  # consults `original` until the user runs `nix flake update`, so first boot
+  # still builds the exact installed rev, offline -- but the update command
+  # has somewhere to go. A rev here froze every installed machine at its
+  # install day: re-resolving a commit returns that commit, forever.
+  #
+  # `release` moves when a human cuts a release, not with the bot merges that
+  # move main. nixpkgs and home-manager are the machine's own inputs and
+  # update independently of it.
+  ref = "release";
+  refUrl = "github:olafkfreund/nixarchy/${ref}";
 in
 runCommand "nixarchy-flake-template"
-  {
-    nativeBuildInputs = [ jq ];
-    inherit rev url;
-    inherit (self) narHash;
+{
+  nativeBuildInputs = [ jq ];
+  inherit
+    rev
+    url
+    ref
+    refUrl
+    ;
+  inherit (self) narHash;
 
-    # And the timestamp, which nix writes into every lock node it produces and
-    # this one was leaving out (#208).
-    #
-    # An input node without it evaluates: `self.lastModified` is simply absent
-    # on the other side, so anything reading it takes its fallback. That made
-    # the omission invisible until something in the closure DEPENDED on it --
-    # nixarchy-version, which prints the build's date. This flake evaluates to
-    # a different omarchy than the one the installer seeded, the offline
-    # install cannot copy what it now has to build, and it walks back to the
-    # source bootstrap and dies fetching a Debian patch for libssh2. The rev
-    # was never the problem: shortRev is identical on both sides.
-    lastModified = toString self.lastModified;
+  # And the timestamp, which nix writes into every lock node it produces and
+  # this one was leaving out (#208).
+  #
+  # An input node without it evaluates: `self.lastModified` is simply absent
+  # on the other side, so anything reading it takes its fallback. That made
+  # the omission invisible until something in the closure DEPENDED on it --
+  # nixarchy-version, which prints the build's date. This flake evaluates to
+  # a different omarchy than the one the installer seeded, the offline
+  # install cannot copy what it now has to build, and it walks back to the
+  # source bootstrap and dies fetching a Debian patch for libssh2. The rev
+  # was never the problem: shortRev is identical on both sides.
+  lastModified = toString self.lastModified;
 
-    passthru = { inherit url rev; };
-  }
+  passthru = { inherit url rev refUrl; };
+}
   ''
     mkdir -p $out/host
     cp ${./template}/flake.nix           $out/flake.nix
@@ -69,7 +88,15 @@ runCommand "nixarchy-flake-template"
     # target would re-resolve every input against whatever is current, so the
     # first `nixos-rebuild switch` would build a different system from the one
     # just installed -- and it needs a network the offline ISO does not have.
-    jq --arg rev "$rev" --arg narHash "$narHash" --argjson lastModified "$lastModified" '
+    #
+    # The `locked`/`original` split is the whole design: `locked` (rev +
+    # narHash) is what evaluation reads, and is where reproducibility lives;
+    # `original` is read only by `nix flake update`, which re-resolves it. So
+    # `locked` carries the installed rev and `original` carries a branch ref.
+    # A rev in `original` is what froze every installed machine: update
+    # re-resolved the commit back to itself, forever.
+    jq --arg rev "$rev" --arg narHash "$narHash" --arg ref "$ref" \
+       --argjson lastModified "$lastModified" '
       # nixarchy inherits our root inputs verbatim. NOT a name-to-name map:
       # once nix has disambiguated names, root.nixpkgs points at a node called
       # "nixpkgs_2", and inventing the mapping rather than copying it points
@@ -78,11 +105,12 @@ runCommand "nixarchy-flake-template"
 
       # An input whose value is an ARRAY is a follows path resolved from the
       # ROOT: disko.nixpkgs is ["nixpkgs"], meaning "whatever the root calls
-      # nixpkgs". Once nixarchy is the root'"'"'s only input every one of those
-      # paths points at nothing, and nix refuses with "follows a non-existent
-      # input" while trying to update a lock it must never update. So re-root
-      # them all under nixarchy. There are around forty, nearly all beneath
-      # hyprland, which is why this is structural rather than a list.
+      # nixpkgs". Once the root'"'"'s inputs are replaced below, every one of
+      # those paths points at nothing, and nix refuses with "follows a
+      # non-existent input" while trying to update a lock it must never
+      # update. So re-root them all under nixarchy. There are around forty,
+      # nearly all beneath hyprland, which is why this is structural rather
+      # than a list.
       | .nodes |= with_entries(
           if .key == "root" or (.value | has("inputs") | not) then .
           else .value.inputs |= with_entries(
@@ -92,7 +120,9 @@ runCommand "nixarchy-flake-template"
           end)
 
       | .nodes.nixarchy = {
-          inputs: $rootInputs,
+          # The machine owns nixpkgs (root input, below) and nixarchy follows
+          # it -- the lock half of the template'"'"'s `follows = "nixpkgs"`.
+          inputs: ($rootInputs | .nixpkgs = ["nixpkgs"]),
           locked: {
             type: "github",
             owner: "olafkfreund",
@@ -105,11 +135,29 @@ runCommand "nixarchy-flake-template"
             type: "github",
             owner: "olafkfreund",
             repo: "nixarchy",
-            rev: $rev
+            ref: $ref
           }
         }
-      | .nodes.root.inputs = { nixarchy: "nixarchy" }
+
+      # nixpkgs re-exposed at the root, pointing at the SAME already-locked
+      # node ($rootInputs.nixpkgs is the disambiguated name -- copy, never
+      # invent). Its original already carries the branch this repo tracks, so
+      # `nix flake update nixpkgs` works from day one; making it a root input
+      # is what lets the user retarget it -- stable instead of unstable -- in
+      # a flake.nix they own.
+      | .nodes.root.inputs = { nixarchy: "nixarchy", nixpkgs: $rootInputs.nixpkgs }
     ' ${../flake.lock} > $out/flake.lock
+
+    # The nixpkgs URL the machine's flake.nix declares must be EXACTLY the
+    # `original` of the node the lock carries -- a mismatch makes nix
+    # re-resolve on first use, which needs the network the offline ISO does
+    # not have. So it is read out of the lock rather than written down a
+    # second time.
+    nixpkgs_url=$(jq -r '
+      .nodes.root.inputs.nixpkgs as $n
+      | .nodes[$n].original
+      | "github:\(.owner)/\(.repo)/\(.ref)"
+    ' $out/flake.lock)
 
     # So the installer does not have to recompute what this already knows.
     #
@@ -121,5 +169,6 @@ runCommand "nixarchy-flake-template"
     # via installer/host.nix. Nothing should gate on this file.
     printf '%s\n' "$url" > $out/.nixarchy-url
 
-    sed -i "s|@nixarchy_url@|$url|g" $out/flake.nix
+    sed -i -e "s|@nixarchy_url@|$refUrl|g" \
+           -e "s|@nixpkgs_url@|$nixpkgs_url|g" $out/flake.nix
   ''

--- a/installer/template/flake.nix
+++ b/installer/template/flake.nix
@@ -21,25 +21,30 @@
 # does not exist as far as evaluation is concerned, and the error says the path
 # is missing rather than that it is untracked.
 {
-  # Your package set. Locked at install time; `nix flake update nixpkgs` (or
-  # `omarchy update`) moves it forward when you decide to.
-  #
-  # To follow STABLE nixpkgs instead, point this at the release branch (e.g.
-  # "github:NixOS/nixpkgs/nixos-25.05") -- and move home-manager with it, as
-  # the two are developed as a pair:
-  #
-  #   inputs.nixarchy.inputs.home-manager.url =
-  #     "github:nix-community/home-manager/release-25.05";
-  #
-  # then `nix flake update nixpkgs` and `nh os switch` (the changed
-  # home-manager override is re-locked in the same pass).
-  inputs.nixpkgs.url = "@nixpkgs_url@";
+  inputs = {
+    # Your package set. Locked at install time; `nix flake update nixpkgs` (or
+    # `omarchy update`) moves it forward when you decide to.
+    #
+    # To follow STABLE nixpkgs instead, point this at the release branch (e.g.
+    # "github:NixOS/nixpkgs/nixos-25.05") -- and move home-manager with it, as
+    # the two are developed as a pair. Add this inside the `nixarchy` block
+    # below, beside the `follows`:
+    #
+    #   inputs.home-manager.url =
+    #     "github:nix-community/home-manager/release-25.05";
+    #
+    # then `nix flake update nixpkgs` and `nh os switch` (the changed
+    # home-manager override is re-locked in the same pass).
+    nixpkgs.url = "@nixpkgs_url@";
 
-  # Nixarchy itself, locked at the revision this machine was installed from.
-  # `nix flake update nixarchy` moves it to the latest release, deliberately
-  # -- nothing moves until you run it. Then `nh os switch`.
-  inputs.nixarchy.url = "@nixarchy_url@";
-  inputs.nixarchy.inputs.nixpkgs.follows = "nixpkgs";
+    # Nixarchy itself, locked at the revision this machine was installed from.
+    # `nix flake update nixarchy` moves it to the latest release, deliberately
+    # -- nothing moves until you run it. Then `nh os switch`.
+    nixarchy = {
+      url = "@nixarchy_url@";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
 
   outputs =
     { nixarchy, ... }:

--- a/installer/template/flake.nix
+++ b/installer/template/flake.nix
@@ -31,7 +31,8 @@
   #   inputs.nixarchy.inputs.home-manager.url =
   #     "github:nix-community/home-manager/release-25.05";
   #
-  # then `nix flake update nixpkgs home-manager` and `nh os switch`.
+  # then `nix flake update nixpkgs` and `nh os switch` (the changed
+  # home-manager override is re-locked in the same pass).
   inputs.nixpkgs.url = "@nixpkgs_url@";
 
   # Nixarchy itself, locked at the revision this machine was installed from.

--- a/installer/template/flake.nix
+++ b/installer/template/flake.nix
@@ -21,9 +21,24 @@
 # does not exist as far as evaluation is concerned, and the error says the path
 # is missing rather than that it is untracked.
 {
-  # Pinned to the nixarchy revision this machine was installed from. Bump it
-  # deliberately with `nix flake update nixarchy`, then `nh os switch`.
+  # Your package set. Locked at install time; `nix flake update nixpkgs` (or
+  # `omarchy update`) moves it forward when you decide to.
+  #
+  # To follow STABLE nixpkgs instead, point this at the release branch (e.g.
+  # "github:NixOS/nixpkgs/nixos-25.05") -- and move home-manager with it, as
+  # the two are developed as a pair:
+  #
+  #   inputs.nixarchy.inputs.home-manager.url =
+  #     "github:nix-community/home-manager/release-25.05";
+  #
+  # then `nix flake update nixpkgs home-manager` and `nh os switch`.
+  inputs.nixpkgs.url = "@nixpkgs_url@";
+
+  # Nixarchy itself, locked at the revision this machine was installed from.
+  # `nix flake update nixarchy` moves it to the latest release, deliberately
+  # -- nothing moves until you run it. Then `nh os switch`.
   inputs.nixarchy.url = "@nixarchy_url@";
+  inputs.nixarchy.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs =
     { nixarchy, ... }:

--- a/pkgs/omarchy/nix-bin/nixarchy-unfreeze
+++ b/pkgs/omarchy/nix-bin/nixarchy-unfreeze
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+# nixarchy:new
+# omarchy:summary=Let this machine receive updates again
+# omarchy:examples=nixarchy unfreeze
+
+# Machines installed before the fix carry a flake that can never move: the
+# installer wrote a COMMIT into both flake.nix's nixarchy URL and the lock's
+# `original`, and `nix flake update` re-resolves `original` -- re-resolving a
+# commit returns that commit, forever. No nixpkgs update, no security fixes,
+# while `omarchy update` printed that inputs were moving forward.
+#
+# This rewrites exactly the two things the installer got wrong, in place:
+#
+#   flake.nix   nixarchy pinned by commit  ->  pinned to the release branch,
+#               plus nixpkgs as an input of your own that nixarchy follows
+#   flake.lock  `original` rev             ->  `original` ref
+#
+# and touches NOTHING else. `locked` keeps the rev and hash you are running
+# today, so nothing changes until you choose to run an update. It only
+# rewrites lines the installer wrote; a flake.nix you have reshaped yourself
+# is yours, and this prints what to change instead of guessing at it.
+
+set -euo pipefail
+
+flake="${NIXARCHY_FLAKE:-/etc/nixos}"
+ref="release"
+
+red() { printf '\033[0;31m%s\033[0m\n' "$1"; }
+dim() { printf '\033[0;90m%s\033[0m\n' "$1"; }
+
+nixfile="$flake/flake.nix"
+lock="$flake/flake.lock"
+
+for f in "$nixfile" "$lock"; do
+  [ -f "$f" ] || { red "No $f."; exit 1; }
+  [ -w "$f" ] || {
+    red "$f is not writable by $USER."
+    echo
+    echo "  sudo chown -R $USER $flake"
+    exit 1
+  }
+done
+
+# Frozen means: the lock's update target is a commit. That is the exact state
+# the old installer wrote, and the only state this command exists to fix.
+if ! jq -e '.nodes.nixarchy.original | has("rev")' "$lock" >/dev/null 2>&1; then
+  echo "This machine is not frozen: the lock's nixarchy input already names"
+  echo "a ref that 'nix flake update' can move. Nothing to do."
+  exit 0
+fi
+
+# Only the installer's own line is rewritten. If the URL has been edited into
+# another shape, this flake has an owner with opinions, and sed-ing their file
+# is how their opinions get destroyed.
+if ! grep -Eq '^  inputs\.nixarchy\.url = "github:olafkfreund/nixarchy/[0-9a-f]{40}";$' "$nixfile"; then
+  red "flake.nix does not carry the installer's nixarchy line, so it will"
+  red "not be edited for you. To unfreeze by hand:"
+  echo
+  echo "  1. point inputs.nixarchy.url at \"github:olafkfreund/nixarchy/$ref\""
+  echo "  2. add   inputs.nixpkgs.url = \"github:NixOS/nixpkgs/nixos-unstable\";"
+  echo "           inputs.nixarchy.inputs.nixpkgs.follows = \"nixpkgs\";"
+  echo "  3. run   nix flake lock $flake"
+  exit 1
+fi
+
+# What nixarchy's nixpkgs is locked to today -- the node name after nix's
+# disambiguation, and the branch its `original` already carries. Copied, never
+# invented, for the same reason mkFlake copies it: inventing "nixpkgs" when
+# the node is called "nixpkgs_2" points the lock at nothing.
+nixpkgs_node=$(jq -r '.nodes.nixarchy.inputs.nixpkgs' "$lock")
+nixpkgs_url=$(jq -r --arg n "$nixpkgs_node" '
+  .nodes[$n].original | "github:\(.owner)/\(.repo)/\(.ref)"' "$lock")
+
+echo "Unfreezing $flake"
+echo
+dim "flake.nix:  nixarchy moves from its install commit to the '$ref' branch,"
+dim "            and nixpkgs ($nixpkgs_url) becomes an input"
+dim "            you own and can retarget."
+dim "flake.lock: the update target loses its rev. The rev you are RUNNING is"
+dim "            untouched -- nothing rebuilds, nothing downloads, and nothing"
+dim "            moves until you run an update yourself."
+echo
+
+read -r -p "Rewrite flake.nix and flake.lock? [y/N] " reply
+case "$reply" in
+  [yY]*) ;;
+  *) echo "Nothing changed."; exit 0 ;;
+esac
+
+# Plain-file backups rather than git: the installer staged this repo but
+# committed nothing, so there may be no commit to go back to.
+cp "$nixfile" "$nixfile.pre-unfreeze"
+cp "$lock" "$lock.pre-unfreeze"
+
+sed -i -E 's|^  inputs\.nixarchy\.url = "github:olafkfreund/nixarchy/[0-9a-f]{40}";$|  inputs.nixpkgs.url = "'"$nixpkgs_url"'";\n  inputs.nixarchy.url = "github:olafkfreund/nixarchy/'"$ref"'";\n  inputs.nixarchy.inputs.nixpkgs.follows = "nixpkgs";|' "$nixfile"
+
+jq --arg ref "$ref" --arg n "$nixpkgs_node" '
+  .nodes.nixarchy.original = {
+    type: "github", owner: "olafkfreund", repo: "nixarchy", ref: $ref }
+  | .nodes.nixarchy.inputs.nixpkgs = ["nixpkgs"]
+  | .nodes.root.inputs.nixpkgs = $n
+' "$lock" > "$lock.tmp" && mv "$lock.tmp" "$lock"
+
+# An unstaged file does not exist as far as flake evaluation is concerned,
+# and the backups should not become part of anyone's configuration.
+git -C "$flake" add flake.nix flake.lock 2>/dev/null || true
+
+echo
+echo "Done. This machine can update again:"
+echo
+echo "  omarchy update              everything, with a confirmation first"
+echo "  nix flake update nixpkgs    just the package set"
+echo "  nix flake update nixarchy   just nixarchy, to its latest release"
+echo
+dim "The previous files are at flake.nix.pre-unfreeze and"
+dim "flake.lock.pre-unfreeze if you want to compare or go back."

--- a/pkgs/omarchy/nix-bin/nixarchy-unfreeze
+++ b/pkgs/omarchy/nix-bin/nixarchy-unfreeze
@@ -93,7 +93,7 @@ esac
 cp "$nixfile" "$nixfile.pre-unfreeze"
 cp "$lock" "$lock.pre-unfreeze"
 
-sed -i -E 's|^  inputs\.nixarchy\.url = "github:olafkfreund/nixarchy/[0-9a-f]{40}";$|  inputs.nixpkgs.url = "'"$nixpkgs_url"'";\n  inputs.nixarchy.url = "github:olafkfreund/nixarchy/'"$ref"'";\n  inputs.nixarchy.inputs.nixpkgs.follows = "nixpkgs";|' "$nixfile"
+sed -i -E 's|^  inputs\.nixarchy\.url = "github:olafkfreund/nixarchy/[0-9a-f]{40}";$|  inputs = {\n    nixpkgs.url = "'"$nixpkgs_url"'";\n    nixarchy = {\n      url = "github:olafkfreund/nixarchy/'"$ref"'";\n      inputs.nixpkgs.follows = "nixpkgs";\n    };\n  };|' "$nixfile"
 
 jq --arg ref "$ref" --arg n "$nixpkgs_node" '
   .nodes.nixarchy.original = {

--- a/pkgs/omarchy/nix-bin/omarchy-update
+++ b/pkgs/omarchy/nix-bin/omarchy-update
@@ -43,10 +43,32 @@ if [ ! -w "$flake" ]; then
   exit 1
 fi
 
+# Machines installed before nixarchy-unfreeze existed carry a lock whose
+# update target is a commit, and updating a commit returns the same commit:
+# `nh os switch --update` would rebuild the identical system while this
+# script narrates progress. Saying "updated" there is the one thing this
+# script must never do, so the frozen shape is caught first and the fix
+# offered -- it is a two-line rewrite with its own confirmation.
+if jq -e '.nodes.nixarchy.original | has("rev")' "$flake/flake.lock" >/dev/null 2>&1; then
+  red "This machine's flake is frozen at its install day."
+  echo
+  echo "The installer pinned nixarchy by commit in the update target, so"
+  echo "'--update' re-resolves to the same commit forever: no new nixpkgs,"
+  echo "no new nixarchy, while everything reports success."
+  echo
+  read -r -p "Run nixarchy-unfreeze to fix that first? [y/N] " reply
+  case "$reply" in
+    [yY]*) nixarchy-unfreeze ;;
+    *) echo "Left frozen. Updating would rebuild what you already have."; exit 0 ;;
+  esac
+  echo
+fi
+
 echo "Updating from $flake"
 echo
-dim "This moves your flake inputs forward -- nixpkgs, nixarchy and Omarchy"
-dim "itself -- and then rebuilds. Your app selections are untouched."
+dim "This moves your flake inputs forward -- nixpkgs, home-manager, and"
+dim "nixarchy to its latest release -- and then rebuilds. Your app"
+dim "selections are untouched."
 echo
 
 read -r -p "Update flake inputs and rebuild? [y/N] " reply

--- a/tests/installer-lock.nix
+++ b/tests/installer-lock.nix
@@ -21,9 +21,9 @@
 # network, seconds. The 25-minute install check can see the same bug, but only
 # after the damage and only as something four levels away.
 pkgs.runCommand "nixarchy-installer-lock"
-{
-  nativeBuildInputs = [ pkgs.jq ];
-}
+  {
+    nativeBuildInputs = [ pkgs.jq ];
+  }
   ''
     lock=${flakeTemplate}/flake.lock
     test -f "$lock" || { echo "no flake.lock in the generated template" >&2; exit 1; }

--- a/tests/installer-lock.nix
+++ b/tests/installer-lock.nix
@@ -97,10 +97,10 @@ pkgs.runCommand "nixarchy-installer-lock"
     # have. A rev-shaped URL here is the same freeze wearing different
     # clothes: `nix flake update nixarchy` obeys flake.nix, not the lock.
     ref=$(jq -r '.ref' <<<"$original")
-    grep -Fq "inputs.nixarchy.url = \"github:olafkfreund/nixarchy/$ref\";" \
+    grep -Fq "url = \"github:olafkfreund/nixarchy/$ref\";" \
       ${flakeTemplate}/flake.nix || {
       echo "flake.nix does not pin nixarchy to the ref the lock names ('$ref'):" >&2
-      grep -n 'inputs.nixarchy.url' ${flakeTemplate}/flake.nix >&2 || true
+      grep -n 'olafkfreund/nixarchy' ${flakeTemplate}/flake.nix >&2 || true
       exit 1
     }
 
@@ -125,7 +125,7 @@ pkgs.runCommand "nixarchy-installer-lock"
     # first offline use re-resolves it and dies without a network.
     nixpkgs_url=$(jq -r '.nodes.root.inputs.nixpkgs as $n
       | .nodes[$n].original | "github:\(.owner)/\(.repo)/\(.ref)"' "$lock")
-    grep -Fq "inputs.nixpkgs.url = \"$nixpkgs_url\";" ${flakeTemplate}/flake.nix || {
+    grep -Fq "nixpkgs.url = \"$nixpkgs_url\";" ${flakeTemplate}/flake.nix || {
       echo "flake.nix's nixpkgs URL does not match the lock's original" >&2
       echo "($nixpkgs_url); nix would re-resolve it on first use, offline:" >&2
       grep -n 'inputs.nixpkgs.url' ${flakeTemplate}/flake.nix >&2 || true

--- a/tests/installer-lock.nix
+++ b/tests/installer-lock.nix
@@ -21,9 +21,9 @@
 # network, seconds. The 25-minute install check can see the same bug, but only
 # after the damage and only as something four levels away.
 pkgs.runCommand "nixarchy-installer-lock"
-  {
-    nativeBuildInputs = [ pkgs.jq ];
-  }
+{
+  nativeBuildInputs = [ pkgs.jq ];
+}
   ''
     lock=${flakeTemplate}/flake.lock
     test -f "$lock" || { echo "no flake.lock in the generated template" >&2; exit 1; }
@@ -68,5 +68,70 @@ pkgs.runCommand "nixarchy-installer-lock"
       echo "lastModified is not a positive timestamp" >&2; exit 1; }
 
     echo "the generated lock carries every field mkFlake writes by hand"
+
+    # The other half of the node: `original` is what `nix flake update`
+    # re-resolves, and a rev there resolves to itself -- which is how every
+    # machine installed before this check existed was frozen at its install
+    # day. `omarchy update` printed "this moves your flake inputs forward"
+    # and moved nothing. `locked` (asserted above) is where reproducibility
+    # lives; `original` must be somewhere update can GO.
+    original=$(jq -c '.nodes.nixarchy.original // empty' "$lock")
+    if jq -e 'has("rev")' <<<"$original" >/dev/null 2>&1; then
+      echo "" >&2
+      echo "the nixarchy lock node's 'original' carries a rev: $original" >&2
+      echo "" >&2
+      echo "'original' is the update target: nix flake update re-resolves it," >&2
+      echo "and re-resolving a commit returns that commit. Every machine" >&2
+      echo "installed from this template can never move -- no nixarchy" >&2
+      echo "update, and since nixarchy used to carry nixpkgs, no nixpkgs" >&2
+      echo "update either. Pin the rev in 'locked'; give 'original' a ref." >&2
+      exit 1
+    fi
+    jq -e '.ref | type == "string" and length > 0' <<<"$original" >/dev/null || {
+      echo "the nixarchy 'original' has no ref to update against: $original" >&2
+      exit 1
+    }
+
+    # And the URL in flake.nix must agree with it, because nix re-resolves on
+    # a flake.nix/lock mismatch -- over a network the offline ISO does not
+    # have. A rev-shaped URL here is the same freeze wearing different
+    # clothes: `nix flake update nixarchy` obeys flake.nix, not the lock.
+    ref=$(jq -r '.ref' <<<"$original")
+    grep -Fq "inputs.nixarchy.url = \"github:olafkfreund/nixarchy/$ref\";" \
+      ${flakeTemplate}/flake.nix || {
+      echo "flake.nix does not pin nixarchy to the ref the lock names ('$ref'):" >&2
+      grep -n 'inputs.nixarchy.url' ${flakeTemplate}/flake.nix >&2 || true
+      exit 1
+    }
+
+    # The machine owns nixpkgs: a root input the user can retarget (stable vs
+    # unstable) and update on its own, with nixarchy following it. Without
+    # the follows re-rooting, nixarchy's locked nixpkgs would shadow the
+    # user's choice and this root input would be decoration.
+    jq -e '.nodes.root.inputs.nixpkgs | type == "string"' "$lock" >/dev/null || {
+      echo "the generated lock has no root nixpkgs input; the machine cannot" >&2
+      echo "choose or update its package set:" >&2
+      jq -c '.nodes.root.inputs' "$lock" >&2
+      exit 1
+    }
+    jq -e '.nodes.nixarchy.inputs.nixpkgs == ["nixpkgs"]' "$lock" >/dev/null || {
+      echo "nixarchy does not follow the machine's nixpkgs; the root input" >&2
+      echo "would be dead weight while nixarchy builds from its own:" >&2
+      jq -c '.nodes.nixarchy.inputs.nixpkgs' "$lock" >&2
+      exit 1
+    }
+
+    # flake.nix's nixpkgs URL must be the locked node's own original, or the
+    # first offline use re-resolves it and dies without a network.
+    nixpkgs_url=$(jq -r '.nodes.root.inputs.nixpkgs as $n
+      | .nodes[$n].original | "github:\(.owner)/\(.repo)/\(.ref)"' "$lock")
+    grep -Fq "inputs.nixpkgs.url = \"$nixpkgs_url\";" ${flakeTemplate}/flake.nix || {
+      echo "flake.nix's nixpkgs URL does not match the lock's original" >&2
+      echo "($nixpkgs_url); nix would re-resolve it on first use, offline:" >&2
+      grep -n 'inputs.nixpkgs.url' ${flakeTemplate}/flake.nix >&2 || true
+      exit 1
+    }
+
+    echo "and 'original' is a ref nix flake update can actually move"
     touch $out
   ''


### PR DESCRIPTION
Fixes #336.

## The bug

`mkFlake.nix` wrote the machine's own revision into **both** halves of its lock node:

```json
locked:   { ..., "rev": "<install-time rev>", "narHash": ..., "lastModified": ... }
original: { ..., "rev": "<install-time rev>" }
```

`original` is what `nix flake update` re-resolves against, and a `github:` URL carrying an explicit rev names an immutable commit. So the update was a **silent no-op**: exit 0, encouraging message, identical system. Forever.

## The fix, in one sentence

`original` carries a **ref**; `locked` keeps rev + narHash + lastModified exactly as before. Reproducibility never came from `original` — nix does not consult it until someone runs `nix flake update`.

## Proven, not argued

Every claim below was exercised against real generated flakes, and the final round against the actually-built `.#flake-template` output rather than a hand-written mock.

| claim | evidence |
|---|---|
| the bug is real | `nix flake update nixarchy` on today's shape → zero output, lock byte-identical |
| **offline first boot is unaffected** | `nix flake metadata --offline` resolves to the exact locked rev; `nix eval --offline .#nixosConfigurations` → `[ "testbox" ]` |
| **updates now work** | after backdating `locked.rev` 5 commits: `Updated input 'nixarchy': 49eee4b… → 55432c1…` |
| **nothing moves silently** | `nix flake lock --offline` on an untouched machine → empty diff |
| the ~40 re-rooted `follows` survive | post-update lock still evaluates |

## Stable or unstable, chosen by the user

The machine's flake now owns `nixpkgs`, and nixarchy follows it:

```nix
inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
inputs.nixarchy.inputs.nixpkgs.follows = "nixpkgs";
```

The lock transform copies the disambiguated node name (it is `nixpkgs_2`, not `nixpkgs` — inventing that mapping points at a node which does not exist), and re-roots the forty `follows` arrays through it.

Exercised with `nixos-25.05`: one `nix flake update nixpkgs` re-locked both nixpkgs and home-manager while nixarchy stayed put, and the lock stayed valid. Switching stable also requires pinning home-manager to the matching `release-XX.XX`, because `flake.nix:9-18` records that pairing as the only tested one; the template documents this inline.

The flake.nix nixpkgs URL is **derived from the lock's own `original`** rather than retyped — a mismatch would trigger online re-resolution on an offline ISO.

## Which ref: `release`

A branch that `release.yml` fast-forwards when a tag is cut (plain non-force push, so a backwards move fails loudly).

The argument: with nixpkgs at the root, nixarchy's ref no longer gates package or security updates — it gates only *nixarchy's own code*, which is exactly the code that should wait for a human, given `main` is now bot-merged (the Omarchy bump, the nightly nixpkgs bump in #335). `main` would deliver commits no human read; a tag would re-freeze, since tags do not move.

## Machines already installed

`mkFlake` only helps new installs, so this adds **`nixarchy-unfreeze`**: detects the frozen shape, rewrites the installer's exact flake.nix line (regex-anchored) and the lock via jq, behind a y/N confirm, with `.pre-unfreeze` plain-file backups — plain files because the installer stages without committing, so git may have zero commits to fall back on. It `git add`s afterwards so evaluation sees the files, and **refuses with hand-instructions if the URL line was user-edited**.

Exercised: migrate → offline eval OK → nixpkgs updates; second run says "not frozen, nothing to do"; a hand-edited flake is refused untouched.

`omarchy update` now checks the lock before its existing confirm, offers to run the migration when frozen, and its text is corrected — it claimed to move "nixpkgs, nixarchy and Omarchy itself" while moving nothing.

## The check

`tests/installer-lock.nix` gains content assertions: `original` must **not** carry a rev and **must** carry a ref; flake.nix's nixarchy URL must name that exact ref; `root.inputs.nixpkgs` exists; `nixarchy.inputs.nixpkgs == ["nixpkgs"]`.

Proven both ways — **fails** on the old mkFlake (`the nixarchy lock node's 'original' carries a rev: …`) and **passes** on the fix. Seconds, no VM. I re-ran it independently; its output states the property plainly: `and 'original' is a ref nix flake update can actually move`.

## ⚠️ Landing prerequisite

**The `release` branch must exist before this merges**, or every new install points at a ref that is not there:

```
git push origin v4.0.2-4^{}:refs/heads/release
```

Known wart, flagged not fixed: an ISO self-built from a `main` commit *ahead* of `release` would downgrade on its first `nix flake update nixarchy`. Official ISOs are tag-built and never see this.

## Not covered

The 25-minute `checks.install` VM run — offline evaluation is proven above, but CI is what exercises the full installer. And `nix flake update nixarchy` against the literal `release` branch is untested live because the branch does not exist yet; the mechanics are proven identically against `main`.
