### PR TITLE
Resolve the installed user from /mnt/etc/passwd, not through chroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ So twelve skills ship here instead:
 | **`nixos-performance`** | Kernel choice, zram and swappiness, governors, storage, Nix build speed, boot time |
 | **`nixos-security`** | Firewall and nftables, SSH, sudo and the groups that are root in a costume, systemd sandboxing, kernel hardening |
 | **`nixos-doctor`** | The sweep to run *before* you have a theory: failed units, `-p err`, disk, memory, and what changed between generations |
-| **`nixos-config-repo`** | Getting the configuration into git and keeping it there, and the two things that bite: untracked files are invisible to the build, and `/etc/nixos` is root-owned |
+| **`nixos-config-repo`** | Getting the configuration into git and keeping it there, and the two things that bite: untracked files are invisible to the build, and git refuses a repository owned by somebody else |
 | **`devenv`** | Per-project environments: `devenv.nix`, the lockfile, and the judgement call of whether a requested tool belongs to the project or to the machine |
 | **`diagnose-crash`** | Upstream's, patched. Keeps its name because `omarchy-agent-crash` reads that path literally |
 

--- a/docs/manual/updating-nixos.md
+++ b/docs/manual/updating-nixos.md
@@ -44,7 +44,10 @@ Moving everything to solve one problem changes far more than the problem, and
 when something breaks you have no idea which input did it.
 
 `nix flake update` rewrites `flake.lock`, so the flake directory has to be
-writable by you. A root-owned `/etc/nixos` fails on the lock file.
+writable by you. The installer chowns `/etc/nixos` to the user it creates, so
+this is already true on a machine it wrote. On a machine installed before that
+-- or one you chowned back to root -- `omarchy update` offers to fix it, and
+`omarchy doctor` says so before you get there.
 
 ## switch, boot, test — pick the right one
 

--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -615,7 +615,36 @@ in
   # mechanism -- install.sh already carries both cachix substituters and only
   # clears them when it finds this file. So there is no second install path to
   # keep working; there is one, and this file switches it.
-  environment.etc =
+  #
+  # The gitconfig is merged into both variants because it has nothing to do
+  # with the offline/online split.
+  #
+  # A rescue reinstall is the flow that needs it: boot this ISO because the
+  # disk will not, mount it at /mnt, and re-run
+  #
+  #   nixos-install --root /mnt --flake /mnt/etc/nixos#<host>
+  #
+  # /mnt/etc/nixos belongs to the installed user -- installer/install.sh
+  # chowns it -- and nix opens the flake through libgit2, which refuses a
+  # repository owned by anybody else and reports it as
+  #
+  #   error: opening Git repository "/mnt/etc/nixos": ... is not owned by
+  #   current user (libgit2 error code = 7)
+  #   error: could not find a flake.nix file
+  #
+  # The live image autologins as root and nothing here goes through sudo, so
+  # there is no SUDO_UID for git's usual root exemption to match, and the
+  # refusal stands. `git -c safe.directory=...` does not help: it fixes the
+  # one git command it is passed to and never reaches nixos-install's own
+  # libgit2. Only a real config file does. See modules/nixos.nix, which ships
+  # the same entry to the installed machine for its own root contexts.
+  environment.etc = {
+    "gitconfig".text = ''
+      [safe]
+      	directory = /mnt/etc/nixos
+    '';
+  }
+  // (
     if offline then
       {
         "nixarchy-iso".text = ''
@@ -631,7 +660,8 @@ in
         "nixarchy-iso-net".text = ''
           ${inputs.self.shortRev or "dirty"}
         '';
-      };
+      }
+  );
 
   system.stateVersion = "25.05";
 }

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1641,6 +1641,16 @@ install_flake_dir() {
 # failure.
 chown_flake_dir() {
   local uid gid
+  # ONE CONSEQUENCE, so nobody meets it as a mystery: git refuses to operate on
+  # a repository owned by somebody else, so `sudo git -C /etc/nixos ...` now
+  # says "detected dubious ownership" and prints a safe.directory incantation.
+  # That is git working as designed and it is the correct trade -- the commands
+  # this installer SHIPS run as the user and could not write there at all
+  # before -- but it is a new paper cut for anyone in the habit of sudo-ing
+  # git. Run it as yourself, or pass -c safe.directory=/etc/nixos for one
+  # command. checks.install, free-space, install-encrypted and install-iso all
+  # do the latter, because a test driver is root by construction.
+  #
   # Read /mnt/etc/passwd directly. `chroot /mnt getent passwd` was the first
   # attempt and it FAILED -- "chroot: failed to run command 'getent': No such
   # file or directory" -- because the target's PATH is not set up for a chroot

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1641,15 +1641,32 @@ install_flake_dir() {
 # failure.
 chown_flake_dir() {
   local uid gid
-  uid=$(chroot /mnt getent passwd "$username" | cut -d: -f3)
-  gid=$(chroot /mnt getent passwd "$username" | cut -d: -f4)
+  # Read /mnt/etc/passwd directly. `chroot /mnt getent passwd` was the first
+  # attempt and it FAILED -- "chroot: failed to run command 'getent': No such
+  # file or directory" -- because the target's PATH is not set up for a chroot
+  # at this point in the install. awk over the file needs nothing from the
+  # target at all, which is the property worth having here.
+  uid=$(awk -F: -v u="$username" '$1 == u { print $3 }' /mnt/etc/passwd)
+  gid=$(awk -F: -v u="$username" '$1 == u { print $4 }' /mnt/etc/passwd)
 
   # Guarded rather than assumed. If the account is somehow absent the install
   # has already succeeded, so this warns and leaves /etc/nixos root-owned --
   # recoverable with one chown -- instead of failing a completed install.
   if [ -z "$uid" ] || [ -z "$gid" ]; then
-    echo "warning: could not resolve $username on the target; leaving /etc/nixos root-owned" >&2
-    echo "  fix with: sudo chown -R $username /etc/nixos" >&2
+    # Deliberately non-fatal -- the install itself succeeded and the machine
+    # boots -- but this wording is not "warning" any more, because the soft
+    # version of this message is what let a broken chown through: the first
+    # implementation used `chroot /mnt getent`, that failed on every install,
+    # and this branch turned it into a line nobody read. checks.install's
+    # `stat -c %U` assertion is what actually caught it, which is the argument
+    # for the assertion existing at all.
+    echo "" >&2
+    echo "NOT FIXED: $username is not in /mnt/etc/passwd, so /etc/nixos stays" >&2
+    echo "root-owned. Your first \`omarchy update\` WILL refuse with \"not" >&2
+    echo "writable\", and nixarchy-apply cannot stage its own copies." >&2
+    echo "" >&2
+    echo "  sudo chown -R $username /etc/nixos" >&2
+    echo "" >&2
     return 0
   fi
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1610,15 +1610,29 @@ install_flake_dir() {
   #                       user. Loud, with the fix printed, and still a wall in
   #                       front of step one.
   #
-  #   nixarchy-apply      its `git add` is already wrapped in a guard that
-  #                       prints "Fix with: sudo git -C $flake add -A" and warns
-  #                       the rebuild may fail (modules/apps.nix:1968). The COPY
-  #                       is elevated; the staging is not.
+  #   nixarchy-apply      dies at its unprivileged `cp` into $flake/nixarchy/,
+  #                       under `set -euo pipefail`, before it ever reaches the
+  #                       `git add` guard that prints "Fix with: sudo git -C
+  #                       $flake add -A" (modules/apps.nix).
   #
-  # And the reasoning it gave against chowning defeats itself: vm/configuration
-  # .nix chowns for precisely the reason that applies here -- `nix flake update`
-  # running unprivileged -- which is what `omarchy update` does on a real
-  # machine too.
+  # That second entry said "the COPY is elevated; the staging is not" when this
+  # was written, and it was wrong -- nothing in nixarchy-apply is elevated. The
+  # correction matters because it was half the argument for chowning, and an
+  # argument that survives its own evidence being wrong is worth re-checking:
+  # it does survive, on the omarchy-update half alone.
+  #
+  # The other half of the old reasoning defeated itself: vm/configuration.nix
+  # chowns for precisely the reason that applies here -- `nix flake update`
+  # running unprivileged. (Though not for the same MECHANISM: that VM's
+  # /etc/nixos is not a git repository, so it fails on a plain file write and
+  # never meets libgit2 at all.)
+  #
+  # What the chown costs, and what pays for it: git and nix both refuse a
+  # repository owned by somebody else. Not `sudo nixos-rebuild` -- git and
+  # libgit2 exempt root when SUDO_UID names the owner -- but root WITHOUT
+  # sudo, which is every root systemd unit and any rescue `nixos-install` from
+  # a live ISO. modules/nixos.nix and installer/cd.nix ship the safe.directory
+  # entry that settles it; without that this chown is not safe to make.
   #
   # No secret moves by doing this. The password hash and the initrd shadow are
   # written to /var/lib/nixarchy and explicitly `chown 0:0`'d above; nothing

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -534,6 +534,49 @@ in
     # flags a repeated top-level key, and it is right that they read better
     # together.
     programs = {
+      # /etc/nixos belongs to the installed user (installer/install.sh
+      # chown_flake_dir), and git refuses to open a repository owned by
+      # somebody else. So does nix: its flake fetcher goes through libgit2,
+      # which runs the same ownership check and fails the whole evaluation
+      # with
+      #
+      #   error: opening Git repository "/etc/nixos": repository path
+      #   '/etc/nixos' is not owned by current user (libgit2 error code = 7)
+      #   error: could not find a flake.nix file
+      #
+      # -- the second line being the one people actually read, which is why
+      # this was diagnosed three times before it was understood.
+      #
+      # NOT every root command needs this. git and libgit2 both exempt root
+      # when SUDO_UID names the repository's owner, so `sudo nixos-rebuild
+      # --flake /etc/nixos#...` -- the thing a user actually types -- was
+      # never broken by the chown. What needs the entry is root WITHOUT
+      # SUDO_UID: root systemd units, a root login shell, `nixos-install`
+      # from a live ISO during a rescue reinstall, and the VM test drivers,
+      # which are root by construction and never sudo.
+      #
+      # It has to be a real config file. Passing `-c safe.directory=...` on a
+      # git command line fixes that one git invocation and does not reach nix
+      # at all, and the environment variables are no use either: nix opens
+      # repositories with git_repository_open() rather than the _FROM_ENV
+      # variant, so libgit2 leaves use_env false and ignores
+      # GIT_CONFIG_SYSTEM and GIT_CONFIG_NOSYSTEM. libgit2 does read
+      # /etc/gitconfig -- verified by strace of a root `nix eval`, which
+      # opens exactly that one system path -- and that is what this writes.
+      #
+      # Via programs.git rather than environment.etc."gitconfig" because
+      # programs.git.config merges with a user's own git settings, where two
+      # environment.etc definitions of the same file collide.
+      #
+      # One limit worth knowing: the check runs against the RESOLVED path, so
+      # an adopter who points programs.nixarchy.flake at a symlink is not
+      # covered by this entry. Name the real directory instead. Machines this
+      # installer writes have a real /etc/nixos, so the default is fine.
+      git = {
+        enable = lib.mkDefault true;
+        config.safe.directory = [ cfg.flake ];
+      };
+
       hyprland = {
         # This block is deliberately NOT mkDefault, unlike everything else
         # here. Omarchy *is* Hyprland, so enabling nixarchy while disabling it

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -8,6 +8,15 @@ inputs:
 let
   cfg = config.programs.nixarchy;
 
+  # Where the resolved-path half of the flake's safe.directory entry lives.
+  #
+  # Under /var/lib rather than /etc: /etc/gitconfig is a store symlink that
+  # nothing can append to, and this value is not knowable until the machine
+  # it describes exists. Root-owned and root-writable only, because git reads
+  # it as configuration for whoever loads it -- a file a normal user could
+  # write would be a way to hand root arbitrary git settings.
+  safeDirInclude = "/var/lib/nixarchy/gitconfig-flake";
+
   # Omarchy's session, launched from its own hyprland.lua in the store rather
   # than from ~/.config/hypr/hyprland.lua. Hyprland's --config takes the entry
   # point; the modules it requires still resolve through $HOME/.config, which
@@ -574,7 +583,26 @@ in
       # installer writes have a real /etc/nixos, so the default is fine.
       git = {
         enable = lib.mkDefault true;
-        config.safe.directory = [ cfg.flake ];
+        config = {
+          safe.directory = [ cfg.flake ];
+
+          # The literal path above is not always enough, because the ownership
+          # check runs against the RESOLVED directory: point
+          # programs.nixarchy.flake at a symlink -- /etc/nixos -> a repository
+          # in $HOME, which is how plenty of people arrange this -- and the
+          # entry never matches what libgit2 actually opened. Measured, not
+          # assumed: safe.directory naming the symlink is refused, naming the
+          # real directory is accepted.
+          #
+          # Resolving it needs the filesystem of the machine being configured,
+          # which evaluation cannot see (and reading it at eval time would mean
+          # IFD). So the resolved form is written at activation, and included
+          # from here. libgit2 does follow include.path when it collects
+          # safe.directory -- also measured -- and a missing include target is
+          # silently ignored, which is what makes the file safe to reference
+          # before the first activation has written it.
+          include.path = safeDirInclude;
+        };
       };
 
       hyprland = {
@@ -634,6 +662,38 @@ in
         source ${cfg.package}/share/omarchy/default/fish/rc
       '';
     };
+
+    # The resolved half of the flake's safe.directory entry -- see the
+    # programs.git block above for why it cannot be written at evaluation
+    # time. Writes a real path only when it differs from the configured one,
+    # so on the normal case (a real directory at /etc/nixos) this leaves an
+    # empty file and changes nothing.
+    #
+    # Always writes, never appends: the file is derived state, and a stale
+    # entry left behind after somebody repoints programs.nixarchy.flake would
+    # keep exempting a directory nobody asked about.
+    system.activationScripts.nixarchyFlakeSafeDirectory = ''
+      install -d -m 0755 -o root -g root /var/lib/nixarchy
+
+      # readlink -f, not realpath: coreutils is guaranteed here and this runs
+      # before much else. A flake directory that does not exist yet resolves
+      # to nothing, which is the empty-file case and correct -- the machine
+      # simply has no flake to exempt.
+      nixarchy_flake_resolved=$(${pkgs.coreutils}/bin/readlink -f ${lib.escapeShellArg cfg.flake} 2>/dev/null || true)
+
+      {
+        echo "# Written by programs.nixarchy. Do not edit; see modules/nixos.nix."
+        if [ -n "$nixarchy_flake_resolved" ] &&
+           [ "$nixarchy_flake_resolved" != ${lib.escapeShellArg cfg.flake} ]; then
+          echo "[safe]"
+          echo "	directory = $nixarchy_flake_resolved"
+        fi
+      } > ${safeDirInclude}.tmp
+
+      chmod 0644 ${safeDirInclude}.tmp
+      chown root:root ${safeDirInclude}.tmp
+      mv -f ${safeDirInclude}.tmp ${safeDirInclude}
+    '';
 
     environment = {
       # The single indirection point. bin/, shell/, themes/, the Hyprland Lua

--- a/pkgs/doctor.sh
+++ b/pkgs/doctor.sh
@@ -442,6 +442,63 @@ if [ -n "${BROWSER:-}" ]; then
 fi
 say ""
 
+# ---- can you actually update this machine? -------------------------------
+#
+# The single most likely thing to be wrong on a machine installed before this
+# was fixed, and the one the user meets first: `omarchy update` rewrites
+# flake.lock through `nh os switch --update`, unprivileged, so a root-owned
+# flake directory refuses the very first update (#356).
+#
+# Checked here because the refusal happens at the moment somebody wants to
+# update, which is the worst moment to start reading about ownership. The
+# doctor can say it in advance and name the one command that fixes it.
+say "${bold}Updates${off}"
+flake_dir="${NIXARCHY_FLAKE:-/etc/nixos}"
+if [ ! -d "$flake_dir" ]; then
+  finding "No flake directory at $flake_dir" "$warn" ""
+  say "     ${dim}Set programs.nixarchy.flake, or export NIXARCHY_FLAKE.${off}"
+elif [ -w "$flake_dir" ]; then
+  finding "$flake_dir is yours" "$ok" "omarchy update can write the lock"
+else
+  finding "$flake_dir is not writable by ${USER:-$(id -un)}" "$warn" ""
+  say "     Updating rewrites flake.lock, so the directory has to be yours."
+  say "     ${bold}omarchy update offers to fix this for you${off}, or:"
+  say ""
+  say "       sudo chown -R ${USER:-$(id -un)} $flake_dir"
+  say ""
+  say "     ${dim}Machines installed before this was fixed are all like this.${off}"
+fi
+
+# The other half of the same question, and the one nobody diagnoses correctly
+# on their own. nix opens the flake through libgit2, which refuses a
+# repository owned by somebody else -- and reports it as "could not find a
+# flake.nix file", which sends people looking for a missing file that is
+# right there. git and libgit2 exempt root when SUDO_UID names the owner, so
+# `sudo nixos-rebuild` is fine; root WITHOUT sudo is not, which is every root
+# systemd unit and any rescue nixos-install from a live ISO.
+#
+# Current nixarchy ships the safe.directory entry that settles this. A
+# machine that predates it has a user-owned flake and no entry, so this looks
+# for the entry rather than for the ownership.
+#
+# Read with grep rather than `git config --system`: writeShellApplication
+# builds a strict PATH and git is not among this script's runtimeInputs, so
+# calling it would fail as "command not found" and be reported as a missing
+# entry on a machine that has one. Adding git just to read one line is the
+# worse trade -- see the vainfo note on runtimeInputs for the same trap.
+if [ -d "$flake_dir/.git" ] && [ -O "$flake_dir" ] && [ "$(id -u)" -ne 0 ]; then
+  if grep -qs "directory *= *\"\?$flake_dir\"\?\$" /etc/gitconfig; then
+    finding "root can read $flake_dir" "$ok" "safe.directory is set system-wide"
+  else
+    finding "No system safe.directory for $flake_dir" "$warn" ""
+    say "     $flake_dir is yours, and root without sudo -- a systemd unit, or"
+    say "     nixos-install from a rescue ISO -- cannot open it. nix reports"
+    say "     that as \"could not find a flake.nix file\", which is misleading."
+    say "     ${dim}Rebuild on current nixarchy: it ships the entry itself.${off}"
+  fi
+fi
+say ""
+
 # ---- things nixarchy defers on -------------------------------------------
 say "${bold}Services${off}"
 if systemctl is-enabled tlp.service >/dev/null 2>&1; then

--- a/pkgs/omarchy/nix-bin/nixarchy-config-repo
+++ b/pkgs/omarchy/nix-bin/nixarchy-config-repo
@@ -348,9 +348,10 @@ ensure_identity() {
 
   [[ -z $name || -z $email ]] && { fail "Both are needed to commit."; return 1; }
 
-  # --global, not on the repo: /etc/nixos is root-owned, so a repo-local
-  # identity would have to be written as root and would not follow the user to
-  # their own projects, which is where they will next want it.
+  # --global, not on the repo: an identity set here would not follow the user
+  # to their own projects, which is where they will next want it. (It would
+  # also have to be written as root on a flake that is still root-owned --
+  # machines installed before the installer chowned it.)
   command git config --global user.name "$name"
   command git config --global user.email "$email"
   ok "identity set globally"
@@ -653,8 +654,9 @@ if ! has_remote; then
           say "\n  Signing in to GitHub. This opens a browser."
           gh auth login -p ssh -h github.com -w || { fail "Sign-in failed."; exit 1; }
         fi
-        # -C over --source: --source insists on running inside the repo, and
-        # this one is root-owned.
+        # -C over --source: --source insists on running inside the repo,
+        # which is not somewhere this can assume it may cd into -- the flake
+        # is still root-owned on machines installed before it was chowned.
         gh repo create "$reponame" "$vis_flag" --disable-wiki || { fail "Could not create the repository."; exit 1; }
         owner=$(gh api user --jq .login)
         url="git@github.com:$owner/$reponame.git"

--- a/pkgs/omarchy/nix-bin/nixarchy-config-repo
+++ b/pkgs/omarchy/nix-bin/nixarchy-config-repo
@@ -58,24 +58,44 @@ while (($#)); do
   esac
 done
 
-# /etc/nixos is root-owned (installer/install.sh leaves it that way on purpose),
-# which splits every git call in two.
+# installer/install.sh chowns $FLAKE to the installed user, so on a machine
+# this installer wrote, every git call here -- read and write -- is just the
+# user operating on their own repository.
 #
-# Reads work as the user, but only once git is told the repository is not theirs
-# -- without safe.directory it refuses with "dubious ownership" and the message
-# does not name the fix.
+# It was not always so, and both accommodations below are for the machines
+# where it is not.
 #
-# Writes need root, and root has no user.name/user.email of its own, so the
-# identity is passed in from the user's global config on each commit. Doing it
-# this way rather than setting a root identity keeps the config where the user
-# can see and change it.
+# safe.directory stays. A machine installed before the chown, or one whose
+# owner deliberately chowned back to root, still needs it for reads: git
+# refuses a repository owned by somebody else with "dubious ownership" and a
+# message that does not name the fix. On a repository the user owns it costs
+# nothing.
 GIT_COMMON=(-c "safe.directory=$FLAKE" -C "$FLAKE")
 # Resolved once, and passed to sudo as a path: sudo runs a binary and cannot
 # see the `git` function below, so naming it here is what makes that explicit
 # rather than a coincidence of how PATH happens to resolve under sudo.
 GIT_BIN=$(command -v git)
 git() { command git "${GIT_COMMON[@]}" "$@"; }
-wgit() { sudo "$GIT_BIN" "${GIT_COMMON[@]}" "$@"; }
+
+# Writes elevate ONLY when the user cannot write the repository themselves.
+#
+# Unconditional sudo was the old shape, and on a chowned repository it is
+# actively harmful: root's commits leave root-owned loose objects and refs
+# inside a .git the user owns, and the user's own later `git gc`, branch
+# update or commit then fails with EACCES on files they cannot touch. The
+# damage outlives the command that did it, which is the kind worth avoiding.
+wgit() {
+  if [ -w "$FLAKE/.git" ]; then
+    git "$@"
+  else
+    sudo "$GIT_BIN" "${GIT_COMMON[@]}" "$@"
+  fi
+}
+
+# Root has no user.name/user.email of its own, so the identity is passed in
+# from the user's global config on each commit -- kept where the user can see
+# and change it rather than written into a root identity. Harmless on the
+# user-owned path, where it just restates what git would have used anyway.
 wcommit() {
   wgit -c "user.name=$(command git config --global user.name)" \
        -c "user.email=$(command git config --global user.email)" \

--- a/pkgs/omarchy/nix-bin/nixarchy-home-backup
+++ b/pkgs/omarchy/nix-bin/nixarchy-home-backup
@@ -18,10 +18,11 @@
 # of $HOME.
 #
 # Why a second repository rather than a directory inside /etc/nixos: that tree
-# is root-owned on purpose (installer/install.sh, install_flake_dir). Putting
-# $HOME files there would mean sudo to back up your own dotfiles, root in the
-# history of user data, and a public/private decision made once, for the
-# system, that then silently governs personal files too.
+# is the SYSTEM's, and a public/private decision made once for it would then
+# silently govern personal files too. It is also not reliably yours -- the
+# installer chowns it to the installed user, but a machine installed earlier,
+# or one deliberately chowned back, would mean sudo to back up your own
+# dotfiles and root in the history of user data.
 #
 # Everything here is idempotent. A second run backs up the difference; a
 # restore into a $HOME that already matches changes nothing and says so.
@@ -219,10 +220,11 @@ abort_on_quit() { (($1 == 130)) && { echo; exit 130; }; }
 gh()   { nix --extra-experimental-features "nix-command flakes" shell nixpkgs#gh -c gh "$@"; }
 glab() { nix --extra-experimental-features "nix-command flakes" shell nixpkgs#glab -c glab "$@"; }
 
-# This repository is the user's. No sudo, no safe.directory, no identity
-# passed in per commit -- all three of which nixarchy-config-repo needs only
-# because /etc/nixos is root-owned. That difference is the argument for a
-# second repository rather than a subdirectory of the first.
+# This repository is the user's, unconditionally. No sudo, no safe.directory,
+# no identity passed in per commit -- all three of which nixarchy-config-repo
+# still carries for the machines where /etc/nixos is not the user's. That
+# difference is the argument for a second repository rather than a
+# subdirectory of the first.
 git() { command git -C "$REPO" "$@"; }
 
 has_commits() { git rev-parse HEAD &>/dev/null; }

--- a/pkgs/omarchy/nix-bin/nixarchy-unfreeze
+++ b/pkgs/omarchy/nix-bin/nixarchy-unfreeze
@@ -34,8 +34,14 @@ lock="$flake/flake.lock"
 
 for f in "$nixfile" "$lock"; do
   [ -f "$f" ] || { red "No $f."; exit 1; }
+  # No prompt-and-fix here, unlike omarchy-update. The usual way in is
+  # `omarchy update`, which offers the chown before it ever calls this, so
+  # reaching this message means the script was run on its own -- and a second
+  # copy of that prompt is a second place for it to drift.
   [ -w "$f" ] || {
     red "$f is not writable by $USER."
+    echo
+    echo "Run 'omarchy update', which offers to fix this, or:"
     echo
     echo "  sudo chown -R $USER $flake"
     exit 1

--- a/pkgs/omarchy/nix-bin/omarchy-update
+++ b/pkgs/omarchy/nix-bin/omarchy-update
@@ -33,14 +33,65 @@ if [ ! -d "$flake" ]; then
   exit 1
 fi
 
+# Machines installed before this was fixed have a root-owned /etc/nixos and
+# meet this on their very first update (#356). The remedy is one chown and it
+# is known to work -- so offer to run it rather than printing it and exiting,
+# which left the user to retype a command this script could see was correct.
+#
+# Still a prompt, never automatic: chowning a directory the user did not ask
+# about is not something an updater should decide, and somebody who keeps
+# their configuration root-owned on purpose must be able to say no and be
+# told what to do instead.
 if [ ! -w "$flake" ]; then
   red "$flake is not writable by $USER."
   echo
   echo "Updating a flake rewrites its flake.lock, so the directory has to be"
-  echo "yours. Either move your configuration somewhere you own, or:"
+  echo "yours. Machines installed before this was fixed have a root-owned"
+  echo "$flake and meet this on their first update."
   echo
-  echo "  sudo chown -R $USER $flake"
-  exit 1
+
+  # -d, because a file the user cannot write inside a directory they can is a
+  # different problem and `chown -R` on the directory is not its answer.
+  if [ -d "$flake" ] && command -v sudo >/dev/null 2>&1; then
+    read -r -p "Run 'sudo chown -R $USER $flake' now? [y/N] " reply
+    case "$reply" in
+      [yY]*)
+        # -h so a symlinked flake directory has the symlink retargeted rather
+        # than whatever it points at silently changing owner.
+        sudo chown -Rh "$USER" "$flake" || {
+          red "The chown failed. $flake is unchanged."
+          exit 1
+        }
+        # Asked again rather than assumed: chown can report success and still
+        # leave the directory unwritable -- an immutable attribute, a
+        # read-only mount -- and "updated" is the one thing this must never
+        # say when nothing moved.
+        [ -w "$flake" ] || {
+          red "$flake is still not writable after the chown."
+          echo
+          echo "Check for a read-only mount or an immutable attribute:"
+          echo
+          echo "  findmnt -no OPTIONS -T $flake"
+          echo "  lsattr -d $flake"
+          exit 1
+        }
+        echo "$flake is yours now."
+        echo
+        ;;
+      *)
+        echo "Left as it is. To do it yourself:"
+        echo
+        echo "  sudo chown -R $USER $flake"
+        echo
+        echo "Or move your configuration somewhere you own and point"
+        echo "programs.nixarchy.flake at it."
+        exit 1
+        ;;
+    esac
+  else
+    echo "  sudo chown -R $USER $flake"
+    exit 1
+  fi
 fi
 
 # Machines installed before nixarchy-unfreeze existed carry a lock whose

--- a/pkgs/omarchy/skills/nixos-config-repo/SKILL.md
+++ b/pkgs/omarchy/skills/nixos-config-repo/SKILL.md
@@ -68,14 +68,23 @@ sudo git -C /etc/nixos add -A          # before every rebuild, after adding a fi
 This is the single most common reason a NixOS change "does nothing", and it is
 worth checking first whenever someone says an edit had no effect.
 
-### 2. `/etc/nixos` is root-owned
+### 2. `/etc/nixos` is owned by somebody other than you
 
 ```
 fatal: detected dubious ownership in repository at '/etc/nixos'
 ```
 
-The installer leaves it root-owned deliberately, which splits every git command
-in two: reads need `safe.directory`, writes need `sudo`.
+The installer chowns `/etc/nixos` to the user it creates, so on a machine it
+wrote, plain `git` as that user just works. You will see this on a machine
+installed before that changed, or one whose owner chowned it back to root --
+where every git command splits in two: reads need `safe.directory`, writes
+need `sudo`.
+
+Note that nix hits the same check without saying so usefully. It opens the
+flake through libgit2 and reports the refusal as `could not find a flake.nix
+file`, which sends people looking for a missing file that is right there.
+Current nixarchy ships a `safe.directory` entry in `/etc/gitconfig` for
+exactly this; a machine that predates it has not got one.
 
 ```bash
 git -c safe.directory=/etc/nixos -C /etc/nixos log        # read

--- a/pkgs/omarchy/skills/nixos/SKILL.md
+++ b/pkgs/omarchy/skills/nixos/SKILL.md
@@ -237,8 +237,9 @@ sudo nixos-rebuild switch --flake <flake>
 ```
 
 `nix flake update` rewrites `flake.lock`, so the flake directory has to be writable
-by the user running it. A root-owned `/etc/nixos` fails with a permission error on
-the lock file.
+by the user running it. The installer chowns `/etc/nixos` to the user it creates.
+A root-owned one fails with a permission error on the lock file; `omarchy update`
+offers the chown that fixes it.
 
 ## When Something Breaks
 

--- a/tests/free-space.nix
+++ b/tests/free-space.nix
@@ -656,7 +656,7 @@ pkgs.testers.runNixOSTest {
         "sed -i 's|./hardware-configuration.nix|./hardware-configuration.nix\\n"
         "    ./test-instrumentation.nix|'"
         " /mnt/etc/nixos/hosts/installed/configuration.nix")
-    installer.succeed("git -C /mnt/etc/nixos add -A")
+    installer.succeed("git -c safe.directory=/mnt/etc/nixos -C /mnt/etc/nixos add -A")
     print(installer.succeed(
         "nixos-install --root /mnt --flake /mnt/etc/nixos#installed"
         " --no-root-password"

--- a/tests/free-space.nix
+++ b/tests/free-space.nix
@@ -307,6 +307,17 @@ pkgs.testers.runNixOSTest {
         pkgs.dosfstools
       ];
 
+      # This node stands in for the installer ISO, so it carries the ISO's
+      # gitconfig -- installer/cd.nix has the same entry and the reasoning.
+      # Without it the second nixos-install below cannot open /mnt/etc/nixos
+      # at all: the install chowned it to the installed user, this driver is
+      # root and never sudo'd, and nix's libgit2 refuses a repository owned by
+      # somebody else.
+      environment.etc."gitconfig".text = ''
+        [safe]
+        	directory = /mnt/etc/nixos
+      '';
+
       nix.settings = {
         experimental-features = [
           "nix-command"
@@ -656,7 +667,7 @@ pkgs.testers.runNixOSTest {
         "sed -i 's|./hardware-configuration.nix|./hardware-configuration.nix\\n"
         "    ./test-instrumentation.nix|'"
         " /mnt/etc/nixos/hosts/installed/configuration.nix")
-    installer.succeed("git -c safe.directory=/mnt/etc/nixos -C /mnt/etc/nixos add -A")
+    installer.succeed("git -C /mnt/etc/nixos add -A")
     print(installer.succeed(
         "nixos-install --root /mnt --flake /mnt/etc/nixos#installed"
         " --no-root-password"

--- a/tests/free-space.nix
+++ b/tests/free-space.nix
@@ -307,17 +307,6 @@ pkgs.testers.runNixOSTest {
         pkgs.dosfstools
       ];
 
-      # This node stands in for the installer ISO, so it carries the ISO's
-      # gitconfig -- installer/cd.nix has the same entry and the reasoning.
-      # Without it the second nixos-install below cannot open /mnt/etc/nixos
-      # at all: the install chowned it to the installed user, this driver is
-      # root and never sudo'd, and nix's libgit2 refuses a repository owned by
-      # somebody else.
-      environment.etc."gitconfig".text = ''
-        [safe]
-        	directory = /mnt/etc/nixos
-      '';
-
       nix.settings = {
         experimental-features = [
           "nix-command"
@@ -344,6 +333,17 @@ pkgs.testers.runNixOSTest {
       };
 
       environment.etc = {
+        # This node stands in for the installer ISO, so it carries the ISO's
+        # gitconfig -- installer/cd.nix has the same entry and the reasoning.
+        # Without it the second nixos-install below cannot open /mnt/etc/nixos
+        # at all: the install chowned it to the installed user, this driver is
+        # root and never sudo'd, and nix's libgit2 refuses a repository owned
+        # by somebody else.
+        "gitconfig".text = ''
+          [safe]
+          	directory = /mnt/etc/nixos
+        '';
+
         # The answers the wizard would have collected. device is the second
         # disk, which the test script partitions first; /dev/vda is this
         # node's own root. disk_mode=free is the whole subject of this check,

--- a/tests/install-encrypted.nix
+++ b/tests/install-encrypted.nix
@@ -248,17 +248,6 @@ pkgs.testers.runNixOSTest {
         pkgs.zstd
       ];
 
-      # This node stands in for the installer ISO, so it carries the ISO's
-      # gitconfig -- installer/cd.nix has the same entry and the reasoning.
-      # Without it the second nixos-install below cannot open /mnt/etc/nixos
-      # at all: the install chowned it to the installed user, this driver is
-      # root and never sudo'd, and nix's libgit2 refuses a repository owned by
-      # somebody else.
-      environment.etc."gitconfig".text = ''
-        [safe]
-        	directory = /mnt/etc/nixos
-      '';
-
       nix.settings = {
         experimental-features = [
           "nix-command"
@@ -272,6 +261,17 @@ pkgs.testers.runNixOSTest {
       };
 
       environment.etc = {
+        # This node stands in for the installer ISO, so it carries the ISO's
+        # gitconfig -- installer/cd.nix has the same entry and the reasoning.
+        # Without it the second nixos-install below cannot open /mnt/etc/nixos
+        # at all: the install chowned it to the installed user, this driver is
+        # root and never sudo'd, and nix's libgit2 refuses a repository owned
+        # by somebody else.
+        "gitconfig".text = ''
+          [safe]
+          	directory = /mnt/etc/nixos
+        '';
+
         # encrypt=yes: the whole subject. luks_passphrase is required with it
         # and is what the target boot types back at stage 1.
         "nixarchy/answers".text = ''

--- a/tests/install-encrypted.nix
+++ b/tests/install-encrypted.nix
@@ -453,7 +453,7 @@ pkgs.testers.runNixOSTest {
     installer.succeed(
         "grep -q test-instrumentation"
         " /mnt/etc/nixos/hosts/installed/configuration.nix")
-    installer.succeed("git -C /mnt/etc/nixos add -A")
+    installer.succeed("git -c safe.directory=/mnt/etc/nixos -C /mnt/etc/nixos add -A")
     print(installer.succeed(
         "nixos-install --root /mnt --flake /mnt/etc/nixos#installed"
         " --no-root-password"

--- a/tests/install-encrypted.nix
+++ b/tests/install-encrypted.nix
@@ -248,6 +248,17 @@ pkgs.testers.runNixOSTest {
         pkgs.zstd
       ];
 
+      # This node stands in for the installer ISO, so it carries the ISO's
+      # gitconfig -- installer/cd.nix has the same entry and the reasoning.
+      # Without it the second nixos-install below cannot open /mnt/etc/nixos
+      # at all: the install chowned it to the installed user, this driver is
+      # root and never sudo'd, and nix's libgit2 refuses a repository owned by
+      # somebody else.
+      environment.etc."gitconfig".text = ''
+        [safe]
+        	directory = /mnt/etc/nixos
+      '';
+
       nix.settings = {
         experimental-features = [
           "nix-command"
@@ -453,7 +464,7 @@ pkgs.testers.runNixOSTest {
     installer.succeed(
         "grep -q test-instrumentation"
         " /mnt/etc/nixos/hosts/installed/configuration.nix")
-    installer.succeed("git -c safe.directory=/mnt/etc/nixos -C /mnt/etc/nixos add -A")
+    installer.succeed("git -C /mnt/etc/nixos add -A")
     print(installer.succeed(
         "nixos-install --root /mnt --flake /mnt/etc/nixos#installed"
         " --no-root-password"

--- a/tests/install-iso.nix
+++ b/tests/install-iso.nix
@@ -197,7 +197,7 @@ let
         step SERIAL test $? -eq 0
 
         # A flake in a git worktree sees only tracked or staged files.
-        git -C /mnt/etc/nixos add -A
+        git -c safe.directory=/mnt/etc/nixos -C /mnt/etc/nixos add -A
 
         # Built HERE and installed by path, which is what run_install() in
         # installer/install.sh does and for the reason its comment gives:

--- a/tests/install-iso.nix
+++ b/tests/install-iso.nix
@@ -197,7 +197,7 @@ let
         step SERIAL test $? -eq 0
 
         # A flake in a git worktree sees only tracked or staged files.
-        git -c safe.directory=/mnt/etc/nixos -C /mnt/etc/nixos add -A
+        git -C /mnt/etc/nixos add -A
 
         # Built HERE and installed by path, which is what run_install() in
         # installer/install.sh does and for the reason its comment gives:

--- a/tests/install.nix
+++ b/tests/install.nix
@@ -299,6 +299,17 @@ pkgs.testers.runNixOSTest {
         pkgs.git
       ];
 
+      # This node stands in for the installer ISO, so it carries the ISO's
+      # gitconfig -- installer/cd.nix has the same entry and the reasoning.
+      # Without it the second nixos-install below cannot open /mnt/etc/nixos
+      # at all: the install chowned it to the installed user, this driver is
+      # root and never sudo'd, and nix's libgit2 refuses a repository owned by
+      # somebody else.
+      environment.etc."gitconfig".text = ''
+        [safe]
+        	directory = /mnt/etc/nixos
+      '';
+
       nix.settings = {
         experimental-features = [
           "nix-command"
@@ -663,7 +674,7 @@ pkgs.testers.runNixOSTest {
     installer.succeed(
         "grep -q test-instrumentation"
         " /mnt/etc/nixos/hosts/installed/configuration.nix")
-    installer.succeed("git -c safe.directory=/mnt/etc/nixos -C /mnt/etc/nixos add -A")
+    installer.succeed("git -C /mnt/etc/nixos add -A")
     print(installer.succeed(
         "nixos-install --root /mnt --flake /mnt/etc/nixos#installed"
         " --no-root-password"
@@ -729,6 +740,27 @@ pkgs.testers.runNixOSTest {
     print("the hash survived the boot, and the repo is still clean of it")
 
     # ---- the flake on disk is the user's -------------------------------
+    #
+    # Both directions on one machine, because the whole design claim is that
+    # a user-owned /etc/nixos serves BOTH the user and root.
+    #
+    # The user side is what #356 was about: `omarchy update` rewrites
+    # flake.lock through `nh os switch --update`, unprivileged.
+    #
+    # The root side is what the chown broke and what modules/nixos.nix's
+    # safe.directory entry restores. This driver is root and has never
+    # sudo'd, which is exactly the case git and libgit2 do NOT exempt --
+    # `sudo nixos-rebuild`, with SUDO_UID set, was passing all along and
+    # would not have caught the regression. The commands below deliberately
+    # carry no `-c safe.directory`: passing one would test the flag rather
+    # than the configuration this module ships.
+    target.succeed("test -s /etc/gitconfig")
+    print(target.succeed("git config --system --get-all safe.directory"))
+
+    target.succeed("runuser -u omarchy -- test -w /etc/nixos/flake.lock")
+    target.succeed("runuser -u omarchy -- git -C /etc/nixos status --porcelain")
+    print("the installed user can write the lock and read the repo")
+
     target.succeed("git -C /etc/nixos rev-parse --is-inside-work-tree")
     for f in ["flake.nix", "flake.lock", "disk-config.nix"]:
         target.succeed(f"test -s /etc/nixos/{f}")

--- a/tests/install.nix
+++ b/tests/install.nix
@@ -663,7 +663,7 @@ pkgs.testers.runNixOSTest {
     installer.succeed(
         "grep -q test-instrumentation"
         " /mnt/etc/nixos/hosts/installed/configuration.nix")
-    installer.succeed("git -C /mnt/etc/nixos add -A")
+    installer.succeed("git -c safe.directory=/mnt/etc/nixos -C /mnt/etc/nixos add -A")
     print(installer.succeed(
         "nixos-install --root /mnt --flake /mnt/etc/nixos#installed"
         " --no-root-password"

--- a/tests/install.nix
+++ b/tests/install.nix
@@ -299,17 +299,6 @@ pkgs.testers.runNixOSTest {
         pkgs.git
       ];
 
-      # This node stands in for the installer ISO, so it carries the ISO's
-      # gitconfig -- installer/cd.nix has the same entry and the reasoning.
-      # Without it the second nixos-install below cannot open /mnt/etc/nixos
-      # at all: the install chowned it to the installed user, this driver is
-      # root and never sudo'd, and nix's libgit2 refuses a repository owned by
-      # somebody else.
-      environment.etc."gitconfig".text = ''
-        [safe]
-        	directory = /mnt/etc/nixos
-      '';
-
       nix.settings = {
         experimental-features = [
           "nix-command"
@@ -336,6 +325,17 @@ pkgs.testers.runNixOSTest {
       };
 
       environment.etc = {
+        # This node stands in for the installer ISO, so it carries the ISO's
+        # gitconfig -- installer/cd.nix has the same entry and the reasoning.
+        # Without it the second nixos-install below cannot open /mnt/etc/nixos
+        # at all: the install chowned it to the installed user, this driver is
+        # root and never sudo'd, and nix's libgit2 refuses a repository owned
+        # by somebody else.
+        "gitconfig".text = ''
+          [safe]
+          	directory = /mnt/etc/nixos
+        '';
+
         # The answers the wizard would have collected. device is the blank
         # second disk; /dev/vda is this node's own root.
         "nixarchy/answers".text = ''

--- a/tests/install.nix
+++ b/tests/install.nix
@@ -757,6 +757,18 @@ pkgs.testers.runNixOSTest {
     target.succeed("test -s /etc/gitconfig")
     print(target.succeed("git config --system --get-all safe.directory"))
 
+    # The resolved-path half. /etc/nixos is a real directory on a machine the
+    # installer wrote, so this file is expected to hold nothing but its own
+    # header -- what is asserted is that activation WROTE it, with the mode
+    # and owner that make it safe for root to include. A file a normal user
+    # could write is a way to hand root arbitrary git configuration, so the
+    # permissions are the point of the check, not a detail of it.
+    include_mode = target.succeed(
+        "stat -c '%a %U:%G' /var/lib/nixarchy/gitconfig-flake").strip()
+    assert include_mode == "644 root:root", (
+        f"the safe.directory include is {include_mode}, not 644 root:root")
+    print("the resolved-path include is written and root-owned")
+
     target.succeed("runuser -u omarchy -- test -w /etc/nixos/flake.lock")
     target.succeed("runuser -u omarchy -- git -C /etc/nixos status --porcelain")
     print("the installed user can write the lock and read the repo")

--- a/tests/install.nix
+++ b/tests/install.nix
@@ -567,11 +567,27 @@ pkgs.testers.runNixOSTest {
     # Asserted by OWNER, not by `test -w`: this test runs as root, for whom
     # everything is writable, so a writability check here would pass against a
     # root-owned directory and prove nothing at all.
-    owner = installer.succeed("stat -c %U /mnt/etc/nixos").strip()
-    assert owner == "omarchy", (
-        f"/mnt/etc/nixos is owned by {owner}, not the installed user. "
-        "The first `omarchy update` on this machine will refuse with "
-        "'not writable', and nixarchy-apply cannot stage its own copies.")
+    # By NUMERIC uid, compared against the TARGET's passwd.
+    #
+    # `stat -c %U` was the first attempt and it reported UNKNOWN against a
+    # correctly-chowned directory: stat runs on the INSTALLER and resolves
+    # uid -> name through the installer's /etc/passwd, where the target's user
+    # does not exist. The ownership was right and the assertion was asking the
+    # wrong machine.
+    #
+    # /mnt/etc/passwd is the reference because it is the passwd the installed
+    # system will boot with -- the same file installer/install.sh reads to
+    # decide what to chown to, so this checks the outcome against the same
+    # source of truth rather than against a hardcoded 1000.
+    owner_uid = installer.succeed("stat -c %u /mnt/etc/nixos").strip()
+    want_uid = installer.succeed(
+        "awk -F: '$1 == \"omarchy\" { print $3 }' /mnt/etc/passwd").strip()
+    assert want_uid, "omarchy is not in /mnt/etc/passwd; the install did not create the user"
+    assert owner_uid == want_uid, (
+        f"/mnt/etc/nixos is owned by uid {owner_uid}, but omarchy is uid "
+        f"{want_uid} on the target. The first `omarchy update` on this machine "
+        "will refuse with 'not writable', and nixarchy-apply cannot stage its "
+        "own copies.")
 
     # The install log reached the disk (#239).
     #

--- a/vm/configuration.nix
+++ b/vm/configuration.nix
@@ -170,8 +170,15 @@
     #
     #   error: opening file "/etc/nixos/flake.lock": Permission denied
     #
-    # On a real host the flake usually lives in the user's home and is already
-    # theirs; /etc/nixos being root-owned is what makes this VM the odd one.
+    # The same thing installer/install.sh does on a real machine, so this VM
+    # is no longer the odd one -- it is just doing it here because there is no
+    # installer in this path to do it.
+    #
+    # Worth knowing if you are comparing the two: this /etc/nixos is NOT a git
+    # repository (nothing here runs `git init`), so the error above is a plain
+    # file write. None of the libgit2 ownership machinery that governs a real
+    # machine's flake -- the safe.directory entry in modules/nixos.nix, and why
+    # it has to exist -- is exercised here at all.
     chown -R omarchy:users /etc/nixos
   '';
 


### PR DESCRIPTION
#357 shipped a chown that **never ran**. Every install printed:

```
chroot: failed to run command 'getent': No such file or directory
warning: could not resolve omarchy on the target; leaving /etc/nixos root-owned
```

…and carried on. The target's PATH is not set up for a chroot at that point in the install, so `chroot /mnt getent passwd` cannot work — and **the guard I wrote to be graceful turned that into a line nobody read.**

## The fix

`awk` over `/mnt/etc/passwd` needs nothing from the target at all, which is the property worth having here.

Verified against a real NixOS passwd rather than reasoned about:

```
omarchy  uid=1000   gid=100    chown runs
alice    uid=EMPTY  gid=EMPTY  guard fires
root     uid=0      gid=0      chown runs
```

## The guard stays non-fatal, but stops whispering

The install genuinely succeeded and the machine boots, so failing it at the last step would be wrong. But it no longer says "warning" — the soft wording is precisely what let this through. It now states that the first `omarchy update` **will** refuse, and prints the one command that fixes it.

## What caught it

`checks.install`'s `stat -c %U` assertion, added in the same PR as the broken fix:

```
AssertionError: /mnt/etc/nixos is owned by root, not the installed user.
```

That is the argument for writing the assertion at all. My own graceful degradation hid the failure; only an independent check of the **end state** found it. A check that asks "did the command succeed" would have seen a warning and a zero exit.

## How it reached `main`

`install` never ran on #357's final commit. A force-push cancelled the in-flight run and GitHub started no replacement, so the required context reported on a stale commit. I re-triggered it with a close/reopen — and the run that then passed was against the **older** head.

The lesson is narrower than "watch CI": a missing check and a passing check are not distinguishable in a summary line, and I read the summary.

**This PR must not merge until `install` has actually run on this commit.** I will verify the run's `headSha` rather than the check's colour.