### PR TITLE
The try front door: boot either ISO in a local VM, refusing in sentences

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,17 @@ jobs:
       - name: The installer refuses a build the live store cannot hold
         run: nix build .#checks.x86_64-linux.installer-store-space --print-build-logs
 
+      # The `nix run #try` front door, on the machines it will actually meet:
+      # no KVM, no kvm group, 1 GB of RAM, a tmpfs working directory, a
+      # declined binary cache, a disk left by a ctrl-C'd install. Each must
+      # refuse in a sentence naming the number and the way out, and a
+      # preflight nobody has seen fail is a preflight nobody knows works --
+      # so every path is driven here with a stubbed environment, in seconds.
+      # The happy path (a bootable UEFI window) needs KVM and a display no
+      # sandbox has; what CAN be asserted cheaply is asserted on every PR.
+      - name: The try front door refuses in sentences, not stack traces
+        run: nix build .#checks.x86_64-linux.try-preflight --print-build-logs
+
       # --from-repo, the install mode that clones the user's OWN configuration
       # repository and installs the host it finds there. Both of its branches
       # -- host already in the repo, host added to it -- had zero coverage

--- a/README.md
+++ b/README.md
@@ -1180,6 +1180,35 @@ from `$HOME/.config` and nothing else. Only the entry point differs.
 
 ## Try it in a VM
 
+The front door needs no repository knowledge at all -- it boots the same
+installer ISO a release ships, in a local UEFI VM, and you answer the wizard
+yourself:
+
+```sh
+nix run github:olafkfreund/nixarchy#try            # offline image, ~5.6 GB download
+nix run github:olafkfreund/nixarchy#try -- --net   # network image, ~1.9 GB download
+```
+
+The offline image installs with no network at all; the network image fetches
+the rest from binary caches during the install. Both write to a
+`nixarchy-try.qcow2` in the current directory (up to 24 GB), and when the
+install finishes, `-- --boot` starts the installed system from that disk;
+`-- --fresh` wipes it and installs again. `-- --help` lists the rest.
+
+Before anything heavy starts it says what is about to happen and refuses what
+cannot work: whether the image is a download or would be a source build --
+and when the commit you are on has no cached image, it falls back to the
+latest release's prebuilt, install-tested one (verified against the
+release's checksums) instead of quietly compiling for hours. It checks there
+is enough RAM (8 GB by default, `--memory` to shrink it) and disk first,
+and whether `/dev/kvm` is usable -- without it the VM still runs, with a
+loud warning, several times slower. On a machine with no display it serves
+the screen over VNC on `127.0.0.1:5900` instead of dying.
+
+The two apps below are different animals: `#vm` boots a prebuilt smoke-test
+*of the installed system* -- no installer, no disk -- and is mainly a
+development tool.
+
 ```sh
 # graphical -- this is the one that shows the desktop
 QEMU_OPTS="-device virtio-vga-gl -display gtk,gl=on" \

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,32 @@
 {
   description = "Nixarchy - Omarchy, vendored for NixOS";
 
+  # For the person who has never seen this repository and types
+  # `nix run github:olafkfreund/nixarchy#try` (or #doctor, or #vm): without
+  # this, nothing tells their nix that this flake's packages and closures
+  # are already built and cached, and Hyprland alone becomes a compile.
+  # nixConfig is honoured only from the flake you invoke -- the same rule
+  # the sops-nix comment below leans on from the other side -- so the
+  # module's `programs.nixarchy.binaryCaches` cannot reach a bare `nix run`;
+  # only this can. Nix asks before trusting either entry (or accepts them
+  # silently for users already trusting the caches), and a "no" costs
+  # nothing but the download it was offered.
+  #
+  # What this does NOT cover, measured rather than assumed: the ISO images
+  # themselves are not pushed to cachix -- they ship as release assets --
+  # so `#try` detects that case with a dry-run and falls back to the
+  # release download instead of leaning on these substituters.
+  nixConfig = {
+    extra-substituters = [
+      "https://nixarchy.cachix.org"
+      "https://hyprland.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM="
+      "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE="
+    ];
+  };
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
@@ -956,6 +982,54 @@
                   (builtins.readFile ./installer/vm-preflight.sh);
             };
 
+          # The front door: `nix run github:olafkfreund/nixarchy#try` boots
+          # the installer ISO in a local UEFI VM, wizard and all, for someone
+          # who knows nothing about this repository. `-- --net` takes the
+          # network image instead.
+          #
+          # Deliberately NOT depending on the ISO derivation: referencing it
+          # here would make `nix run .#try` download -- or worse, silently
+          # build -- 5.6 GB before the script's first line ran. The script
+          # resolves the image itself at runtime, dry-run first, so "this is
+          # a download of X" or "STOP, this would be a source build" is said
+          # BEFORE either happens. See installer/try.sh for the rest of the
+          # refusals; checks.try-preflight exercises each of them.
+          #
+          # Also not a wrapper around .#installer-vm: that VM answers the
+          # wizard itself from a baked answers file -- a test harness, and
+          # exactly the thing a person trying nixarchy must not get.
+          try =
+            let
+              pkgs = pkgsFor.${system};
+            in
+            pkgs.writeShellApplication {
+              name = "nixarchy-try";
+              runtimeInputs = with pkgs; [
+                coreutils # df, install, mktemp, nproc, sha256sum
+                curl # the release-image fallback
+                gnugrep
+                gnused
+                gawk
+              ];
+              text =
+                builtins.replaceStrings
+                  [
+                    "@rev@"
+                    "@qemu@"
+                    "@qemu_img@"
+                    "@ovmf_code@"
+                    "@ovmf_vars@"
+                  ]
+                  [
+                    (self.rev or "")
+                    "${pkgs.qemu_kvm}/bin/qemu-system-x86_64"
+                    "${pkgs.qemu_kvm}/bin/qemu-img"
+                    "${pkgs.OVMF.firmware}"
+                    "${pkgs.OVMF.variables}"
+                  ]
+                  (builtins.readFile ./installer/try.sh);
+            };
+
           # Every command the vendored scripts exec by name, in one prefix.
           # The bins are unwrapped on purpose, so an incomplete runtimeDeps list
           # produces a package that builds cleanly and then fails at the click
@@ -1322,6 +1396,17 @@
             pkgs = pkgsFor.${system};
             installScript = ./installer/install.sh;
             dashboardScript = ./installer/lib/dashboard.sh;
+          };
+
+          # The `try` front door's refusals, each driven with a stubbed
+          # environment that lies about KVM, RAM, disk and the build plan.
+          # Building tryApp is itself half the assertion: the app evaluates
+          # and its script passes shellcheck, by writeShellApplication's own
+          # checkPhase. See tests/try-preflight.nix.
+          try-preflight = import ./tests/try-preflight.nix {
+            pkgs = pkgsFor.${system};
+            tryScript = ./installer/try.sh;
+            tryApp = self.packages.${system}.try;
           };
 
           # --from-repo's two branches -- host already in the repository, host

--- a/installer/try.sh
+++ b/installer/try.sh
@@ -1,0 +1,566 @@
+# shellcheck shell=bash
+# Boot the nixarchy installer in a local virtual machine, for someone who
+# knows nothing about this repository:
+#
+#   nix run github:olafkfreund/nixarchy#try            the offline image
+#   nix run github:olafkfreund/nixarchy#try -- --net   the network image
+#
+# The qemu line is the small part of this file. The large part is refusing
+# early, in sentences, on the machines this will actually meet: no /dev/kvm,
+# /dev/kvm without the group, too little RAM, too little disk, an image that
+# would be a three-hour source build rather than a download, and a disk left
+# behind by a previous or interrupted run. Every refusal names the number it
+# measured and the way out. checks.try-preflight drives each of these paths
+# with a stubbed environment, so the messages below are asserted text, not
+# hope -- change one and the check will tell you.
+#
+# Deliberately NOT a wrapper around `.#installer-vm`: that VM answers the
+# wizard itself from a baked-in answers file, which is exactly what a person
+# trying nixarchy must not get. This boots the same ISO a release ships and
+# leaves the questions to the human.
+#
+# The script does not depend on the ISO derivation. If it did, `nix run #try`
+# would download (or worse, build) 5.6 GB before one line of this file ran,
+# and the whole point of the preflight -- say what is about to happen BEFORE
+# it happens -- would be lost. Instead the ISO is resolved at runtime with a
+# dry-run first, from the very source this script was built from.
+#
+# @-placeholders are substituted by flake.nix; everything above `main` is
+# sourced verbatim by tests/try-preflight.nix (NIXARCHY_TRY_SOURCED=1), which
+# is why the probes read their paths from TRY_* variables: the check lies to
+# them the same way tests/installer-store-space.nix lies to install.sh.
+
+REV="@rev@"
+GH_API="${TRY_GH_API:-https://api.github.com/repos/olafkfreund/nixarchy/releases/latest}"
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/nixarchy-try"
+QEMU="@qemu@"
+QEMU_IMG="@qemu_img@"
+OVMF_CODE="@ovmf_code@"
+OVMF_VARS="@ovmf_vars@"
+
+DISK=nixarchy-try.qcow2
+VARS=nixarchy-try-efivars.fd
+# Matches installer/vm.nix's emptyDiskImages, for the same measured reason:
+# a 2G ESP plus ~14 GiB of closure, with room for a rebuild on top.
+DISK_MB=24576
+MEM_MB=8192
+MEM_MIN=4096
+
+say() { echo "try: $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Probes. Each returns a word or a verdict and is tested with a stubbed
+# environment; none of them touches qemu or nix.
+
+# kvm | nogroup | none. Existence alone is not the answer: on most distros
+# /dev/kvm exists and the user is simply not in the `kvm` group, and qemu's
+# accel=kvm:tcg fallback would then run 10x slower without a word.
+detect_kvm() {
+  local dev="${TRY_KVM_DEV:-/dev/kvm}"
+  if [ ! -e "$dev" ]; then
+    echo none
+  elif [ ! -r "$dev" ] || [ ! -w "$dev" ]; then
+    echo nogroup
+  else
+    echo kvm
+  fi
+}
+
+explain_kvm() {
+  case "$1" in
+    kvm)
+      say "hardware virtualisation: yes (/dev/kvm)"
+      ;;
+    none)
+      say "WARNING: no /dev/kvm -- this machine offers no hardware virtualisation."
+      say "  Falling back to software emulation, which is SEVERAL TIMES SLOWER."
+      say "  The VM will feel sluggish; nixarchy on real hardware is not."
+      say "  If the CPU has VT-x/AMD-V, enable it in the firmware setup."
+      ;;
+    nogroup)
+      say "WARNING: /dev/kvm exists but you may not open it -- you are probably"
+      say "  not in the 'kvm' group. Falling back to software emulation, which"
+      say "  is SEVERAL TIMES SLOWER. The VM will feel sluggish; nixarchy on"
+      say "  real hardware is not. To fix it:"
+      # shellcheck disable=SC2016  # $USER is theirs to expand, not ours
+      say '    sudo usermod -aG kvm $USER    # then log out and back in'
+      ;;
+  esac
+}
+
+# Refuse rather than OOM: a guest that outgrows the host dies mid-install
+# under errors that name neither RAM nor the guest. A meminfo with no
+# MemAvailable line proceeds -- a probe that cannot read must not invent a
+# refusal (the tolerance rule tests/installer-store-space.nix already states).
+check_ram() {
+  local need=$1 meminfo="${TRY_MEMINFO:-/proc/meminfo}" avail_kb avail
+  avail_kb=$(awk '/^MemAvailable:/ { print $2 }' "$meminfo" 2>/dev/null || :)
+  [ -n "$avail_kb" ] || return 0
+  avail=$((avail_kb / 1024))
+  if [ "$avail" -lt $((need + 512)) ]; then
+    say "not enough free memory: the VM wants ${need} MB and this machine has"
+    say "  ${avail} MB available. Close something, or run a smaller VM:"
+    say "    nix run github:olafkfreund/nixarchy#try -- --memory ${MEM_MIN}"
+    say "  (${MEM_MIN} MB is the floor: below it the install dies partway through"
+    say "  with errors that name none of this.)"
+    return 1
+  fi
+}
+
+# The same probe installer/vm-preflight.sh runs, for the same reason: sparse
+# images fail LATE, from inside the guest, under an error naming nothing. And
+# on a tmpfs the number df prints is RAM, not disk.
+check_disk() {
+  local dir=$1 need=$2 what=$3 fstype avail
+  read -r fstype avail < <(df --output=fstype,avail -BM "$dir" | tail -n1)
+  avail=${avail%M}
+  case "$fstype" in
+    tmpfs | ramfs)
+      say "$dir is on $fstype -- RAM, not disk. $what would be written there,"
+      say "  competing with the memory the VM itself needs. df calls it free"
+      say "  space; it is not. Run this from a directory on a real filesystem."
+      return 1
+      ;;
+  esac
+  if [ "$avail" -lt "$need" ]; then
+    say "not enough disk space: $what needs up to ${need} MB and $dir has"
+    say "  ${avail} MB free. Free some space, or run this somewhere larger."
+    return 1
+  fi
+}
+
+# The flakeref the image is built from: the commit this script was built
+# from, by rev. NOT the source store path, though it would be local and
+# cheaper: a path flakeref has no git metadata, so `self.rev` is missing
+# under it, and installer/mkFlake.nix rightly refuses to generate a flake
+# that cannot pin nixarchy by commit -- measured, not theorised: the store
+# path route died with "flake-template: build from a committed tree" on a
+# fully committed tree. The rev costs nothing a stranger has not already
+# paid: `nix run github:...#try` resolved and cached this exact rev to run
+# the script at all.
+resolve_ref() {
+  local rev=$1
+  if [ -z "$rev" ]; then
+    say "this was built from a tree with uncommitted changes, and the installer"
+    say "  image embeds the commit it is built from, so it cannot be built from"
+    say "  a dirty checkout. Commit your changes and run it again -- or run the"
+    say "  published one: nix run github:olafkfreund/nixarchy#try"
+    return 1
+  fi
+  echo "github:olafkfreund/nixarchy/$rev"
+}
+
+# What `nix build --dry-run` is about to do, in one word:
+#   build        the image itself would be compiled from source -- hours
+#   fetch (...)  a download, with nix's own size figures attached
+#   ready        already in the local store
+# Anything unparseable is `ready`: a plan we cannot read must not become a
+# new way to refuse a run that would work.
+classify_plan() {
+  local f=$1 built_section built fetched
+  built_section=$(sed -n '/will be built/,/^[^ ]/p' "$f")
+  built=$(grep -cE '^ */nix/store/.*\.drv' <<<"$built_section" || :)
+  if [ "${built:-0}" -gt 0 ] && grep -qE 'iso|squashfs' <<<"$built_section"; then
+    echo build
+    return 0
+  fi
+  fetched=$(grep -oE 'will be fetched \([^)]*\)' "$f" | head -n1 || :)
+  if [ -n "$fetched" ]; then
+    echo "fetch ${fetched#will be fetched }"
+  elif [ "${built:-0}" -gt 50 ]; then
+    # No single telltale name, but nobody's cache miss builds this many
+    # derivations for an image that exists in a cache.
+    echo build
+  else
+    echo ready
+  fi
+}
+
+# "(1.87 GiB download, 5.61 GiB unpacked)" -> unpacked size in MB, rounded
+# up, or nothing when the text carries no such figure.
+plan_unpacked_mb() {
+  # shellcheck disable=SC2312  # a plan with no size figure prints nothing
+  grep -oE '[0-9.]+ [KMGT]iB unpacked' <<<"$1" | awk '
+    { n = $1; u = $2 }
+    END {
+      if (u == "KiB") n /= 1024
+      else if (u == "GiB") n *= 1024
+      else if (u == "TiB") n *= 1024 * 1024
+      if (n > 0) printf "%d\n", n + 1
+    }' || :
+}
+
+# From a GitHub release JSON in file $1, the download URLs for $2 -- `iso`
+# (the offline parts, in order), `iso-net`, or `sums`. Prints nothing when
+# the release does not carry the asset, which is a real state: recent
+# releases name a -net.iso in SHA256SUMS and do not attach one.
+release_urls() {
+  local f=$1 what=$2 urls
+  urls=$(grep -oE '"browser_download_url": *"[^"]*"' "$f" | grep -oE 'https://[^"]*' || :)
+  case "$what" in
+    iso-net) grep -E -- '-net\.iso$' <<<"$urls" || : ;;
+    iso) grep -E '\.iso(\.part-[a-z]+)?$' <<<"$urls" | grep -vE -- '-net\.iso$' | sort || : ;;
+    sums) grep -E '/SHA256SUMS$' <<<"$urls" | head -n1 || : ;;
+  esac
+}
+
+release_tag() {
+  grep -oE '"tag_name": *"[^"]*"' "$1" | head -n1 | cut -d'"' -f4 || :
+}
+
+# Download the latest release image for $1 (iso | iso-net) into CACHE_DIR,
+# verify it against the release's SHA256SUMS, and print its path. A file
+# that already verified on a previous run is reused; an interrupted or
+# corrupt download is deleted, never reused -- the qcow2 rule again, one
+# layer down. All progress goes to stderr; stdout is the path alone.
+fetch_release() {
+  local attr=$1 json tag urls sums_url base iso_name tmp want got u len total_mb
+  json=$(mktemp)
+  if ! curl -fsSL "$GH_API" -o "$json"; then
+    rm -f "$json"
+    say "could not reach the GitHub releases API to look for a prebuilt image."
+    return 1
+  fi
+  tag=$(release_tag "$json")
+  urls=$(release_urls "$json" "$attr")
+  sums_url=$(release_urls "$json" sums)
+  if [ -z "$tag" ] || [ -z "$urls" ] || [ -z "$sums_url" ]; then
+    rm -f "$json"
+    say "the latest release carries no downloadable '$attr' image."
+    return 1
+  fi
+  rm -f "$json"
+
+  base=$(basename "$(head -n1 <<<"$urls")")
+  iso_name=${base%.part-*}
+  mkdir -p "$CACHE_DIR"
+  if [ -e "$CACHE_DIR/$iso_name" ]; then
+    say "reusing the release image already downloaded and verified:"
+    say "  $CACHE_DIR/$iso_name"
+    echo "$CACHE_DIR/$iso_name"
+    return 0
+  fi
+
+  total_mb=0
+  while IFS= read -r u; do
+    len=$(curl -fsIL "$u" | grep -i '^content-length:' | tail -n1 | grep -oE '[0-9]+' || :)
+    if [ -n "$len" ]; then total_mb=$((total_mb + len / 1048576)); fi
+  done <<<"$urls"
+  say "downloading release $tag image $iso_name (about ${total_mb} MB)"
+  say "  into $CACHE_DIR -- kept there, so a second run skips this."
+  if [ "$total_mb" -gt 0 ]; then
+    check_disk "$CACHE_DIR" $((total_mb + 512)) "the downloaded image" || return 1
+  fi
+
+  curl -fsSL "$sums_url" -o "$CACHE_DIR/SHA256SUMS" || {
+    say "could not download the release's SHA256SUMS; not fetching an image"
+    say "  that cannot be verified."
+    return 1
+  }
+  tmp="$CACHE_DIR/$iso_name.part"
+  rm -f "$tmp"
+  while IFS= read -r u; do
+    say "  fetching $(basename "$u") ..."
+    if ! curl -fL --progress-bar "$u" >>"$tmp"; then
+      rm -f "$tmp"
+      say "download failed partway; the partial file was deleted. Check the"
+      say "  connection and run it again."
+      return 1
+    fi
+  done <<<"$urls"
+  want=$(grep " ${iso_name}\$" "$CACHE_DIR/SHA256SUMS" | awk '{ print $1 }' || :)
+  got=$(sha256sum "$tmp" | awk '{ print $1 }')
+  if [ -z "$want" ] || [ "$got" != "$want" ]; then
+    rm -f "$tmp"
+    say "the downloaded image did not match the release's checksum, so it was"
+    say "  deleted. Run it again; if this repeats, report it:"
+    say "  https://github.com/olafkfreund/nixarchy/issues"
+    return 1
+  fi
+  mv "$tmp" "$CACHE_DIR/$iso_name"
+  say "checksum verified."
+  echo "$CACHE_DIR/$iso_name"
+}
+
+# ---------------------------------------------------------------------------
+
+usage() {
+  cat <<EOF
+Try nixarchy in a virtual machine. No repository knowledge required.
+
+  nix run github:olafkfreund/nixarchy#try            offline image (~5.6 GB download,
+                                                     installs with no network at all)
+  nix run github:olafkfreund/nixarchy#try -- --net   network image (~1.9 GB download;
+                                                     the install then fetches the rest
+                                                     from binary caches)
+
+What happens: the installer ISO boots in a window (UEFI), you answer its
+questions, and it installs onto a virtual disk -- $DISK, up to
+${DISK_MB} MB, created in the current directory. When the install finishes
+and the machine powers off:
+
+  nix run github:olafkfreund/nixarchy#try -- --boot    boot the installed system
+  nix run github:olafkfreund/nixarchy#try -- --fresh   wipe the disk, install again
+
+Options:
+  --net          install from the small network image instead of the offline one
+  --boot         boot the already-installed disk instead of the installer
+  --fresh        delete the disk a previous run left, then install
+  --memory MB    RAM for the VM (default ${MEM_MB}, minimum ${MEM_MIN})
+  --cpus N       virtual CPUs (default: what the host has, up to 4)
+  --vnc          no window: serve the VM's screen on VNC at 127.0.0.1:5900
+  --build        compile this exact commit's image from source (hours) rather
+                 than falling back to the latest release's prebuilt image
+  --help         this text
+
+Needs: x86_64 Linux with nix, about $((MEM_MB + 512)) MB of free RAM,
+${DISK_MB} MB of free disk in the current directory, and /dev/kvm for full
+speed (without it you get a loud warning and slow emulation, not a failure).
+EOF
+}
+
+main() {
+  local attr=iso mem=$MEM_MB cpus="" vnc=0 fresh=0 boot=0 srcbuild=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --net) attr="iso-net" ;;
+      --build) srcbuild=1 ;;
+      --boot) boot=1 ;;
+      --fresh) fresh=1 ;;
+      --vnc) vnc=1 ;;
+      --memory)
+        if [ $# -lt 2 ]; then
+          say "--memory needs a number of megabytes after it."
+          exit 1
+        fi
+        mem=$2
+        shift
+        ;;
+      --cpus)
+        if [ $# -lt 2 ]; then
+          say "--cpus needs a number after it."
+          exit 1
+        fi
+        cpus=$2
+        shift
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      *)
+        say "unknown option: $1"
+        say "  --help lists what this understands."
+        exit 1
+        ;;
+    esac
+    shift
+  done
+
+  case "$mem" in
+    '' | *[!0-9]*)
+      say "--memory wants a number of megabytes, not '${mem}'."
+      exit 1
+      ;;
+  esac
+  if [ "$mem" -lt "$MEM_MIN" ]; then
+    say "--memory ${mem} is below the ${MEM_MIN} MB floor. The installer runs"
+    say "  out of memory below that and fails with errors that name none of"
+    say "  this, so refusing up front instead."
+    exit 1
+  fi
+  if [ -z "$cpus" ]; then
+    cpus=$(nproc)
+    [ "$cpus" -le 4 ] || cpus=4
+  fi
+  case "$cpus" in
+    *[!0-9]* | 0 | '')
+      say "--cpus wants a positive number, not '${cpus}'."
+      exit 1
+      ;;
+  esac
+
+  # The disk decision comes before everything else: it needs no probe, and an
+  # interrupted install must never be silently reused as if it were fresh,
+  # nor silently destroyed as if it were disposable.
+  if [ "$fresh" = 1 ] && [ "$boot" = 1 ]; then
+    say "--fresh wipes the disk and --boot boots it; they contradict. Pick one."
+    exit 1
+  fi
+  if [ "$boot" = 1 ] && [ ! -e "$DISK" ]; then
+    say "--boot: there is no $DISK in this directory to boot."
+    say "  Run without --boot first to install one."
+    exit 1
+  fi
+  if [ "$boot" = 0 ] && [ -e "$DISK" ]; then
+    if [ "$fresh" = 1 ]; then
+      rm -f "$DISK" "$VARS"
+    else
+      say "$DISK already exists here -- a previous run made it, and it may"
+      say "  hold a finished install or an interrupted one. Refusing to guess:"
+      say "    --boot     boot whatever is installed on it"
+      say "    --fresh    delete it and start a clean install"
+      exit 1
+    fi
+  fi
+
+  local kvm
+  kvm=$(detect_kvm)
+  explain_kvm "$kvm"
+  check_ram "$mem" || exit 1
+  check_disk "$PWD" "$DISK_MB" "the VM's target disk ($DISK)" || exit 1
+
+  local iso=""
+  if [ "$boot" = 0 ]; then
+    if ! command -v nix >/dev/null; then
+      say "nix is not on PATH, and the installer image is fetched with nix."
+      exit 1
+    fi
+    local ref
+    ref=$(resolve_ref "$REV") || exit 1
+
+    # Dry-run first, so "download" and "three-hour source build" are told
+    # apart BEFORE either starts. The evaluation itself is the slow part of
+    # this step, so say that too.
+    say "checking whether the installer image is a download or a build"
+    say "  (evaluating -- takes a minute or two the first time) ..."
+    local dry plan
+    dry=$(mktemp)
+    trap 'rm -f "$dry"' EXIT
+    if ! nix build --dry-run \
+      --extra-experimental-features 'nix-command flakes' \
+      "$ref#$attr" >"$dry" 2>&1; then
+      say "evaluating the installer image failed. nix said:"
+      sed 's/^/  | /' "$dry" >&2
+      exit 1
+    fi
+    plan=$(classify_plan "$dry")
+    case "$plan" in
+      build*)
+        say "the image for this exact commit is not in a binary cache -- images"
+        say "  are cached for releases and nightly-tested commits, not every"
+        say "  push -- so nix would COMPILE it from source: hours of building"
+        say "  and tens of gigabytes."
+        if [ "$srcbuild" = 0 ]; then
+          say "falling back to the latest RELEASE image instead: the same"
+          say "  installer, built and install-tested by CI. (--build compiles"
+          say "  this exact commit from source instead.)"
+          iso=$(fetch_release "$attr") || iso=""
+        fi
+        if [ -z "$iso" ]; then
+          if [ "$srcbuild" = 0 ]; then
+            say "no release image could be fetched, so a source build is the"
+            say "  only path left."
+          fi
+          if [ -t 0 ]; then
+            local answer
+            read -r -p "try: build it from source (hours)? [y/N] " answer
+            case "$answer" in
+              y* | Y*) ;;
+              *)
+                say "not building. Nothing was changed."
+                exit 1
+                ;;
+            esac
+          else
+            say "stdin is not a terminal, so not asking. Refusing."
+            exit 1
+          fi
+        fi
+        ;;
+      fetch*)
+        say "downloading the installer image: ${plan#fetch }"
+        local need
+        need=$(plan_unpacked_mb "${plan#fetch }")
+        if [ -n "$need" ]; then
+          check_disk /nix/store $((need + 1024)) "the installer image" || exit 1
+        fi
+        ;;
+      ready)
+        say "installer image already in the local store -- nothing to fetch."
+        ;;
+    esac
+
+    if [ -z "$iso" ]; then
+      local out
+      out=$(nix build --no-link --print-out-paths \
+        --extra-experimental-features 'nix-command flakes' \
+        "$ref#$attr" | head -n1)
+      local f
+      for f in "$out"/iso/*.iso; do iso=$f; done
+      if [ ! -e "$iso" ]; then
+        say "built $out but found no ISO inside it. That is a nixarchy bug;"
+        say "  please report it: https://github.com/olafkfreund/nixarchy/issues"
+        exit 1
+      fi
+    fi
+
+    "$QEMU_IMG" create -q -f qcow2 "$DISK" "${DISK_MB}M"
+  fi
+
+  # UEFI, not a nicety: the installer refuses a BIOS machine, correctly --
+  # its layout is an ESP with systemd-boot and there is no BIOS path. A VM
+  # that boots legacy shows a stranger a refusal as their first experience.
+  # Writable vars beside the disk, so the boot entry the install writes
+  # survives into --boot (tests/install-iso.nix, the readonly=on lesson).
+  if [ ! -e "$VARS" ]; then
+    install -m 644 "$OVMF_VARS" "$VARS"
+  fi
+
+  local display_args=()
+  if [ "$vnc" = 1 ] || { [ -z "${WAYLAND_DISPLAY:-}" ] && [ -z "${DISPLAY:-}" ]; }; then
+    if [ "$vnc" = 0 ]; then
+      say "no graphical display here (neither WAYLAND_DISPLAY nor DISPLAY is set)."
+    fi
+    say "serving the VM's screen over VNC instead: point a VNC viewer at"
+    say "  127.0.0.1:5900 on this machine. From elsewhere:"
+    say "    ssh -L 5900:127.0.0.1:5900 <this-host>   then view localhost:5900"
+    display_args=(-display none -vnc 127.0.0.1:0)
+  else
+    display_args=(-display gtk)
+  fi
+
+  local accel_args=(-accel tcg -cpu max)
+  if [ "$kvm" = kvm ]; then
+    accel_args=(-accel kvm -cpu host)
+  fi
+
+  local drive_args=(
+    -drive "if=pflash,format=raw,readonly=on,file=$OVMF_CODE"
+    -drive "if=pflash,format=raw,file=$VARS"
+    -drive "id=hd0,if=none,format=qcow2,file=$DISK"
+  )
+  if [ "$boot" = 1 ]; then
+    drive_args+=(-device "virtio-blk-pci,drive=hd0,bootindex=0")
+    say "booting the system installed on $DISK"
+  else
+    drive_args+=(
+      -device "virtio-blk-pci,drive=hd0,bootindex=1"
+      -device "virtio-scsi-pci,id=scsi0"
+      -drive "id=cd0,if=none,media=cdrom,readonly=on,format=raw,file=$iso"
+      -device "scsi-cd,bus=scsi0.0,drive=cd0,bootindex=0"
+    )
+    say "starting the installer. Answer its questions in the window; it"
+    say "  installs onto $DISK in this directory. When it finishes and the"
+    say "  machine powers off, boot the result with:"
+    say "    nix run github:olafkfreund/nixarchy#try -- --boot"
+  fi
+  local speed="software emulation (slow)"
+  if [ "$kvm" = kvm ]; then speed=KVM; fi
+  say "VM: ${mem} MB RAM, ${cpus} CPUs, $speed"
+
+  exec "$QEMU" \
+    -name nixarchy-try \
+    -machine q35 \
+    -m "$mem" -smp "$cpus" \
+    "${accel_args[@]}" \
+    "${drive_args[@]}" \
+    "${display_args[@]}" \
+    -device virtio-vga \
+    -device qemu-xhci -device usb-tablet \
+    -nic user,model=virtio-net-pci
+}
+
+if [ -z "${NIXARCHY_TRY_SOURCED:-}" ]; then
+  main "$@"
+fi

--- a/tests/try-preflight.nix
+++ b/tests/try-preflight.nix
@@ -1,0 +1,232 @@
+{
+  pkgs,
+  tryScript,
+  tryApp,
+}:
+# The `try` front door's preflight, driven with an environment that lies.
+#
+# `nix run .#try` is the first thing a stranger types, on a machine nobody
+# here has seen: no /dev/kvm, or /dev/kvm without the group; too little RAM;
+# a dry-run that says "source build" because a cache prompt was declined; a
+# qcow2 left behind by a ctrl-C. Each of those must produce a sentence naming
+# the number measured and the way out -- and a preflight nobody has seen fail
+# is a preflight nobody knows works, so every refusal below is exercised
+# here, cheaply, with the same stub idiom tests/installer-store-space.nix
+# uses against a lying df.
+#
+# No VM is booted and no network is touched: every asserted path exits before
+# the script would reach nix or qemu. What this deliberately cannot prove --
+# that the qemu invocation itself brings up a bootable UEFI window -- is the
+# same class of gap microvm-template documents: the happy path needs a
+# machine with KVM and a display, which a sandboxed derivation is not.
+#
+# Two layers:
+#   1. the probe functions, sourced from installer/try.sh raw
+#      (NIXARCHY_TRY_SOURCED=1 stops main) and fed stubbed TRY_* paths and a
+#      lying df;
+#   2. the BUILT app end to end -- which also makes the check depend on the
+#      package, so "the app evaluates and its script passes shellcheck"
+#      (writeShellApplication's own checkPhase) is asserted by construction.
+pkgs.runCommand "nixarchy-try-preflight" { } ''
+  test -x ${tryApp}/bin/nixarchy-try
+
+  cp ${tryScript} try.sh
+  cat > t.sh <<'EOF'
+  set -u
+  NIXARCHY_TRY_SOURCED=1
+  . ./try.sh
+
+  fails=0
+  ok() { echo "  ok      $1"; }
+  no() { echo "  FAILED  $1"; [ -s msg ] && sed 's/^/            /' msg; fails=$((fails + 1)); }
+
+  # ---- KVM: existence is not the answer; openability is -------------------
+  [ "$(TRY_KVM_DEV=/does/not/exist detect_kvm)" = none ] \
+    && ok "no /dev/kvm -> none" || no "no /dev/kvm -> none"
+  touch kvmfile && chmod 000 kvmfile
+  [ "$(TRY_KVM_DEV=$PWD/kvmfile detect_kvm)" = nogroup ] \
+    && ok "unopenable /dev/kvm -> nogroup" || no "unopenable /dev/kvm -> nogroup"
+  chmod 600 kvmfile
+  [ "$(TRY_KVM_DEV=$PWD/kvmfile detect_kvm)" = kvm ] \
+    && ok "openable /dev/kvm -> kvm" || no "openable /dev/kvm -> kvm"
+
+  explain_kvm none 2>msg
+  grep -q 'SLOWER' msg && grep -q 'real hardware is not' msg \
+    && ok "TCG fallback is loud, and blames the VM not nixarchy" \
+    || no "TCG fallback is loud, and blames the VM not nixarchy"
+  explain_kvm nogroup 2>msg
+  grep -q "kvm' group" msg && grep -q 'usermod -aG kvm' msg \
+    && ok "group refusal names the group and the command" \
+    || no "group refusal names the group and the command"
+
+  # ---- RAM: refuse with numbers, never OOM mid-boot -----------------------
+  printf 'MemTotal: 4096 kB\nMemAvailable: %s kB\n' $((2048 * 1024)) > meminfo
+  if TRY_MEMINFO=$PWD/meminfo check_ram 8192 2>msg; then
+    no "2 GB free vs 8 GB wanted refuses"
+  else
+    grep -q '2048 MB' msg && grep -q '8192 MB' msg && grep -q -- '--memory' msg \
+      && ok "RAM refusal carries both numbers and the way out" \
+      || no "RAM refusal carries both numbers and the way out"
+  fi
+  if TRY_MEMINFO=$PWD/meminfo check_ram 1024 2>msg; then
+    ok "2 GB free vs 1 GB wanted proceeds"
+  else
+    no "2 GB free vs 1 GB wanted proceeds"
+  fi
+  # Tolerance: a meminfo it cannot read must not invent a refusal.
+  : > meminfo
+  if TRY_MEMINFO=$PWD/meminfo check_ram 8192 2>msg; then
+    ok "unreadable meminfo proceeds"
+  else
+    no "unreadable meminfo proceeds"
+  fi
+
+  # ---- disk: a lying df, exactly as installer-store-space does ------------
+  df() { printf 'Type Avail\n%s %sM\n' "$FS" "$AVAIL"; }
+  FS=tmpfs AVAIL=999999
+  if check_disk /somewhere 100 "the target disk" 2>msg; then
+    no "tmpfs refuses however much df claims"
+  else
+    grep -q 'RAM, not disk' msg \
+      && ok "tmpfs refusal says RAM, not disk" \
+      || no "tmpfs refusal says RAM, not disk"
+  fi
+  FS=ext4 AVAIL=100
+  if check_disk /somewhere 24576 "the target disk" 2>msg; then
+    no "100 MB free vs 24576 MB needed refuses"
+  else
+    grep -q '24576 MB' msg && grep -q '100 MB' msg \
+      && ok "disk refusal carries both numbers" \
+      || no "disk refusal carries both numbers"
+  fi
+  FS=ext4 AVAIL=999999
+  if check_disk /somewhere 24576 "the target disk" 2>msg; then
+    ok "room on a real filesystem proceeds"
+  else
+    no "room on a real filesystem proceeds"
+  fi
+  unset -f df
+
+  # ---- the flakeref the image comes from ----------------------------------
+  [ "$(resolve_ref abc123)" = "github:olafkfreund/nixarchy/abc123" ] \
+    && ok "a committed rev resolves to a pinned github ref" \
+    || no "a committed rev resolves to a pinned github ref"
+  if resolve_ref "" 2>msg; then
+    no "a dirty build refuses to guess an image"
+  else
+    grep -q 'uncommitted' msg && grep -q 'github:olafkfreund/nixarchy#try' msg \
+      && ok "a dirty build refuses, naming the published front door" \
+      || no "a dirty build refuses, naming the published front door"
+  fi
+
+  # ---- the release fallback's parse, on a JSON shaped like the real one ---
+  # Including what v4.0.2-4 really looks like: SHA256SUMS names a -net.iso
+  # and the release does not attach one. `iso-net` must come back empty
+  # there, not grab an offline part.
+  cat > rel.json <<'P'
+  { "tag_name": "v9.9.9-9",
+    "assets": [
+      { "name": "nixarchy-v9.9.9-9.iso.part-ab",
+        "browser_download_url": "https://example.invalid/nixarchy-v9.9.9-9.iso.part-ab" },
+      { "name": "nixarchy-v9.9.9-9.iso.part-aa",
+        "browser_download_url": "https://example.invalid/nixarchy-v9.9.9-9.iso.part-aa" },
+      { "name": "SHA256SUMS",
+        "browser_download_url": "https://example.invalid/SHA256SUMS" } ] }
+  P
+  [ "$(release_tag rel.json)" = "v9.9.9-9" ] \
+    && ok "the release tag parses" || no "the release tag parses"
+  [ "$(release_urls rel.json iso | head -n1)" = "https://example.invalid/nixarchy-v9.9.9-9.iso.part-aa" ] \
+    && ok "offline parts come back sorted, aa first" \
+    || no "offline parts come back sorted, aa first"
+  [ "$(release_urls rel.json iso | wc -l)" = 2 ] \
+    && ok "offline parts exclude SHA256SUMS" || no "offline parts exclude SHA256SUMS"
+  [ -z "$(release_urls rel.json iso-net)" ] \
+    && ok "a release with no net image says so, not a wrong URL" \
+    || no "a release with no net image says so, not a wrong URL"
+  [ "$(release_urls rel.json sums)" = "https://example.invalid/SHA256SUMS" ] \
+    && ok "the checksum file is found" || no "the checksum file is found"
+
+  # ---- the download-or-build decision, on plans nix really prints ---------
+  cat > plan.build <<'P'
+  these 431 derivations will be built:
+    /nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-nixarchy-v4.0.2.iso.drv
+    /nix/store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-squashfs.img.drv
+  P
+  [ "$(classify_plan plan.build)" = build ] \
+    && ok "an image in the build list -> build" || no "an image in the build list -> build"
+
+  cat > plan.fetch <<'P'
+  these 12 paths will be fetched (1.87 GiB download, 5.61 GiB unpacked):
+    /nix/store/cccccccccccccccccccccccccccccccc-nixarchy-v4.0.2.iso
+  P
+  [ "$(classify_plan plan.fetch)" = "fetch (1.87 GiB download, 5.61 GiB unpacked)" ] \
+    && ok "a fetch plan -> fetch, with nix's sizes" || no "a fetch plan -> fetch, with nix's sizes"
+
+  : > plan.ready
+  [ "$(classify_plan plan.ready)" = ready ] \
+    && ok "an empty plan -> ready" || no "an empty plan -> ready"
+  echo 'some other nix message entirely' > plan.noise
+  [ "$(classify_plan plan.noise)" = ready ] \
+    && ok "an unparseable plan -> ready, never a refusal" \
+    || no "an unparseable plan -> ready, never a refusal"
+  cat > plan.small <<'P'
+  these 2 derivations will be built:
+    /nix/store/dddddddddddddddddddddddddddddddd-something-tiny.drv
+  P
+  [ "$(classify_plan plan.small)" = ready ] \
+    && ok "two stray drvs are not a source build" || no "two stray drvs are not a source build"
+
+  [ "$(plan_unpacked_mb '(1.87 GiB download, 5.61 GiB unpacked)')" -ge 5744 ] \
+    && ok "unpacked GiB parses into MB" || no "unpacked GiB parses into MB"
+
+  exit $fails
+  EOF
+  echo "--- probe functions, against a stubbed environment"
+  bash t.sh
+
+  # ---- the built app end to end, on its refusal paths ---------------------
+  # Each exits before nix or qemu would run, so no network and no KVM are
+  # needed here -- which is the point: these are the paths a sandbox CAN see.
+  echo "--- the built app"
+  app=${tryApp}/bin/nixarchy-try
+
+  $app --help > help.out
+  grep -q -- '--net' help.out && grep -q 'nix run github:olafkfreund/nixarchy#try' help.out
+  echo "  ok      --help reads as instructions, not as a stack trace"
+
+  if $app --frobnicate 2>msg; then exit 1; fi
+  grep -q 'unknown option' msg && grep -q -- '--help' msg
+  echo "  ok      an unknown flag refuses and points at --help"
+
+  if $app --memory 2048 2>msg; then exit 1; fi
+  grep -q '4096' msg
+  echo "  ok      --memory below the floor refuses with the floor"
+
+  if $app --boot 2>msg; then exit 1; fi
+  grep -q 'no nixarchy-try.qcow2' msg
+  echo "  ok      --boot with nothing installed says so"
+
+  # A leftover disk -- a ctrl-C'd install, or simply a second run -- is
+  # never silently reused as fresh, and never silently destroyed.
+  mkdir leftover && cd leftover && touch nixarchy-try.qcow2
+  if $app 2>msg; then exit 1; fi
+  grep -q -- '--fresh' msg && grep -q -- '--boot' msg
+  echo "  ok      a leftover disk refuses with both ways out"
+  cd ..
+
+  # No KVM plus a meminfo claiming 1 GB: the warning and the refusal both
+  # fire from the real script, in order, before anything heavier runs. The
+  # KVM device is stubbed away explicitly -- nix's sandbox passes the host's
+  # real /dev/kvm through when it has one, so "the sandbox has no KVM" is
+  # not a fact this check may lean on.
+  mkdir starved && cd starved
+  printf 'MemAvailable: %s kB\n' $((1024 * 1024)) > meminfo
+  if TRY_KVM_DEV=/does/not/exist TRY_MEMINFO=$PWD/meminfo $app 2>msg; then exit 1; fi
+  grep -q 'SLOWER' msg
+  grep -q -- '--memory' msg
+  echo "  ok      no KVM warns, 1 GB of RAM refuses, in one run"
+  cd ..
+
+  echo "the front door refuses in sentences, on every machine it was shown"
+  touch $out
+''


### PR DESCRIPTION
## What

A flake app a stranger can run to boot nixarchy in a local VM, from either ISO, with no repository knowledge:

```sh
nix run github:olafkfreund/nixarchy#try            # offline image
nix run github:olafkfreund/nixarchy#try -- --net   # network image
nix run github:olafkfreund/nixarchy#try -- --boot  # boot the installed disk afterwards
```

UEFI (OVMF, writable vars so the install's boot entry survives into `--boot`) — the installer refuses BIOS, so anything less shows a stranger a refusal as their first experience. `--fresh`, `--memory`, `--cpus`, `--vnc`, `--build`, and a `--help` written for someone who has never seen this repo.

Deliberately **not** a wrapper around `.#installer-vm`: that VM answers the wizard itself from a baked `--answers` file — a test harness, exactly what a person trying nixarchy must not get. This boots the same ISO a release ships and leaves the questions to the human.

## The part that was measured, not assumed

**No ISO is in cachix at all.** Not main's, not the release tags' — `nix path-info --store https://nixarchy.cachix.org` on the `v4.0.2-4` and current-main ISO outpaths both come back invalid. Images ship only as GitHub release assets. So the make-or-break UX line was never a substituter entry: it is a **fallback**. When the dry-run says the commit's image would be a source build, `try` downloads the latest release's prebuilt, install-tested image, verifies it against the release's `SHA256SUMS`, caches it under `~/.cache/nixarchy-try/`, and boots that. `--build` remains for whoever genuinely wants the compile (interactive y/N; non-tty refuses).

The flake-level `nixConfig` is still added — cachix does carry hyprland, the packages and the closures, and nothing but the invoked flake's own `nixConfig` can offer them to a bare `nix run`.

Two more measured facts baked in as comments so they are not re-learned:
- a `path:` flakeref loses `self.rev`, and `installer/mkFlake.nix` rightly refuses to generate a flake that cannot pin by commit — so the runtime flakeref is `github:…/<rev>`, never the source store path (the store-path route died on a fully committed tree);
- recent releases name a `-net.iso` in `SHA256SUMS` and do not attach one, so the release parser must return "no such image" there rather than a wrong URL. (That missing asset itself looks like a release.yml regression worth its own issue.)

## Failure paths, each exercised

`checks.try-preflight` (wired into `build.yml`'s lint job, on every PR — the coverage guard sees it) drives every refusal with a stubbed environment, the `tests/installer-store-space.nix` idiom: 31 assertions against a lying `df`, a fake meminfo, a `TRY_KVM_DEV` that does not exist or cannot be opened, fixture `nix build --dry-run` plans, and a release JSON shaped like `v4.0.2-4`. Building the app inside the check is itself half the assertion: it evaluates, and `writeShellApplication` shellchecks the final script.

Exercised **live** on this machine as well, with the message each produced:
- dirty tree → refuses naming the published front door (and the eval-failure path prints nix's own error under a one-line `try: evaluating … failed. nix said:`)
- uncached commit, non-tty → source-build STOP, `stdin is not a terminal, so not asking. Refusing.`
- uncached commit, fallback → `downloading release v4.0.2-4 image nixarchy-v4.0.2-4.iso (about 5739 MB)` → `checksum verified.` → **VM boots to the NIXARCHY installer welcome screen over VNC** (screenshot taken via gvnccapture; KVM path confirmed: `hardware virtualisation: yes (/dev/kvm)`)
- run again with the qcow2 left behind → refuses with `--boot` / `--fresh`, exit 1, before anything heavy runs
- `--fresh` rerun → `reusing the release image already downloaded and verified`, boots again

Not proven live (flagged, not smoothed over): a full 22-minute interactive install inside the VM and the subsequent `--boot` of the installed disk (`checks.install-iso` covers the image's installability); the `gtk` window path (this session is headless — the VNC path is the one exercised, and it is the display qemu measured as safe where `-display none` stalls a Wayland guest).

## Docs

README's "Try it in a VM" now leads with `try` and distinguishes it from `.#vm` (a smoke test of the installed system). The derived app-count lines are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xfc2nmiVLAMQvHHqpTbHw