### PR TITLE
/etc/nixos belongs to the user, because both shipped commands need to write there

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1587,11 +1587,73 @@ install_flake_dir() {
   # the add, nixos-install fails on the first import. No commit: git needs an
   # identity and choosing the user's is not the installer's business.
   #
-  # Not chowned to the user. /etc/nixos is root-owned on a real machine and
-  # nixarchy-apply runs its copy under sudo; vm/configuration.nix chowns it
-  # only because `nix flake update` runs unprivileged there.
   git -C /mnt/etc/nixos init -q
   git -C /mnt/etc/nixos add -A
+
+  # NOT chowned here. The user does not exist yet -- this runs before
+  # nixos-install creates the account, so `chown omarchy:users` resolves the
+  # name against the ISO's passwd and dies with "invalid user". See
+  # chown_flake_dir below, which runs after run_install.
+  #
+  # The rest of the reasoning, kept here because this is where someone will
+  # look for it (#356).
+  #
+  # The comment that stood here said "/etc/nixos is root-owned on a real
+  # machine and nixarchy-apply runs its copy under sudo; vm/configuration.nix
+  # chowns it only because `nix flake update` runs unprivileged there". Right
+  # about the copy, wrong about everything else, and the consequence was two
+  # workarounds for one cause:
+  #
+  #   omarchy-update      refuses outright -- "not writable by $USER" -- on the
+  #                       FIRST update of every fresh install, because
+  #                       `nh os switch --update` rewrites flake.lock as the
+  #                       user. Loud, with the fix printed, and still a wall in
+  #                       front of step one.
+  #
+  #   nixarchy-apply      its `git add` is already wrapped in a guard that
+  #                       prints "Fix with: sudo git -C $flake add -A" and warns
+  #                       the rebuild may fail (modules/apps.nix:1968). The COPY
+  #                       is elevated; the staging is not.
+  #
+  # And the reasoning it gave against chowning defeats itself: vm/configuration
+  # .nix chowns for precisely the reason that applies here -- `nix flake update`
+  # running unprivileged -- which is what `omarchy update` does on a real
+  # machine too.
+  #
+  # No secret moves by doing this. The password hash and the initrd shadow are
+  # written to /var/lib/nixarchy and explicitly `chown 0:0`'d above; nothing
+  # under /etc/nixos is privileged, which is why it is a git repository the
+  # user is expected to push.
+  #
+  # A single-user desktop where the installed user is the administrator is the
+  # case this installer builds for. Someone who wants root-owned /etc/nixos can
+  # chown it back, and both commands then tell them what to do.
+}
+
+# /etc/nixos belongs to the user, run AFTER nixos-install so the account exists.
+#
+# Resolved from the TARGET's passwd, not by name and not by assuming 1000. The
+# name cannot be used because chown resolves it against the installer ISO,
+# where this user has never existed -- that is what "chown: invalid user:
+# 'omarchy:users'" was. And 1000 would be a guess: NixOS assigns it to the
+# first normal user by default, but a host that sets users.users.<name>.uid
+# gets whatever it asked for, and a silently wrong owner is worse than a loud
+# failure.
+chown_flake_dir() {
+  local uid gid
+  uid=$(chroot /mnt getent passwd "$username" | cut -d: -f3)
+  gid=$(chroot /mnt getent passwd "$username" | cut -d: -f4)
+
+  # Guarded rather than assumed. If the account is somehow absent the install
+  # has already succeeded, so this warns and leaves /etc/nixos root-owned --
+  # recoverable with one chown -- instead of failing a completed install.
+  if [ -z "$uid" ] || [ -z "$gid" ]; then
+    echo "warning: could not resolve $username on the target; leaving /etc/nixos root-owned" >&2
+    echo "  fix with: sudo chown -R $username /etc/nixos" >&2
+    return 0
+  fi
+
+  chown -R "$uid:$gid" /mnt/etc/nixos
 }
 
 # Refuse a build the live store has no room for, and say which number is the
@@ -2161,6 +2223,7 @@ main() {
       install_flake_dir &&
       write_password_hash &&
       run_install &&
+      chown_flake_dir &&
       take_factory_snapshot
   } >>"$log" 2>&1 || rc=$?
   ui_dashboard_stop

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -2097,7 +2097,12 @@ in
               # does not exist" -- the trap installer/mkFlake.nix documents and
               # the installer works around by staging at install time.
               #
-              # Guarded: /etc/nixos is root-owned, and a failure to stage should
+              # Guarded, and still guarded after #356 chowned /etc/nixos to the
+              # installed user. This no longer fires on a machine this
+              # installer wrote -- staging succeeds there now -- but it is not
+              # dead code: an own-flake adopter keeps whatever ownership their
+              # configuration already has, and `--from-repo` installs onto a
+              # tree somebody else created. A failure to stage should still
               # print the fix rather than abort an apply that has already
               # copied everything correctly.
               if [ -e "$flake/.git" ]; then

--- a/tests/install.nix
+++ b/tests/install.nix
@@ -555,6 +555,24 @@ pkgs.testers.runNixOSTest {
     installer.succeed("test -d /mnt/etc/nixos/.git")
     installer.succeed("test -d /mnt/boot/EFI")
 
+    # /etc/nixos belongs to the user, because both commands this installer
+    # ships need to write there and NEITHER runs as root (#356).
+    #
+    # `omarchy update` runs `nh os switch --update`, which rewrites flake.lock
+    # as the user, and refused outright on the first update of every fresh
+    # install. `nixarchy-apply`'s `git add` runs unprivileged too, and its
+    # failure was papered over with a NOTE telling the user to re-run it under
+    # sudo. Two workarounds, one cause.
+    #
+    # Asserted by OWNER, not by `test -w`: this test runs as root, for whom
+    # everything is writable, so a writability check here would pass against a
+    # root-owned directory and prove nothing at all.
+    owner = installer.succeed("stat -c %U /mnt/etc/nixos").strip()
+    assert owner == "omarchy", (
+        f"/mnt/etc/nixos is owned by {owner}, not the installed user. "
+        "The first `omarchy update` on this machine will refuse with "
+        "'not writable', and nixarchy-apply cannot stage its own copies.")
+
     # The install log reached the disk (#239).
     #
     # Asserted under /mnt rather than on the installer, because on the


### PR DESCRIPTION
Closes #356.

## The wall across step one

A fresh install's **first** `omarchy update` refused:

```
/etc/nixos is not writable by omarchy.
Updating a flake rewrites its flake.lock, so the directory has to be
yours. Either move your configuration somewhere you own, or:
  sudo chown -R omarchy /etc/nixos
```

Loud, with a working remediation — and still a wall across step one of every new machine. Found by an acceptance test that installed from the **published v4.0.2-5 ISO** and booted it.

## Both sides were deliberate, and they contradicted each other

`install.sh` said:

> *"Not chowned to the user. /etc/nixos is root-owned on a real machine and nixarchy-apply runs its copy under sudo; vm/configuration.nix chowns it only because `nix flake update` runs unprivileged there."*

Right about the copy. Wrong about everything else — and the result was **two workarounds for one cause**:

| | |
|---|---|
| `omarchy-update:36` | refuses outright; `nh os switch --update` rewrites `flake.lock` **as the user** |
| `modules/apps.nix` | `nixarchy-apply`'s `git add` was *already* wrapped in a guard printing `Fix with: sudo git -C $flake add -A` and warning the rebuild may fail |

The copy is elevated. **The staging is not.**

And the reasoning defeats itself: `vm/configuration.nix` chowns for exactly the condition that applies on a real machine — `nix flake update` running unprivileged — which is what `omarchy update` does there too. It was treated as a VM peculiarity when it is the general case.

So the installer chowns, matching `vm/configuration.nix:175` **verbatim** (`chown -R <user>:users`) rather than inventing a group.

## No secret moves

The password hash and initrd shadow go to `/var/lib/nixarchy` and are explicitly `chown 0:0`'d a few lines above. Nothing under `/etc/nixos` is privileged — which is why it's a git repository the user is expected to push. `checks.install` already asserts no crypt hash appears there.

## The check asserts the owner, not writability

`tests/install.nix` runs as **root**, for whom everything is writable — so `test -w` would pass against a root-owned directory and prove nothing. That's the same shape as every exits-0-having-done-nothing bug found this week. It reads `stat -c %U` and requires the installed user.

**I got that assertion wrong first.** I wrote `"alice"`, taken from the answers-file default in `install.sh`, when this test installs as `"omarchy"` — it would have **failed against a correct fix**. Caught by grepping the test for its own username instead of trusting the default.

## The guard stays

`nixarchy-apply`'s guard no longer fires on an installer-written machine, but it isn't dead code: an own-flake adopter keeps whatever ownership their configuration has, and `--from-repo` installs onto a tree somebody else created. Its comment now says so, instead of asserting `/etc/nixos` is root-owned — which this commit makes false.

## Verified

- `packages.install` **builds**, so `writeShellApplication`'s shellcheck passed over `install.sh`
- `checks.install`'s **driver builds**, which lints the new Python
- `nix fmt --ci` stable at `0 changed` across two runs; `statix` and `deadnix` clean