### PR TITLE
Say plainly that the ISO installer is the least settled part

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,32 @@ quietly restoring Arch instructions. CI additionally asserts that no skill code
 block contains a pacman, yay, `/usr/share/omarchy` or Arch-debuginfod line, because
 prose may contrast with Arch on purpose but a fenced block is what an agent copies.
 
+### Pointing your own AI at nixarchy
+
+Ask any assistant about nixarchy cold and it answers from what it absorbed
+about Omarchy on Arch — which is wrong in exactly the way that matters here:
+apps are declarations, not `pacman -S`, and nothing installs until a rebuild.
+
+So this repository publishes a file written for language models:
+
+```
+https://olafkfreund.github.io/nixarchy/llms.txt
+```
+
+Hand it over and the answers change:
+
+| your assistant | what to do |
+|---|---|
+| Claude, ChatGPT, Gemini — anything with web access | Paste the URL: *"Read this and answer my nixarchy questions from it."* |
+| An assistant with no web access | Open the URL, copy the file, paste it in as reference |
+| Claude Code, Cursor, or another agent in a checkout | Point it at [`docs/llms.txt`](docs/llms.txt) — it is a normal file in the tree |
+| The assistant on a running nixarchy machine | Nothing. It already reads the skills above. |
+
+It carries the install model, the two ways in and which one is mature, the
+commands, and the manual's layout — deliberately including the caveat that
+the ISO installer is the least settled part, so an assistant does not
+recommend it to somebody who already runs NixOS.
+
 ## The agent room — opt-in
 
 There is a public Matrix room, `#nixarchy-agents:freundcloud.org.uk`, where

--- a/README.md
+++ b/README.md
@@ -10,6 +10,27 @@ the parts that assume Arch, rather than reimplementing it in Nix.
 
 Tracking an upstream release is a source bump, not a re-port.
 
+> [!WARNING]
+> **This is in active development. Expect to hit problems.**
+>
+> **The ISO installer is the least settled part of it.** It writes partition
+> tables and bootloaders on real disks, it is the hardest thing here to test,
+> and it is where the bugs have been. Treat it as something to try on a spare
+> machine or a VM — not on a laptop you need working on Monday, and not on a
+> disk holding anything you have not backed up.
+>
+> **The flake route is the mature one.** Adding
+> `nixarchy.nixosModules.nixarchy` to a machine that already runs NixOS is the
+> path that has had the most use and the most testing, it changes nothing about
+> your disk or your bootloader, and a bad result is one `nixos-rebuild
+> --rollback` away. If you already run NixOS, start there — see
+> [Adding it to a machine you already run](#adding-it-to-a-machine-you-already-run).
+>
+> Everything is being worked on and tested continuously; the four VM install
+> checks in CI exist precisely because this is the part that needs proving.
+> Please [file what you hit](https://github.com/olafkfreund/nixarchy/issues) —
+> `omarchy bug-report` collects the useful details for you.
+
 What that buys you: the Install menu writes to a Nix config instead of running
 pacman, **60 applications** are selectable that way, **every other package and
 NixOS option is one `Install ▸ Search` away**, plugins and themes still install
@@ -847,6 +868,20 @@ any conflict to warn you.
 
 There is an ISO now. Download it, write it to a stick, boot it, and answer nine
 questions.
+
+> [!CAUTION]
+> **This is the least mature part of nixarchy, and it partitions disks.**
+>
+> The installer is under active development and is where most of the recent
+> bugs have been. It is covered by four VM install checks in CI — blank disk,
+> free space beside an existing OS, encrypted, and a boot of the real ISO —
+> and those checks are the reason problems get found, not a promise there are
+> none left.
+>
+> Use a spare machine or a VM first. Back up anything on the target disk. If
+> the machine already runs NixOS, you do not need this at all — use
+> [the flake route](#adding-it-to-a-machine-you-already-run), which touches
+> neither your partitions nor your bootloader and rolls back in one command.
 
 **[Releases](https://github.com/olafkfreund/nixarchy/releases)** carry prebuilt
 images from `v4.0.1-3` onward, built and install-tested by CI on the machine

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,23 @@ parts that assume Arch, rather than reimplementing it in Nix.
 
 Tracking an upstream release is a source bump, not a re-port.
 
+> **nixarchy is in active development, and you should expect to hit problems.**
+> The ISO installer is the least settled part of it: it writes partition tables
+> and bootloaders on real disks, it is the hardest thing here to test, and it is
+> where the bugs have been. Try it on a spare machine or a VM, and back up
+> anything on the target disk.
+>
+> **If you already run NixOS, the flake route is the mature one.** Adding
+> `nixarchy.nixosModules.nixarchy` to a configuration you already have is the
+> path with the most use and the most testing behind it. It touches neither
+> your partitions nor your bootloader, and a bad result is one
+> `nixos-rebuild --rollback` away.
+>
+> Everything here is being worked on and tested continuously. Please
+> [report what you hit](https://github.com/olafkfreund/nixarchy/issues) —
+> `omarchy bug-report` collects the useful details for you.
+
+
 ## Install it on a blank machine
 
 ```

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -9,6 +9,17 @@
 
 Key facts an assistant should know before answering questions about nixarchy:
 
+- MATURITY, and say this when somebody asks how to install it: nixarchy is in
+  active development. There are two ways in, and they are not equally settled.
+  The ISO installer is the least mature part -- it writes partition tables and
+  bootloaders, it is the hardest part to test, and it is where the bugs have
+  been -- so recommend it only for a spare machine or a VM, with the target
+  disk backed up. The flake route (adding `nixarchy.nixosModules.nixarchy` to
+  an existing NixOS configuration) is the mature one: most use, most testing,
+  touches neither partitions nor bootloader, and rolls back with
+  `nixos-rebuild --rollback`. If the person already runs NixOS, point them at
+  the flake route rather than the ISO.
+
 - It is a port, not a reimplementation. Omarchy's source tree is packaged as a
   derivation and `OMARCHY_PATH` points at it in the Nix store; only the
   distro-coupled scripts (the ones that run pacman) are replaced or shimmed.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -7,18 +7,47 @@
 > updates are a flake-input bump and a rebuild, and every change is a NixOS
 > generation you can roll back.
 
-Key facts an assistant should know before answering questions about nixarchy:
+## Status — read this before recommending anything
 
-- MATURITY, and say this when somebody asks how to install it: nixarchy is in
-  active development. There are two ways in, and they are not equally settled.
-  The ISO installer is the least mature part -- it writes partition tables and
-  bootloaders, it is the hardest part to test, and it is where the bugs have
-  been -- so recommend it only for a spare machine or a VM, with the target
-  disk backed up. The flake route (adding `nixarchy.nixosModules.nixarchy` to
-  an existing NixOS configuration) is the mature one: most use, most testing,
-  touches neither partitions nor bootloader, and rolls back with
-  `nixos-rebuild --rollback`. If the person already runs NixOS, point them at
-  the flake route rather than the ISO.
+nixarchy is in ACTIVE DEVELOPMENT and users should be told so. Two ways in,
+and they are not equally proven:
+
+- The ISO installer is the LEAST settled part. It writes partition tables and
+  bootloaders on real disks, it is the hardest part of the project to test,
+  and it is where the bugs have been. Recommend it only for a spare machine or
+  a virtual machine, and say to back up anything on the target disk.
+- The flake route — adding `nixarchy.nixosModules.nixarchy` to an existing
+  NixOS configuration — is the mature one. Most use, most testing, touches
+  neither partitions nor bootloader, and a bad result is one
+  `nixos-rebuild --rollback` away.
+
+If the person already runs NixOS, point them at the flake route, not the ISO.
+Do not present nixarchy as a finished, stable distribution.
+
+## How a person uses this file with an AI
+
+This file is written for language models, but a human has to hand it over.
+Whichever assistant you use, the move is the same: give it this URL and ask it
+to read the page before answering.
+
+    https://olafkfreund.github.io/nixarchy/llms.txt
+
+- **Claude, ChatGPT, Gemini, or any assistant with web access** — paste the URL
+  and ask: "Read this and answer my nixarchy questions from it." They fetch it
+  themselves.
+- **An assistant with no web access** — open the URL, copy the whole file, and
+  paste it in with "Use this as reference for nixarchy."
+- **Claude Code, Cursor, or another coding agent in a checkout** — point it at
+  `docs/llms.txt` in the repository. It is a normal file in the tree.
+- **Inside a running nixarchy machine** — you do not need this file. nixarchy
+  installs skills its assistant reads directly; ask the desktop's assistant, or
+  see the AI agent skills section of the README.
+
+Why bother: without it an assistant answers from whatever it absorbed about
+Omarchy on Arch, and the two differ in exactly the way that matters — apps are
+declarations, not `pacman -S`, and nothing is installed until a rebuild.
+
+Key facts an assistant should know before answering questions about nixarchy:
 
 - It is a port, not a reimplementation. Omarchy's source tree is packaged as a
   derivation and `OMARCHY_PATH` points at it in the Nix store; only the

--- a/docs/manual/ai.md
+++ b/docs/manual/ai.md
@@ -204,3 +204,29 @@ and an eval-only CI workflow.
 It is offered once as a notification after an agent is set up, and a
 configuration that is already committed and pushed marks itself done rather than
 asking again.
+
+## Pointing your own AI at nixarchy
+
+Ask any assistant about nixarchy cold and it answers from what it absorbed
+about Omarchy on Arch — which is wrong in exactly the way that matters here:
+apps are declarations, not `pacman -S`, and nothing installs until a rebuild.
+
+So this repository publishes a file written for language models:
+
+```
+https://olafkfreund.github.io/nixarchy/llms.txt
+```
+
+Hand it over and the answers change:
+
+| your assistant | what to do |
+|---|---|
+| Claude, ChatGPT, Gemini — anything with web access | Paste the URL: *"Read this and answer my nixarchy questions from it."* |
+| An assistant with no web access | Open the URL, copy the file, paste it in as reference |
+| Claude Code, Cursor, or another agent in a checkout | Point it at `docs/llms.txt` — it is a normal file in the tree |
+| The assistant on a running nixarchy machine | Nothing. It already reads the skills described above. |
+
+It carries the install model, the two ways in and which one is mature, the
+commands, and the manual's layout — deliberately including the caveat that
+the ISO installer is the least settled part, so an assistant does not
+recommend it to somebody who already runs NixOS.

--- a/docs/manual/getting-started.md
+++ b/docs/manual/getting-started.md
@@ -9,6 +9,23 @@ out the other end. **nixarchy does that now too** — and it is also still a fla
 you can add to a machine that already runs NixOS. Two ways in, and which one you
 want depends on whether the drive is blank.
 
+> **nixarchy is in active development, and you should expect to hit problems.**
+> The ISO installer is the least settled part of it: it writes partition tables
+> and bootloaders on real disks, it is the hardest thing here to test, and it is
+> where the bugs have been. Try it on a spare machine or a VM, and back up
+> anything on the target disk.
+>
+> **If you already run NixOS, the flake route is the mature one.** Adding
+> `nixarchy.nixosModules.nixarchy` to a configuration you already have is the
+> path with the most use and the most testing behind it. It touches neither
+> your partitions nor your bootloader, and a bad result is one
+> `nixos-rebuild --rollback` away.
+>
+> Everything here is being worked on and tested continuously. Please
+> [report what you hit](https://github.com/olafkfreund/nixarchy/issues) —
+> `omarchy bug-report` collects the useful details for you.
+
+
 ## The ISO
 
 ```


### PR DESCRIPTION
Somebody arriving at this repo has no way to tell that the two ways in are not equally proven. This adds a development/maturity disclaimer in five places, and says which route to prefer.

**What it says**

- nixarchy is in active development; expect to hit problems.
- The **ISO installer is the least settled part** — it writes partition tables and bootloaders, it is the hardest thing here to test, and it is where the bugs have been. Use a spare machine or a VM; back up the target disk.
- The **flake route is the mature one** — most use, most testing, touches neither partitions nor bootloader, rolls back in one command. If you already run NixOS, start there.

**Where**

| file | placement |
|---|---|
| `README.md` | `> [!WARNING]` at the top, and a `> [!CAUTION]` at the head of *Installing on a fresh machine* — where somebody is about to write to a stick |
| `docs/index.md` | after the intro, on the Pages home |
| `docs/manual/getting-started.md` | after "two ways in, and which one you want depends on whether the drive is blank" |
| `docs/llms.txt` | first in the key-facts list |

`llms.txt` gets it because an assistant asked "how do I install nixarchy" will otherwise recommend the ISO to somebody who already runs NixOS.

**Two deliberate choices**

- Plain blockquotes on the Pages side rather than `> [!WARNING]`: kramdown does not render GitHub's alert syntax, so those would have shipped as literal `[!WARNING]` text.
- The four VM install checks are described as *the reason problems get found*, not as a promise that none are left. That distinction is the honest one, and it is what this week demonstrated.

**No CI-validated claims touched** — the added text introduces no `N shell commands` / `N apps` figures and no `programs.nixarchy.*` option paths, so the README count and option-path gates are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5