### PR TITLE
.#update runs every updateScript that exists, not one named by hand

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -56,8 +56,17 @@ jobs:
           # A stale hash left behind by a broken rewrite fails here rather than
           # in a user's rebuild. The updater refuses to bump a version without
           # its hashes, but this is the check that actually proves it.
-          nix build --impure --print-build-logs \
-            .#once .#grok-bot
+          #
+          # Derived from the same set the updater ran, not named by hand: the
+          # old list here was `.#once .#grok-bot`, which built a package this
+          # job could never change (grok-bot has no updateScript) and skipped
+          # one it could (hey-cli). Building every covered package rather than
+          # only what changed is deliberate -- the set is two small binary
+          # repacks, and it avoids trusting a filename-to-attribute convention
+          # nothing enforces.
+          mapfile -t attrs < <(nix eval --json .#update.pinned | jq -r '.[] | ".#" + .')
+          echo "building: ${attrs[*]}"
+          nix build --impure --print-build-logs "${attrs[@]}"
 
       - name: Open a pull request
         if: steps.bump.outputs.changed == 'true'

--- a/README.md
+++ b/README.md
@@ -1310,12 +1310,13 @@ Most of it is not our job, and should not be:
 | where the app comes from | who updates it |
 |---|---|
 | nixpkgs (49 of 59 apps) | **nobody** — your own `nix flake update` |
-| pinned in this repo (2) | a weekly bot, opening a PR |
+| pinned in this repo (2) | a nightly bot, opening a PR |
 | `zen` | upstream's own flake |
 | `retroarch` | nixpkgs, via this flake's own pin — it is a rebuild with cores |
 
 For the handful pinned here by version and hash, `.github/workflows/update.yml`
-runs `nix run .#update` weekly, builds everything it changed, and opens a
+runs `nix run .#update` nightly — every package with an `updateScript`, listed
+by `nix eval .#update.pinned` — builds each of them, and opens a
 PR. Those PRs are **not** auto-merged: a build proves a package assembles, not
 that it still launches, and two of them are proprietary Electron bundles that
 can do the first without the second.

--- a/flake.nix
+++ b/flake.nix
@@ -899,10 +899,39 @@
           # `ours` app, without every consumer needing the extra flake input.
           zen-browser = zen-browser.packages.${system}.default;
 
-          # `nix run .#update` -- rewrites the pinned version and hashes in
-          # place. CI runs it weekly and opens a PR. Only `once` is pinned by
-          # hand now; everything else follows nixpkgs or upstream's own flake.
-          update = pkgsFor.${system}.nixarchy-apps.once.updateScript;
+          # `nix run .#update` -- rewrites the pinned versions and hashes in
+          # place. CI runs it nightly and opens a PR (update.yml).
+          #
+          # Derived, not enumerated: every nixarchy-apps package carrying a
+          # passthru.updateScript is run, so a new hand-pinned package is
+          # covered the day it lands, without an edit here. This line used to
+          # name `once` alone -- beside a comment claiming once was the only
+          # hand pin -- while hey-cli sat pinned with an updateScript nothing
+          # reached, and needed a human (#195, 2026-09-05).
+          #
+          # `nix eval .#update.pinned` lists the covered attributes; update.yml
+          # builds exactly those after a rewrite, off the same set. Packages
+          # pinned by hand WITHOUT an updateScript are still invisible to this
+          # -- as of this writing grok-bot, omacalc, omacut, omawrite and ttfx
+          # carry none.
+          update =
+            let
+              pinned = lib.filterAttrs (_: p: p ? updateScript) pkgsFor.${system}.nixarchy-apps;
+            in
+            pkgsFor.${system}.writeShellApplication {
+              name = "nixarchy-update";
+              text = ''
+                rc=0
+                ${lib.concatMapStrings (p: ''
+                  ${lib.getExe p.updateScript} || rc=1
+                '') (lib.attrValues pinned)}
+                exit "$rc"
+              '';
+              # `|| rc=1` rather than fail-fast: one upstream breaking its
+              # release layout (hey-cli's 1.4.1 SBOMs did exactly that) must
+              # not block every other package's bump for the night.
+              derivationArgs.passthru.pinned = lib.attrNames pinned;
+            };
 
           # Boot the smoke test: `nix run .#vm`
           vm = self.nixosConfigurations.vm.config.system.build.vm;


### PR DESCRIPTION
Follow-up to the finding in #341: `nix run .#update` — the thing update.yml runs nightly since #335 — was wired to `nixarchy-apps.once.updateScript` alone, under a comment claiming once was the only hand pin. hey-cli sat pinned with a `passthru.updateScript` nothing could reach, and needed a human on 2026-09-05 (#195) exactly because of this. A nightly cadence that can bump one package delivers a fraction of what #335's argument claimed.

## What changed

- **flake.nix**: `update` is now derived — `lib.filterAttrs (_: p: p ? updateScript)` over `nixarchy-apps`, running each script. A future package that lands with an updateScript is covered without anyone editing flake.nix. One updater failing no longer blocks the rest (`|| rc=1`, exit 1 overall) — hey-cli 1.4.1's SBOM layout change showed how one upstream can break its own rewrite for a night. `nix eval .#update.pinned` names the covered set.
- **update.yml**: the proof build reads `.#update.pinned` instead of the hand-list `.#once .#grok-bot`, which built a package this job could never change (grok-bot has no updateScript) and skipped one it could (hey-cli). I chose *build every covered package* over *build only what changed*: the set is two small binary repacks, and it avoids trusting a filename→attribute convention nothing enforces.
- **flake.nix comment + README**: the stale claims fixed — "weekly" → nightly, "only `once` is pinned by hand" → the truth, including that grok-bot, omacalc, omacut, omawrite and ttfx are hand-pinned with **no** updateScript and remain outside this job's reach.

## Proof

- `nix eval --json .#update.pinned` → `["hey-cli","once"]` (derived, matches team-lead's independent count of two).
- Ran the new `.#update` against a tree pinned at hey-cli 1.4.0 (with #341's anchored grep — the unanchored one is a separate bug fixed there):
  ```
  hey-cli: 1.4.0 -> 1.4.1
  hey-cli: rewrote pkgs/apps/hey-cli.nix to 1.4.1
  once: already at 0.3.2
  exit: 0
  ```
  and the file held the checksums.txt hashes afterwards.
- The workflow's `mapfile`/`jq` pipeline run under bash locally prints `building: .#hey-cli .#once`.
- `nix fmt -- --ci` (0 changed), statix, deadnix, and actionlint on update.yml all clean. `data/apps.nix` untouched.

## Ordering note

Independent of #341, but until #341 lands, a nightly run of this derived updater will hit hey-cli's unanchored-grep sed failure (exit 1, once still bumped — the `|| rc=1` path working as designed). Merging #341 first avoids one noisy night.

## Checked while in there

Only `once` and `hey-cli` carry updateScripts. once's takes hashes via `nix-prefetch-url` on direct binary URLs — no checksums.txt grep — so the unanchored-grep/SBOM shape existed only in hey-cli, already fixed in #341. Nothing else to patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFX6WZHR1gRmeAm8QEPJpY