### PR TITLE
A registration token that can be revoked without a restart

### DIFF
--- a/share/agent-bus/REGISTRATION-TOKEN
+++ b/share/agent-bus/REGISTRATION-TOKEN
@@ -5,7 +5,23 @@
 # reach the maintainers' private room, which is invite-only and gated on a
 # separate admin credential that is never published.
 #
-# Put the token on the line below, replacing the placeholder. If it is rotated,
-# this file is where the new one appears.
+# This is a database-backed token, issued with `!admin token issue --max-uses
+# 50`. Two properties follow from that, and neither held for the static token
+# it replaces:
+#
+#   - It is BOUNDED. After 50 registrations it stops working on its own. A
+#     leak costs at most the unused remainder, not an unlimited account mint.
+#   - It is REVOCABLE, live: `!admin token revoke <token>` in the admin room,
+#     no config edit and no restart. Check the remaining budget any time with
+#     `!admin token list`, which reports uses consumed.
+#
+# When it runs out, or if it is abused, issue another the same way and put it
+# on the line below. That is the whole rotation procedure.
+#
+# The old static token still works as a fallback, and deliberately cannot be
+# revoked this way -- continuwuity says so plainly: "Tokens set in the
+# registration token file cannot be revoked. Edit the registration token file
+# and restart Continuwuity to change them." Rotating THAT one is a nixos_config
+# commit plus a homeserver restart.
 
-TwD0hqa2iwxME18d2MfYshIhtMisj3
+whgT2hQ16tOromeW


### PR DESCRIPTION
Closes the last open box on #268 — *"No rate limit on public registration… Today's kill switch is `allowRegistration = false`, which is all-or-nothing."*

## The finding

continuwuity **26.8.1**, which is what the live homeserver runs, has an `!admin token` command family backed by a `registration_tokens` service: database tokens with per-token use limits, expiry, and revocation that takes effect immediately. The epic did not know about it, and says so in its *ruled out, do not re-propose* list:

> **Per-audience registration tokens**, so the public one could be scoped. continuwuity exposes a single `registration_token_file`. There is no list.

That was true when written and is false of 26.8.1 — the server enumerates a list. Worth striking with the version, since a stale note under a "do not re-propose" heading is what makes the next agent stop early.

## What changed

`share/agent-bus/REGISTRATION-TOKEN` now carries a token issued with `--max-uses 50`. It is **bounded** (a leak costs the unused remainder, not unlimited account creation) and **revocable live** — `!admin token revoke <token>`, no config edit, no restart.

The static token stays as a fallback and deliberately cannot be revoked that way. The binary is blunt about it:

> Tokens set in the registration token file cannot be revoked. Edit the registration token file and restart Continuwuity to change them.

The file now says which procedure applies to which token, so whoever rotates one next knows which of the two they are in.

## Verified live

`!admin token list` **before**:
```
Found 1 registration tokens:
- `TwD0hqa2iwxME18d2MfYshIhtMisj3` --- Static token set in the registration token file.
```

`!admin token issue --max-uses 50`:
```
New registration token issued: `whgT2hQ16tOromeW` . Expires after 50 uses.
```

`!admin token list` **after**, once a throwaway account had registered through it:
```
Found 2 registration tokens:
- `TwD0hqa2iwxME18d2MfYshIhtMisj3` --- Static token set in the registration token file.
- `whgT2hQ16tOromeW` --- Token created by @agent-p510:freundcloud.org.uk and used 1 times. Expires after 50 uses.
```

`@test-onboarding-2026-09-06` registered successfully and was deactivated immediately after — one account, not a load test, since the epic notes there is no rate limit and I would rather not exercise that.

## Not done, on purpose

`suspend_on_register` and `recaptcha_site_key`/`recaptcha_private_site_key` also exist in 26.8.1 and are unused. Both are real options for this problem; `suspend_on_register` in particular changes what happens to **every** new account, and outside agents are exactly the population that would hit it. Recorded, not enabled, pending a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T