### PR TITLE
The welcome notification is checked for not coming back, not just for being guarded

### DIFF
--- a/tests/session.nix
+++ b/tests/session.nix
@@ -490,6 +490,37 @@ pkgs.testers.runNixOSTest {
             f"a notification is sent before `{guard.strip()}` decided it should be")
     print("both post-boot notifications stand behind a check")
 
+    # ...and the OTHER notification, the welcome one, stops coming back.
+    #
+    # That assertion above reads the hook's SHAPE -- each send sits behind a
+    # guard. It cannot see whether a guard ever becomes true, and #278 was
+    # exactly that failure: omarchy-provision-first-run marks itself done only
+    # when EVERY step succeeded, two user units can never exist on NixOS, so
+    # the marker was never written and first-run ran again at every login. A
+    # welcome notification on every boot, for the life of the machine.
+    #
+    # Nothing checked it. There is no test in this repo that boots twice, so
+    # the fix shipped verified only by reading the code that was changed.
+    #
+    # This checks the property WITHOUT a second boot, which would double the
+    # cost of the most expensive check here: the marker is what a second login
+    # consults, so asserting the marker exists and that a re-run declines is
+    # the same question asked cheaply.
+    #
+    # Red before green: on the pre-#278 tree this fails on the first assertion,
+    # because the marker is precisely what never got written.
+    machine.succeed("su - omarchy -c 'omarchy-done check first-run-user'")
+    print("first-run wrote its completion marker")
+
+    # And the marker is USED, not merely present. A machine that records
+    # completion and re-provisions anyway would pass the line above.
+    again = machine.succeed(
+        "su - omarchy -c 'omarchy-provision-first-run 2>&1'")
+    assert "already complete" in again, (
+        "a second first-run did not decline; the welcome notification would "
+        f"fire again on every login. It said:\n{again}")
+    print("a second first-run declines, so the welcome notification is once-only")
+
     # Silence, gate zero: nixarchy did not write this machine.
     #
     # This VM imports nixosModules.nixarchy into a configuration of its own and


### PR DESCRIPTION
## The gap

#278 fixed a real annoyance: `omarchy-provision-first-run` marks itself done only when **every** step succeeded, two of upstream's user units can never exist on NixOS, so the marker was never written and first-run ran again at **every login** — a welcome notification on every boot, for the life of the machine.

**It shipped verified only by reading the code that changed.**

`tests/session.nix` asserts that each post-boot notification sits behind a guard — it reads the hook's *shape*. Worth having, and it cannot see whether a guard ever becomes true, which is exactly what #278 was.

And **nothing in `tests/` boots twice.** I grepped every file for a reboot, a shutdown or a second login: none. So the property a user actually cares about — that the popup stops coming back — was unmeasured.

## Measured without a second boot

A reboot would double the cost of the most expensive check in the repo. But the **marker is what a second login consults**, so asking whether it exists and whether a re-run declines is the same question, asked cheaply:

```python
machine.succeed("su - omarchy -c 'omarchy-done check first-run-user'")
again = machine.succeed("su - omarchy -c 'omarchy-provision-first-run 2>&1'")
assert "already complete" in again
```

**Both halves matter.** The first is what #278 fixed, and is precisely what never happened before it — **so this fails red on the pre-#278 tree.** The second stops a machine passing by recording completion and re-provisioning anyway, which the first assertion alone would not catch.

`su - omarchy` rather than `su omarchy`, matching `session.nix:230`: the state directory is `~/.local/state/omarchy` and the marker cannot be found without a login shell's `HOME`.

## Related, from today's demo recording

The same popups turned out to be **undismissable by the command everything was using**. `makoctl dismiss` silently did nothing — those toasts belong to `omarchy-shell`, not mako, and the right call is `omarchy-shell -q notifications dismissAll`. A command that ran, exited 0, and dismissed nothing.

That is a *recording* concern rather than this one, but it is the same family: something that appeared to work and did not, with nothing to say so.

## Verified

- `nix fmt --ci` stable at `0 changed` across two runs — one run proves nothing here, since the local editor hook rewrites `.nix` files in a style the repo rejects
- `checks.session`'s **driver builds**, which runs the Python lint over the composed test script

**Not run end to end:** `checks.session` is a ~17 minute VM and the self-hosted runners are 3/4 busy with a demo recording. CI runs it on this PR, which is what the gate is for.