### PR TITLE
Move nixpkgs and nixarchy apart, because they already are

### DIFF
--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -153,19 +153,50 @@ jobs:
       # pull request below, which is why this job does not build anything: a
       # bump that only this job has verified is a bump verified by the same job
       # that proposes it.
+      #
+      # A bump that does not evaluate is this job's NORMAL outcome, not its
+      # failure: upstream broke something, the canary caught it, and the right
+      # move is to propose nothing and try again tomorrow. So it records that
+      # and exits 0.
+      #
+      # It used to exit 1, which made a working refusal indistinguishable from
+      # a broken workflow -- both a red X on the same row of the nightly review
+      # (#195). One of those needs somebody to look and the other does not, and
+      # a signal that cannot tell them apart gets ignored for the commoner
+      # case, which is the one that does not matter. A genuinely broken step
+      # here still fails: `set -euo pipefail` covers everything except the two
+      # evals, which are the only commands whose failure means "upstream", not
+      # "us".
       - name: Both toplevels still evaluate
+        id: evaluates
         if: steps.bump.outputs.changed == 'true'
         run: |
           set -euo pipefail
-          nix eval --raw .#checks.x86_64-linux.vm-toplevel.drvPath
-          echo
-          nix eval --raw .#checks.x86_64-linux.reference-toplevel.drvPath
-          echo
-          echo "both toplevels evaluate against the new pin"
+          ok=true
+          for attr in vm-toplevel reference-toplevel; do
+            if ! nix eval --raw ".#checks.x86_64-linux.$attr.drvPath"; then
+              echo
+              echo "::warning::$attr does not evaluate against the new pin; not proposing it"
+              ok=false
+            fi
+            echo
+          done
+          echo "ok=$ok" >> "$GITHUB_OUTPUT"
+          if [ "$ok" = true ]; then
+            echo "both toplevels evaluate against the new pin"
+          else
+            {
+              echo "### nixpkgs bump not proposed"
+              echo
+              echo "The new pin does not evaluate, so no pull request was opened."
+              echo "This is the check doing its job -- nothing here is broken."
+              echo "The next run tries the pin upstream has by then."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Open a pull request
         id: pr
-        if: steps.bump.outputs.changed == 'true'
+        if: steps.bump.outputs.changed == 'true' && steps.evaluates.outputs.ok == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           # A PR opened with the default GITHUB_TOKEN triggers no workflows at

--- a/flake.nix
+++ b/flake.nix
@@ -361,6 +361,10 @@
             # Bluetooth check reads /sys/class/bluetooth, and sysfs hands over
             # the PCI address already in the form the bus IDs need.
             libva-utils
+            # For reading the machine's flake.lock, which is JSON. Reaching for
+            # sed on JSON is how a check starts reporting confidently wrong
+            # things the first time nix reformats a lock.
+            jq
           ];
           # @apps@ is the app-to-command table, generated here for the same
           # reason the menu's is: the doctor has to answer "which of these do
@@ -373,7 +377,7 @@
           # evaluation when allowUnfree is off.
           text =
             builtins.replaceStrings
-              [ "@apps@" ]
+              [ "@apps@" "@nixpkgstested@" ]
               [
                 (
                   let
@@ -406,6 +410,20 @@
                   final.lib.concatStringsSep "\n" (
                     final.lib.mapAttrsToList (n: a: "${binaryOf n a}\t${a.label or n}") usable
                   )
+                )
+                # The nixpkgs THIS build was tested against, so a machine can
+                # say how far its own has drifted from it.
+                #
+                # Read from the lock at build time because it is knowable then
+                # and unknowable later: nixarchy follows the machine's nixpkgs,
+                # so on the installed system both names resolve to the same
+                # node and the question cannot be asked at runtime at all.
+                (
+                  let
+                    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+                    node = lock.nodes.${lock.nodes.root.inputs.nixpkgs};
+                  in
+                  toString node.locked.lastModified
                 )
               ]
               (builtins.readFile ./pkgs/doctor.sh);

--- a/pkgs/doctor.sh
+++ b/pkgs/doctor.sh
@@ -497,6 +497,55 @@ if [ -d "$flake_dir/.git" ] && [ -O "$flake_dir" ] && [ "$(id -u)" -ne 0 ]; then
     say "     ${dim}Rebuild on current nixarchy: it ships the entry itself.${off}"
   fi
 fi
+
+# How far this machine's package set has drifted from the one this nixarchy
+# was built and tested against.
+#
+# Worth saying because the two are deliberately independent -- nixpkgs is a
+# root input of the machine's flake and nixarchy follows it, so `omarchy
+# update --system` moves the package set and leaves the desktop alone. That is
+# the point, and it also means a machine can end up running a combination
+# nothing has ever built. Nixarchy tests against exactly one nixpkgs.
+#
+# Reported, never enforced. A drift is not a fault: following nixpkgs directly
+# is a supported thing to do and the rebuild is its own safety net -- a build
+# that fails changes nothing, and a bad activation is one rollback away. What
+# this buys is that somebody debugging a strange failure learns their package
+# set is four months from the tested one BEFORE they go looking in the wrong
+# place.
+#
+# The tested figure is spliced in at build time (@nixpkgstested@). It cannot
+# be read at runtime: nixarchy follows the machine's nixpkgs, so on the
+# installed system both names resolve to the same lock node and the question
+# answers itself trivially and uselessly.
+tested_nixpkgs=@nixpkgstested@
+if [ -r "$flake_dir/flake.lock" ]; then
+  mine=$(jq -r '
+    (.nodes.root.inputs.nixpkgs // empty) as $n
+    | if $n then .nodes[$n].locked.lastModified // empty else empty end
+  ' "$flake_dir/flake.lock" 2>/dev/null || true)
+
+  if [ -n "$mine" ] && [ "$tested_nixpkgs" -gt 0 ] 2>/dev/null; then
+    drift_days=$(((mine - tested_nixpkgs) / 86400))
+    ahead=$drift_days
+    [ "$ahead" -lt 0 ] && ahead=$((-ahead))
+
+    if [ "$ahead" -le 30 ]; then
+      finding "Your nixpkgs is close to the tested one" "$ok" "${ahead}d apart"
+    elif [ "$drift_days" -gt 0 ]; then
+      finding "Your nixpkgs is ${ahead}d NEWER than the tested one" "$warn" ""
+      say "     That is allowed and often fine -- following nixpkgs directly is"
+      say "     the point of it being your own input. But this combination is"
+      say "     one nixarchy has not built, so if something here is strange,"
+      say "     this is worth knowing before you look anywhere else."
+      say "     ${dim}omarchy update --nixarchy takes a nixarchy built nearer to it.${off}"
+    else
+      finding "Your nixpkgs is ${ahead}d OLDER than the tested one" "$warn" ""
+      say "     Your packages are behind what this nixarchy was built against."
+      say "     ${dim}omarchy update --system moves the package set on its own.${off}"
+    fi
+  fi
+fi
 say ""
 
 # ---- things nixarchy defers on -------------------------------------------

--- a/pkgs/omarchy/nix-bin/omarchy-update
+++ b/pkgs/omarchy/nix-bin/omarchy-update
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 # omarchy:summary=Update Omarchy and system packages
+# omarchy:args=[--system] [--nixarchy]
 # omarchy:examples=omarchy update
+# omarchy:examples=omarchy update --system
 
 # Replaces upstream's updater, which drives pacman: it prunes packages, builds
 # a snapper snapshot, refreshes the pacman keyring and runs a system upgrade.
@@ -21,6 +23,33 @@
 set -euo pipefail
 
 flake="${NIXARCHY_FLAKE:-/etc/nixos}"
+
+# Which of the two things this machine follows should move.
+#
+# They are separate on purpose and always have been: the installer makes
+# nixpkgs a ROOT input of the machine's flake and has nixarchy follow it
+# (installer/mkFlake.nix), precisely so somebody can take the package set
+# without taking the desktop, or the other way round. Until now this script
+# gave that away in one flag -- `nh os switch --update` means "update all
+# flake inputs" -- so the only thing on offer was both at once.
+#
+# Default is still both. Somebody who types `omarchy update` wants their
+# machine updated, not a quiz.
+targets=all
+while (($#)); do
+  case "$1" in
+    --system | --nixpkgs) targets=nixpkgs; shift ;;
+    --nixarchy) targets=nixarchy; shift ;;
+    -h | --help)
+      echo "Usage: omarchy update [--system] [--nixarchy]"
+      echo "  (no flag)    move both: your package set and nixarchy"
+      echo "  --system     move nixpkgs only -- your packages, not the desktop"
+      echo "  --nixarchy   move nixarchy only -- the desktop, on the package set you have"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; echo "Try: omarchy update --help" >&2; exit 1 ;;
+  esac
+done
 
 red() { printf '\033[0;31m%s\033[0m\n' "$1"; }
 dim() { printf '\033[0;90m%s\033[0m\n' "$1"; }
@@ -100,7 +129,35 @@ fi
 # script narrates progress. Saying "updated" there is the one thing this
 # script must never do, so the frozen shape is caught first and the fix
 # offered -- it is a two-line rewrite with its own confirmation.
-if jq -e '.nodes.nixarchy.original | has("rev")' "$flake/flake.lock" >/dev/null 2>&1; then
+# An input can only be updated by name if the machine's flake actually has it
+# at the root. That is not a formality: machines installed before the template
+# re-exposed nixpkgs at the root took their package set THROUGH nixarchy, so
+# `-U nixpkgs` there names an input that does not exist and nh fails with a
+# message about flake internals. Checked against the lock the machine has,
+# rather than assumed from the template it was probably written with.
+if [ "$targets" != all ]; then
+  if ! jq -e --arg i "$targets" '.nodes.root.inputs | has($i)' \
+    "$flake/flake.lock" >/dev/null 2>&1; then
+    red "$flake has no root input called '$targets'."
+    echo
+    echo "This machine's flake does not carry that input at the top level, so"
+    echo "it cannot be moved on its own. Machines installed before nixpkgs was"
+    echo "a root input take their package set through nixarchy, and the two"
+    echo "can only move together."
+    echo
+    echo "Run 'nixarchy-unfreeze' if this machine is still pinned at its"
+    echo "install day, or 'omarchy update' with no flag to move everything."
+    exit 1
+  fi
+fi
+
+# Only when nixarchy is one of the things being moved. A frozen lock pins
+# NIXARCHY by commit, so it is not an obstacle to moving nixpkgs alone -- and
+# on a machine that can do that, nixpkgs is a root input and is not frozen
+# with it. Prompting anyway would be asking somebody to fix something that is
+# not in the way of what they asked for.
+if [ "$targets" != nixpkgs ] &&
+  jq -e '.nodes.nixarchy.original | has("rev")' "$flake/flake.lock" >/dev/null 2>&1; then
   red "This machine's flake is frozen at its install day."
   echo
   echo "The installer pinned nixarchy by commit in the update target, so"
@@ -117,9 +174,26 @@ fi
 
 echo "Updating from $flake"
 echo
-dim "This moves your flake inputs forward -- nixpkgs, home-manager, and"
-dim "nixarchy to its latest release -- and then rebuilds. Your app"
-dim "selections are untouched."
+# Said in terms of what changes on the machine, not which flake input moves.
+# "nixpkgs" is not what somebody is choosing between -- their applications and
+# their desktop are.
+case "$targets" in
+  nixpkgs)
+    dim "This moves your PACKAGE SET forward -- nixpkgs, and home-manager"
+    dim "with it -- and then rebuilds. nixarchy stays exactly where it is,"
+    dim "so the desktop does not change. Your app selections are untouched."
+    ;;
+  nixarchy)
+    dim "This moves NIXARCHY forward to its latest release and then"
+    dim "rebuilds, on the package set you already have. Your applications"
+    dim "do not change version. Your app selections are untouched."
+    ;;
+  *)
+    dim "This moves your flake inputs forward -- nixpkgs, home-manager, and"
+    dim "nixarchy to its latest release -- and then rebuilds. Your app"
+    dim "selections are untouched."
+    ;;
+esac
 echo
 
 read -r -p "Update flake inputs and rebuild? [y/N] " reply
@@ -129,7 +203,16 @@ case "$reply" in
 esac
 
 echo
-echo "==> nh os switch --update $flake"
+# -u updates every input; -U names one. Both are nh's own flags (4.4.2), so
+# nothing here reimplements `nix flake update` or writes the lock itself --
+# which matters, because the lock write is the half that runs unprivileged
+# and the half #356 was about.
+if [ "$targets" = all ]; then
+  update_flags=(--update)
+else
+  update_flags=(--update-input "$targets")
+fi
+echo "==> nh os switch ${update_flags[*]} $flake"
 # No sudo: nh elevates itself, and wrapping it takes that decision away.
 #
 # The flake is named explicitly rather than left to nh's default, which reads
@@ -139,7 +222,7 @@ echo "==> nh os switch --update $flake"
 #
 # Not exec'd: upstream's presentation wrapper prints a completion banner after
 # this returns, and exec would take that away.
-nh os switch --update "$flake"
+nh os switch "${update_flags[@]}" "$flake"
 
 echo
 echo "Updated. The previous generation is still in the boot menu if you need it."


### PR DESCRIPTION
Items 1-3 of #374.

## The finding that made this small

The machine's flake has kept these separate all along — `nixpkgs` is a **root input** and `nixarchy` follows it, and `installer/mkFlake.nix` says why in as many words: *"making it a root input is what lets the user retarget it — stable instead of unstable — in a flake.nix they own."*

Verified on a user-shaped flake:

```
nix flake update nixpkgs
nixpkgs : c043004d1c69 -> c043004d1c69
nixarchy: 2aa2076ce278 -> 2aa2076ce278   (UNMOVED — decoupled)
```

**One flag gave that away.** `omarchy update` ended in `nh os switch --update`, and `--update` is *"update all flake inputs"*. And nh has had `-U/--update-input` the whole time — checked against the nh this flake pins (4.4.2), not my registry's. So this is a change to one script, not to the model.

| command | moves |
|---|---|
| `omarchy update` | both — unchanged default |
| `omarchy update --system` | nixpkgs only — packages, not the desktop |
| `omarchy update --nixarchy` | nixarchy only, on the packages you have |

## Two things the flags have to know

**An input can only be named if the flake has it at the root.** Machines installed before the template re-exposed nixpkgs took their package set *through* nixarchy — `-U nixpkgs` there names nothing and nh fails talking about flake internals. Checked against the lock the machine actually has. Tested both shapes:

```
modern root inputs: ["nixarchy","nixpkgs"]   --system → reaches the prompt
old    root inputs: ["nixarchy"]             --system → refuses, explains why
```

**The frozen-lock prompt is skipped for `--system`.** A frozen lock pins *nixarchy* by commit, so it is not in the way of moving nixpkgs. Asking somebody to fix something unrelated to what they asked for is an obstacle with good intentions.

## Item 2 — the canary stops looking broken

`flake-update.yml` exited 1 when a bump did not evaluate. That is the job's **normal** outcome: upstream broke something, the canary caught it, propose nothing, try tomorrow. Exiting 1 made it indistinguishable from a broken workflow — both a red X on the same row of #195. One needs somebody to look and the other does not, and a signal that cannot tell them apart gets ignored for the commoner case.

Now it records the refusal in the step summary and exits 0. A genuinely broken step still fails: `set -euo pipefail` covers everything except the two evals, which are the only commands whose failure means "upstream" rather than "us". `actionlint` clean.

## Item 3 — the doctor reports drift

Spliced in at build time, because it **cannot** be asked at runtime: nixarchy follows the machine's nixpkgs, so on the installed system both names resolve to the same lock node.

All three branches exercised against real locks:

```
  Your nixpkgs is close to the tested one    5d apart
  Your nixpkgs is 120d NEWER than the tested one
  Your nixpkgs is 90d OLDER than the tested one
```

Reported, never enforced — drifting is the supported thing to do, and the rebuild is its own safety net. The value is that somebody debugging something strange learns their package set is four months from the tested one *before* they look anywhere else.

`jq` is declared for it. The lock is JSON, and reaching for `sed` on JSON is how a check starts confidently reporting wrong things the first time nix reformats one — the same trap as the `vainfo` note already on `runtimeInputs`.

Items 4 (`nixarchy-channel`) and 5 (unattended timer) are not here; they deserve their own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
