### PR TITLE
Demo GIFs on the pages that describe them, and an llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ NixOS option is one `Install ▸ Search` away**, plugins and themes still instal
 from a git URL at runtime the way upstream intends, and every command that
 assumed `/usr` either points at what NixOS uses or says why it cannot.
 
-![A tour of nixarchy: the greeter, the menus, themes and the app selection](docs/nixarchy-demo.gif)
+![nixarchy-app-enable helix writing a declaration into ~/.config/nixarchy/apps.nix, grep showing the uncommented line, then nixarchy-apply copying it into the flake and stopping at "Not switching. Run: nh os switch /etc/nixos"](docs/img/features/install.gif)
 
-*Login through the branded greeter, the Omarchy menu, four themes, an app
-selected and applied, and a third-party plugin installed from a git URL into
-the running bar — captured from a real VM by `nix build .#demo`.*
+*The whole model in one clip: a pick becomes a declaration in
+`~/.config/nixarchy/apps.nix`, `nixarchy-apply` copies it into your flake, and
+only then does anything build. More recordings — boxes, sandboxes, themes,
+plugins — throughout [the manual](https://olafkfreund.github.io/nixarchy/).*
 
 ![The Omarchy desktop on NixOS](docs/screenshots/00-desktop.jpg)
 
@@ -723,6 +724,8 @@ them. Adding one is a command, not a rebuild:
 ```bash
 omarchy plugin add https://github.com/seyhunak/omteleprompt.git --enable
 ```
+
+![omarchy plugin add in a terminal — Cloning, then Added, then Enabled remco.bar-toggle — and the bar showing the plugin's toggle](docs/img/features/plugin.gif)
 
 Or from the menu above, which is where most people will find it. Add opens a
 floating terminal and asks for the URL. Those rows are upstream's own — nixarchy

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,11 @@ Nothing is built until you apply. The index comes from *this machine's* nixpkgs
 and options rather than from search.nixos.org, so it can never offer something
 the machine will then refuse to build.
 
+This is the whole model in twenty seconds — a pick becomes a line in a file
+you own, and only then a rebuild:
+
+![nixarchy-app-enable helix writes a declaration into ~/.config/nixarchy/apps.nix — grep shows the uncommented line — then nixarchy-apply copies it into the flake and offers the rebuild](img/features/install.gif)
+
 See **[other packages](manual/other-packages)** for the whole flow.
 
 ## An agent that knows this machine

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,93 @@
+# nixarchy
+
+> nixarchy is Omarchy — DHH's Hyprland desktop — vendored for NixOS. The whole
+> desktop ships as upstream builds it (the QuickShell bar, the menus, the
+> themes, the 430 shell commands), with the parts that assume Arch Linux
+> replaced: the Install menu writes Nix declarations instead of running pacman,
+> updates are a flake-input bump and a rebuild, and every change is a NixOS
+> generation you can roll back.
+
+Key facts an assistant should know before answering questions about nixarchy:
+
+- It is a port, not a reimplementation. Omarchy's source tree is packaged as a
+  derivation and `OMARCHY_PATH` points at it in the Nix store; only the
+  distro-coupled scripts (the ones that run pacman) are replaced or shimmed.
+  Tracking an upstream Omarchy release is a source bump, not a re-port.
+- The app-selection model is the core difference from Omarchy: picking an app
+  in the Install menu (or running `nixarchy-app-enable <app>`) uncomments one
+  declaration in `~/.config/nixarchy/apps.nix`, a file nixarchy writes fully
+  populated with every app commented out. Nothing is installed at that point.
+  `nixarchy-apply` copies the file into your flake as `nixarchy-apps.nix`, and
+  a rebuild (`nh os switch <flake>`) is what installs. Your flake must contain
+  `imports = [ ./nixarchy-apps.nix ];` for any of it to take effect.
+- **Install ▸ Search** is one fuzzy picker over every nixpkgs package, every
+  NixOS option and the app selection (~137k rows), indexed from the machine's
+  own nixpkgs rather than search.nixos.org.
+- Install: build the ISO yourself with
+  `nix build github:olafkfreund/nixarchy#iso`, write it to a USB stick, and
+  boot it — the installer asks Omarchy's questions and produces a flake you
+  own at `/etc/nixos`. The installer needs a network: the image downloads the
+  system closure rather than carrying it. UEFI only. On a machine already
+  running NixOS, add nixarchy as a flake input instead of using the ISO.
+- Updates: `omarchy update` (or Update ▸ Nixarchy in the menu) runs
+  `nh os switch --update <flake>`, moving every flake input — Omarchy, nixpkgs
+  and nixarchy — forward together. Rollback is a NixOS generation:
+  `sudo nixos-rebuild --rollback switch`, or the boot menu.
+- Themes and plugins keep Omarchy's runtime model on purpose:
+  `omarchy theme install <url>` and `omarchy plugin add <url>` clone into
+  `~/.config/omarchy/` at runtime, no rebuild involved. Stock themes live in
+  the read-only store under `$OMARCHY_PATH/themes/`; your own go in
+  `~/.config/omarchy/themes/`.
+- Several features are opt-in and off by default: per-project environments
+  (devenv), Boxes (Arch/Debian userlands via rootless podman + distrobox),
+  the declarative half of Sandboxes (MicroVMs), remote desktop (RDP), and
+  local AI. Each is one `nixarchy-service-enable <name>` or one option in
+  your flake.
+- Sandboxes: `nixarchy vm create <name>` / `nixarchy vm run <name>` boots a
+  disposable NixOS MicroVM (microvm.nix) that 9p-mounts the host's /nix/store
+  read-only — no root, no rebuild, megabytes not gigabytes. Root filesystem is
+  tmpfs; it is not a hardened security boundary.
+- Boxes are a compatibility layer, not a sandbox: `nixarchy box create dev
+  --template archlinux` gives a privileged distrobox container with your $HOME
+  mounted, for AUR packages, .deb installers and other software NixOS will not
+  run. nixpkgs first, always.
+- Unfree packages are allowed by default (`programs.nixarchy.allowUnfree =
+  false;` restores nixpkgs' policy).
+- Ten AI agent skills written for NixOS ship with the desktop and are exposed
+  through Menu ▸ Trigger ▸ Ask; `programs.nixarchy.localAi.enable = true`
+  runs them against local models via Ollama (needs a supported GPU).
+
+## Manual
+
+- [Welcome to nixarchy](https://olafkfreund.github.io/nixarchy/manual/): what the manual covers — of Omarchy's 51 manual pages, 38 are true here unchanged and are linked through; the rest are rewritten here
+- [The NixOS Philosophy](https://olafkfreund.github.io/nixarchy/manual/philosophy): why installs are declarations, what is yours to edit imperatively vs. what a rebuild owns
+- [Getting Started](https://olafkfreund.github.io/nixarchy/manual/getting-started): building and booting the installer ISO, the seven install questions, and the first hour on the desktop
+- [Updating NixOS](https://olafkfreund.github.io/nixarchy/manual/updating-nixos): flake updates, the rebuild modes, generations, rollback, and the stale-session trap
+- [Updates](https://olafkfreund.github.io/nixarchy/manual/updates): what Update ▸ Nixarchy does here, why release channels do not exist, firmware updates, rolling back
+- [Packages](https://olafkfreund.github.io/nixarchy/manual/other-packages): the app selection, apps.nix and nixarchy-apply, Install ▸ Search, services.nix, unfree software, removing apps
+- [Dotfiles](https://olafkfreund.github.io/nixarchy/manual/dotfiles): which config files are yours, which are seeded, and how the menu is extended
+- [Making Your Own Theme](https://olafkfreund.github.io/nixarchy/manual/making-your-own-theme): overlaying or forking a stock theme out of the read-only store
+- [Development Tools](https://olafkfreund.github.io/nixarchy/manual/development-tools): editors, and the 13 language toolchains from nixpkgs instead of mise
+- [Per-Project Environments](https://olafkfreund.github.io/nixarchy/manual/per-project-environments): nixarchy dev init and devenv — a pinned toolchain that activates on cd (opt-in)
+- [Boxes](https://olafkfreund.github.io/nixarchy/manual/boxes): Arch or Debian userlands via rootless podman and distrobox, ad hoc or declared (opt-in)
+- [Sandboxes](https://olafkfreund.github.io/nixarchy/manual/sandboxes): disposable NixOS MicroVMs sharing the host store, and the declarative always-up half (opt-in)
+- [AI](https://olafkfreund.github.io/nixarchy/manual/ai): the ten NixOS agent skills, the Ask menu, choosing an agent, and running it all locally
+- [Gaming](https://olafkfreund.github.io/nixarchy/manual/gaming): Steam, RetroArch, the launchers and cloud gaming — how each Install ▸ Gaming row lands on NixOS
+- [Security](https://olafkfreund.github.io/nixarchy/manual/security): the firewall, disk encryption, and what the port changes
+- [Remote Desktop](https://olafkfreund.github.io/nixarchy/manual/remote-desktop): serving the running Hyprland session over RDP (opt-in)
+- [System Snapshots](https://olafkfreund.github.io/nixarchy/manual/system-snapshots): generations replace snapper for the system; snapper covers /home on installer-built machines
+- [Many machines, one repo](https://olafkfreund.github.io/nixarchy/manual/many-machines): one flake for a fleet, and machines that pull their configuration on a timer
+- [Dual Boot Install](https://olafkfreund.github.io/nixarchy/manual/dual-boot-install): the installer's free-space mode — installing into unpartitioned space beside an existing OS
+- [Unattended Installs](https://olafkfreund.github.io/nixarchy/manual/unattended-installs): an answers file so an image boots, installs and reboots with nobody at the keyboard
+- [Troubleshooting](https://olafkfreund.github.io/nixarchy/manual/troubleshooting): start with `nix run github:olafkfreund/nixarchy#doctor`, then the specific failures and their fixes
+
+## Source
+
+- [README](https://github.com/olafkfreund/nixarchy): installation, the full feature table, module options, design notes on why vendoring, and what is left
+- [Repository](https://github.com/olafkfreund/nixarchy): the flake — `github:olafkfreund/nixarchy`
+- [Issues](https://github.com/olafkfreund/nixarchy/issues): known limits and planned work
+
+## Optional
+
+- [Omarchy's manual](https://omarchy.org/manual/): the desktop itself — most of its pages are true here unchanged; nixarchy's manual covers only the port
+- [Omarchy](https://omarchy.org): the upstream project this is a port of

--- a/docs/manual/boxes.md
+++ b/docs/manual/boxes.md
@@ -74,6 +74,8 @@ nixarchy box create dev --template archlinux
 nixarchy box enter dev
 ```
 
+![nixarchy box templates listing archlinux and debian, box create pulling the Arch image with podman, distrobox enter, /etc/os-release answering Arch Linux, pacman installing fastfetch inside the box, and fastfetch printing "OS: Arch Linux x86_64" with "WM: Hyprland (Wayland)"](../img/features/boxes.gif)
+
 `nixarchy box` is also reachable from the menu -- `Trigger ▸ Boxes`, or
 search for "box" or "distrobox" -- as one row per template, plus "Enter a
 box" and "Remove a box", which prompt for which one.

--- a/docs/manual/making-your-own-theme.md
+++ b/docs/manual/making-your-own-theme.md
@@ -15,6 +15,11 @@ configs and `vscode.json` dropped for the reasons upstream gives. Read
 [the upstream page](https://omarchy.org/manual/making-your-own-theme/) for all
 of that. This page covers only what is different.
 
+What one `colors.toml` drives — the bar, the terminal, the borders and the
+wallpaper all restyle together when a theme is applied:
+
+![Three full desktop restyles in a row: applying a theme recolours the bar, the terminal, the window borders and the wallpaper in one step](../img/features/themes.gif)
+
 ## Where the stock themes live, and why you cannot copy-edit them in place
 
 Upstream says: copy one of the existing themes from `/usr/share/omarchy/themes`

--- a/docs/manual/other-packages.md
+++ b/docs/manual/other-packages.md
@@ -49,6 +49,8 @@ nixarchy-apply                 # copy into the flake and rebuild
 The ids are the ones in `apps.nix`; `omarchy pkg install` prints the file's
 location and nothing else, because it is the list.
 
+![nixarchy-app-enable helix printing "enabled helix in ~/.config/nixarchy/apps.nix (1 queued)", grep showing the uncommented declaration in apps.nix, then nixarchy-apply copying the file and ending on "Not switching. Run: nh os switch /etc/nixos"](../img/features/install.gif)
+
 One thing has to be true for any of this to work: **your flake must import the
 file.**
 

--- a/docs/manual/per-project-environments.md
+++ b/docs/manual/per-project-environments.md
@@ -17,6 +17,8 @@ The next prompt in that directory is inside the environment, and `node
 installed on the machine: that Node is pinned in a file the project owns, and
 committing that file is how a colleague gets the same one.
 
+![nixarchy dev init listing the presets, then scaffolding a real project — the devenv files written into the directory](../img/features/devenv.gif)
+
 This is nixarchy's, not Omarchy's — upstream reaches for `mise use`, which
 [Development tools](development-tools) explains does not fit here. It is also
 not on by default.

--- a/docs/manual/sandboxes.md
+++ b/docs/manual/sandboxes.md
@@ -16,6 +16,8 @@ booted with your host's `/nix/store` mounted read-only over 9p rather than
 copied into a disk image — a sandbox costs megabytes, not gigabytes, and the
 packages inside it are the same store paths as the ones outside it.
 
+![nixarchy vm templates listing shell, python, podman and persistent; vm create demo --template shell; vm list; then vm run booting the guest through systemd to "Welcome to NixOS 26.11", automatic login as dev, and uname -a answering from inside the guest](../img/features/microvm.gif)
+
 ## What it is not
 
 **Not a desktop VM.** Headless, no display. If you want a GUI machine with a

--- a/docs/manual/updates.md
+++ b/docs/manual/updates.md
@@ -12,6 +12,8 @@ what happened to the rest of upstream's update machinery. The mechanics —
 stale-session trap — are on [Updating NixOS](updating-nixos.md), and are not
 repeated here.
 
+![The Omarchy menu opening its Update submenu, with the rows Nixarchy, Config, Process, Hardware, Firmware, Password, Timezone and Time](../img/features/menus.gif)
+
 ## What an update is
 
 On Arch an update installs a new `omarchy` package, runs its migrations, and


### PR DESCRIPTION
The seven recordings merged in #353 were files nothing linked. Now each sits beside the prose that describes the feature it shows, on the Pages site and in the README, and the site gains an `llms.txt`.

## Where each GIF landed, and why

| GIF | landed in | because |
|---|---|---|
| `install.gif` | README hero, `docs/index.md` (install-declaratively section), `manual/other-packages.md` | the centrepiece: a pick becomes a declaration in `apps.nix`, then a rebuild. other-packages' terminal snippet is the exact commands on camera |
| `boxes.gif` | `manual/boxes.md` § Making one | the section whose commands it records, ending on fastfetch printing Arch inside the box |
| `microvm.gif` | `manual/sandboxes.md` intro | create → real boot to "Welcome to NixOS 26.11" → `uname` from inside the guest |
| `devenv.gif` | `manual/per-project-environments.md` intro | the preset list and a real scaffold |
| `themes.gif` | `manual/making-your-own-theme.md` intro | shows what one `colors.toml` drives — three full restyles |
| `menus.gif` | `manual/updates.md` intro | it opens the Update submenu that page describes row by row |
| `plugin.gif` | README § Plugins | `plugin add` live: Cloning → Added → Enabled, then the toggle in the bar |

Every image has alt text that says what is in the frames, for screen readers and for machine readers.

## README

The front page no longer opens on `docs/nixarchy-demo.gif` (2.6 MB, and its middle is a static wallpaper with notification popups) — it opens on `install.gif` with a caption naming the model. The demo GIF file itself stays: `nix build .#demo` regenerates it and `tests/demo/default.nix` references it. The three app-count strings that `build.yml` checks are untouched, verified byte-for-byte with `grep -F`.

## llms.txt

`docs/llms.txt`, served at https://olafkfreund.github.io/nixarchy/llms.txt, follows the llmstxt.org structure exactly: H1, blockquote summary, a key-facts body, then H2 link sections (`Manual`, `Source`, `Optional`) with one-line descriptions checked against each page's actual content. It states the opt-in features as opt-in, says the ISO must be built from the flake and needs a network during install, and claims nothing about release assets.

## Verified

- every image path resolves from both roots — Jekyll paths (`img/...`, `../img/...`) and README paths (`docs/img/...`) checked separately, since they differ
- `nix fmt -- --ci` clean, run twice
- the three guarded README strings present byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8UjW3MGdMLoAQPSdAEepc