### PR TITLE
CI honours the flake's own binary caches instead of discarding them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,22 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          # Honour this flake's own nixConfig instead of warning and
+          # discarding it. Without this every `nix build` here prints
+          #
+          #   warning: ignoring untrusted flake configuration setting
+          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
+          #
+          # and the nixarchy and hyprland caches flake.nix declares are
+          # simply not used. The hyprland one was then re-added by hand in
+          # ONE job, writing /etc/nix/nix.conf because "without this the
+          # runner compiles a compositor from source and times out" -- a
+          # workaround for a setting the flake already carried.
+          #
+          # Scoped to the flake being invoked, which is this repository's
+          # own. It does not extend trust to inputs.
+          extra-conf: accept-flake-config = true
       - uses: cachix/cachix-action@v17
         # A failed cache upload must not fail a build that succeeded. #235: three
         # of four concurrent pull requests went red in `Post Run
@@ -228,6 +244,22 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          # Honour this flake's own nixConfig instead of warning and
+          # discarding it. Without this every `nix build` here prints
+          #
+          #   warning: ignoring untrusted flake configuration setting
+          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
+          #
+          # and the nixarchy and hyprland caches flake.nix declares are
+          # simply not used. The hyprland one was then re-added by hand in
+          # ONE job, writing /etc/nix/nix.conf because "without this the
+          # runner compiles a compositor from source and times out" -- a
+          # workaround for a setting the flake already carried.
+          #
+          # Scoped to the flake being invoked, which is this repository's
+          # own. It does not extend trust to inputs.
+          extra-conf: accept-flake-config = true
       - uses: cachix/cachix-action@v17
         # A cache upload failing must not fail a build that succeeded (#235).
         continue-on-error: true
@@ -245,6 +277,22 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          # Honour this flake's own nixConfig instead of warning and
+          # discarding it. Without this every `nix build` here prints
+          #
+          #   warning: ignoring untrusted flake configuration setting
+          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
+          #
+          # and the nixarchy and hyprland caches flake.nix declares are
+          # simply not used. The hyprland one was then re-added by hand in
+          # ONE job, writing /etc/nix/nix.conf because "without this the
+          # runner compiles a compositor from source and times out" -- a
+          # workaround for a setting the flake already carried.
+          #
+          # Scoped to the flake being invoked, which is this repository's
+          # own. It does not extend trust to inputs.
+          extra-conf: accept-flake-config = true
       - uses: cachix/cachix-action@v17
         # A cache upload failing must not fail a build that succeeded (#235).
         continue-on-error: true
@@ -900,6 +948,22 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          # Honour this flake's own nixConfig instead of warning and
+          # discarding it. Without this every `nix build` here prints
+          #
+          #   warning: ignoring untrusted flake configuration setting
+          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
+          #
+          # and the nixarchy and hyprland caches flake.nix declares are
+          # simply not used. The hyprland one was then re-added by hand in
+          # ONE job, writing /etc/nix/nix.conf because "without this the
+          # runner compiles a compositor from source and times out" -- a
+          # workaround for a setting the flake already carried.
+          #
+          # Scoped to the flake being invoked, which is this repository's
+          # own. It does not extend trust to inputs.
+          extra-conf: accept-flake-config = true
       - uses: cachix/cachix-action@v17
         # A cache upload failing must not fail a build that succeeded (#235).
         continue-on-error: true
@@ -1014,6 +1078,22 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          # Honour this flake's own nixConfig instead of warning and
+          # discarding it. Without this every `nix build` here prints
+          #
+          #   warning: ignoring untrusted flake configuration setting
+          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
+          #
+          # and the nixarchy and hyprland caches flake.nix declares are
+          # simply not used. The hyprland one was then re-added by hand in
+          # ONE job, writing /etc/nix/nix.conf because "without this the
+          # runner compiles a compositor from source and times out" -- a
+          # workaround for a setting the flake already carried.
+          #
+          # Scoped to the flake being invoked, which is this repository's
+          # own. It does not extend trust to inputs.
+          extra-conf: accept-flake-config = true
       - uses: cachix/cachix-action@v17
         # A cache upload failing must not fail a build that succeeded (#235).
         continue-on-error: true

--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -68,6 +68,22 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          # Honour this flake's own nixConfig instead of warning and
+          # discarding it. Without this every `nix build` here prints
+          #
+          #   warning: ignoring untrusted flake configuration setting
+          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
+          #
+          # and the nixarchy and hyprland caches flake.nix declares are
+          # simply not used. The hyprland one was then re-added by hand in
+          # ONE job, writing /etc/nix/nix.conf because "without this the
+          # runner compiles a compositor from source and times out" -- a
+          # workaround for a setting the flake already carried.
+          #
+          # Scoped to the flake being invoked, which is this repository's
+          # own. It does not extend trust to inputs.
+          extra-conf: accept-flake-config = true
 
       - name: What the apps are on today
         id: before

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -207,6 +207,22 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          # Honour this flake's own nixConfig instead of warning and
+          # discarding it. Without this every `nix build` here prints
+          #
+          #   warning: ignoring untrusted flake configuration setting
+          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
+          #
+          # and the nixarchy and hyprland caches flake.nix declares are
+          # simply not used. The hyprland one was then re-added by hand in
+          # ONE job, writing /etc/nix/nix.conf because "without this the
+          # runner compiles a compositor from source and times out" -- a
+          # workaround for a setting the flake already carried.
+          #
+          # Scoped to the flake being invoked, which is this repository's
+          # own. It does not extend trust to inputs.
+          extra-conf: accept-flake-config = true
 
       - name: The cache holds what main last built
         run: |
@@ -292,6 +308,22 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          # Honour this flake's own nixConfig instead of warning and
+          # discarding it. Without this every `nix build` here prints
+          #
+          #   warning: ignoring untrusted flake configuration setting
+          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
+          #
+          # and the nixarchy and hyprland caches flake.nix declares are
+          # simply not used. The hyprland one was then re-added by hand in
+          # ONE job, writing /etc/nix/nix.conf because "without this the
+          # runner compiles a compositor from source and times out" -- a
+          # workaround for a setting the flake already carried.
+          #
+          # Scoped to the flake being invoked, which is this repository's
+          # own. It does not extend trust to inputs.
+          extra-conf: accept-flake-config = true
 
       - name: Resolve every input the way a user would tomorrow
         run: nix flake update

--- a/.github/workflows/omarchy.yml
+++ b/.github/workflows/omarchy.yml
@@ -34,6 +34,22 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          # Honour this flake's own nixConfig instead of warning and
+          # discarding it. Without this every `nix build` here prints
+          #
+          #   warning: ignoring untrusted flake configuration setting
+          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
+          #
+          # and the nixarchy and hyprland caches flake.nix declares are
+          # simply not used. The hyprland one was then re-added by hand in
+          # ONE job, writing /etc/nix/nix.conf because "without this the
+          # runner compiles a compositor from source and times out" -- a
+          # workaround for a setting the flake already carried.
+          #
+          # Scoped to the flake being invoked, which is this repository's
+          # own. It does not extend trust to inputs.
+          extra-conf: accept-flake-config = true
       - uses: cachix/cachix-action@v17
         # A cache upload failing must not fail a build that succeeded (#235).
         continue-on-error: true

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -37,6 +37,22 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          # Honour this flake's own nixConfig instead of warning and
+          # discarding it. Without this every `nix build` here prints
+          #
+          #   warning: ignoring untrusted flake configuration setting
+          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
+          #
+          # and the nixarchy and hyprland caches flake.nix declares are
+          # simply not used. The hyprland one was then re-added by hand in
+          # ONE job, writing /etc/nix/nix.conf because "without this the
+          # runner compiles a compositor from source and times out" -- a
+          # workaround for a setting the flake already carried.
+          #
+          # Scoped to the flake being invoked, which is this repository's
+          # own. It does not extend trust to inputs.
+          extra-conf: accept-flake-config = true
 
       - name: Review, and say so
         # always(), because a review that only reports when it feels like it is

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,6 +29,22 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          # Honour this flake's own nixConfig instead of warning and
+          # discarding it. Without this every `nix build` here prints
+          #
+          #   warning: ignoring untrusted flake configuration setting
+          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
+          #
+          # and the nixarchy and hyprland caches flake.nix declares are
+          # simply not used. The hyprland one was then re-added by hand in
+          # ONE job, writing /etc/nix/nix.conf because "without this the
+          # runner compiles a compositor from source and times out" -- a
+          # workaround for a setting the flake already carried.
+          #
+          # Scoped to the flake being invoked, which is this repository's
+          # own. It does not extend trust to inputs.
+          extra-conf: accept-flake-config = true
       - uses: cachix/cachix-action@v17
         # A cache upload failing must not fail a build that succeeded (#235).
         continue-on-error: true


### PR DESCRIPTION
Every `nix build` in every workflow printed this, and nobody read it:

```
warning: ignoring untrusted flake configuration setting 'extra-substituters'.
Pass '--accept-flake-config' to trust it
```

`flake.nix` declares `nixarchy.cachix.org` and `hyprland.cachix.org` in `nixConfig`, with a comment explaining that *"nixConfig is honoured only from the flake you invoke … only this can"*. **Nothing passed `--accept-flake-config`**, so nix warned and used neither. The declaration has been decorative in CI for its entire life.

## The workaround is the evidence

`build.yml:678` has a step that writes hyprland's cache into `/etc/nix/nix.conf` **by hand** and restarts the daemon — in one job — because, in its own words:

> *Nixarchy pins Hyprland ahead of nixpkgs, so without this the runner compiles a compositor from source and times out.*

That's a manual re-declaration of a setting the flake already carried, added because the flake's copy was being thrown away. **The symptom was fixed where it hurt most and the cause was never found.**

## The change

`extra-conf: accept-flake-config = true` on all **eleven** `nix-installer-action` invocations across six workflows. Scoped to the flake being invoked — this repository's own — and it does not extend trust to inputs.

## The hand-written hyprland step stays

It should now be redundant, and I'm **not** removing it on the strength of a reasoning chain. It exists because a job *timed out* without it, and the cost of being wrong is a 30-minute compositor build on the most expensive check here. If CI shows the cache arriving from the flake, deleting it is a separate cheap commit with evidence behind it.

## Who this actually hurt most

Not CI, which had the workaround. **A stranger running `nix run github:olafkfreund/nixarchy#try`** hits the same warning: untrusted flake config, ignored, no caches — and #346's make-or-break argument (*"a stranger who types `nix run` and gets a three-hour source build will simply leave"*) lands squarely on them. They're prompted if they're a trusted user and silently unhelped if they're not.

That deserves a line in the README's try section. This PR doesn't add it — worth doing separately with the prompt's exact wording in front of me rather than described from memory.

## Verified

- `actionlint` clean on all six files
- **every job list byte-identical to `main`'s** — `build`, `nightly`, `omarchy`, `review`, `update`, `flake-update`

A workflow can parse under `yq` and still be rejected by GitHub, which is how `main` once produced zero jobs for hours.