### PR TITLE
A plugin that runs pacman fails the rebuild, not the click

### DIFF
--- a/modules/home.nix
+++ b/modules/home.nix
@@ -180,6 +180,51 @@ let
           exit 1
         fi
 
+        # A plugin that shells out to pacman fails the REBUILD, not the click.
+        #
+        # omarchy-plugin-validate above checks the manifest and the shape the
+        # shell requires. It does not read what the plugin RUNS, and the
+        # marketplace is written for Arch: a widget whose QML calls
+        # `pacman -S` or `yay -S` installs cleanly here, appears in the bar,
+        # and fails the first time somebody presses it -- on a machine where
+        # pacman does not exist and could not be allowed to.
+        #
+        # This is build.yml's "no bin touches pacman outside the allowlist"
+        # applied one layer out. That scan walks Omarchy's own bins in this
+        # repository; nothing looked at code a USER brings in.
+        #
+        # No allowlist here, deliberately. build.yml has one because upstream's
+        # own Arch-only plumbing legitimately calls pacman and has to keep
+        # working on Arch. A third-party plugin installed on a NixOS machine
+        # has no such case: there is nothing for it to be right about.
+        #
+        # COMMENT STRIPPING, and why it is not the shell scanner's `s/#.*//`:
+        # QML comments with // and stripping that naively eats `https://...`,
+        # which would hide anything after a URL on the same line. So only
+        # WHOLE-LINE comments are removed -- `//` or `#` at the start of a
+        # line, after optional whitespace. A trailing `// mentions pacman`
+        # after real code still trips this, which is the safe direction for a
+        # check about what a machine will execute.
+        hits=$(
+          find "$src" -type f \( -name '*.qml' -o -name '*.js' -o -name '*.sh' -o -name '*.bash' \) -print0 |
+            xargs -0 -r grep -nHE '\bpacman\b|\byay\b' |
+            grep -vE ':[0-9]+:[[:space:]]*(//|#)' || true
+        )
+        if [ -n "$hits" ]; then
+          echo "" >&2
+          echo "programs.nixarchy.plugins.${name} runs pacman or yay:" >&2
+          printf '%s\n' "$hits" | sed "s|^$src/|  |" >&2
+          echo "" >&2
+          echo "Neither exists on NixOS, so this plugin would install, appear in" >&2
+          echo "the bar, and fail the first time it is used. Packages come from" >&2
+          echo "the Install menu or your configuration here; a plugin cannot" >&2
+          echo "install its own." >&2
+          echo "" >&2
+          echo "If the plugin only MENTIONS them in prose, move that to a" >&2
+          echo "whole-line comment -- this ignores those." >&2
+          exit 1
+        fi
+
         id=$(jq -r '.id' "$src/manifest.json")
         mkdir -p $out
         echo -n "$id" > $out/id


### PR DESCRIPTION
Prompted by [adsellor/omaplug](https://github.com/adsellor/omaplug) — @adsellor's Nix packaging of the Omarchy Quattro plugin runtime. Nothing here is copied from it; the gap became obvious once its README named what nixarchy was not doing.

## The gap

omaplug's `buildOmarchyPlugin` is *"one plugin, validated and **command-rewritten** at evaluation time"*.

nixarchy validates. It never reads what a plugin **runs**.

`modules/home.nix` builds each declared plugin through upstream's own `omarchy-plugin-validate` — deliberately, rather than reimplementing those rules, and that reasoning stands. But that script checks the manifest and the shape the shell requires. It has no opinion about the plugin's code.

The marketplace is written for Arch, so a widget whose QML does

```qml
onClicked: Quickshell.execDetached(["sh", "-c", "pacman -S --noconfirm foo"])
```

installs cleanly, appears in the bar, and **fails the first time somebody presses it** — on a machine where `pacman` does not exist and could not be allowed to. The failure lands at the click, far from the cause, after the user has already rebuilt.

## The fix

`build.yml`'s *"no bin touches pacman outside the allowlist"* (#330), applied one layer out. That scan walks Omarchy's own bins **in this repository**; nothing looked at code a *user* brings in.

**No allowlist**, deliberately. `build.yml` needs one because upstream's Arch-only plumbing legitimately calls `pacman` and must keep working on Arch. A third-party plugin on a NixOS machine has no equivalent case — there is nothing for it to be right about.

## The comment stripping is not the shell scanner's, and that matters

The shell scan does `sed 's/#.*//'`. QML comments with `//` — and stripping *that* naively eats `https://`, hiding anything after a URL on the same line. Measured rather than assumed:

```
property string u: "https://example.com"; onClicked: run("pacman -S foo")

  naive //-stripping:  MISSED — the URL ate the rest of the line
  whole-line only:     CAUGHT — with file and line number
```

So only whole-line comments are ignored. A trailing `// mentions pacman` after real code still trips it, which is the safe direction for a check about what a machine will execute.

## Proven both ways

| fixture | result |
|---|---|
| QML calling `pacman -S` from `execDetached` | **caught**, with `file:line` |
| QML mentioning pacman in a whole-line comment, plus a URL | **passes clean** |
| `pacman` after a URL on the same line | **caught** (naive stripping misses it) |

## Verified

- `nix fmt --ci` stable at `0 changed` over two runs
- `statix` and `deadnix` clean
- `checks.options` still evaluates

## Not in this PR

omaplug also has a marketplace package set, and the sharper insight that `qs.Commons` and `qs.Ui` import nothing from Omarchy's shell tree — so plugins are not coupled to Omarchy, only to those two namespaces. Recorded in the issue rather than acted on here.