### PR TITLE
The doctor's no-VAAPI-driver branch could never fire, and its fixture agreed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,13 +100,13 @@ jobs:
       # checks.install cannot see this: it installs onto a machine whose store
       # fits, which is the only shape that does not fail. So the decision is
       # unit-tested here instead, in seconds.
+      - name: The installer refuses a build the live store cannot hold
+        run: nix build .#checks.x86_64-linux.installer-store-space --print-build-logs
+
       # The doctor's GPU rules, against fixture machines. checks.install's VM
       # has no PCI display controller, so nothing else can reach these branches.
       - name: The doctor reads a GPU correctly
         run: nix build .#checks.x86_64-linux.doctor-graphics --print-build-logs
-
-      - name: The installer refuses a build the live store cannot hold
-        run: nix build .#checks.x86_64-linux.installer-store-space --print-build-logs
 
       # The `nix run #try` front door, on the machines it will actually meet:
       # no KVM, no kvm group, 1 GB of RAM, a tmpfs working directory, a

--- a/flake.nix
+++ b/flake.nix
@@ -1457,15 +1457,20 @@
           # The installer's interactive screens, at every width worth caring
           # about. Nothing else draws them: every other harness passes
           # --answers, which is exactly how #133 shipped.
-          doctor-graphics = import ./tests/doctor-graphics.nix {
-            pkgs = pkgsFor.${system};
-            inherit (self.packages.${system}) doctor;
-          };
-
           installer-store-space = import ./tests/installer-store-space.nix {
             pkgs = pkgsFor.${system};
             installScript = ./installer/install.sh;
             dashboardScript = ./installer/lib/dashboard.sh;
+          };
+
+          # The doctor's GPU rules, against fixture machines. checks.install's
+          # VM runs llvmpipe and has no PCI display controller, so this is the
+          # only place these branches are ever exercised -- and one of them was
+          # unreachable until the fixtures grew a vainfo that behaves like the
+          # real one.
+          doctor-graphics = import ./tests/doctor-graphics.nix {
+            pkgs = pkgsFor.${system};
+            inherit (self.packages.${system}) doctor;
           };
 
           # The `try` front door's refusals, each driven with a stubbed

--- a/pkgs/doctor.sh
+++ b/pkgs/doctor.sh
@@ -521,16 +521,39 @@ enc=$(printf '%s' "$va" | grep -c 'VAEntrypointEncSlice' 2>/dev/null) || enc=0
 
 if [ -z "$igpu$dgpu" ]; then
   say "  ${dim}No PCI display controller here -- a VM, or a framebuffer.${off}"
-elif [ -z "$va" ]; then
+elif [ -z "$va_driver" ]; then
+  # On the DRIVER line, not on emptiness. `[ -z "$va" ]` was unreachable: real
+  # vainfo writes "Trying display: wayland" to STDOUT before it opens anything,
+  # and keeps writing it when va_openDriver() fails. Measured with the pinned
+  # binary the doctor actually runs:
+  #
+  #   LIBVA_DRIVER_NAME=nosuchdrv vainfo 2>/dev/null
+  #   -> "Trying display: wayland", exit 3, 23 bytes on stdout
+  #
+  # So $va was never empty, this branch never fired, and a machine with NO
+  # driver fell through to "This driver cannot encode -- decode only" and was
+  # told about nvidia-vaapi-driver it may not have. The one branch written for
+  # those users was the one they could not reach.
+  #
+  # `Driver version:` is printed only once a driver has actually opened, so an
+  # empty $va_driver is the honest test -- and it still covers vainfo being
+  # absent entirely, where both are empty.
   finding "No VAAPI driver answered" "$warn" "video will decode and encode on the CPU"
-  snippet+=("  hardware.graphics.extraPackages = with pkgs; [ intel-media-driver ];")
+  if [ "$igpu" = Intel ]; then
+    snippet+=("  hardware.graphics.extraPackages = with pkgs; [ intel-media-driver ];")
+  fi
   notes+=("Nothing answered vainfo. On Intel that is usually intel-media-driver, which mesa does not ship; AMD gets one from mesa already.")
 elif [ "$enc" -gt 0 ]; then
   finding "Video encoding available" "$ok" "${va_driver:-a VAAPI driver}"
 else
   finding "This driver cannot encode" "$warn" "${va_driver:-VAAPI}, decode only"
   notes+=("vainfo reports no VAEntrypointEncSlice, so screen recording and any encoder that wants the GPU will fail. nvidia-vaapi-driver is decode-only by design; Intel's iHD, from intel-media-driver, does encode.")
-  snippet+=("  hardware.graphics.extraPackages = with pkgs; [ intel-media-driver ];")
+  # Only where it can help. The note above hedges in prose, but the SNIPPET is
+  # what people paste, and on an NVIDIA-only desktop intel-media-driver is a
+  # package for hardware that is not there. $igpu is already known.
+  if [ "$igpu" = Intel ]; then
+    snippet+=("  hardware.graphics.extraPackages = with pkgs; [ intel-media-driver ];")
+  fi
 fi
 
 # And the variable that hides all of the above. Set to a decode-only driver, it
@@ -568,6 +591,17 @@ if [ -n "$igpu" ] && [ -n "$dgpu" ]; then
   notes+=("offload is written above because it is the better default on a laptop, but it IS a choice: offload for battery, sync for performance. Read both before rebuilding.")
 elif [ -n "$dgpu" ]; then
   finding "Discrete $dgpu only" "$ok" "no hybrid setup needed"
+elif [ -n "$igpu" ]; then
+  # The case that printed NOTHING. `dgpu` is only ever set for 0x10de, so an
+  # AMD or Intel machine with no NVIDIA card -- which includes every AMD
+  # desktop, this one among them -- fell past both branches above and the
+  # Graphics section named no GPU at all. It reported on a VAAPI driver for
+  # hardware it never mentioned.
+  #
+  # "single" rather than "integrated": the vendor tells us who made it, not
+  # whether it is on the CPU package. Calling a discrete Radeon "integrated"
+  # would be a confident wrong answer, and the honest one costs nothing.
+  finding "Single $igpu GPU" "$ok" "no hybrid setup needed"
 fi
 
 # ---- what a laptop or a shared machine will want to know ----------------
@@ -626,7 +660,7 @@ case "$(basename "${SHELL:-unknown}")" in
 esac
 if [ -n "$devenv_rc" ] && [ -r "$devenv_rc" ] && grep -q 'devenv hook' "$devenv_rc"; then
   if command -v devenv >/dev/null 2>&1; then
-    finding "devenv activates in ${SHELL:-unknown}" "$ok" "cd into a devenv allow'ed project"
+    finding "devenv activates in $(basename "${SHELL:-unknown}")" "$ok" "cd into a devenv allow'ed project"
   else
     finding "devenv is selected but not on this session's PATH" "$warn" ""
     say "     ${devenv_rc} has the activation hook, so the rebuild landed."

--- a/tests/doctor-graphics.nix
+++ b/tests/doctor-graphics.nix
@@ -23,7 +23,28 @@ pkgs.runCommand "nixarchy-doctor-graphics" { nativeBuildInputs = [ pkgs.gnugrep 
   printf '#!/bin/sh\necho "vainfo: Driver version: VA-API NVDEC driver"\necho "  VAProfileH264Main : VAEntrypointVLD"\n' > fix/bin/vainfo
   # And one that can.
   printf '#!/bin/sh\necho "vainfo: Driver version: Mesa Gallium radeonsi"\necho "  VAProfileH264Main : VAEntrypointEncSlice"\n' > fix/bin/vainfo-enc
-  chmod +x fix/bin/vainfo fix/bin/vainfo-enc
+
+  # NO driver at all -- and this stub is why the branch for it was broken.
+  #
+  # The other two stubs print only what a SUCCEEDING vainfo prints, so they
+  # never reproduced the preamble real vainfo writes to STDOUT before it opens
+  # anything, and keeps writing when va_openDriver() fails. Measured against
+  # the pinned binary the doctor runs:
+  #
+  #   LIBVA_DRIVER_NAME=nosuchdrv vainfo 2>/dev/null
+  #   -> "Trying display: wayland", exit 3
+  #
+  # With no fixture for it, `[ -z "$va" ]` looked correct and could never fire
+  # on a real machine: $va always held that line. The no-driver branch was
+  # untested AND unreachable, so a machine with no VAAPI at all was told
+  # "decode only" and pointed at nvidia-vaapi-driver. A stub that omits the
+  # preamble is a stub that agrees with the bug.
+  printf '#!/bin/sh\necho "Trying display: wayland"\nexit 3\n' > fix/bin/vainfo-none
+
+  # NVIDIA alone, to catch Intel advice on a machine with no Intel in it.
+  mk fix/nvidia "0000:01:00.0" 0x10de
+
+  chmod +x fix/bin/vainfo fix/bin/vainfo-enc fix/bin/vainfo-none
 
   # HOME and USER because the doctor reads ~/.config and names the user in its
   # snippet, and a build sandbox has neither -- without them it dies on line 24
@@ -79,6 +100,34 @@ pkgs.runCommand "nixarchy-doctor-graphics" { nativeBuildInputs = [ pkgs.gnugrep 
   # e3 is the case that makes the conversion undeniable: read as decimal it is
   # nonsense, and this machine really has a GPU there.
   wantnot "no prime for one GPU"     "$a" 'nvidiaBusId'
+  # The section named a VAAPI driver and never named the GPU: `dgpu` is set
+  # only for 0x10de, so every AMD and Intel machine without an NVIDIA card
+  # fell past both the hybrid and the discrete branch in silence.
+  want    "a single GPU is named"    "$a" 'Single AMD GPU'
+
+  # No driver answered -- the branch that could not fire.
+  n=$(run amd vainfo-none)
+  want    "no driver is said so"     "$n" 'No VAAPI driver answered'
+  # And is NOT mistaken for a driver that merely cannot encode, which is what
+  # this machine was told before: a wrong diagnosis, plus advice about
+  # nvidia-vaapi-driver it does not have.
+  wantnot "not called decode-only"   "$n" 'cannot encode'
+
+  # Intel advice belongs on Intel machines. Matched on the SNIPPET LINE, not on
+  # the string: the notes mention intel-media-driver in prose on purpose
+  # ("on Intel that is usually...") and that prose is fine to read on any
+  # machine. What was wrong is a paste-in line installing a package for
+  # hardware that is not there -- a first draft of this assertion forbade the
+  # bare string and failed against correctly-gated code, which would have sent
+  # someone deleting the explanation instead of the snippet.
+  nv=$(run nvidia vainfo-none)
+  wantnot "no intel snippet on nvidia" "$nv" 'extraPackages.*intel-media-driver'
+  nvd=$(run nvidia vainfo)
+  wantnot "none on decode-only nvidia" "$nvd" 'extraPackages.*intel-media-driver'
+  # ...and it is still offered where it helps, so the gate did not simply
+  # delete the advice.
+  i=$(run hybrid vainfo-none)
+  want    "intel snippet on intel"    "$i" 'extraPackages.*intel-media-driver'
 
   [ "$fails" = 0 ] || { echo "$fails case(s) failed"; exit 1; }
   echo "the doctor reads a GPU correctly"


### PR DESCRIPTION
Six findings from a review of #284 — my own commit. The first is the one that mattered; the second is why it survived.

## The branch that could never fire

`elif [ -z "$va" ]` never fired on a real machine. Real `vainfo` writes `Trying display: wayland` to **stdout** before it opens anything, and keeps writing it when `va_openDriver()` fails. Measured against the pinned binary the doctor actually runs:

```
LIBVA_DRIVER_NAME=nosuchdrv vainfo 2>/dev/null
  -> "Trying display: wayland", exit 3, 23 bytes on stdout
```

So `$va` always held that line. A machine with **no VAAPI driver at all** fell through to *"This driver cannot encode — decode only"* and was pointed at `nvidia-vaapi-driver` it may not even have. A wrong diagnosis, and the one branch written for those users was the branch they could not reach.

Now tested on `$va_driver`, which is empty exactly when no driver opened — and still covers `vainfo` being absent entirely, where both are empty.

## The fixture agreed with the bug

Both stubs printed only what a **succeeding** `vainfo` prints, so neither reproduced the preamble — and there was no fixture at all for "no driver answered", the case the section's own comment says it exists for.

**A stub that omits what makes the code wrong is a stub that certifies it.**

## The other four

- **Intel advice on machines with no Intel.** Both branches appended `intel-media-driver` to the paste-in snippet unconditionally. The notes hedge in prose; the *snippet* is what people paste. Gated on `$igpu = Intel`, which the script already knew.
- **A single GPU was never named.** `dgpu` is set only for `0x10de`, so every AMD or Intel machine without an NVIDIA card fell past both the hybrid and the discrete branch — the Graphics section reported on a VAAPI driver for hardware it never mentioned. This workstation, with an RX 7900 XT, is one of them.
- A lost `basename`, printing a full shell path.
- Two comments my insertions had separated from what they document.

## Red before green, both ways round

New fixtures against the **old** `doctor.sh`:

```
ok      hybrid is detected            (10 pre-existing cases pass)
FAILED  a single GPU is named
FAILED  no driver is said so
FAILED  not called decode-only
FAILED  no intel snippet on nvidia
FAILED  none on decode-only nvidia
5 case(s) failed
```

Against the fixed one: **all 16 pass.**

## One of my own assertions was wrong, and running it is what showed me

It forbade the bare string `intel-media-driver` anywhere in the output, and **failed against correctly-gated code** — because the notes mention the package in prose *on purpose* (`"on Intel that is usually…"`). Matching `extraPackages.*intel-media-driver` distinguishes the paste-in line from the explanation.

The first version would have sent someone deleting the explanation instead of the snippet. There is now also a case asserting the snippet still appears **on** Intel, so the gate cannot pass by deleting the advice everywhere.

## Verified

- `nix fmt --ci` stable at `0 changed` over two runs
- `statix`, `deadnix`, `shellcheck`, `actionlint` clean
- `build.yml`'s job list unchanged: `lint,devenv-presets,omarchy,system,box`