### PR TITLE
What to delete when the hypr-rdp upstream work lands

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -135,6 +135,22 @@
     # The input has a named exit: when hypr-rdp lands in nixpkgs, delete this
     # and point the module at pkgs.hypr-rdp.
     #
+    # That exit is now IN FLIGHT rather than hypothetical -- NixOS/nixpkgs#560204
+    # ("hypr-rdp: init at 0.1.5") is open. When it merges and reaches the nixpkgs
+    # revision this flake pins, the deletion is:
+    #
+    #   1. remove this input and its `follows`
+    #   2. modules/services/hypr-rdp.nix: `inputs.hypr-rdp.packages.${system}...`
+    #      becomes `pkgs.hypr-rdp`
+    #   3. check nothing else reads `inputs.hypr-rdp` (grep; the module is the
+    #      only consumer today)
+    #
+    # Do NOT delete it merely because the nixpkgs PR merged: a merge into
+    # nixpkgs master is not the same as being present in the revision we pin,
+    # and removing the input before then leaves the module reaching for an
+    # attribute that does not exist yet. The condition is `pkgs.hypr-rdp`
+    # evaluating against OUR lock, not a green tick on a pull request.
+    #
     # `follows` is right here and wrong for hyprland above -- upstream's
     # pkg/nix/package.nix is a plain rustPlatform.buildRustPackage whose
     # cargoHash does not depend on which nixpkgs supplies ffmpeg, and they

--- a/modules/services/hypr-rdp.nix
+++ b/modules/services/hypr-rdp.nix
@@ -23,6 +23,36 @@
 # built only `if !(username.is_empty() && password.is_empty())`, so with
 # neither set there is no authentication at all.
 #
+# UPSTREAM HAS SINCE FIXED THE CAUSE, and this module can shed most of the
+# machinery below once that reaches a tag. MuNeNICK/hypr-rdp#84 is MERGED
+# (2026-09-04), adding `--password-file` and a `password_file` config key: the
+# secret no longer has to live inside the config file, which is the single fact
+# that forced the sops.templates shim. Upstream also made the empty case fail
+# startup rather than fall through to unauthenticated.
+#
+# NOT YET USABLE HERE: it is on upstream main and in no tag -- v0.1.5 is still
+# the newest, and the input above pins a tag deliberately ("a bad rebuild here
+# breaks the machine you are remote to"). So this stays exactly as it is until
+# a release carries it.
+#
+# WHEN A TAG SHIPS IT, the deletion is:
+#
+#   1. bump inputs.hypr-rdp to that tag
+#   2. replace the sops.templates."hypr-rdp.toml" render with a plain config
+#      file in the store plus `password_file = <the sops secret's path>`
+#   3. delete `secretUsable`, `configPath` and the whole ExecStartPre guard
+#      below -- upstream now refuses on an empty password itself, which is what
+#      that guard exists to do
+#   4. KEEP the evaluation-time assertion. It catches "no secret named at all",
+#      which upstream cannot see and which is a configuration mistake rather
+#      than a runtime one.
+#
+# Verify before deleting step 3, do not assume: confirm against the tagged
+# binary that an empty password_file exits non-zero. The guard exists because
+# this daemon FAILED OPEN once; removing it on the strength of a merged PR
+# rather than an observed refusal would be trading a checked property for a
+# trusted one.
+#
 # So this module is the only thing between an unrendered secret and an open
 # remote desktop, and it refuses in two places rather than one:
 #


### PR DESCRIPTION
Closes #157.

Its last open item was *"follow-up notes in the module/package children saying what to delete when each lands."* Both upstream contributions now exist, so the exits stop being wishes:

| | |
|---|---|
| **MuNeNICK/hypr-rdp#84** | **MERGED** 2026-09-04 — `--password-file` and a `password_file` config key, plus an empty password now *failing startup* instead of falling through to unauthenticated |
| **NixOS/nixpkgs#560204** | **OPEN** — `hypr-rdp: init at 0.1.5` |

## Neither is usable yet, and the notes say why, not just what

**The `password_file` work is on upstream `main` and in no tag.** `v0.1.5` is still newest, and the input pins a tag deliberately — *"a bad rebuild here breaks the machine you are remote to, from where you cannot fix it."*

**A nixpkgs merge is not the same as being in the revision this flake pins.** So the condition for deleting the input is `pkgs.hypr-rdp` evaluating against **our lock**, not a green tick on a pull request. Deleting it early leaves the module reaching for an attribute that doesn't exist yet.

## The part I'd most want a future reader to obey

The module note lists what to remove — the `sops.templates` render, `secretUsable`, `configPath`, the `ExecStartPre` guard — and then says the guard goes **only after observing the tagged binary refuse an empty `password_file`**.

That daemon **failed open**. `unwrap_or_default()` yielded an empty string, no `bail!`, no exit — it logged two warnings and served the session unauthenticated. That is the entire reason the guard exists. Removing it on the strength of a merged PR rather than a witnessed refusal would trade a checked property for a trusted one, which is the trade this repo has spent the week undoing.

It also says to **keep** the evaluation-time assertion regardless: it catches "no secret named at all", which upstream cannot see, and which is a configuration mistake rather than a runtime one.

## Verified

Comments only, no behaviour change.

- `nix fmt --ci` stable at `0 changed` across two consecutive runs (the local editor hook rewrites `.nix` files, so one run proves nothing)
- `statix` and `deadnix` clean
- `checks.options` still evaluates