### PR TITLE
nixpkgs: 20 app version(s) move

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -508,11 +508,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1787498568,
-        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Nightly bump of the `nixpkgs` input. Only that input: the others
are left where they are, because at least one of them is pinned on
purpose.

| app | was | now |
|---|---|---|
| `brave` | 1.93.138 | 1.94.117 |
| `google-chrome` | 151.0.7922.173 | 152.0.7977.82 |
| `claude-code` | 2.1.238 | 2.1.260 |
| `codex` | 0.149.0 | 0.151.0 |
| `code-cursor` | 3.16.29 | 3.17.21 |
| `deno` | 2.9.4 | 2.9.5 |
| `microsoft-edge` | 150.0.4078.105 | 152.0.4191.66 |
| `elixir` | 1.18.4 | 1.18.5 |
| `emacs` | 30.2 | 31.1 |
| `foot` | 1.27.0 | 1.28.0 |
| `go` | 1.26.5 | 1.26.7 |
| `heroic` | 2.22.0 | 2.22.1 |
| `lmstudio` | 0.4.21-2 | 0.4.23-1 |
| `nordvpn` | 5.2.0 | 5.3.0 |
| `php` | 8.4.24 | 8.4.25 |
| `signal-desktop` | 8.24.0 | 8.25.0 |
| `spotify` | 1.2.92.147.g5b8f9367 | 1.2.95.453.g0eeebbed |
| `t3code` | 0.0.33 | 0.0.38 |
| `vscode` | 1.133.0 | 1.136.1 |
| `zed-editor` | 1.16.1 | 1.17.2 |

Verified before this PR was opened:

- `.#checks.x86_64-linux.vm-toplevel` evaluates
- `.#checks.x86_64-linux.reference-toplevel` evaluates

That is an evaluation check, not a build. **The gate is the CI on
this pull request**, which runs because the PR was opened with
`BUMP_TOKEN`; it merges when the required contexts report green and
not before.

What CI does not cover: an app that builds and then misbehaves at
runtime. If a package here is one you rely on, launch it before
this lands, or roll back afterwards with `nixos-rebuild --rollback`.