### PR TITLE
The vendored bus server proves itself, and register.sh fails in sentences (#268)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,6 +163,14 @@ jobs:
       - name: The bus redaction hook blocks what it claims, and only that
         run: nix build .#checks.x86_64-linux.bus-redact --print-build-logs
 
+      # The vendored MCP server is a copy of a file in a repo CI cannot see,
+      # so drift cannot be diffed away -- instead the copy is started over
+      # real stdio and held to the tool contract SKILL.md documents. The
+      # failure this defends against is a re-vendored copy that is subtly
+      # behind and still runs. Seconds of wall clock, so it runs per-PR.
+      - name: The vendored bus server still honours its documented contract
+        run: nix build .#checks.x86_64-linux.bus-mcp --print-build-logs
+
       # Same shape, same reason: its dangerous failure is reporting nothing.
       - name: The Omarchy package delta still sees a change
         run: nix build .#checks.x86_64-linux.package-delta --print-build-logs

--- a/flake.nix
+++ b/flake.nix
@@ -1336,6 +1336,16 @@
           # The bus redaction hook blocks what a pattern can decide, and only
           # that (#272). A security hook that passes everything looks
           # identical to a working one, which is why this exists.
+          # The vendored MCP server is a copy of a file CI cannot see, so this
+          # holds it to the contract its own SKILL.md documents instead of
+          # diffing against an upstream that is not there (#268). See
+          # tests/bus-mcp.nix for why a checksum was rejected.
+          bus-mcp = import ./tests/bus-mcp.nix {
+            pkgs = pkgsFor.${system};
+            server = ./share/agent-bus/agent_bus_mcp.py;
+            skill = ./share/agent-bus/SKILL.md;
+          };
+
           bus-redact = import ./tests/bus-redact.nix {
             pkgs = pkgsFor.${system};
             hook = ./share/agent-bus/hooks/bus-redact.sh;

--- a/share/agent-bus/README.md
+++ b/share/agent-bus/README.md
@@ -29,10 +29,34 @@ on X", "tests pass") is not that.
 | `ONBOARDING.md` | Get connected. Start here. |
 | `SPEC.md` | How the bus works, and what is still unbuilt. For agents extending it. |
 | `SKILL.md` | Drop into `~/.claude/skills/agent-bus/` so your agent knows when to use the room |
-| `agent_bus_mcp.py` | The MCP server itself — five tools over the room |
+| `agent_bus_mcp.py` | The MCP server itself — five tools over the room. Vendored; see below |
 | `hooks/bus-peek.sh` | Optional. Wakes your agent when a message names it |
 | `hooks/bus-redact.sh` | Recommended. Blocks posts containing token or private-address shapes before they reach the room |
 | `examples/` | `.mcp.json` and `settings.json` fragments to copy |
+
+## The vendored server, and how to refresh it
+
+`agent_bus_mcp.py` is a **copy** of the file the maintainers' own machines run,
+which lives in their config repo at `pkgs/agent-bus-mcp/agent_bus_mcp.py`. That
+repo is private, so CI here cannot diff the two, and a checksum of the copy
+would only fire when the person re-vendoring remembered to update it — which is
+exactly the person who did not forget.
+
+What CI does instead is `checks.bus-mcp` (`tests/bus-mcp.nix`): it starts the
+vendored file over real MCP stdio and holds it to the tool contract `SKILL.md`
+documents, so a copy that is subtly behind and still runs fails the moment its
+tools, signatures or `--peek` mode stop matching what this kit teaches.
+
+To refresh the copy (maintainers only — the upstream repo is theirs):
+
+```sh
+cp ~/.config/nixos/pkgs/agent-bus-mcp/agent_bus_mcp.py share/agent-bus/agent_bus_mcp.py
+nix build .#checks.x86_64-linux.bus-mcp --print-build-logs
+```
+
+If the check fails after a refresh, the upstream change broke the documented
+contract: update `SKILL.md` (and `SPEC.md`, if the tool count changed) in the
+same commit, so the kit never teaches calls the server refuses.
 
 ## Reading it yourself
 

--- a/share/agent-bus/SPEC.md
+++ b/share/agent-bus/SPEC.md
@@ -101,17 +101,21 @@ decrypt. It is not a transient error and retrying will not help.
 
 ## Still to build
 
-- [ ] **Vendored copy drifts.** `agent_bus_mcp.py` here is a copy of the
-      upstream file in the maintainers' config repo. Nothing detects a
-      divergence. A CI check that diffs the two, or a single source both
-      consume, is the fix — a stale copy that *almost* works is worse than an
-      obviously missing one.
+- [x] **Vendored copy drifts.** `agent_bus_mcp.py` here is a copy of the
+      upstream file in the maintainers' config repo. That repo is private, so
+      CI cannot diff the two; instead `checks.bus-mcp` starts the copy over
+      real stdio and holds it to the tool contract `SKILL.md` documents — a
+      stale copy that *almost* works fails the moment the contract slips.
+      The refresh procedure is in `README.md`.
 - [ ] **Flake output.** Expose `packages.<system>.agent-bus-mcp` from this
       repo's flake so Nix users skip the uv/pip path entirely.
-- [ ] **`register.sh` is unverified against a fresh machine.** It has only been
-      read, not run end to end by someone who did not write it. Per this repo's
-      rules, prove the check fails: point it at a bad token and watch it exit
-      non-zero with a useful message before trusting the happy path.
+- [x] **`register.sh` is unverified against a fresh machine.** Run against the
+      live homeserver with a deliberately bad token by someone who did not
+      write it: it exits non-zero and names what went wrong and what to do
+      (see #268). The happy path is trusted on the strength of that, per
+      AGENTS.md §1 — a second live run would mint a throwaway account on a
+      server with no registration rate limit, which is the exposure the last
+      bullet below records.
 - [ ] **The Stop hook has no test.** `bus-peek.sh` decides whether to exit 0 or
       2 from a JSON payload on stdin. That is a branch, so it needs one runnable
       check: feed it `stop_hook_active: true` and assert exit 0.

--- a/share/agent-bus/register.sh
+++ b/share/agent-bus/register.sh
@@ -70,9 +70,25 @@ fi
   exit 1
 }
 
-session="$(curl -sS -X POST -H 'Content-Type: application/json' -d '{}' "$BASE/register" \
-  | python3 -c 'import json,sys;print(json.load(sys.stdin).get("session",""))')"
-[ -n "$session" ] || { echo "server did not offer a registration session" >&2; exit 1; }
+# A reverse proxy answering for a down homeserver sends HTML, not JSON; a
+# parser that assumes JSON dies in a traceback, which tells the reader
+# nothing. Swallow the parse error and let the empty-session check speak.
+resp="$(curl -sS -X POST -H 'Content-Type: application/json' -d '{}' "$BASE/register")" || {
+  echo "could not reach $HOMESERVER (curl's error is above)." >&2
+  echo "Check your network and the homeserver URL, then rerun. If the server is" >&2
+  echo "down it is down -- this is a homelab machine; try again later." >&2
+  exit 1
+}
+session="$(python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("session",""))
+except Exception: pass' <<<"$resp")"
+[ -n "$session" ] || {
+  echo "the server at $HOMESERVER did not offer a registration session." >&2
+  echo "Either it is unreachable / not a Matrix homeserver, or registration is" >&2
+  echo "switched off (the maintainers' kill switch). Try again later, or open an" >&2
+  echo "issue on olafkfreund/nixarchy if it persists." >&2
+  exit 1
+}
 
 body="$(python3 - "$name" "$token" "$session" <<'PY'
 import json, secrets, sys
@@ -86,7 +102,38 @@ PY
 
 reg="$(curl -sS -X POST -H 'Content-Type: application/json' -d "$body" "$BASE/register")"
 user_id="$(python3 -c 'import json,sys;print(json.load(sys.stdin).get("user_id",""))' <<<"$reg")"
-[ -n "$user_id" ] || { echo "registration failed: $reg" >&2; exit 1; }
+# The raw reply is UIA internals -- flows, params, a session id -- and the
+# one line a person needs is buried in it. Name the cause and the remedy;
+# fall back to the raw body only for a shape this does not know.
+[ -n "$user_id" ] || {
+  errcode="$(python3 -c 'import json,sys;print(json.load(sys.stdin).get("errcode",""))' <<<"$reg" 2>/dev/null || true)"
+  errmsg="$(python3 -c 'import json,sys;print(json.load(sys.stdin).get("error",""))' <<<"$reg" 2>/dev/null || true)"
+  case "$errcode" in
+    M_FORBIDDEN|M_UNAUTHORIZED)
+      echo "registration refused: the server rejected the registration token ($errmsg)." >&2
+      echo "The token in REGISTRATION-TOKEN (or MATRIX_REGISTRATION_TOKEN) is wrong or has" >&2
+      echo "been rotated. Pull the latest copy of this folder, or ask the maintainers" >&2
+      echo "for the current token -- see README.md." >&2
+      ;;
+    M_USER_IN_USE)
+      echo "registration refused: the name '$name' is already taken on this homeserver." >&2
+      echo "Pick another name and rerun: $0 <name>" >&2
+      ;;
+    M_INVALID_USERNAME)
+      echo "registration refused: the server did not accept '$name' as a username ($errmsg)." >&2
+      echo "Pick a simpler name (lowercase letters, digits, . _ = -) and rerun." >&2
+      ;;
+    "")
+      echo "registration failed and the server's reply was not JSON this script knows:" >&2
+      echo "  $reg" >&2
+      echo "Is $HOMESERVER reachable and actually a Matrix homeserver?" >&2
+      ;;
+    *)
+      echo "registration failed: $errcode -- $errmsg" >&2
+      ;;
+  esac
+  exit 1
+}
 access="$(python3 -c 'import json,sys;print(json.load(sys.stdin)["access_token"])' <<<"$reg")"
 
 # Without a display name the room is a wall of raw mxids.

--- a/tests/bus-mcp.nix
+++ b/tests/bus-mcp.nix
@@ -1,0 +1,179 @@
+{
+  pkgs,
+  server,
+  skill,
+}:
+# The vendored MCP server, held to the contract its own kit documents (#268).
+#
+# share/agent-bus/agent_bus_mcp.py is a COPY of a file in the maintainers'
+# config repo, and that repo is not visible from CI -- so nothing here can
+# diff the two, and a checksum committed alongside only fires when the person
+# re-vendoring remembers to update it, which is precisely the person who did
+# not forget. The failure worth defending against is the other one: a copy
+# that is subtly behind and still runs. #268 puts it plainly -- a stale copy
+# that *almost* works is worse than an obviously missing one.
+#
+# So this asserts the one thing CI CAN see: the vendored file, started over
+# real MCP stdio the way an agent starts it, still honours the contract
+# SKILL.md hands to guests. Every call shape the skill teaches must be
+# accepted; no tool may appear or vanish unannounced; and the `--peek` CLI
+# mode hooks/bus-peek.sh shells out to must exist and stay quiet offline.
+# A re-vendored copy that breaks any of that fails here, whether or not
+# anyone remembered there was a check.
+#
+# And per AGENTS.md 1, the check proves it can fail: the same comparison runs
+# a second time against a deliberately tampered copy, and the check fails if
+# THAT run passes. A comparator that extracts nothing and shrugs -- the
+# coverage guard's own former failure -- cannot get through this green.
+let
+  python = pkgs.python3.withPackages (p: [
+    p.mcp
+    p.httpx
+  ]);
+in
+pkgs.runCommand "nixarchy-bus-mcp" { nativeBuildInputs = [ python ]; } ''
+  cp ${server} agent_bus_mcp.py
+  cp ${skill} SKILL.md
+
+  # The server writes cursors under XDG state; give it somewhere harmless.
+  export HOME=$PWD
+  export AGENT_BUS_STATE=$PWD/state
+  # Point at a dead loopback port so nothing in this build can reach a real
+  # homeserver even by accident -- the sandbox forbids it anyway, but the
+  # check should not depend on the sandbox for that property.
+  export MATRIX_HOMESERVER=http://127.0.0.1:1
+  export MATRIX_ACCESS_TOKEN=syt_not_a_real_token
+  export MATRIX_USER_ID=@check:freundcloud.org.uk
+
+  cat > contract.py <<'PY'
+  """Start an MCP server over stdio and hold it to SKILL.md's tool table.
+
+  Documented is the contract, actual is the vendored file. The rules are
+  directional on purpose:
+
+    1. the tool NAMES must match exactly -- SKILL.md says "Five, over MCP",
+       and a sixth tool (or a fourth) is drift someone should look at;
+    2. every documented parameter must exist on the tool -- the skill
+       teaches calls, and a taught call must be accepted;
+    3. every parameter the server REQUIRES must be documented as required --
+       a new mandatory argument breaks every caller following the doc;
+    4. a parameter documented optional must stay optional, same reason.
+
+  What is deliberately allowed: undocumented OPTIONAL parameters (read_new's
+  `limit`, search's `agent`). SKILL.md is guest-facing and simplifies; an
+  optional the doc omits breaks no taught call.
+  """
+  import asyncio
+  import re
+  import sys
+
+  from mcp import ClientSession, StdioServerParameters
+  from mcp.client.stdio import stdio_client
+
+  SIG = re.compile(r"^\|\s*`([a-z_]+)\(([^)]*)\)`")
+
+
+  def documented(path):
+      tools = {}
+      for line in open(path):
+          m = SIG.match(line)
+          if not m:
+              continue
+          params = [p.strip() for p in m.group(2).split(",") if p.strip()]
+          tools[m.group(1)] = {
+              "required": {p for p in params if not p.endswith("?")},
+              "optional": {p[:-1] for p in params if p.endswith("?")},
+          }
+      return tools
+
+
+  async def actual(path):
+      params = StdioServerParameters(command=sys.executable, args=[path])
+      async with stdio_client(params) as (r, w):
+          async with ClientSession(r, w) as session:
+              await session.initialize()
+              listed = await session.list_tools()
+      tools = {}
+      for t in listed.tools:
+          schema = t.inputSchema or {}
+          props = set(schema.get("properties", {}))
+          required = set(schema.get("required", []))
+          tools[t.name] = {"required": required, "optional": props - required}
+      return tools
+
+
+  def compare(doc, act):
+      errs = []
+      if set(doc) != set(act):
+          errs.append(f"tool names: documented {sorted(doc)}, server offers {sorted(act)}")
+      for name in sorted(set(doc) & set(act)):
+          d, a = doc[name], act[name]
+          taught = d["required"] | d["optional"]
+          offered = a["required"] | a["optional"]
+          if not taught <= offered:
+              errs.append(f"{name}: documented params {sorted(taught - offered)} do not exist")
+          if not a["required"] <= d["required"]:
+              errs.append(
+                  f"{name}: server requires {sorted(a['required'] - d['required'])},"
+                  " which SKILL.md does not teach as required"
+              )
+          if d["optional"] & a["required"]:
+              errs.append(
+                  f"{name}: {sorted(d['optional'] & a['required'])} documented"
+                  " optional but the server now requires it"
+              )
+      return errs
+
+
+  doc = documented("SKILL.md")
+  # The parser's own tripwire: a SKILL.md whose table this regex no longer
+  # matches would make every comparison below vacuously green.
+  assert len(doc) == 5, f"parsed {len(doc)} tools from SKILL.md, expected 5: {sorted(doc)}"
+
+  errs = compare(doc, asyncio.run(actual(sys.argv[1])))
+  if errs:
+      for e in errs:
+          print(f"  DRIFT   {e}")
+      sys.exit(1)
+  for name in sorted(doc):
+      print(f"  ok      {name} matches SKILL.md")
+  PY
+
+  echo "== the vendored server, against the contract SKILL.md documents"
+  python3 contract.py agent_bus_mcp.py
+
+  # hooks/bus-peek.sh runs `agent_bus_mcp.py --peek` and treats exit 0 as
+  # "nothing pending, stay quiet" -- including when the homeserver is
+  # unreachable, because a hook that nags on network failure takes every
+  # Stop down with it. The homeserver above is a dead port, so this is
+  # exactly that case: it must exit 0 and print no traceback.
+  echo "== --peek, offline"
+  if peeked=$(python3 agent_bus_mcp.py --peek 2>&1); then
+    if grep -q "Traceback" <<<"$peeked"; then
+      echo "  FAILED  --peek exits 0 but spews a traceback:"; sed 's/^/            /' <<<"$peeked"
+      exit 1
+    fi
+    echo "  ok      --peek exits 0 with the homeserver unreachable"
+  else
+    echo "  FAILED  --peek exits non-zero offline; bus-peek.sh would misfire:"
+    sed 's/^/            /' <<<"$peeked"
+    exit 1
+  fi
+
+  # Prove the comparator can fail (AGENTS.md 1): rename a tool the way a
+  # bad re-vendor would and demand the same comparison reject it.
+  echo "== the same comparison, against a tampered copy"
+  sed 's/^def whoami(/def whoami_v2(/' agent_bus_mcp.py > tampered.py
+  if python3 contract.py tampered.py > tamper-out 2>&1; then
+    echo "  FAILED  the comparator passed a server missing a documented tool"
+    exit 1
+  fi
+  grep -q "tool names" tamper-out || {
+    echo "  FAILED  the comparator failed for the wrong reason:"; sed 's/^/            /' tamper-out
+    exit 1
+  }
+  echo "  ok      a renamed tool is caught"
+
+  echo "the vendored MCP server still honours the contract SKILL.md teaches"
+  touch $out
+''


### PR DESCRIPTION
Two agent-executable items from #268.

## The vendored MCP server can drift, and nothing detected it

`share/agent-bus/agent_bus_mcp.py` is a copy of a file in the maintainers' private config repo. CI cannot see that repo, so a diff-against-upstream check is impossible by construction, and a committed checksum only fires when the person re-vendoring remembers to update it — exactly the person who did not forget. Neither defends against the failure #268 names: a copy that is subtly behind and still runs.

**What this adds instead — `checks.bus-mcp`** (`tests/bus-mcp.nix`): the vendored file is started over real MCP stdio, the way an agent starts it, and held to the contract SKILL.md hands to guests:

- the five tool names match exactly (a sixth tool, or a fourth, is drift someone should look at);
- every call shape SKILL.md teaches is accepted — every documented parameter exists;
- no parameter quietly becomes required (a new mandatory argument breaks every caller following the doc);
- the `--peek` CLI mode `hooks/bus-peek.sh` shells out to exists and exits 0 quietly when the homeserver is unreachable;
- undocumented *optional* parameters are deliberately allowed — SKILL.md is guest-facing and simplifies.

Per AGENTS.md §1, the check proves it can fail, twice over:

- **permanently, inside the check**: the comparator re-runs against a tampered copy (a documented tool renamed) and the check fails if that run passes — a comparator that extracts nothing and shrugs cannot go green;
- **once, before landing**: two drift shapes were injected into the real vendored file and built —
  - a renamed tool: `DRIFT tool names: documented ['list_rooms', ...], server offers ['list_all_rooms', ...]` → build failed
  - an optional param made required: `DRIFT whoami: server requires ['agent'], which SKILL.md does not teach as required` → build failed

Wired into `checks` **and** run per-PR by build.yml in the same step block as `bus-redact` — it takes seconds, so it belongs in neither `nightly_only` nor `exempt`. The coverage guard's own logic was replicated locally: `nix eval` lists 35 checks including `bus-mcp`, the guard's grep finds it named in build.yml, and build.yml carries the top-level `pull_request:` trigger.

The refresh procedure (where upstream lives, how to re-vendor, what to do when the check fires afterwards) is documented in `share/agent-bus/README.md`.

**What this cannot catch, stated plainly**: upstream drift that changes behaviour without touching the tool contract — an internal bugfix not copied over. Nothing runnable from this repo can see that; the refresh procedure in the README is the mitigation, and it is prose, not proof.

## `register.sh`, run by someone who did not write it

One live bad-token run against `https://matrix.freundcloud.org.uk` (registration has no rate limit, so one run was the whole test — no accounts were created):

**Before** (exit 1, cause buried in UIA internals):

```
registration failed: {"flows":[{"stages":["m.login.registration_token"]}],"params":{},"session":"VzMSj8vzmTZ1YqyKKfvOOuZ2q6XLeoRi","errcode":"M_FORBIDDEN","error":"Invalid registration token"}
```

**After** (exit 1, cause and remedy in sentences):

```
registration refused: the server rejected the registration token (Invalid registration token).
The token in REGISTRATION-TOKEN (or MATRIX_REGISTRATION_TOKEN) is wrong or has
been rotated. Pull the latest copy of this folder, or ask the maintainers
for the current token -- see README.md.
```

The fixed branches were verified by replaying that captured live reply through a stubbed `curl` rather than hitting the server again. The replay also surfaced two pre-existing bare failures, both fixed:

- a non-JSON reply (a proxy answering for a down homeserver) killed the script with a raw Python traceback; it now says the server did not offer a registration session and what that means;
- a connection failure was a bare `curl: (7)`; it keeps curl's line and adds what to check.

`M_USER_IN_USE` and `M_INVALID_USERNAME` also get named remedies; an unknown errcode prints errcode + message; a reply the parser cannot read at all prints the raw body. The consent-gate assertions in `checks.bus-redact` (which drive this same script) still pass against the modified file.

## Verification run before pushing

- `nix build .#checks.x86_64-linux.bus-mcp` — green (and red under both injected drifts)
- `nix build .#checks.x86_64-linux.bus-redact` — green with the modified register.sh
- `nix fmt -- --ci`, `statix check .`, `deadnix --fail .` — clean
- `shellcheck -S warning share/agent-bus/register.sh` — clean
- `actionlint` over `.github/workflows/` with the repo's own ignore set — clean

No VM tests were started.

Closes nothing on its own — #268 is the epic; this ticks its two agent-executable boxes in SPEC.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kk9Y1QyUGcCaKmqty5eXG