### PR TITLE
The Roadmap gains Android and stops listing a finished epic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1706,9 +1706,16 @@ is the shape.
 | epic | what it is for | |
 | --- | --- | --- |
 | [#159](https://github.com/olafkfreund/nixarchy/issues/159) | **remote desktop** — reaching the Hyprland session from elsewhere | 4 of 5 done |
-| [#268](https://github.com/olafkfreund/nixarchy/issues/268) | **agent bus** — a public room where agents working on this repo leave each other notes, and the setup to join it | room live, kit landed, 3 issues |
+| [#364](https://github.com/olafkfreund/nixarchy/issues/364) | **Android** — apps from the phone in your pocket, or without one at all | 2 of 6 filed |
 
 **Recently finished:**
+[agent bus](https://github.com/olafkfreund/nixarchy/issues/268)
+— a public room outside agents can actually join, and the kit to join it in
+about ten minutes: `#nixarchy-agents` live and world-readable, `#agents` fenced
+to invite-only, the vendored MCP server held to its documented tool contract by
+a check, `register.sh` failing in sentences rather than raw UIA JSON, and a
+registration token that can be revoked without a homeserver restart.
+Also
 [sandboxes](https://github.com/olafkfreund/nixarchy/issues/221)
 — a throwaway NixOS MicroVM from a template, in seconds, with no root and no
 rebuild: the catalogue and guest module, the declarative service, `nixarchy


### PR DESCRIPTION
Two changes to one table.

## #364 added — the Android epic

Filed **without** the `epic` label on purpose, and the label goes on once this lands.

`build.yml` compares open `epic`-labelled issues against this table and fails the `omarchy` job **in both directions** — an epic not listed, or a listed epic that has closed. Labelling before the row exists reddens every open PR, and #268's comment records **five previous victims** of exactly that.

## #268 moved to Recently finished

It closed today with all thirteen boxes.

**The guard could not have caught this.** It only inspects rows whose issue still carries the `epic` label — and #268's was removed in September *because it was reddening CI*. So a closed epic sat in the planned table where nothing structural would ever notice it.

Worth stating plainly: the README claims CI keeps this section honest, and that is true **only for labelled epics**. An unlabelled one can rot there indefinitely.

## Verified by running the guard, not reading it

```
open epics:   159
roadmap rows: 159, 364
missing:      none, in either direction
```

#364 is listed and unlabelled, so the guard ignores it; once labelled it is open and listed, which passes.