### PR TITLE
hey-cli 1.4.1, and the updater survives upstream's new SBOM files

### DIFF
--- a/pkgs/apps/hey-cli.nix
+++ b/pkgs/apps/hey-cli.nix
@@ -11,15 +11,15 @@
   gnugrep,
 }:
 let
-  version = "1.4.0";
+  version = "1.4.1";
 
   # Straight from the release's own checksums.txt, which upstream signs with a
   # keyless Sigstore bundle -- not from a local download. Same reasoning as
   # pkgs/apps/once.nix: these should be the artefacts basecamp published, not
   # whatever a machine here happened to fetch.
   hashes = {
-    "x86_64-linux" = "316423686028bbbc999cf0ee0443d9ca73a737681c1515588470774f2b394f10";
-    "aarch64-linux" = "7cb79d265d5491a9d9967c00e36d748bcec0021d0d52c64163d7b8a8bb528466";
+    "x86_64-linux" = "18c4a5eb86dc98a7416fd6c452537a0968df7080cda6c20bd9192f06d95e58b1";
+    "aarch64-linux" = "2a7e3124e8b09313f013dee9f72bef7d302cff27e5e2d7f36571c30b5289ab58";
   };
   arches = {
     "x86_64-linux" = "amd64";
@@ -99,7 +99,11 @@ stdenvNoCC.mkDerivation {
       for pair in "x86_64-linux:amd64" "aarch64-linux:arm64"; do
         key=''${pair%%:*}
         arch=''${pair##*:}
-        hex=$(echo "$sums" | grep "hey_''${latest}_linux_''${arch}.tar.gz" | cut -d' ' -f1 || true)
+        # Anchored to end of line: since 1.4.1 the release also publishes a
+        # .sbom.json beside each tarball, and an unanchored match returned
+        # both hashes -- two lines in $hex, which then broke the sed below
+        # with "unterminated `s' command".
+        hex=$(echo "$sums" | grep "hey_''${latest}_linux_''${arch}.tar.gz\$" | cut -d' ' -f1 || true)
         if [ -z "$hex" ]; then
           echo "hey-cli: checksums.txt names no hey_''${latest}_linux_''${arch}.tar.gz" >&2
           exit 1


### PR DESCRIPTION
The nightly review (#195) flags hey-cli at 1.4.0 with 1.4.1 upstream. Verified independently: basecamp published v1.4.1 on 2026-09-04 (`gh api /repos/basecamp/hey-cli/releases/latest` → `v1.4.1`).

## What was driven, and what it found

Bumped via the package's own `passthru.updateScript` rather than by hand — note that `nix run .#update` (what update.yml runs nightly) is wired to **once's updateScript only**, so the update job would never have moved this pin; see the finding below.

Running the hey-cli updateScript against v1.4.1 **failed**:

```
hey-cli: 1.4.0 -> 1.4.1
sed: -e expression #1, char 125: unterminated 's' command
```

Root cause: v1.4.1's checksums.txt newly lists a `.sbom.json` beside every tarball, so the unanchored `grep "hey_1.4.1_linux_amd64.tar.gz"` matched both `hey_1.4.1_linux_amd64.tar.gz` and `hey_1.4.1_linux_amd64.tar.gz.sbom.json` — two hashes with a newline between them, which broke the sed expression. It failed before writing anything, so no partial rewrite. This PR anchors the grep to end of line and re-runs the updater, which then rewrote version + both hashes cleanly.

## Proof

- Both hashes match the release's signed checksums.txt fetched independently (`18c4a5eb…` amd64, `2a7e3124…` arm64).
- `nix build .#hey-cli` built from source and `./result/bin/hey --version` → `hey version 1.4.1`.
- `nix fmt -- --ci`, `statix check .`, `deadnix --fail .` all clean.
- `data/apps.nix` untouched — no README count changes apply.

## Follow-up worth its own issue

`nix run .#update` = `nixarchy-apps.once.updateScript`, and update.yml builds only `.#once .#grok-bot` afterwards. hey-cli's updateScript exists but is unreachable from the nightly job, and its comment ("Only `once` is pinned by hand now") is stale. Not changed here to keep this PR a version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFX6WZHR1gRmeAm8QEPJpY