### PR TITLE
Four more pins the nightly can move: updateScripts for the omacom apps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -910,10 +910,10 @@
           # reached, and needed a human (#195, 2026-09-05).
           #
           # `nix eval .#update.pinned` lists the covered attributes; update.yml
-          # builds exactly those after a rewrite, off the same set. Packages
-          # pinned by hand WITHOUT an updateScript are still invisible to this
-          # -- as of this writing grok-bot, omacalc, omacut, omawrite and ttfx
-          # carry none.
+          # builds exactly those after a rewrite, off the same set. A package
+          # pinned by hand WITHOUT an updateScript is still invisible to this
+          # -- as of this writing only grok-bot, whose Cursor CDN pin has no
+          # queryable "latest" (pkgs/review.sh probes its age instead).
           update =
             let
               pinned = lib.filterAttrs (_: p: p ? updateScript) pkgsFor.${system}.nixarchy-apps;

--- a/pkgs/apps/omacalc.nix
+++ b/pkgs/apps/omacalc.nix
@@ -5,6 +5,8 @@
   qt6,
   makeDesktopItem,
   copyDesktopItems,
+  nix-update,
+  writeShellApplication,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "omacalc";
@@ -66,6 +68,19 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm755 omacalc $out/bin/omacalc
     runHook postInstall
   '';
+
+  # Same shape as omawrite's, and the reasoning lives there. One note of its
+  # own: this repo has no GitHub releases, only tags -- nix-update still
+  # resolves the newest (GitHub's releases.atom is fed by tags), proven by
+  # winding version back to 0.2.1 and watching it restore 0.2.2's exact hash.
+  passthru.updateScript = writeShellApplication {
+    name = "update-omacalc";
+    runtimeInputs = [ nix-update ];
+    text = ''
+      [ -f flake.nix ] || { echo "omacalc: run from the repo root" >&2; exit 1; }
+      nix-update --flake omacalc
+    '';
+  };
 
   meta = {
     description = "Calculator built with Qt Quick, from the Omarchy family";

--- a/pkgs/apps/omacut.nix
+++ b/pkgs/apps/omacut.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   qt6,
   ffmpeg,
+  nix-update,
+  writeShellApplication,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "omacut";
@@ -51,6 +53,17 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  # Same shape as omawrite's, and the reasoning lives there. Proven by winding
+  # version back to 0.3.0 and watching it restore 0.4.0's exact hash.
+  passthru.updateScript = writeShellApplication {
+    name = "update-omacut";
+    runtimeInputs = [ nix-update ];
+    text = ''
+      [ -f flake.nix ] || { echo "omacut: run from the repo root" >&2; exit 1; }
+      nix-update --flake omacut
+    '';
+  };
 
   meta = {
     description = "Cut a video to the right trim, built with Qt Quick";

--- a/pkgs/apps/omawrite.nix
+++ b/pkgs/apps/omawrite.nix
@@ -3,6 +3,8 @@
   stdenv,
   fetchFromGitHub,
   qt6,
+  nix-update,
+  writeShellApplication,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "omawrite";
@@ -53,6 +55,29 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  # Found and run by `nix run .#update` (see .#update.pinned in flake.nix).
+  #
+  # Unlike once's and hey-cli's hand-rolled fetch-and-sed, this delegates to
+  # nix-update: the pin is a plain GitHub tag plus a source hash, exactly the
+  # case it handles structurally. It rewrites version and hash by nix position
+  # rather than by grepping a release manifest, so there is no pattern to
+  # anchor and nothing for upstream growing a new file beside its artefacts to
+  # collide with -- which is how hey-cli's updater broke on 1.4.1's SBOMs.
+  # once and hey-cli keep their own scripts on purpose: their hashes come from
+  # upstream's signed checksums.txt, a provenance nix-update cannot give.
+  #
+  # Proven by winding version back to 0.4.0 and watching it restore the exact
+  # committed hash for 0.5.0. Its siblings (omacalc, omacut, ttfx) carry the
+  # same script and point here.
+  passthru.updateScript = writeShellApplication {
+    name = "update-omawrite";
+    runtimeInputs = [ nix-update ];
+    text = ''
+      [ -f flake.nix ] || { echo "omawrite: run from the repo root" >&2; exit 1; }
+      nix-update --flake omawrite
+    '';
+  };
 
   meta = {
     description = "Dead-simple Markdown writing app built with Qt Quick";

--- a/pkgs/apps/ttfx.nix
+++ b/pkgs/apps/ttfx.nix
@@ -3,6 +3,8 @@
   rustPlatform,
   installShellFiles,
   fetchFromGitHub,
+  nix-update,
+  writeShellApplication,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ttfx";
@@ -27,6 +29,21 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --bash <($out/bin/ttfx --print-completion bash) \
       --zsh  <($out/bin/ttfx --print-completion zsh)
   '';
+
+  # Same shape as omawrite's, and the reasoning lives there. The one thing
+  # this package adds is cargoHash, and it is the reason nix-update earns its
+  # keep here: it recomputes the vendored-dependency hash too, which a
+  # hand-rolled sed script has no honest way to know. Proven by winding
+  # version back to 0.3.1 and watching it restore 0.3.2's exact hash AND
+  # cargoHash.
+  passthru.updateScript = writeShellApplication {
+    name = "update-ttfx";
+    runtimeInputs = [ nix-update ];
+    text = ''
+      [ -f flake.nix ] || { echo "ttfx: run from the repo root" >&2; exit 1; }
+      nix-update --flake ttfx
+    '';
+  };
 
   meta = {
     description = "Terminal text effects as a single static binary, a Rust port of terminaltexteffects";


### PR DESCRIPTION
~~Stacked on #343 — merge #343 first.~~ #343 is merged (ef621dc); this branch is rebased onto main and carries exactly one commit: the four updateScripts plus the flake comment naming grok-bot as the sole remaining exception.

Coverage goes 2/7 → 6/7 of the packages this repo pins by hand.

## What each package got, and why this shape

omacalc, omacut, omawrite and ttfx each carry a thin wrapper over `nix-update --flake <name>`. Not hand-rolled fetch-and-sed like once's and hey-cli's: these pins are plain GitHub tags plus source hashes, which nix-update rewrites **structurally, by nix position** — no release-manifest grep, so there is no pattern to anchor and nothing for upstream growing a new file beside its artifacts to collide with (the way hey-cli's updater broke on 1.4.1's SBOMs, #341). ttfx is where the tool earns its keep: it recomputes `cargoHash` through a fixed-output rebuild, which a sed script has no honest way to know.

once and hey-cli deliberately keep their own scripts: their hashes come from upstream's **signed** checksums.txt, a provenance nix-update cannot give.

## grok-bot stays uncovered, deliberately

Its pin is a Cursor CDN commit hash with no queryable "latest" — pkgs/review.sh already says so and probes file age instead, and four plausible latest-endpoints answer 403/404. An updateScript that guesses a URL shape will one day rewrite a hash to something that builds and is not what upstream shipped. The flake comment now names grok-bot as the sole remaining exception so nobody "finishes the job" by guessing.

## Proof (each against its real upstream)

- Wound each back one real tag: omacalc 0.2.1→0.2.2 (tags only, **no** GitHub releases — releases.atom still resolves), omacut 0.3.0→0.4.0, omawrite 0.4.0→0.5.0, ttfx 0.3.1→0.3.2 incl. cargoHash. Every run restored the exact committed hashes (empty `git diff` after).
- `nix eval .#update.pinned` → `["hey-cli","omacalc","omacut","omawrite","once","ttfx"]` with zero edits to #343's mechanism — the derivation picked all four up, which was its acceptance criterion.
- Full `nix run .#update` with omacut wound back: all six ran, omacut rewritten, hey-cli failed on its pre-#341 sed bug while the other five completed, overall exit **1** (measured from the command directly, not a pipeline stage).
- Idempotent at current versions: "0.2.2 -> 0.2.2, no changes", exit 0.
- All four packages still build; `nix fmt -- --ci` 0 changed; statix and deadnix clean. `data/apps.nix` untouched.

## Cost note

The nightly's proof build grows from two binary repacks to also include three small Qt apps and one Rust build — on update.yml's GitHub-hosted runner, not the self-hosted one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFX6WZHR1gRmeAm8QEPJpY
