### PR TITLE
The reasoning moves to AGENTS.md, and Claude Code can finally read it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ failure history for its own area, and they are where the long reasoning lives:
 | `modules/AGENTS.md` | the option surface, Mode A, and what each module owns |
 | `pkgs/AGENTS.md` | the vendored tree, the patch rules, and `runtimeInputs` |
 | `tests/AGENTS.md` | what each check covers, and what only a cheap one can reach |
+| `docs/internals/flake.md` | the flake's own reasoning — inputs, the overlay, the checks |
 
 `CLAUDE.md` is a symlink to this file, because Claude Code reads `CLAUDE.md`
 and not `AGENTS.md`. Without it none of this loads.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,20 @@ a reason gets rationalised away the moment it is inconvenient.
 `CONTRIBUTING.md` covers the human-facing process (forking, PR conventions,
 review). This file covers what goes wrong at the keyboard.
 
+**Read the `AGENTS.md` in the directory you are working in.** This file is the
+repository-wide register; each of these adds the intent, the layout and the
+failure history for its own area, and they are where the long reasoning lives:
+
+| | |
+|---|---|
+| `installer/AGENTS.md` | the ISO, the wizard, the phase chain, and the flake it writes |
+| `modules/AGENTS.md` | the option surface, Mode A, and what each module owns |
+| `pkgs/AGENTS.md` | the vendored tree, the patch rules, and `runtimeInputs` |
+| `tests/AGENTS.md` | what each check covers, and what only a cheap one can reach |
+
+`CLAUDE.md` is a symlink to this file, because Claude Code reads `CLAUDE.md`
+and not `AGENTS.md`. Without it none of this loads.
+
 ## 1. Prove your check fails
 
 This is the most important rule in the file.
@@ -178,11 +192,24 @@ files carry the full reasoning and the failure history.
   the off state is the one a refactor breaks quietly. (#180, open at the time
   of writing, adds `programs.nixarchy.installerManaged` to mark the other
   mode; check whether it has merged before referring to it.)
-- **Comments explain WHY, and record what was tried and what went wrong.**
-  `installer/cd.nix`, `modules/flatpaks.nix` and `installer/vm.nix` are the
-  register. A comment that narrates what the next line does is noise; a
-  comment that says which approach failed and why saves the next agent from
-  re-failing it.
+- **Reasoning lives in the directory's `AGENTS.md`, not in the code.** Each
+  directory that has one — `installer/`, `modules/`, `pkgs/`, `tests/` — states
+  its intent, what it owns, and which checks cover it, followed by the design
+  reasoning and failure history. Claude Code loads the nearest one when it
+  reads a file in that directory; other agents follow the same nearest-file
+  rule.
+- **What still belongs in the code is a short note that stops the next edit
+  being wrong.** One to three lines, at the line it protects: an invariant, a
+  gotcha, the reason a call is shaped the way it is. The test is whether
+  somebody editing THAT line needs it in front of them. `runtimeInputs` needs
+  the note that an undeclared command reads as a wrong answer rather than a
+  missing one; the history of why a package is not in nixpkgs does not.
+- **Long blocks move, they do not get deleted.** If an explanation is worth
+  more than three lines, put it in the directory's `AGENTS.md` and leave a
+  `# Why: <dir>/AGENTS.md#<anchor>` pointer. What was tried and what went wrong
+  is still the most valuable thing to write down — it just belongs where it can
+  be read without scrolling through it to reach the code.
+- **A comment that narrates what the next line does is noise**, wherever it is.
 - **`writeShellApplication` builds a strict PATH from `runtimeInputs`.** A
   command your script calls and does not declare is a runtime failure that no
   build catches.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/internals/flake.md
+++ b/docs/internals/flake.md
@@ -1,0 +1,810 @@
+# flake.nix
+
+The reasoning behind the repository's flake, moved out of the file so it reads
+as code. Every entry is reachable from a `# Why:` pointer at the line it
+explains.
+
+Deliberately **not** in the root `AGENTS.md`: that file is symlinked as
+`CLAUDE.md` and loads into every session, so a thousand lines of build
+reasoning there would cost context on every task that has nothing to do with
+it. This page is read when somebody follows a pointer.
+
+## What the flake is for
+
+- **inputs** — nixpkgs is the package set; hyprland, zen-browser, microvm and
+  the rest are pinned separately because they publish on their own schedule.
+  Some pins are deliberate and must not be bumped by an automated job; the
+  nightly review reports them and `flake-update.yml` names `nixpkgs` explicitly
+  for that reason.
+- **overlay** — how a package reaches a configuration. A module cannot take
+  packages from `inputs.self.packages`: those are built from *nixarchy's*
+  nixpkgs, and mixing instances makes `buildEnv` refuse a profile holding two
+  builds of the same version.
+- **packages** — the ISO, the installer, the doctor, `#try`, `#vm`.
+- **checks** — 37 of them; `tests/AGENTS.md` covers what each proves.
+- **nixosConfigurations** — `reference` is the machine the installer writes,
+  `vm` is the smoke-test guest, `iso`/`iso-net` are the images.
+
+## Two rules with teeth
+
+- **A check here and in no workflow is not a check.** `build.yml` asserts every
+  `checks.*` is run by some workflow, because one shipped that way and its pull
+  request went green without it ever executing.
+- **`self.rev` is absent on a dirty tree**, and `installer/mkFlake.nix` throws
+  rather than pinning a user's machine to a store path that may be garbage
+  collected. A build from an uncommitted tree fails on purpose.
+
+---
+
+## `flake.nix`
+
+<a id="for-the-person-who-has-never-seen-this-repository-"></a>
+### For the person who has never seen this repository and types
+
+```nix
+nixConfig = {
+```
+
+For the person who has never seen this repository and types
+`nix run github:olafkfreund/nixarchy#try` (or #doctor, or #vm): without
+this, nothing tells their nix that this flake's packages and closures
+are already built and cached, and Hyprland alone becomes a compile.
+nixConfig is honoured only from the flake you invoke -- the same rule
+the sops-nix comment below leans on from the other side -- so the
+module's `programs.nixarchy.binaryCaches` cannot reach a bare `nix run`;
+only this can. Nix asks before trusting either entry (or accepts them
+silently for users already trusting the caches), and a "no" costs
+nothing but the download it was offered.
+
+What this does NOT cover, measured rather than assumed: the ISO images
+themselves are not pushed to cachix -- they ship as release assets --
+so `#try` detects that case with a dry-run and falls back to the
+release download instead of leaning on these substituters.
+
+<a id="deliberately-unpinned-unlike-hyprland-sops-nix-and"></a>
+### Deliberately UNPINNED, unlike hyprland, sops-nix and microvm below, and
+
+```nix
+home-manager = {
+```
+
+Deliberately UNPINNED, unlike hyprland, sops-nix and microvm below, and
+not for lack of tags (home-manager has none; its releases are
+`release-XX.XX` branches that pair with STABLE nixpkgs, which is not
+what this flake tracks). master is co-developed against
+nixpkgs-unstable, and nixpkgs above is itself a branch ref: one `nix
+flake update` moves both to their tips together, which is the only
+pairing home-manager tests. Pinning one side of that pair would CREATE
+skew -- a frozen home-manager evaluating renamed and removed nixpkgs
+attrs a few updates from now -- which is the exact failure pinning is
+supposed to prevent. Pin this the day nixpkgs is pinned, and not before.
+
+<a id="omarchy-4-x-configures-hyprland-through-the-lua-ap"></a>
+### Omarchy 4.x configures Hyprland through the Lua API that landed in
+
+```nix
+hyprland.url = "github:hyprwm/Hyprland/0bd11c7a04a63d2785abd53363f09d552175d67d";
+```
+
+Omarchy 4.x configures Hyprland through the Lua API that landed in
+0.55; nixpkgs is still on 0.54.3.
+
+Pinned to a COMMIT, not the v0.56.2 tag, because that tag does not build
+against its own flake.lock: its CMakeLists asks for
+`find_package(glaze 7...<8)` while nix/overlays.nix feeds it the
+glaze 8.0.0 from its locked nixpkgs. find_package fails, CMake falls
+back to cloning glaze over the network, and the sandbox has none.
+Upstream dropped the version bound after tagging, and v0.56.2 is the
+newest tag, so there is no fixed tag to move to.
+
+A commit is just as reproducible as a tag. Bump it deliberately; never
+track a branch here, or `nix flake update` could break the bar on its
+own while the Lua bindings are still moving.
+
+Deliberately NOT `inputs.nixpkgs.follows = "nixpkgs"`: hyprwm asks
+consumers not to override it, and doing so forfeits their binary cache
+and rebuilds the compositor from source. See nix.settings in
+modules/nixos.nix for the matching substituter.
+
+<a id="declarative-flatpaks-for-the-software-nixpkgs-genu"></a>
+### Declarative Flatpaks, for the software nixpkgs genuinely does not carry
+
+```nix
+nix-flatpak.url = "github:gmodena/nix-flatpak/v0.7.0";
+```
+
+Declarative Flatpaks, for the software nixpkgs genuinely does not carry.
+
+nixpkgs' own services.flatpak is infrastructure only -- the daemon, the
+portals, polkit, FUSE -- and manages no applications. It does not even
+add the flathub remote. So the honest answer this repo has been giving
+is data/arch-extras.nix's `note = "then: flatpak install flathub ..."`,
+which is advice to do the one thing this project exists to prevent:
+install something imperatively that will not survive a rebuild.
+
+This adds `services.flatpak.packages`, overloading the same option
+namespace nixpkgs uses -- worth knowing, because a reader will look for
+`packages` in nixpkgs' module and not find it.
+
+Declared, not reproducible, and the distinction is real: the app IDS are
+in your configuration and travel to a new machine, but the BITS are
+whatever Flathub serves that day unless every entry pins a commit.
+Rollback restores the list, not the version. Upstream nixpkgs has
+declined to bless the equivalent (PR #347605, open since October 2024)
+on exactly that objection. We take it anyway, because the alternative on
+offer is a shell command in a comment.
+
+No `follows`: v0.7.0 has no inputs at all, which makes this the cheapest
+kind of dependency -- nothing to override, nothing to drift.
+
+<a id="zen-is-not-in-nixpkgs-and-upstream-maintains-its-o"></a>
+### Zen is not in nixpkgs and upstream maintains its own flake, which tracks
+
+```nix
+zen-browser = {
+```
+
+Zen is not in nixpkgs and upstream maintains its own flake, which tracks
+Zen's releases far more closely than a derivation here ever would.
+
+Pinned to a COMMIT because upstream's only tags are automated
+`twilight-*` build tags, not releases of the flake -- main is the
+release channel, the same position sops-nix and microvm already hold in
+this file. What makes the pin worth its bump burden here is that this
+flake's default.nix couples to nixpkgs' wrapFirefox SIGNATURE: at this
+rev it overrides both the `ffmpeg_7` and `ffmpeg_8` formals, so it
+needs a nixpkgs that declares both -- ours does -- and a branch ref
+here hands whatever main has become to every downstream lock, against
+whatever nixpkgs THEY have, where an eval throw is a break our CI
+structurally cannot see (#320 was this, in one direction; stable
+consumers hit it in the other). A commit makes the pair deliberate.
+
+What the pin costs: Zen security releases stop arriving on their own.
+Bump this routinely alongside `nix flake update`, and expect the bump
+to become MANDATORY the day nixpkgs drops its `ffmpeg_7` formal, when
+this rev's override starts throwing. Never track a branch here.
+
+<a id="the-rdp-server-behind-the-remote-desktop-feature-1"></a>
+### The RDP server behind the remote-desktop feature (#159)
+
+```nix
+hypr-rdp = {
+```
+
+The RDP server behind the remote-desktop feature (#159). Not in nixpkgs
+-- nothing under that name as of 2026-09 -- and the two RDP servers that
+are there cannot serve Hyprland: krdp needs the
+org.freedesktop.portal.RemoteDesktop interface, which
+xdg-desktop-portal-hyprland 1.4.1 does not advertise, and xrdp only
+reaches Wayland through a wayvnc chain built from an unreleased commit.
+So nixarchy carries the package until nixpkgs does.
+
+The cost, stated rather than hidden: a flake input lands in EVERY user's
+lock, including the Mode A machine that will never enable RDP. It is one
+more ref `nix flake update` can move and one more repository that has to
+keep existing. That is paid because the thing it buys -- reaching this
+desktop from a Windows machine with nothing installed on it -- has no
+other implementation at all, at any price. See the alternatives survey
+on #159; every other route is closed, not merely worse.
+
+What this project is taking on: v0.1.5, six months old, one primary
+author. The protocol stack is not theirs -- it is IronRDP, Devolutions'
+maintained Rust implementation -- so what this author owns is the
+Hyprland glue: capture, input, audio, clipboard. That is a real
+dependency on a small project, and a bad rebuild here breaks the machine
+you are remote to, from where you cannot fix it. Hence a tag. Never a
+branch, and bump it deliberately.
+
+The input has a named exit: when hypr-rdp lands in nixpkgs, delete this
+and point the module at pkgs.hypr-rdp.
+
+That exit is now IN FLIGHT rather than hypothetical -- NixOS/nixpkgs#560204
+("hypr-rdp: init at 0.1.5") is open. When it merges and reaches the nixpkgs
+revision this flake pins, the deletion is:
+
+  1. remove this input and its `follows`
+  2. modules/services/hypr-rdp.nix: `inputs.hypr-rdp.packages.${system}...`
+     becomes `pkgs.hypr-rdp`
+  3. check nothing else reads `inputs.hypr-rdp` (grep; the module is the
+     only consumer today)
+
+Do NOT delete it merely because the nixpkgs PR merged: a merge into
+nixpkgs master is not the same as being present in the revision we pin,
+and removing the input before then leaves the module reaching for an
+attribute that does not exist yet. The condition is `pkgs.hypr-rdp`
+evaluating against OUR lock, not a green tick on a pull request.
+
+`follows` is right here and wrong for hyprland above -- upstream's
+pkg/nix/package.nix is a plain rustPlatform.buildRustPackage whose
+cargoHash does not depend on which nixpkgs supplies ffmpeg, and they
+publish no binary cache to forfeit by overriding it.
+
+<a id="declarative-secrets-adopted-for-one-concrete-reaso"></a>
+### Declarative secrets, adopted for one concrete reason rather than as a
+
+```nix
+sops-nix = {
+```
+
+Declarative secrets, adopted for one concrete reason rather than as a
+general capability. #121 deliberately did not take a secrets mechanism
+("a separate decision with a key-management story attached"), and #122
+got away without one because `hashedPasswordFile` is consumed by NixOS
+itself, so the cleartext could live outside git and be pointed at.
+
+hypr-rdp removes that dodge. It reads its password from exactly two
+places -- an inline string in config.toml, or `-p` on the command line,
+which is world-readable in /proc/*/cmdline. Verified against v0.1.5:
+src/config.rs resolves `args.password.or(config.password)` and nothing
+else, there is no `password_file`, and clap reads no environment
+variable for it. So the secret has to end up INSIDE a config file, and
+something has to put it there at runtime from material safe to commit.
+
+That requirement is what picks sops-nix over agenix. agenix delivers
+files of raw secrets and has no templating, so composing one into a TOML
+would mean a hand-rolled per-service ExecStartPre shim -- the exact hack
+this is meant to avoid. `sops.templates` is that shim, upstreamed, with
+the mode and owner declared. Everything else between the two is taste.
+
+Pinned to a COMMIT because sops-nix publishes no release tags at all --
+its only tag, `assets`, is from 2021 and is not a release. master is the
+release channel. This is the same call flake.nix already makes for
+hyprland above: a commit is exactly as reproducible as a tag. Bump it
+deliberately; never track a branch.
+
+What this costs a user's lock: ONE node. sops-nix declares exactly one
+input, nixpkgs, which follows ours, so nothing transitive arrives. (Its
+dev inputs live in a private flake under dev/ that consumers never see.)
+Its nixConfig asks for cache.thalheim.io, which does NOT apply to us --
+nixConfig is honoured only from the flake you invoke, not from inputs --
+so no substituter and no trust is granted by taking this.
+
+Inert on import, which is what makes it safe for Mode A: both halves of
+the upstream module are gated, `lib.mkIf (cfg.secrets != { })` and
+`lib.mkIf (config.sops.templates != { })`. A machine that defines
+neither gets no unit, no activation script and no package. nixarchy sets
+no sops scalar of its own -- `sops.age.sshKeyPaths` already defaults to
+the ed25519 keys from services.openssh.hostKeys upstream -- so the
+mkDefault rule in modules/services/default.nix never even arises here.
+tests/options.nix asserts the inertness rather than trusting this note.
+
+<a id="221-222"></a>
+### #221/#222
+
+```nix
+microvm = {
+```
+
+#221/#222: the foundation of the sandboxes epic. A guest whose
+`/nix/store` is a 9p share of the HOST's store -- `microvm.storeOnDisk
+= false`, computed by upstream itself the moment
+`microvm.shares` contains a `source = "/nix/store"` entry -- so no
+image is ever built for a template and the closure a user runs is
+store paths the host already had.
+
+`follows = "nixpkgs"`, and deliberately not the reflex hyprland.url
+above declines: microvm.cachix.org (this flake's own `nixConfig`,
+inert unless a consumer opts in -- which nothing here does) carries the
+non-qemu hypervisors, and every guest this repo builds is qemu. What a
+user actually downloads on first launch is the template CLOSURE, built
+from THIS lock and served by nixarchy.cachix.org -- following buys
+nothing to forfeit there. What it buys instead is disko's argument, not
+hyprland's: a guest and host that share glibc, systemd and openssh
+store paths rather than each carrying a second copy, because the same
+nixpkgs built both.
+
+Pinned to a COMMIT. The newest tag, v0.5.0, is from April 2024 and
+predates options modules/microvm/guest.nix depends on (`microvm.shares`
+gained fields since); upstream publishes no newer tags and treats
+`main` as its release channel -- the same position sops-nix already
+takes in this file, for the same reason. Bump it deliberately; never
+track a branch.
+
+Lock cost, stated rather than hidden: TWO nodes for this one input, not
+one. microvm.nix declares `nixpkgs` (which follows ours, so nothing
+transitive) and `spectrum`, a `flake = false` tree it reads only to
+patch cloud-hypervisor's graphics support -- a hypervisor nothing in
+this repo will ever build, on a patch nothing here will ever apply.
+`spectrum` still lands in every user's flake.lock, including the Mode A
+machine that never asked for a VM at all. Paid because the alternative
+-- vendoring a runner ourselves -- is the copy-upstream-and-keep-it-green
+trade #221 already surveyed and rejected.
+
+<a id="which-nixarchy-built-this-machine-208-for-nixarchy"></a>
+### Which nixarchy built this machine (#208), for nixarchy-version
+
+```nix
+nixarchyRev = self.shortRev or self.dirtyShortRev or "unknown";
+```
+
+Which nixarchy built this machine (#208), for nixarchy-version.
+
+`self` is the only place the answer exists, and it is only reachable
+here -- pkgs/omarchy/default.nix cannot see the flake it belongs to --
+so the two values are computed once and threaded into the package.
+
+Not a tag: a flake cannot know its own, and the ordinary consumer
+flake.nix tracks main and has none. Not a hand-kept literal beside
+omarchyVersion either; that is the class of stale string #201 had to
+fix. A rev cannot go stale.
+
+`dirtyShortRev` is what a working copy with uncommitted changes gets
+instead of `shortRev` -- it reads "800af40-dirty", which is the honest
+thing for a machine built from someone's checkout to say. Neither
+exists when the source is not a git tree at all, hence the last
+fallback.
+
+<a id="vainfo-for-the-graphics-section"></a>
+### vainfo, for the Graphics section
+
+```nix
+libva-utils
+```
+
+vainfo, for the Graphics section. Declared because
+writeShellApplication builds a strict PATH, and an undeclared
+vainfo does not read as "vainfo is missing" -- it reads as "no
+VAAPI driver answered", which is a different and much worse
+answer to hand someone. It ran anyway while this was being
+written, from the developer's own PATH, which is exactly how
+that goes unnoticed.
+
+No pciutils: the GPUs come from /sys/bus/pci, the same way the
+Bluetooth check reads /sys/class/bluetooth, and sysfs hands over
+the PCI address already in the form the bus IDs need.
+
+<a id="nixarchy-apps-first-then-the-top-level"></a>
+### nixarchy-apps first, then the top level
+
+```nix
+path = final.lib.splitString "." (app.attr or name);
+```
+
+nixarchy-apps first, then the top level. Apps
+this repo packages live under nixarchy-apps, so
+probing only the top level returned null for every
+one of them and the fallback answered with the
+attribute name. That is right by luck when the
+attribute matches the binary -- once, omacut,
+ttfx -- and wrong when it does not: `zen` for a
+package installing bin/zen-beta, `hey-cli` for one
+installing bin/hey. Both were reported as absent
+on machines that had them.
+
+<a id="podman-info-podman-inspect-for-the-boxes-section"></a>
+### podman info / podman inspect, for the Boxes section
+
+```nix
+podman
+```
+
+podman info / podman inspect, for the Boxes section. Safe to
+pin here -- unlike distrobox, podman does not resolve anything
+relative to argv[0], so a /nix/store path to it carries none of
+pkgs/box.nix's hazard. distrobox itself is deliberately NOT
+here: it is looked up by bare name (`command -v distrobox`),
+the same wrapper-only rule that command's own header explains.
+hyprctl is deliberately not here either -- the client has to
+match the RUNNING compositor, which the session's PATH carries
+and this list cannot; the Graphics section's comment in
+verify.sh makes the argument.
+
+<a id="not-built-here-upstreams-own-flake-re-exported-int"></a>
+### Not built here -- upstream's own flake, re-exported into the overlay
+
+```nix
+zen-browser = zen-browser.packages.${final.stdenv.hostPlatform.system}.default;
+```
+
+Not built here -- upstream's own flake, re-exported into the overlay
+so nixarchy-doctor can find it.
+
+The doctor asks pkgs for an app's meta.mainProgram to learn which
+command it puts on PATH, and falls back to the attribute name when
+the lookup fails. zen-browser lived only in packages.<system>, so
+the lookup returned null and the fallback answered "zen" -- a
+command that does not exist, because this package installs
+bin/zen-beta. The doctor could never report Zen as present.
+
+Exactly the vscode/code trap the doctor was written to avoid, reached
+by a different road: not a wrong mainProgram, but a package the probe
+could not see. The Install menu's copy of the probe had the same bug
+for longer -- it reads cfg.apps.<name>.package instead of this
+overlay; see appBinary in modules/apps.nix.
+
+<a id="nixpkgs-retroarch-is-retroarch-with-cores-built-wi"></a>
+### nixpkgs' `retroarch` is `retroarch-with-cores` built with an
+
+```nix
+retroarch = final.retroarch.withCores (
+```
+
+nixpkgs' `retroarch` is `retroarch-with-cores` built with an
+EMPTY core list, so installing it gives an emulator that can run
+nothing. `retroarch-full` is the obvious fix and the wrong one:
+it pulls unfree cores, and an unfree package in the app list
+aborts the whole rebuild rather than failing on its own.
+
+So: every core Omarchy's own picker offers that nixpkgs ships
+under a free licence, minus the two that dwarf the rest.
+snes9x and genesis-plus-gx are unfree, hence bsnes and blastem
+for those systems.
+
+<a id="the-rdp-daemon-re-exported-from-its-own-flake-so-t"></a>
+### The RDP daemon, re-exported from its own flake so the module that
+
+```nix
+hypr-rdp = inputs.hypr-rdp.packages.${final.stdenv.hostPlatform.system}.hypr-rdp;
+```
+
+The RDP daemon, re-exported from its own flake so the module that
+will run it (#156) can say `pkgs.hypr-rdp` and never mention an
+input. Built by upstream's pkg/nix/package.nix against OUR nixpkgs,
+through the `follows` on the input.
+
+This indirection is what makes the input's exit cheap: when nixpkgs
+carries hypr-rdp, delete the input and this attribute, and every
+`pkgs.hypr-rdp` in the tree keeps resolving -- to nixpkgs' own.
+
+Lazy, so a machine that never enables RDP never builds it. Being in
+the overlay is not being on the system.
+
+<a id="nixpkgs-is-on-0-3-0-whose-session-lock-aborts-on-d"></a>
+### nixpkgs is on 0.3.0, whose session lock aborts on DPMS
+
+```nix
+quickshell = final.quickshell.overrideAttrs (_: rec {
+```
+
+nixpkgs is on 0.3.0, whose session lock aborts on DPMS.
+
+WlSessionLock::updateSurfaces reached qFatal -- "Tried to show
+lockscreen surfaces without active lock" -- when screens slept and
+woke while locked. quickshell dies, and because the Wayland
+session-lock protocol deliberately keeps the compositor locked when
+its lock client disappears, the machine is left blank with nothing to
+type a password into. Reboot is the only way out. Seen three times in
+one night, ~65-70 MB of coredump each.
+
+v0.3.1 fixes it, and says so in as many words: "Fixed session lock
+crashes on sleep, wake, DPMS, and unlocking." Three commits touch
+wayland/lock; 897fcdaa is this one -- it null-checks the wayland
+output and skips placeholder screens instead of asserting.
+
+overrideAttrs rather than a fork: nixpkgs keeps the build, the Qt
+wrapper and the dependency set, and only the tag moves. Passed here
+rather than set on the overlay, so a machine using quickshell for
+something of its own keeps nixpkgs'.
+
+DELETE THIS once nixpkgs ships >= 0.3.1.
+
+<a id="the-boot-splash-and-nothing-else-on-the-disk-with-"></a>
+### The boot splash, and nothing else on the disk with it
+
+```nix
+nixarchy-plymouth = final.runCommand "nixarchy-plymouth-theme" { } ''
+```
+
+The boot splash, and nothing else on the disk with it.
+
+The omarchy package already carries share/plymouth/themes/omarchy,
+and on a desktop that is the right place for it: the machine has the
+package anyway. The live image does not. It deliberately does not
+import nixosModules.nixarchy (see installer/cd.nix), so naming the
+desktop package in boot.plymouth.themePackages would be the only
+reason it were there -- and nixpkgs' plymouth module puts
+themePackages into environment.etc, so the named package joins the
+system closure whole: 411.9 MiB on an image budgeted at 2.00 GiB,
+which is GitHub's limit on a release asset rather than a preference.
+These assets are 180 KiB.
+
+Copied out of the same package rather than assembled again, so the
+theme is built in exactly one place and the image's splash cannot
+differ from the installed one. Nothing is rewritten here:
+omarchy.plymouth already points at /etc/plymouth/themes/omarchy, so
+this output has no store references and costs only its own size.
+
+<a id="nix-run-github-olafkfreund-nixarchy-verify-from-in"></a>
+### `nix run github:olafkfreund/nixarchy#verify`, from inside a running
+
+```nix
+install = pkgsFor.${system}.writeShellApplication {
+```
+
+`nix run github:olafkfreund/nixarchy#verify`, from inside a running
+Omarchy session. Everything in checks/ runs in a machine with no GPU,
+no Bluetooth radio, no network and no sound; this asks the questions
+that leaves unanswered.
+`nix run github:olafkfreund/nixarchy#install`, as root, from a NixOS
+live ISO. Formats ONE disk with installer/disk-config.nix, writes the
+generated flake to /mnt/etc/nixos and runs nixos-install against it.
+
+Every answer ends up as text in that flake: the machine it produces
+belongs to the flake, not to this script.
+
+<a id="nix-run-release-notes-from-tag-to-ref-what-changed"></a>
+### `nix run .#release-notes <from-tag> <to-ref>` -- what changed for
+
+```nix
+release-notes = pkgsFor.${system}.writeShellApplication {
+```
+
+`nix run .#release-notes <from-tag> <to-ref>` -- what changed for
+someone running nixarchy, between two releases. release.yml puts its
+output above the download instructions on the release page.
+
+An app for the same reason `review` is one: it evaluates the option
+set at two revisions and asks GitHub what upstream shipped, and a
+check has neither a network nor a second checkout. The half that
+needs neither is checks.release-notes, which drives this whole script
+against a fixture repository.
+
+It carries omarchy-package-delta.sh rather than reimplementing it:
+the question "what did this Omarchy release add and drop" already has
+an answer here, and two of them would disagree eventually.
+
+<a id="nix-run-devenv-presets-scaffolds-every-preset-in"></a>
+### `nix run .#devenv-presets` -- scaffolds every preset in
+
+```nix
+devenv-presets =
+```
+
+`nix run .#devenv-presets` -- scaffolds every preset in
+data/devenv-presets.nix with the real `nixarchy dev init`, then asks a
+real devenv to evaluate what it wrote.
+
+This is the whole safety net under that catalogue. `lines` is a
+string, so a preset that names an option devenv renamed is a valid Nix
+file and a broken project, and nothing in `nix flake check` would ever
+say so. It runs the command rather than reproducing what it does,
+because a check that scaffolds its own devenv.nix tests a copy.
+
+NOT in `checks`, and that is not an oversight. #150 proposed it as one
+on the reasoning that a full `devenv shell` needs the network but
+evaluation does not. That is wrong, twice over: evaluating a devenv
+project fetches the inputs devenv.yaml names
+(github:cachix/devenv-nixpkgs/rolling), and devenv's own flake reaches
+them through import-from-derivation -- `nix flake show
+github:cachix/devenv` fails with `allow-import-from-derivation is
+disabled` before it prints anything. A sandboxed derivation has
+neither, so `checks.devenv-presets` could not run at all. A workflow
+job that has a network does, and build.yml has one.
+
+<a id="screencasts-of-a-real-session-scene-by-scene-see"></a>
+### Screencasts of a real session, scene by scene -- see
+
+```nix
+inherit
+```
+
+Screencasts of a real session, scene by scene -- see
+tests/demo/default.nix. Not checks: each boots a desktop, drives
+it and encodes a GIF, which is minutes of work nobody wants on
+every push.
+
+  nix build .#demo                 the full tour (mp4 + gif)
+  nix run   .#demo-record -- <s>   re-record ONE scene's GIF and
+                                   drop it in docs/img/features/
+  nix run   .#demo-verify -- f.gif audit any GIF: sampled frames
+                                   must change, and must OCR to
+                                   what the scene claims to show
+
+<a id="nix-run-update-rewrites-the-pinned-versions-and-ha"></a>
+### `nix run .#update` -- rewrites the pinned versions and hashes in
+
+```nix
+update =
+```
+
+`nix run .#update` -- rewrites the pinned versions and hashes in
+place. CI runs it nightly and opens a PR (update.yml).
+
+Derived, not enumerated: every nixarchy-apps package carrying a
+passthru.updateScript is run, so a new hand-pinned package is
+covered the day it lands, without an edit here. This line used to
+name `once` alone -- beside a comment claiming once was the only
+hand pin -- while hey-cli sat pinned with an updateScript nothing
+reached, and needed a human (#195, 2026-09-05).
+
+`nix eval .#update.pinned` lists the covered attributes; update.yml
+builds exactly those after a rewrite, off the same set. A package
+pinned by hand WITHOUT an updateScript is still invisible to this
+-- as of this writing only grok-bot, whose Cursor CDN pin has no
+queryable "latest" (pkgs/review.sh probes its age instead).
+
+<a id="a-vm-that-installs-onto-a-blank-disk-with-a-networ"></a>
+### A VM that installs onto a blank disk, WITH a network -- which
+
+```nix
+installer-vm =
+```
+
+A VM that installs onto a blank disk, WITH a network -- which
+checks.install cannot have, because it is a sandboxed derivation and
+its whole point is that a rebuild afterwards cannot fetch anything.
+See installer/vm.nix.
+
+Wrapped rather than exported raw: the generated run script creates
+two sparse qcow2 images and only discovers they do not fit hours
+later, from inside the guest. installer/vm-preflight.sh checks first
+and says so. The sizes come from the configuration itself so the
+check cannot drift away from what the VM actually asks for.
+
+<a id="the-front-door"></a>
+### The front door
+
+```nix
+try =
+```
+
+The front door: `nix run github:olafkfreund/nixarchy#try` boots
+the installer ISO in a local UEFI VM, wizard and all, for someone
+who knows nothing about this repository. `-- --net` takes the
+network image instead.
+
+Deliberately NOT depending on the ISO derivation: referencing it
+here would make `nix run .#try` download -- or worse, silently
+build -- 5.6 GB before the script's first line ran. The script
+resolves the image itself at runtime, dry-run first, so "this is
+a download of X" or "STOP, this would be a source build" is said
+BEFORE either happens. See installer/try.sh for the rest of the
+refusals; checks.try-preflight exercises each of them.
+
+Also not a wrapper around .#installer-vm: that VM answers the
+wizard itself from a baked answers file -- a test harness, and
+exactly the thing a person trying nixarchy must not get.
+
+<a id="two-runners-per-data-microvm-templates-nix-entry-b"></a>
+### Two runners per data/microvm-templates.nix entry, both built by
+
+```nix
+// lib.concatMapAttrs (
+```
+
+Two runners per data/microvm-templates.nix entry, both built by
+`lib.mkMicrovm` above from the same template and the same
+modules/microvm/guest.nix -- only `microvm.cpu` differs between
+them.
+
+`microvm-<t>` passes nothing extra: `cpu = null` is upstream's own
+default, which on x86_64-linux means `-enable-kvm -cpu
+host,+x2apic,-sgx` (lib/runners/qemu.nix in the pinned commit --
+`-enable-kvm` is added exactly when `cpu == null`). That is what
+nearly every user runs, and #221 says outright it is not provable
+in CI without nested virtualisation.
+
+`microvm-<t>-tcg` sets `microvm.cpu = "max"`. The same `cpu !=
+null` branch that changes the `-cpu` argument ALSO removes
+`-enable-kvm` from the same conditional -- one option, both
+effects -- which is what makes this the runner a host with no
+`/dev/kvm` (including nixarchy running inside a VM) can boot, and
+the one CI builds. No separate "disable kvm" option exists to set;
+there is only this one.
+
+machineOpts on the -tcg variant, and every entry is load-bearing:
+
+  - `pit = "on"`, `pic = "on"`. Upstream's default microvm machine
+    sets both off, which is correct under KVM -- kvmclock is the
+    guest's clock -- and fatal under TCG, which has no kvmclock:
+    with no PIT, no PIC and no HPET on this machine type, early
+    timer init has nothing to calibrate from, and the kernel
+    triple-faults or wedges right after "Poking KASLR", outcome
+    depending on where KASLR happened to land. Measured on a real
+    A/B: the shipped runner under forced TCG produced zero output
+    for five minutes; the same runner with pit/pic on booted to a
+    login prompt in 2m13s. `-cpu qemu64` wedged identically, so
+    the CPU model was ruled out.
+
+  - `accel = "tcg"`, PINNED -- not upstream's `kvm:tcg` fallback
+    chain. The fallback is how the wedge above shipped unnoticed:
+    qemu silently takes KVM wherever /dev/kvm exists (including
+    inside a test VM on a host with nested virtualisation), so
+    every local run of the "-tcg" artifact was measuring a KVM
+    boot, and the one environment that exercised real TCG was CI
+    -- at the moment something first tried to boot it. This
+    variant's entire reason to exist is hosts with no /dev/kvm; a
+    KVM host should run the normal runner. Do not "optimise" the
+    fallback back in: an artifact that never runs as what its
+    name promises is how this bug lived long enough to gate a PR.
+
+  - the rest reproduce upstream's x86 defaults (machineOpts
+    REPLACES the whole set, so omitting one is turning it off).
+    `pcie = "on"` because the 9p shares sit on virtio-pci.
+
+<a id="the-same-vm-with-room-to-run-a-model"></a>
+### The same VM with room to run a model
+
+```nix
+vm-big = nixpkgs.lib.nixosSystem {
+```
+
+The same VM with room to run a model.
+
+`.#vm` is a smoke test and is sized like one: 8GB, and an ephemeral
+root, which is right for catching a broken desktop and wrong for
+anything to do with programs.nixarchy.localAi. Two reasons, and the
+second is the one that is not obvious:
+
+  - 8GB does not hold a useful model. qwen3:8b is 5.2GB of weights
+    before any cache.
+
+  - diskImage = null puts the root on a tmpfs, so the weights live in
+    RAM. They are then paid for twice, once to store and once to load,
+    out of the same pool -- and the service is OOM-killed while every
+    visible number says it had room. Observed, not theorised.
+
+So this one has a real disk, which also means a pulled model survives
+a restart rather than being re-downloaded every time.
+
+  nix run .#vm-big
+  ssh -p 2224 omarchy@localhost      (password: omarchy)
+
+It writes nixarchy-vm-big.qcow2 into the working directory and REUSES
+it, which is the point here and is exactly what .#vm avoids. Delete
+that file to start clean.
+
+<a id="one-module-that-imports-the-machines-own-two-rathe"></a>
+### One module that imports the machine's own two, rather than two
+
+```nix
+{
+```
+
+One module that imports the machine's own two, rather than two
+entries in this list. It has to be shaped this way, because the
+generated flake's hosts/<name>/default.nix is shaped this way:
+`imports` inside a module and entries in `modules` are merged in
+different orders, so the flat form gives a different
+environment.systemPackages ORDER -- same packages, same closure,
+different list -- and system-path hashes that order into
+chosenOutputs. A different system-path is a different toplevel,
+and on an ISO with no network the installed machine can no longer
+copy the one baked here: it has to build it, which means stdenv,
+which means the source bootstrap from hex0-seed.
+
+Nothing about the packages differs. Only the order does, and only
+the order has to.
+
+<a id="one-closure-per-template-shared-by-every-vm-a-user"></a>
+### One closure per template, shared by every VM a user ever names from
+
+```nix
+lib.mkMicrovm =
+```
+
+One closure per template, shared by every VM a user ever names from
+it. #221's "the name is never a Nix argument" is exactly what makes
+this possible: `template` and `modules` are the only things this
+function is allowed to vary on, and neither is a per-VM value.
+
+`template` is a path from data/microvm-templates.nix -- plain NixOS
+plus microvm.nix's own options, per that catalogue's bar.
+modules/microvm/guest.nix is what every template gets underneath it,
+imported here rather than by each template file so a template cannot
+forget it. `modules` exists for exactly one caller below: the `-tcg`
+packages, which add `microvm.cpu = "max"` without a second template.
+
+Returns `declaredRunner`, upstream's own name for
+`config.microvm.runner.${config.microvm.hypervisor}` -- a package,
+which is what `packages.<system>.microvm-<template>` has to be.
+
+<a id="both-images-against-the-budgets-recorded-in-instal"></a>
+### Both images, against the budgets recorded in installer/cd.nix
+
+```nix
+iso-budget =
+```
+
+Both images, against the budgets recorded in installer/cd.nix.
+
+A check rather than a comment because a number nobody enforces is a
+number that drifts. The nightly runs this; it costs nothing beyond
+the ISO builds it already does.
+
+The iso-net budget is the load-bearing one, and it is not a taste
+question: GitHub refuses a release asset over 2 GiB, so an iso-net
+that crosses it stops being publishable as a single file and
+release.yml would have to start splitting it. Failing here says so
+while there is still something to do about it, rather than at the
+next tag.

--- a/flake.nix
+++ b/flake.nix
@@ -1,21 +1,7 @@
 {
   description = "Nixarchy - Omarchy, vendored for NixOS";
 
-  # For the person who has never seen this repository and types
-  # `nix run github:olafkfreund/nixarchy#try` (or #doctor, or #vm): without
-  # this, nothing tells their nix that this flake's packages and closures
-  # are already built and cached, and Hyprland alone becomes a compile.
-  # nixConfig is honoured only from the flake you invoke -- the same rule
-  # the sops-nix comment below leans on from the other side -- so the
-  # module's `programs.nixarchy.binaryCaches` cannot reach a bare `nix run`;
-  # only this can. Nix asks before trusting either entry (or accepts them
-  # silently for users already trusting the caches), and a "no" costs
-  # nothing but the download it was offered.
-  #
-  # What this does NOT cover, measured rather than assumed: the ISO images
-  # themselves are not pushed to cachix -- they ship as release assets --
-  # so `#try` detects that case with a dry-run and falls back to the
-  # release download instead of leaning on these substituters.
+  # Why: docs/internals/flake.md#for-the-person-who-has-never-seen-this-repository-
   nixConfig = {
     extra-substituters = [
       "https://nixarchy.cachix.org"
@@ -32,40 +18,13 @@
 
     systems.url = "github:nix-systems/default-linux";
 
-    # Deliberately UNPINNED, unlike hyprland, sops-nix and microvm below, and
-    # not for lack of tags (home-manager has none; its releases are
-    # `release-XX.XX` branches that pair with STABLE nixpkgs, which is not
-    # what this flake tracks). master is co-developed against
-    # nixpkgs-unstable, and nixpkgs above is itself a branch ref: one `nix
-    # flake update` moves both to their tips together, which is the only
-    # pairing home-manager tests. Pinning one side of that pair would CREATE
-    # skew -- a frozen home-manager evaluating renamed and removed nixpkgs
-    # attrs a few updates from now -- which is the exact failure pinning is
-    # supposed to prevent. Pin this the day nixpkgs is pinned, and not before.
+    # Why: docs/internals/flake.md#deliberately-unpinned-unlike-hyprland-sops-nix-and
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # Omarchy 4.x configures Hyprland through the Lua API that landed in
-    # 0.55; nixpkgs is still on 0.54.3.
-    #
-    # Pinned to a COMMIT, not the v0.56.2 tag, because that tag does not build
-    # against its own flake.lock: its CMakeLists asks for
-    # `find_package(glaze 7...<8)` while nix/overlays.nix feeds it the
-    # glaze 8.0.0 from its locked nixpkgs. find_package fails, CMake falls
-    # back to cloning glaze over the network, and the sandbox has none.
-    # Upstream dropped the version bound after tagging, and v0.56.2 is the
-    # newest tag, so there is no fixed tag to move to.
-    #
-    # A commit is just as reproducible as a tag. Bump it deliberately; never
-    # track a branch here, or `nix flake update` could break the bar on its
-    # own while the Lua bindings are still moving.
-    #
-    # Deliberately NOT `inputs.nixpkgs.follows = "nixpkgs"`: hyprwm asks
-    # consumers not to override it, and doing so forfeits their binary cache
-    # and rebuilds the compositor from source. See nix.settings in
-    # modules/nixos.nix for the matching substituter.
+    # Why: docs/internals/flake.md#omarchy-4-x-configures-hyprland-through-the-lua-ap
     hyprland.url = "github:hyprwm/Hyprland/0bd11c7a04a63d2785abd53363f09d552175d67d";
 
     omarchy = {
@@ -73,29 +32,7 @@
       flake = false;
     };
 
-    # Declarative Flatpaks, for the software nixpkgs genuinely does not carry.
-    #
-    # nixpkgs' own services.flatpak is infrastructure only -- the daemon, the
-    # portals, polkit, FUSE -- and manages no applications. It does not even
-    # add the flathub remote. So the honest answer this repo has been giving
-    # is data/arch-extras.nix's `note = "then: flatpak install flathub ..."`,
-    # which is advice to do the one thing this project exists to prevent:
-    # install something imperatively that will not survive a rebuild.
-    #
-    # This adds `services.flatpak.packages`, overloading the same option
-    # namespace nixpkgs uses -- worth knowing, because a reader will look for
-    # `packages` in nixpkgs' module and not find it.
-    #
-    # Declared, not reproducible, and the distinction is real: the app IDS are
-    # in your configuration and travel to a new machine, but the BITS are
-    # whatever Flathub serves that day unless every entry pins a commit.
-    # Rollback restores the list, not the version. Upstream nixpkgs has
-    # declined to bless the equivalent (PR #347605, open since October 2024)
-    # on exactly that objection. We take it anyway, because the alternative on
-    # offer is a shell command in a comment.
-    #
-    # No `follows`: v0.7.0 has no inputs at all, which makes this the cheapest
-    # kind of dependency -- nothing to override, nothing to drift.
+    # Why: docs/internals/flake.md#declarative-flatpaks-for-the-software-nixpkgs-genu
     nix-flatpak.url = "github:gmodena/nix-flatpak/v0.7.0";
 
     # The installer's one disk layout is a disko expression, and the installed
@@ -110,162 +47,25 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # Zen is not in nixpkgs and upstream maintains its own flake, which tracks
-    # Zen's releases far more closely than a derivation here ever would.
-    #
-    # Pinned to a COMMIT because upstream's only tags are automated
-    # `twilight-*` build tags, not releases of the flake -- main is the
-    # release channel, the same position sops-nix and microvm already hold in
-    # this file. What makes the pin worth its bump burden here is that this
-    # flake's default.nix couples to nixpkgs' wrapFirefox SIGNATURE: at this
-    # rev it overrides both the `ffmpeg_7` and `ffmpeg_8` formals, so it
-    # needs a nixpkgs that declares both -- ours does -- and a branch ref
-    # here hands whatever main has become to every downstream lock, against
-    # whatever nixpkgs THEY have, where an eval throw is a break our CI
-    # structurally cannot see (#320 was this, in one direction; stable
-    # consumers hit it in the other). A commit makes the pair deliberate.
-    #
-    # What the pin costs: Zen security releases stop arriving on their own.
-    # Bump this routinely alongside `nix flake update`, and expect the bump
-    # to become MANDATORY the day nixpkgs drops its `ffmpeg_7` formal, when
-    # this rev's override starts throwing. Never track a branch here.
+    # Why: docs/internals/flake.md#zen-is-not-in-nixpkgs-and-upstream-maintains-its-o
     zen-browser = {
       url = "github:0xc000022070/zen-browser-flake/51df7b8cbb0fcba14a9b159531ef48d0cd69dde9";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # The RDP server behind the remote-desktop feature (#159). Not in nixpkgs
-    # -- nothing under that name as of 2026-09 -- and the two RDP servers that
-    # are there cannot serve Hyprland: krdp needs the
-    # org.freedesktop.portal.RemoteDesktop interface, which
-    # xdg-desktop-portal-hyprland 1.4.1 does not advertise, and xrdp only
-    # reaches Wayland through a wayvnc chain built from an unreleased commit.
-    # So nixarchy carries the package until nixpkgs does.
-    #
-    # The cost, stated rather than hidden: a flake input lands in EVERY user's
-    # lock, including the Mode A machine that will never enable RDP. It is one
-    # more ref `nix flake update` can move and one more repository that has to
-    # keep existing. That is paid because the thing it buys -- reaching this
-    # desktop from a Windows machine with nothing installed on it -- has no
-    # other implementation at all, at any price. See the alternatives survey
-    # on #159; every other route is closed, not merely worse.
-    #
-    # What this project is taking on: v0.1.5, six months old, one primary
-    # author. The protocol stack is not theirs -- it is IronRDP, Devolutions'
-    # maintained Rust implementation -- so what this author owns is the
-    # Hyprland glue: capture, input, audio, clipboard. That is a real
-    # dependency on a small project, and a bad rebuild here breaks the machine
-    # you are remote to, from where you cannot fix it. Hence a tag. Never a
-    # branch, and bump it deliberately.
-    #
-    # The input has a named exit: when hypr-rdp lands in nixpkgs, delete this
-    # and point the module at pkgs.hypr-rdp.
-    #
-    # That exit is now IN FLIGHT rather than hypothetical -- NixOS/nixpkgs#560204
-    # ("hypr-rdp: init at 0.1.5") is open. When it merges and reaches the nixpkgs
-    # revision this flake pins, the deletion is:
-    #
-    #   1. remove this input and its `follows`
-    #   2. modules/services/hypr-rdp.nix: `inputs.hypr-rdp.packages.${system}...`
-    #      becomes `pkgs.hypr-rdp`
-    #   3. check nothing else reads `inputs.hypr-rdp` (grep; the module is the
-    #      only consumer today)
-    #
-    # Do NOT delete it merely because the nixpkgs PR merged: a merge into
-    # nixpkgs master is not the same as being present in the revision we pin,
-    # and removing the input before then leaves the module reaching for an
-    # attribute that does not exist yet. The condition is `pkgs.hypr-rdp`
-    # evaluating against OUR lock, not a green tick on a pull request.
-    #
-    # `follows` is right here and wrong for hyprland above -- upstream's
-    # pkg/nix/package.nix is a plain rustPlatform.buildRustPackage whose
-    # cargoHash does not depend on which nixpkgs supplies ffmpeg, and they
-    # publish no binary cache to forfeit by overriding it.
+    # Why: docs/internals/flake.md#the-rdp-server-behind-the-remote-desktop-feature-1
     hypr-rdp = {
       url = "github:MuNeNiCK/hypr-rdp/v0.1.5";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # Declarative secrets, adopted for one concrete reason rather than as a
-    # general capability. #121 deliberately did not take a secrets mechanism
-    # ("a separate decision with a key-management story attached"), and #122
-    # got away without one because `hashedPasswordFile` is consumed by NixOS
-    # itself, so the cleartext could live outside git and be pointed at.
-    #
-    # hypr-rdp removes that dodge. It reads its password from exactly two
-    # places -- an inline string in config.toml, or `-p` on the command line,
-    # which is world-readable in /proc/*/cmdline. Verified against v0.1.5:
-    # src/config.rs resolves `args.password.or(config.password)` and nothing
-    # else, there is no `password_file`, and clap reads no environment
-    # variable for it. So the secret has to end up INSIDE a config file, and
-    # something has to put it there at runtime from material safe to commit.
-    #
-    # That requirement is what picks sops-nix over agenix. agenix delivers
-    # files of raw secrets and has no templating, so composing one into a TOML
-    # would mean a hand-rolled per-service ExecStartPre shim -- the exact hack
-    # this is meant to avoid. `sops.templates` is that shim, upstreamed, with
-    # the mode and owner declared. Everything else between the two is taste.
-    #
-    # Pinned to a COMMIT because sops-nix publishes no release tags at all --
-    # its only tag, `assets`, is from 2021 and is not a release. master is the
-    # release channel. This is the same call flake.nix already makes for
-    # hyprland above: a commit is exactly as reproducible as a tag. Bump it
-    # deliberately; never track a branch.
-    #
-    # What this costs a user's lock: ONE node. sops-nix declares exactly one
-    # input, nixpkgs, which follows ours, so nothing transitive arrives. (Its
-    # dev inputs live in a private flake under dev/ that consumers never see.)
-    # Its nixConfig asks for cache.thalheim.io, which does NOT apply to us --
-    # nixConfig is honoured only from the flake you invoke, not from inputs --
-    # so no substituter and no trust is granted by taking this.
-    #
-    # Inert on import, which is what makes it safe for Mode A: both halves of
-    # the upstream module are gated, `lib.mkIf (cfg.secrets != { })` and
-    # `lib.mkIf (config.sops.templates != { })`. A machine that defines
-    # neither gets no unit, no activation script and no package. nixarchy sets
-    # no sops scalar of its own -- `sops.age.sshKeyPaths` already defaults to
-    # the ed25519 keys from services.openssh.hostKeys upstream -- so the
-    # mkDefault rule in modules/services/default.nix never even arises here.
-    # tests/options.nix asserts the inertness rather than trusting this note.
+    # Why: docs/internals/flake.md#declarative-secrets-adopted-for-one-concrete-reaso
     sops-nix = {
       url = "github:Mic92/sops-nix/a8627b21b9107c5711c96b84f32a9a4b3d45295f";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # #221/#222: the foundation of the sandboxes epic. A guest whose
-    # `/nix/store` is a 9p share of the HOST's store -- `microvm.storeOnDisk
-    # = false`, computed by upstream itself the moment
-    # `microvm.shares` contains a `source = "/nix/store"` entry -- so no
-    # image is ever built for a template and the closure a user runs is
-    # store paths the host already had.
-    #
-    # `follows = "nixpkgs"`, and deliberately not the reflex hyprland.url
-    # above declines: microvm.cachix.org (this flake's own `nixConfig`,
-    # inert unless a consumer opts in -- which nothing here does) carries the
-    # non-qemu hypervisors, and every guest this repo builds is qemu. What a
-    # user actually downloads on first launch is the template CLOSURE, built
-    # from THIS lock and served by nixarchy.cachix.org -- following buys
-    # nothing to forfeit there. What it buys instead is disko's argument, not
-    # hyprland's: a guest and host that share glibc, systemd and openssh
-    # store paths rather than each carrying a second copy, because the same
-    # nixpkgs built both.
-    #
-    # Pinned to a COMMIT. The newest tag, v0.5.0, is from April 2024 and
-    # predates options modules/microvm/guest.nix depends on (`microvm.shares`
-    # gained fields since); upstream publishes no newer tags and treats
-    # `main` as its release channel -- the same position sops-nix already
-    # takes in this file, for the same reason. Bump it deliberately; never
-    # track a branch.
-    #
-    # Lock cost, stated rather than hidden: TWO nodes for this one input, not
-    # one. microvm.nix declares `nixpkgs` (which follows ours, so nothing
-    # transitive) and `spectrum`, a `flake = false` tree it reads only to
-    # patch cloud-hypervisor's graphics support -- a hypervisor nothing in
-    # this repo will ever build, on a patch nothing here will ever apply.
-    # `spectrum` still lands in every user's flake.lock, including the Mode A
-    # machine that never asked for a VM at all. Paid because the alternative
-    # -- vendoring a runner ourselves -- is the copy-upstream-and-keep-it-green
-    # trade #221 already surveyed and rejected.
+    # Why: docs/internals/flake.md#221-222
     microvm = {
       url = "github:microvm-nix/microvm.nix/fdfc1821a0eb76e44a13d206b72e6ca6961fbb7c";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -296,22 +96,7 @@
 
       omarchyVersion = "4.0.2";
 
-      # Which nixarchy built this machine (#208), for nixarchy-version.
-      #
-      # `self` is the only place the answer exists, and it is only reachable
-      # here -- pkgs/omarchy/default.nix cannot see the flake it belongs to --
-      # so the two values are computed once and threaded into the package.
-      #
-      # Not a tag: a flake cannot know its own, and the ordinary consumer
-      # flake.nix tracks main and has none. Not a hand-kept literal beside
-      # omarchyVersion either; that is the class of stale string #201 had to
-      # fix. A rev cannot go stale.
-      #
-      # `dirtyShortRev` is what a working copy with uncommitted changes gets
-      # instead of `shortRev` -- it reads "800af40-dirty", which is the honest
-      # thing for a machine built from someone's checkout to say. Neither
-      # exists when the source is not a git tree at all, hence the last
-      # fallback.
+      # Why: docs/internals/flake.md#which-nixarchy-built-this-machine-208-for-nixarchy
       nixarchyRev = self.shortRev or self.dirtyShortRev or "unknown";
       #
       # `lastModifiedDate` is absent, not empty, when a lock node has no
@@ -349,17 +134,7 @@
             gnugrep
             gawk
             coreutils
-            # vainfo, for the Graphics section. Declared because
-            # writeShellApplication builds a strict PATH, and an undeclared
-            # vainfo does not read as "vainfo is missing" -- it reads as "no
-            # VAAPI driver answered", which is a different and much worse
-            # answer to hand someone. It ran anyway while this was being
-            # written, from the developer's own PATH, which is exactly how
-            # that goes unnoticed.
-            #
-            # No pciutils: the GPUs come from /sys/bus/pci, the same way the
-            # Bluetooth check reads /sys/class/bluetooth, and sysfs hands over
-            # the PCI address already in the form the bus IDs need.
+            # Why: docs/internals/flake.md#vainfo-for-the-graphics-section
             libva-utils
             # For reading the machine's flake.lock, which is JSON. Reaching for
             # sed on JSON is how a check starts reporting confidently wrong
@@ -389,16 +164,7 @@
                       let
                         probe = builtins.tryEval (
                           let
-                            # nixarchy-apps first, then the top level. Apps
-                            # this repo packages live under nixarchy-apps, so
-                            # probing only the top level returned null for every
-                            # one of them and the fallback answered with the
-                            # attribute name. That is right by luck when the
-                            # attribute matches the binary -- once, omacut,
-                            # ttfx -- and wrong when it does not: `zen` for a
-                            # package installing bin/zen-beta, `hey-cli` for one
-                            # installing bin/hey. Both were reported as absent
-                            # on machines that had them.
+                            # Why: docs/internals/flake.md#nixarchy-apps-first-then-the-top-level
                             path = final.lib.splitString "." (app.attr or name);
                             p = final.lib.attrByPath path (final.lib.attrByPath path null pkgs) pkgs.nixarchy-apps;
                           in
@@ -462,16 +228,7 @@
             # machine" rather than "rfkill is missing" -- the same trap the
             # doctor's vainfo hit.
             util-linux
-            # podman info / podman inspect, for the Boxes section. Safe to
-            # pin here -- unlike distrobox, podman does not resolve anything
-            # relative to argv[0], so a /nix/store path to it carries none of
-            # pkgs/box.nix's hazard. distrobox itself is deliberately NOT
-            # here: it is looked up by bare name (`command -v distrobox`),
-            # the same wrapper-only rule that command's own header explains.
-            # hyprctl is deliberately not here either -- the client has to
-            # match the RUNNING compositor, which the session's PATH carries
-            # and this list cannot; the Graphics section's comment in
-            # verify.sh makes the argument.
+            # Why: docs/internals/flake.md#podman-info-podman-inspect-for-the-boxes-section
             podman
             # nix-store, for the MicroVM guests section's GC-root check
             # (#229): `--print-roots` reads the store, never `--gc`. Pinning
@@ -499,21 +256,7 @@
           # simply follow nixpkgs the way most apps here do.
           hey-cli = final.callPackage ./pkgs/apps/hey-cli.nix { };
 
-          # Not built here -- upstream's own flake, re-exported into the overlay
-          # so nixarchy-doctor can find it.
-          #
-          # The doctor asks pkgs for an app's meta.mainProgram to learn which
-          # command it puts on PATH, and falls back to the attribute name when
-          # the lookup fails. zen-browser lived only in packages.<system>, so
-          # the lookup returned null and the fallback answered "zen" -- a
-          # command that does not exist, because this package installs
-          # bin/zen-beta. The doctor could never report Zen as present.
-          #
-          # Exactly the vscode/code trap the doctor was written to avoid, reached
-          # by a different road: not a wrong mainProgram, but a package the probe
-          # could not see. The Install menu's copy of the probe had the same bug
-          # for longer -- it reads cfg.apps.<name>.package instead of this
-          # overlay; see appBinary in modules/apps.nix.
+          # Why: docs/internals/flake.md#not-built-here-upstreams-own-flake-re-exported-int
           zen-browser = zen-browser.packages.${final.stdenv.hostPlatform.system}.default;
 
           # Two of the four applications Omarchy writes itself. nixpkgs has
@@ -527,16 +270,7 @@
           # same authors, packaged because it was asked for.
           ttfx = final.callPackage ./pkgs/apps/ttfx.nix { };
 
-          # nixpkgs' `retroarch` is `retroarch-with-cores` built with an
-          # EMPTY core list, so installing it gives an emulator that can run
-          # nothing. `retroarch-full` is the obvious fix and the wrong one:
-          # it pulls unfree cores, and an unfree package in the app list
-          # aborts the whole rebuild rather than failing on its own.
-          #
-          # So: every core Omarchy's own picker offers that nixpkgs ships
-          # under a free licence, minus the two that dwarf the rest.
-          # snes9x and genesis-plus-gx are unfree, hence bsnes and blastem
-          # for those systems.
+          # Why: docs/internals/flake.md#nixpkgs-retroarch-is-retroarch-with-cores-built-wi
           retroarch = final.retroarch.withCores (
             cores:
             map (n: cores.${n}) [
@@ -565,17 +299,7 @@
           inherit omarchyVersion;
         };
 
-        # The RDP daemon, re-exported from its own flake so the module that
-        # will run it (#156) can say `pkgs.hypr-rdp` and never mention an
-        # input. Built by upstream's pkg/nix/package.nix against OUR nixpkgs,
-        # through the `follows` on the input.
-        #
-        # This indirection is what makes the input's exit cheap: when nixpkgs
-        # carries hypr-rdp, delete the input and this attribute, and every
-        # `pkgs.hypr-rdp` in the tree keeps resolving -- to nixpkgs' own.
-        #
-        # Lazy, so a machine that never enables RDP never builds it. Being in
-        # the overlay is not being on the system.
+        # Why: docs/internals/flake.md#the-rdp-daemon-re-exported-from-its-own-flake-so-t
         hypr-rdp = inputs.hypr-rdp.packages.${final.stdenv.hostPlatform.system}.hypr-rdp;
 
         omarchy = final.callPackage ./pkgs/omarchy {
@@ -585,27 +309,7 @@
           # The compositor the Lua config is written against, not nixpkgs'.
           inherit (hyprland.packages.${final.stdenv.hostPlatform.system}) hyprland;
 
-          # nixpkgs is on 0.3.0, whose session lock aborts on DPMS.
-          #
-          # WlSessionLock::updateSurfaces reached qFatal -- "Tried to show
-          # lockscreen surfaces without active lock" -- when screens slept and
-          # woke while locked. quickshell dies, and because the Wayland
-          # session-lock protocol deliberately keeps the compositor locked when
-          # its lock client disappears, the machine is left blank with nothing to
-          # type a password into. Reboot is the only way out. Seen three times in
-          # one night, ~65-70 MB of coredump each.
-          #
-          # v0.3.1 fixes it, and says so in as many words: "Fixed session lock
-          # crashes on sleep, wake, DPMS, and unlocking." Three commits touch
-          # wayland/lock; 897fcdaa is this one -- it null-checks the wayland
-          # output and skips placeholder screens instead of asserting.
-          #
-          # overrideAttrs rather than a fork: nixpkgs keeps the build, the Qt
-          # wrapper and the dependency set, and only the tag moves. Passed here
-          # rather than set on the overlay, so a machine using quickshell for
-          # something of its own keeps nixpkgs'.
-          #
-          # DELETE THIS once nixpkgs ships >= 0.3.1.
+          # Why: docs/internals/flake.md#nixpkgs-is-on-0-3-0-whose-session-lock-aborts-on-d
           quickshell = final.quickshell.overrideAttrs (_: rec {
             version = "0.3.1";
             src = final.fetchzip {
@@ -619,24 +323,7 @@
           inherit (final.nixarchy-apps) ttfx;
         };
 
-        # The boot splash, and nothing else on the disk with it.
-        #
-        # The omarchy package already carries share/plymouth/themes/omarchy,
-        # and on a desktop that is the right place for it: the machine has the
-        # package anyway. The live image does not. It deliberately does not
-        # import nixosModules.nixarchy (see installer/cd.nix), so naming the
-        # desktop package in boot.plymouth.themePackages would be the only
-        # reason it were there -- and nixpkgs' plymouth module puts
-        # themePackages into environment.etc, so the named package joins the
-        # system closure whole: 411.9 MiB on an image budgeted at 2.00 GiB,
-        # which is GitHub's limit on a release asset rather than a preference.
-        # These assets are 180 KiB.
-        #
-        # Copied out of the same package rather than assembled again, so the
-        # theme is built in exactly one place and the image's splash cannot
-        # differ from the installed one. Nothing is rewritten here:
-        # omarchy.plymouth already points at /etc/plymouth/themes/omarchy, so
-        # this output has no store references and costs only its own size.
+        # Why: docs/internals/flake.md#the-boot-splash-and-nothing-else-on-the-disk-with-
         nixarchy-plymouth = final.runCommand "nixarchy-plymouth-theme" { } ''
           install -d $out/share/plymouth/themes
           cp -r ${final.omarchy}/share/plymouth/themes/omarchy \
@@ -670,16 +357,7 @@
             '';
           };
 
-          # `nix run github:olafkfreund/nixarchy#verify`, from inside a running
-          # Omarchy session. Everything in checks/ runs in a machine with no GPU,
-          # no Bluetooth radio, no network and no sound; this asks the questions
-          # that leaves unanswered.
-          # `nix run github:olafkfreund/nixarchy#install`, as root, from a NixOS
-          # live ISO. Formats ONE disk with installer/disk-config.nix, writes the
-          # generated flake to /mnt/etc/nixos and runs nixos-install against it.
-          #
-          # Every answer ends up as text in that flake: the machine it produces
-          # belongs to the flake, not to this script.
+          # Why: docs/internals/flake.md#nix-run-github-olafkfreund-nixarchy-verify-from-in
           install = pkgsFor.${system}.writeShellApplication {
             name = "nixarchy-install";
             runtimeInputs = with pkgsFor.${system}; [
@@ -810,19 +488,7 @@
             text = builtins.readFile ./pkgs/review.sh;
           };
 
-          # `nix run .#release-notes <from-tag> <to-ref>` -- what changed for
-          # someone running nixarchy, between two releases. release.yml puts its
-          # output above the download instructions on the release page.
-          #
-          # An app for the same reason `review` is one: it evaluates the option
-          # set at two revisions and asks GitHub what upstream shipped, and a
-          # check has neither a network nor a second checkout. The half that
-          # needs neither is checks.release-notes, which drives this whole script
-          # against a fixture repository.
-          #
-          # It carries omarchy-package-delta.sh rather than reimplementing it:
-          # the question "what did this Omarchy release add and drop" already has
-          # an answer here, and two of them would disagree eventually.
+          # Why: docs/internals/flake.md#nix-run-release-notes-from-tag-to-ref-what-changed
           release-notes = pkgsFor.${system}.writeShellApplication {
             name = "nixarchy-release-notes";
             runtimeInputs = with pkgsFor.${system}; [
@@ -846,26 +512,7 @@
           # deciding whether to adopt it actually has.
           doctor = pkgsFor.${system}.nixarchy-doctor;
 
-          # `nix run .#devenv-presets` -- scaffolds every preset in
-          # data/devenv-presets.nix with the real `nixarchy dev init`, then asks a
-          # real devenv to evaluate what it wrote.
-          #
-          # This is the whole safety net under that catalogue. `lines` is a
-          # string, so a preset that names an option devenv renamed is a valid Nix
-          # file and a broken project, and nothing in `nix flake check` would ever
-          # say so. It runs the command rather than reproducing what it does,
-          # because a check that scaffolds its own devenv.nix tests a copy.
-          #
-          # NOT in `checks`, and that is not an oversight. #150 proposed it as one
-          # on the reasoning that a full `devenv shell` needs the network but
-          # evaluation does not. That is wrong, twice over: evaluating a devenv
-          # project fetches the inputs devenv.yaml names
-          # (github:cachix/devenv-nixpkgs/rolling), and devenv's own flake reaches
-          # them through import-from-derivation -- `nix flake show
-          # github:cachix/devenv` fails with `allow-import-from-derivation is
-          # disabled` before it prints anything. A sandboxed derivation has
-          # neither, so `checks.devenv-presets` could not run at all. A workflow
-          # job that has a network does, and build.yml has one.
+          # Why: docs/internals/flake.md#nix-run-devenv-presets-scaffolds-every-preset-in
           devenv-presets =
             let
               pkgs = pkgsFor.${system};
@@ -935,17 +582,7 @@
               '';
             };
 
-          # Screencasts of a real session, scene by scene -- see
-          # tests/demo/default.nix. Not checks: each boots a desktop, drives
-          # it and encodes a GIF, which is minutes of work nobody wants on
-          # every push.
-          #
-          #   nix build .#demo                 the full tour (mp4 + gif)
-          #   nix run   .#demo-record -- <s>   re-record ONE scene's GIF and
-          #                                    drop it in docs/img/features/
-          #   nix run   .#demo-verify -- f.gif audit any GIF: sampled frames
-          #                                    must change, and must OCR to
-          #                                    what the scene claims to show
+          # Why: docs/internals/flake.md#screencasts-of-a-real-session-scene-by-scene-see
           inherit
             (import ./tests/demo {
               inherit inputs;
@@ -984,21 +621,7 @@
           # `ours` app, without every consumer needing the extra flake input.
           zen-browser = zen-browser.packages.${system}.default;
 
-          # `nix run .#update` -- rewrites the pinned versions and hashes in
-          # place. CI runs it nightly and opens a PR (update.yml).
-          #
-          # Derived, not enumerated: every nixarchy-apps package carrying a
-          # passthru.updateScript is run, so a new hand-pinned package is
-          # covered the day it lands, without an edit here. This line used to
-          # name `once` alone -- beside a comment claiming once was the only
-          # hand pin -- while hey-cli sat pinned with an updateScript nothing
-          # reached, and needed a human (#195, 2026-09-05).
-          #
-          # `nix eval .#update.pinned` lists the covered attributes; update.yml
-          # builds exactly those after a rewrite, off the same set. A package
-          # pinned by hand WITHOUT an updateScript is still invisible to this
-          # -- as of this writing only grok-bot, whose Cursor CDN pin has no
-          # queryable "latest" (pkgs/review.sh probes its age instead).
+          # Why: docs/internals/flake.md#nix-run-update-rewrites-the-pinned-versions-and-ha
           update =
             let
               pinned = lib.filterAttrs (_: p: p ? updateScript) pkgsFor.${system}.nixarchy-apps;
@@ -1037,16 +660,7 @@
           # is for.
           iso-net = self.nixosConfigurations.iso-net.config.system.build.isoImage;
 
-          # A VM that installs onto a blank disk, WITH a network -- which
-          # checks.install cannot have, because it is a sandboxed derivation and
-          # its whole point is that a rebuild afterwards cannot fetch anything.
-          # See installer/vm.nix.
-          #
-          # Wrapped rather than exported raw: the generated run script creates
-          # two sparse qcow2 images and only discovers they do not fit hours
-          # later, from inside the guest. installer/vm-preflight.sh checks first
-          # and says so. The sizes come from the configuration itself so the
-          # check cannot drift away from what the VM actually asks for.
+          # Why: docs/internals/flake.md#a-vm-that-installs-onto-a-blank-disk-with-a-networ
           installer-vm =
             let
               cfg = self.nixosConfigurations.installer-vm.config;
@@ -1070,22 +684,7 @@
                   (builtins.readFile ./installer/vm-preflight.sh);
             };
 
-          # The front door: `nix run github:olafkfreund/nixarchy#try` boots
-          # the installer ISO in a local UEFI VM, wizard and all, for someone
-          # who knows nothing about this repository. `-- --net` takes the
-          # network image instead.
-          #
-          # Deliberately NOT depending on the ISO derivation: referencing it
-          # here would make `nix run .#try` download -- or worse, silently
-          # build -- 5.6 GB before the script's first line ran. The script
-          # resolves the image itself at runtime, dry-run first, so "this is
-          # a download of X" or "STOP, this would be a source build" is said
-          # BEFORE either happens. See installer/try.sh for the rest of the
-          # refusals; checks.try-preflight exercises each of them.
-          #
-          # Also not a wrapper around .#installer-vm: that VM answers the
-          # wizard itself from a baked answers file -- a test harness, and
-          # exactly the thing a person trying nixarchy must not get.
+          # Why: docs/internals/flake.md#the-front-door
           try =
             let
               pkgs = pkgsFor.${system};
@@ -1129,55 +728,7 @@
             ignoreCollisions = true;
           };
         }
-        # Two runners per data/microvm-templates.nix entry, both built by
-        # `lib.mkMicrovm` above from the same template and the same
-        # modules/microvm/guest.nix -- only `microvm.cpu` differs between
-        # them.
-        #
-        # `microvm-<t>` passes nothing extra: `cpu = null` is upstream's own
-        # default, which on x86_64-linux means `-enable-kvm -cpu
-        # host,+x2apic,-sgx` (lib/runners/qemu.nix in the pinned commit --
-        # `-enable-kvm` is added exactly when `cpu == null`). That is what
-        # nearly every user runs, and #221 says outright it is not provable
-        # in CI without nested virtualisation.
-        #
-        # `microvm-<t>-tcg` sets `microvm.cpu = "max"`. The same `cpu !=
-        # null` branch that changes the `-cpu` argument ALSO removes
-        # `-enable-kvm` from the same conditional -- one option, both
-        # effects -- which is what makes this the runner a host with no
-        # `/dev/kvm` (including nixarchy running inside a VM) can boot, and
-        # the one CI builds. No separate "disable kvm" option exists to set;
-        # there is only this one.
-        #
-        # machineOpts on the -tcg variant, and every entry is load-bearing:
-        #
-        #   - `pit = "on"`, `pic = "on"`. Upstream's default microvm machine
-        #     sets both off, which is correct under KVM -- kvmclock is the
-        #     guest's clock -- and fatal under TCG, which has no kvmclock:
-        #     with no PIT, no PIC and no HPET on this machine type, early
-        #     timer init has nothing to calibrate from, and the kernel
-        #     triple-faults or wedges right after "Poking KASLR", outcome
-        #     depending on where KASLR happened to land. Measured on a real
-        #     A/B: the shipped runner under forced TCG produced zero output
-        #     for five minutes; the same runner with pit/pic on booted to a
-        #     login prompt in 2m13s. `-cpu qemu64` wedged identically, so
-        #     the CPU model was ruled out.
-        #
-        #   - `accel = "tcg"`, PINNED -- not upstream's `kvm:tcg` fallback
-        #     chain. The fallback is how the wedge above shipped unnoticed:
-        #     qemu silently takes KVM wherever /dev/kvm exists (including
-        #     inside a test VM on a host with nested virtualisation), so
-        #     every local run of the "-tcg" artifact was measuring a KVM
-        #     boot, and the one environment that exercised real TCG was CI
-        #     -- at the moment something first tried to boot it. This
-        #     variant's entire reason to exist is hosts with no /dev/kvm; a
-        #     KVM host should run the normal runner. Do not "optimise" the
-        #     fallback back in: an artifact that never runs as what its
-        #     name promises is how this bug lived long enough to gate a PR.
-        #
-        #   - the rest reproduce upstream's x86 defaults (machineOpts
-        #     REPLACES the whole set, so omitting one is turning it off).
-        #     `pcie = "on"` because the 9p shares sit on virtio-pci.
+        # Why: docs/internals/flake.md#two-runners-per-data-microvm-templates-nix-entry-b
         // lib.concatMapAttrs (
           name: template:
           let
@@ -1260,30 +811,7 @@
           ];
         };
 
-        # The same VM with room to run a model.
-        #
-        # `.#vm` is a smoke test and is sized like one: 8GB, and an ephemeral
-        # root, which is right for catching a broken desktop and wrong for
-        # anything to do with programs.nixarchy.localAi. Two reasons, and the
-        # second is the one that is not obvious:
-        #
-        #   - 8GB does not hold a useful model. qwen3:8b is 5.2GB of weights
-        #     before any cache.
-        #
-        #   - diskImage = null puts the root on a tmpfs, so the weights live in
-        #     RAM. They are then paid for twice, once to store and once to load,
-        #     out of the same pool -- and the service is OOM-killed while every
-        #     visible number says it had room. Observed, not theorised.
-        #
-        # So this one has a real disk, which also means a pulled model survives
-        # a restart rather than being re-downloaded every time.
-        #
-        #   nix run .#vm-big
-        #   ssh -p 2224 omarchy@localhost      (password: omarchy)
-        #
-        # It writes nixarchy-vm-big.qcow2 into the working directory and REUSES
-        # it, which is the point here and is exactly what .#vm avoids. Delete
-        # that file to start clean.
+        # Why: docs/internals/flake.md#the-same-vm-with-room-to-run-a-model
         vm-big = nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
           specialArgs = { inherit inputs; };
@@ -1366,20 +894,7 @@
             home-manager.nixosModules.home-manager
             inputs.disko.nixosModules.disko
 
-            # One module that imports the machine's own two, rather than two
-            # entries in this list. It has to be shaped this way, because the
-            # generated flake's hosts/<name>/default.nix is shaped this way:
-            # `imports` inside a module and entries in `modules` are merged in
-            # different orders, so the flat form gives a different
-            # environment.systemPackages ORDER -- same packages, same closure,
-            # different list -- and system-path hashes that order into
-            # chosenOutputs. A different system-path is a different toplevel,
-            # and on an ISO with no network the installed machine can no longer
-            # copy the one baked here: it has to build it, which means stdenv,
-            # which means the source bootstrap from hex0-seed.
-            #
-            # Nothing about the packages differs. Only the order does, and only
-            # the order has to.
+            # Why: docs/internals/flake.md#one-module-that-imports-the-machines-own-two-rathe
             {
               imports = [
                 (import ./installer/host.nix {
@@ -1395,21 +910,7 @@
           ];
         };
 
-      # One closure per template, shared by every VM a user ever names from
-      # it. #221's "the name is never a Nix argument" is exactly what makes
-      # this possible: `template` and `modules` are the only things this
-      # function is allowed to vary on, and neither is a per-VM value.
-      #
-      # `template` is a path from data/microvm-templates.nix -- plain NixOS
-      # plus microvm.nix's own options, per that catalogue's bar.
-      # modules/microvm/guest.nix is what every template gets underneath it,
-      # imported here rather than by each template file so a template cannot
-      # forget it. `modules` exists for exactly one caller below: the `-tcg`
-      # packages, which add `microvm.cpu = "max"` without a second template.
-      #
-      # Returns `declaredRunner`, upstream's own name for
-      # `config.microvm.runner.${config.microvm.hypervisor}` -- a package,
-      # which is what `packages.<system>.microvm-<template>` has to be.
+      # Why: docs/internals/flake.md#one-closure-per-template-shared-by-every-vm-a-user
       lib.mkMicrovm =
         {
           template,
@@ -1751,18 +1252,7 @@
           reference-unencrypted-toplevel =
             self.nixosConfigurations.reference-unencrypted.config.system.build.toplevel;
 
-          # Both images, against the budgets recorded in installer/cd.nix.
-          #
-          # A check rather than a comment because a number nobody enforces is a
-          # number that drifts. The nightly runs this; it costs nothing beyond
-          # the ISO builds it already does.
-          #
-          # The iso-net budget is the load-bearing one, and it is not a taste
-          # question: GitHub refuses a release asset over 2 GiB, so an iso-net
-          # that crosses it stops being publishable as a single file and
-          # release.yml would have to start splitting it. Failing here says so
-          # while there is still something to do about it, rather than at the
-          # next tag.
+          # Why: docs/internals/flake.md#both-images-against-the-budgets-recorded-in-instal
           iso-budget =
             let
               pkgs = pkgsFor.${system};

--- a/installer/AGENTS.md
+++ b/installer/AGENTS.md
@@ -1,0 +1,69 @@
+# installer/
+
+The ISO, the wizard, and the flake it writes to `/etc/nixos`.
+
+## Intent
+
+Answer a few questions and hand back **a flake the user owns** — a git
+repository holding the disk layout, the configuration and the app selection. A
+rebuild straight after installing builds nothing, because everything the
+installer did is written there rather than done behind it.
+
+This is the least settled part of the project. It writes partition tables and
+bootloaders on real disks, it is the hardest thing here to test, and it is where
+the bugs have been. The README and the Pages docs say so to users.
+
+| file | what it is |
+|---|---|
+| `install.sh` | the wizard and the phases; `@tokens@` substituted by `flake.nix` |
+| `cd.nix` | the ISO — one module behind both `#iso` and `#iso-net` |
+| `mkFlake.nix` | assembles the flake and lock written to the target |
+| `template/` | that flake, with its `@tokens@` still in place |
+| `host.nix` | the installed machine's own configuration |
+| `lib/ui.sh`, `lib/dashboard.sh` | the screens; no gum widget without a pty |
+| `try.sh` | `nix run …#try` — boots the real ISO in a local VM |
+
+## The phase chain
+
+```
+format_disk → verify_subvolume_mounts → generate_hardware_config
+  → install_flake_dir → write_password_hash → run_install
+  → chown_flake_dir → take_factory_snapshot
+```
+
+Order is load-bearing. `chown_flake_dir` runs **after** `run_install` because
+the user does not exist until `nixos-install` creates it, and chowning by name
+before that resolves against the ISO's passwd, not the target's.
+
+## Things that are true and easy to get wrong
+
+- **The install log must never be written to the ESP.** FAT32 has no
+  permissions, and the crypt hash would be offline-crackable.
+- **No crypt hash may appear in `/etc/nixos`** — it is a git repository the user
+  is expected to push. The hash goes to `/var/lib/nixarchy`, `chown 0:0`, `0600`,
+  and `checks.install` asserts no `$6$` appears under the flake.
+- **Verify disks by serial, never by letter.**
+- **`/etc/nixos` belongs to the installed user**, and root without `SUDO_UID`
+  cannot open a git repository it does not own — which is why `modules/nixos.nix`
+  and `cd.nix` both ship a `safe.directory` entry. nix hits the same check and
+  reports it as `could not find a flake.nix file`.
+- **A flake in a git worktree sees only tracked or staged files.** The installer
+  stages everything and deliberately makes no commit: git needs an identity, and
+  choosing the user's is not the installer's business.
+
+## Tests
+
+| check | covers |
+|---|---|
+| `install` | blank disk, and the machine boots |
+| `free-space` | installing beside an existing OS |
+| `install-encrypted` | LUKS, unlocked over the serial console |
+| `install-iso` / `-net` | the real published image; `-iso` with no network device at all |
+| `installer-from-repo` | `--from-repo`, installing a host out of the user's own repo |
+| `installer-wizard` | the questions themselves, answered over a serial line |
+| `installer-ui` | gum widgets at every terminal width |
+| `installer-refusal` | that it refuses, in sentences, rather than crashing |
+| `installer-store-space` | the live store's ceiling, which `install` cannot see |
+| `installer-lock` | the generated lock has the fields nix would have written |
+| `dashboard-clock` | a clock that goes backwards mid-install |
+| `try-preflight` | every refusal path of the `#try` front door |

--- a/modules/AGENTS.md
+++ b/modules/AGENTS.md
@@ -1,0 +1,1551 @@
+# modules/
+
+The NixOS and Home Manager modules. What an existing NixOS machine imports
+when it adds `nixarchy.nixosModules.nixarchy`, and what the installer's own
+host configuration builds on.
+
+## Intent
+
+One option namespace, `programs.nixarchy`, and two modes that must both keep
+working:
+
+- **Mode A** — somebody imports this into a configuration they already run.
+  Everything opt-in must leave them untouched. This is the mode a refactor
+  breaks quietly, because the off state is the one nobody looks at.
+- **Mode B** — the installer wrote the machine, so `programs.nixarchy` is the
+  whole desktop and `installerManaged` is set.
+
+| file | what it owns |
+|---|---|
+| `nixos.nix` | the system: session, greeter, graphics, services, the option surface |
+| `home.nix` | the Home Manager side: the seed, plugins, per-user state |
+| `apps.nix` | the app catalogue and the selection model (`nixarchy-apply`) |
+| `flatpaks.nix` | the software nixpkgs genuinely does not carry |
+| `fleet.nix` | pull-based `system.autoUpgrade` from a remote flake, opt-in |
+
+## Tests
+
+| check | covers |
+|---|---|
+| `checks.options` | every option asserted in BOTH states — this is what protects Mode A |
+| `checks.session` | a booted desktop; does not run locally, CI only |
+| `checks.reference-toplevel` | the machine the installer writes, built |
+| `checks.vm-toplevel` | the smoke-test guest, built |
+| `checks.coexist` | an existing Hyprland configuration alongside this |
+
+## Working here
+
+- An option added without a `checks.options` assertion in both states is not
+  finished.
+- `writeShellApplication` builds a strict PATH from `runtimeInputs`. A command
+  a script calls and does not declare is a runtime failure no build catches.
+- The rest of this file is the reasoning that used to sit in the code, moved
+  here so the modules read as code. Each one is reachable from a `# Why:`
+  pointer at the line it explains — follow the anchor, and if you change the
+  decision, change the entry with it.
+
+---
+
+## `modules/nixos.nix`
+
+<a id="omarchys-session-launched-from-its-own-hyprland-lu"></a>
+### Omarchy's session, launched from its own hyprland.lua in the store…
+
+```nix
+omarchySessionLauncher = pkgs.writeShellScript "omarchy-session" ''
+```
+
+Omarchy's session, launched from its own hyprland.lua in the store rather
+than from ~/.config/hypr/hyprland.lua. Hyprland's --config takes the entry
+point; the modules it requires still resolve through $HOME/.config, which
+is where the Home Manager seed puts them.
+
+Through start-hyprland rather than the Hyprland binary. Booting this on a
+real laptop logged
+
+  WARNING: Hyprland is being launched without start-hyprland.
+  This is highly advised against.
+
+start-hyprland is the watchdog Hyprland 0.56 wants supervising it, and it
+is what nixpkgs' own hyprland.desktop execs. Everything after its `--` is
+passed through to Hyprland, so --config still arrives where it was going.
+The VM never complained because a warning is not a failure -- it took
+somebody reading the journal on a machine that had actually logged in.
+
+<a id="nixarchy-wrote-this-machine-as-a-property-of-the-c"></a>
+### "Nixarchy wrote this machine", as a property of the configuration rather
+
+```nix
+installerManaged = lib.mkOption {
+```
+
+"Nixarchy wrote this machine", as a property of the configuration rather
+than of the install event.
+
+Set in exactly one place -- installer/host.nix, which is imported only by
+a hosts/<name>/default.nix the installer generated. That is what makes a
+machine nixarchy-shaped: snapper, nh, the registry pin, the seeded user.
+So the question "did nixarchy build this?" is answered by whether that
+module is in the evaluation, and re-answered at every rebuild.
+
+Not /etc/nixos/.nixarchy-url, which used to look like the same signal and
+is not one any more. `git add -A` tracks it, so it is committed, pushed,
+and cloned onto every machine enrolled with `nixarchy install --from` --
+including a machine the installer never touched. And an admin-authored
+repo of the shape `--from` accepts carries no such file while being a
+perfectly good nixarchy install. Presence stopped meaning "here", absence
+stopped meaning "hands off". It survives as provenance of the *repo*.
+
+Not a heuristic either. Sniffing flake.lock's root inputs or testing for
+hosts/$(hostname) reads state the user is invited to edit, and would one
+day refuse a machine to its own owner.
+
+<a id="built-from-your-nixpkgs-through-this-flakes-overla"></a>
+### Built from *your* nixpkgs through this flake's overlay, not from
+
+```nix
+default = (pkgs.extend inputs.self.overlays.default).omarchy;
+```
+
+Built from *your* nixpkgs through this flake's overlay, not from
+inputs.self.packages -- which is built from nixarchy's own nixpkgs.
+
+Those look identical and are not: every one of the ~80 runtime
+dependencies would come from a different nixpkgs instance than the
+rest of your system, and the first one you also install yourself makes
+buildEnv refuse the profile --
+
+  two given paths contain a conflicting subpath:
+    .../tesseract-5.5.3/bin/tesseract and .../tesseract-5.5.3/bin/tesseract
+
+-- two builds of the same version, which reads like a bug in nix until
+you notice the hashes differ. Found by building a real config that had
+tesseract of its own.
+
+<a id="most-of-what-the-install-menu-offers-is-unfree"></a>
+### Most of what the Install menu offers is unfree
+
+```nix
+nixpkgs.config = lib.mkIf cfg.allowUnfree (lib.mkDefault { allowUnfree = true; });
+```
+
+Most of what the Install menu offers is unfree: the browsers, the editors,
+Steam, the AI clients, several of the fonts. Leaving licence policy to the
+consumer sounded principled and in practice meant a new user picked an app,
+ran nixarchy-apply, and watched a rebuild die on a licence error partway
+through -- with nothing on screen explaining that the fix was a line in a
+file they had never opened.
+
+Behind an option rather than mkDefault, because mkDefault does not work
+here: nixpkgs.config is a free-form attribute set, so `mkDefault true` on
+one of its keys is stored as the override attrset itself and nixpkgs is
+handed { _type = "override"; ... } where it expects a bool. mkDefault on
+the whole set does resolve, but then any other nixpkgs.config key a user
+sets replaces our definition wholesale and unfree silently goes away.
+
+mkIf so that turning the option off removes the definition entirely rather
+than asserting false, and mkDefault so that ours is the one that yields
+wherever something else already owns nixpkgs.config. That is not
+hypothetical: a NixOS VM test takes its pkgs from outside and imports
+misc/nixpkgs/read-only.nix, which defines nixpkgs.config as a unique
+option -- so any definition of ours, at any priority above default, makes
+every runNixOSTest node fail to evaluate.
+
+The cost is that priorities filter before merging: a user who sets any
+other nixpkgs.config key, say permittedInsecurePackages, outranks this
+default and drops it, and unfree goes off again. That case is not silent,
+which is the only reason it is acceptable -- modules/apps.nix warns at
+evaluation time when an enabled app is unfree and allowUnfree is off, and
+names the fix.
+
+<a id="etc-nixos-belongs-to-the-installed-user-installer-"></a>
+### /etc/nixos belongs to the installed user (installer/install.sh
+
+```nix
+git = {
+```
+
+/etc/nixos belongs to the installed user (installer/install.sh
+chown_flake_dir), and git refuses to open a repository owned by
+somebody else. So does nix: its flake fetcher goes through libgit2,
+which runs the same ownership check and fails the whole evaluation
+with
+
+  error: opening Git repository "/etc/nixos": repository path
+  '/etc/nixos' is not owned by current user (libgit2 error code = 7)
+  error: could not find a flake.nix file
+
+-- the second line being the one people actually read, which is why
+this was diagnosed three times before it was understood.
+
+NOT every root command needs this. git and libgit2 both exempt root
+when SUDO_UID names the repository's owner, so `sudo nixos-rebuild
+--flake /etc/nixos#...` -- the thing a user actually types -- was
+never broken by the chown. What needs the entry is root WITHOUT
+SUDO_UID: root systemd units, a root login shell, `nixos-install`
+from a live ISO during a rescue reinstall, and the VM test drivers,
+which are root by construction and never sudo.
+
+It has to be a real config file. Passing `-c safe.directory=...` on a
+git command line fixes that one git invocation and does not reach nix
+at all, and the environment variables are no use either: nix opens
+repositories with git_repository_open() rather than the _FROM_ENV
+variant, so libgit2 leaves use_env false and ignores
+GIT_CONFIG_SYSTEM and GIT_CONFIG_NOSYSTEM. libgit2 does read
+/etc/gitconfig -- verified by strace of a root `nix eval`, which
+opens exactly that one system path -- and that is what this writes.
+
+Via programs.git rather than environment.etc."gitconfig" because
+programs.git.config merges with a user's own git settings, where two
+environment.etc definitions of the same file collide.
+
+One limit worth knowing: the check runs against the RESOLVED path, so
+an adopter who points programs.nixarchy.flake at a symlink is not
+covered by this entry. Name the real directory instead. Machines this
+installer writes have a real /etc/nixos, so the default is fine.
+
+<a id="the-literal-path-above-is-not-always-enough-becaus"></a>
+### The literal path above is not always enough, because the ownership
+
+```nix
+include.path = safeDirInclude;
+```
+
+The literal path above is not always enough, because the ownership
+check runs against the RESOLVED directory: point
+programs.nixarchy.flake at a symlink -- /etc/nixos -> a repository
+in $HOME, which is how plenty of people arrange this -- and the
+entry never matches what libgit2 actually opened. Measured, not
+assumed: safe.directory naming the symlink is refused, naming the
+real directory is accepted.
+
+Resolving it needs the filesystem of the machine being configured,
+which evaluation cannot see (and reading it at eval time would mean
+IFD). So the resolved form is written at activation, and included
+from here. libgit2 does follow include.path when it collects
+safe.directory -- also measured -- and a missing include target is
+silently ignored, which is what makes the file safe to reference
+before the first activation has written it.
+
+<a id="mise-is-in-omarchys-base-packages-and-its-dev-env-"></a>
+### mise is in Omarchy's base packages and its dev-env installers lean on
+
+```nix
+nix-ld.enable = lib.mkDefault true;
+```
+
+mise is in Omarchy's base packages and its dev-env installers lean on
+it heavily. It downloads prebuilt runtimes, which cannot run against
+NixOS' non-standard loader, so it detects NixOS and falls back to
+compiling from source -- which then fails, because there is no compiler
+on the session PATH. mise's own message names the fix:
+
+  "The automatic all_compile=true default on NixOS caused python to
+   compile from source. Enable nix-ld to use precompiled binaries"
+
+This is what makes `omarchy install dev-env` work rather than print a
+wall of build errors.
+
+<a id="minus-hyprland-itself"></a>
+### Minus Hyprland itself
+
+```nix
+++ builtins.filter (d: !(lib.hasPrefix "hyprland-" (d.name or ""))) cfg.package.passthru.runtimeDeps
+```
+
+Minus Hyprland itself.
+
+The package carries the compositor its Lua config is written against as
+a runtime dependency, and putting that in systemPackages made it the
+Hyprland on PATH -- so on a machine that already ran Hyprland, enabling
+nixarchy silently swapped the compositor behind the user's *existing*
+sessions. Its share/wayland-sessions/hyprland.desktop won the buildEnv
+collision too, so `hyprland.desktop` pointed at nixarchy's build rather
+than theirs. Found by building this against a real configuration; the
+doctor tells people to keep their own Hyprland, and this quietly did
+the opposite.
+
+programs.hyprland already puts the right one on PATH -- ours when
+nixarchy sets the option, theirs when they mkForce it -- so dropping it
+here changes nothing on a clean machine and stops overriding anyone
+else's. omarchy-session still runs the Lua config through
+config.programs.hyprland.package, which is the same binary either way.
+
+<a id="config-hypr-xdph-conf-which-the-package-seeds-into"></a>
+### config/hypr/xdph.conf, which the package seeds into
+
+```nix
+hyprland-preview-share-picker
+```
+
+config/hypr/xdph.conf, which the package seeds into
+~/.config/hypr, sets
+`custom_picker_binary = hyprland-preview-share-picker`.
+xdg-desktop-portal-hyprland execs that name for every ScreenCast
+request, so with nothing providing it the exec fails, the backend
+reads selection -1 and destroys the session -- screen sharing dies
+in every application, with no dialog and no error anywhere a user
+looks. Upstream declares it in install/omarchy-base.packages, which
+pacman honours and nothing on NixOS reads. (#202)
+
+From nixpkgs rather than the hyprland input that supplies the portal
+at programs.hyprland.portalPackage: that flake publishes only
+hyprland and xdg-desktop-portal-hyprland, so there is no picker
+there to match. Nothing is mismatched by taking it from nixpkgs
+either -- the picker links no Hyprland library (gtk4,
+gtk4-layer-shell, cairo, pango and nothing else), and the portal
+reaches it by exec plus a selection line on stdout, not an ABI.
+
+Editing the seeded xdph.conf was the other option and is the wrong
+one: the file is upstream's, so the edit is undone by the next
+Omarchy bump.
+
+<a id="passed-straight-through"></a>
+### Passed straight through
+
+```nix
+flatpak.uninstallUnmanaged = lib.mkDefault cfg.flatpaks.uninstallUnmanaged;
+```
+
+Passed straight through: nix-flatpak's own option carries the
+behaviour, ours carries the decision and its reasoning. mkDefault so a
+user who sets services.flatpak.uninstallUnmanaged directly keeps their
+value -- this is a convenience over an upstream option, not a
+replacement for it.
+
+In this block rather than as its own `services.flatpak...` line
+because statix rejects a second `services` key in the same attribute
+set, and it is right to: two places setting services is two places to
+look.
+
+<a id="cups-avahi-and-nss-mdns-are-all-in-base-packages"></a>
+### cups, avahi and nss-mdns are all in base.packages
+
+```nix
+printing.enable = lib.mkDefault true;
+```
+
+cups, avahi and nss-mdns are all in base.packages. cups-browsed was
+too until 4.0.2 dropped it -- "Harden CUPS printer discovery and
+administration" -- along with the unit that started it, leaving only a
+hardened drop-in for machines that already had it. cups-pk-helper
+replaced it for the administration half, and NixOS' own cupsd module
+adds that wherever polkit is on, so nothing here has to name it.
+
+Turning it off is not just comment maintenance: NixOS defaults
+services.printing.browsed.enable to services.avahi.enable, which the
+lines below set, so `printing.enable` alone did leave cups-browsed
+running -- as root, with none of the User=/ProtectSystem= hardening
+upstream's drop-in adds, listening for mDNS printer announcements and
+creating queues from them. That is the daemon upstream deliberately
+removed, so it does not stay on here by inheritance.
+
+Only browsed goes: avahi stays on for driverless IPP discovery, which
+is how modern printers are found and is what cupsd does by itself.
+
+<a id="the-ownership-marker-for-the-shell-tools-that-cann"></a>
+### The ownership marker, for the shell tools that cannot ask the module
+
+```nix
+environment.etc."nixarchy/managed" = lib.mkIf cfg.installerManaged {
+```
+
+The ownership marker, for the shell tools that cannot ask the module
+system anything.
+
+Declarative on purpose: it is in the closure, it is rewritten by every
+rebuild, and a machine that stops descending from installer/host.nix
+loses it in the same switch that made that true. A file the installer
+wrote once could not say that -- it would survive being wrong, and a
+`--from` rebuild that never created it would leave the machine looking
+unmanaged for the rest of its life.
+
+The contents are for the person who finds the file and wonders. Nothing
+reads them, and nothing should start: the predicate is the file's
+existence, which is the only part that is cheap to get right in every
+shell script that needs it.
+
+<a id="the-other-half-of-that-script-which-this-module-le"></a>
+### The other half of that script, which this module left behind
+
+```nix
+allowedTCPPorts = [ 53317 ];
+```
+
+The other half of that script, which this module left behind.
+Upstream's is not merely "turn the firewall on":
+
+    ufw default deny incoming
+    ufw allow 53317/udp
+    ufw allow 53317/tcp   # "Allow ports for LocalSend."
+
+Porting only the deny half enables a firewall that blocks the one
+service Omarchy's manual promises works out of the box: "Omarchy's
+firewall is closed by default except for LocalSend's port, so this
+works out of the box on a fresh install." On a machine taking this
+module's firewall default it did not -- Share > Receive listened on
+53317 and nothing on the network could reach it.
+
+Discovery was never the missing part: services.avahi above already
+opens 5353. Only LocalSend's own transfer port was closed.
+
+Not mkDefault: these are list options, so they merge with whatever
+the user opens rather than replacing it. A mkDefault list would be
+dropped whole the moment they opened a port of their own.
+
+<a id="install-config-lockscreen-pam-sh-whose-one-line-is"></a>
+### install/config/lockscreen-pam.sh, whose one line is `omarchy-apply-lock`
+
+```nix
+security.pam.services = {
+```
+
+install/config/lockscreen-pam.sh, whose one line is `omarchy-apply-lock`
+-- and that writes /etc/pam.d/omarchy-lock-password. Omarchy 4's lock
+screen is the Quickshell one, which names that stack itself
+(shell/plugins/lock/Service.qml: `config: "omarchy-lock-password"`), and
+watches the file's existence to decide whether locking is possible at
+all. hyprlock appears nowhere in the tree except omarchy-upgrade-to-
+quattro, which *removes* it -- so what was declared here was PAM for a
+program the desktop no longer runs. On a live session:
+
+  /etc/pam.d/omarchy-lock-password  ->  No such file or directory
+  omarchy-shell lock lock           ->  missing-pam, screen stayed up
+
+Five paths reach that no-op: SUPER + CTRL + L, Menu > System > Lock, the
+idle timeout, lid close, and suspend.
+
+An empty attrset is the whole fix. NixOS' generated stack is pam_unix
+auth plus an account section, which is upstream's file with faillock and
+pam_systemd_home taken out. faillock is deliberately not reproduced:
+NixOS' only handle on it is `logFailures`, which emits pam_faillock with
+no preauth/authfail/authsucc arguments, so nothing ever resets the
+counter -- three bad unlocks would lock a user out of their own screen
+for good. Upstream's deny=10 needs the raw `rules` interface, and a
+lockout is a worse failure than the logging it would buy.
+
+<a id="omarchy-path-default-systemd-user-which-upstream-i"></a>
+### $OMARCHY_PATH/default/systemd/user/, which upstream installs into
+
+```nix
+user.services = {
+```
+
+$OMARCHY_PATH/default/systemd/user/, which upstream installs into
+/usr/lib/systemd/user and nothing here installed anywhere -- that
+directory is not a systemd search path. `systemctl --user status
+bt-agent.service` answered "could not be found" on a live session, and
+with it went the pairing agent, the crash watcher, the input method, the
+internal-monitor recovery, and -- the one that matters -- the sleep lock,
+so suspend did not lock even once the PAM stack above exists.
+
+Declared here rather than linked out of the package, because every
+shipped ExecStart is a /usr/bin path that resolves to nothing on NixOS
+and the package is not this module's to patch. The bodies are upstream's:
+same conditions, same ordering, same restart policy, binaries named by
+store path.
+
+omarchy-migrate-notify and omarchy-tailscale-receive are deliberately
+absent. Their conditions (ConditionPathIsDirectory=/usr/share/omarchy/
+migrations, ConditionPathExists=/usr/bin/tailscale) can never hold here,
+and both jobs belong elsewhere on NixOS: migrations arrive with a
+rebuild, and Taildrop with services.tailscale.
+
+Each omarchy-* unit gets /run/current-system/sw on its PATH. NixOS gives
+every unit a stub PATH of coreutils, findutils, grep, sed and systemd,
+and unlike the copies upstream drops in ~/.config/systemd/user that stub
+*overrides* the session PATH uwsm imported -- omarchy-system-sleep-
+monitor would not find dbus-monitor, and none of them would find the
+other omarchy-* commands they call. The system profile is where the
+package's runtimeDeps already live, by the package's own design: bin/ is
+a symlink farm rather than wrapped programs, so the CLI can still read
+the `# omarchy:summary=` metadata out of each script.
+
+omarchy-speaker-tuning is absent for a different reason: omarchy-audio-
+tuning installs it itself, by copying the unit into
+~/.config/systemd/user and running `systemctl --user enable`. Declaring
+it would not race that copy -- the user directory outranks /etc -- but
+`omarchy audio tuning off` disables and deletes it, and `disable` cannot
+remove an [Install] symlink that lives in a read-only /etc, so the
+tuning would come back at the next login with the config it needs gone.
+
+<a id="default-systemd-user-app-slice-d-10-oomd-conf"></a>
+### default/systemd/user/app.slice.d/10-oomd.conf
+
+```nix
+user.units."app.slice" = {
+```
+
+default/systemd/user/app.slice.d/10-oomd.conf. systemd-oomd is on by
+default in NixOS, and with no slice marked as a candidate it has nothing
+it is allowed to kill. Marking app.slice -- where uwsm-app puts every
+launched application -- leaves the compositor structurally ineligible:
+Hyprland runs in session.slice, so oomd takes the browser or terminal
+that caused the pressure and the session survives to report it.
+
+Deliberately not systemd.oomd.enableUserSlices, which is the obvious
+switch and the wrong one: it sets the same properties on user.slice and
+on the user manager's own root slice, which puts the compositor back in
+the candidate pool. asDropin rather than a systemd.user.slices entry so
+systemd's own app.slice definition is extended, not replaced.
+
+Upstream's oomd.conf.d also lowers the global thresholds to 50% over 20s
+from systemd's 60% over 30s. Not carried over: those are a tuning
+preference, and the defaults still fire.
+
+<a id="bluez-bluez-tools-and-bluez-utils-are-all-in"></a>
+### bluez, bluez-tools and bluez-utils are all in
+
+```nix
+hardware.bluetooth.enable = lib.mkDefault true;
+```
+
+bluez, bluez-tools and bluez-utils are all in
+install/omarchy-base.packages, the bar has a Bluetooth widget, and
+omarchy-bluetooth-device and omarchy-bluetooth-power are two of the
+commands the menu offers -- but none of it works without the service,
+and nothing here was starting it. Every session logged
+
+  quickshell.dbus.objectmanager: Failed to create
+  DBusObjectManagerInterface for "org.bluez" "/"
+
+which was written off as a VM artefact for as long as this was in the
+README's known gaps. It is the same shape as UPower: the tools were
+installed, the daemon was not.
+
+<a id="our-own-splash-in-the-theme-directory-upstreams-oc"></a>
+### Our own splash, in the theme directory upstream's occupies -- upstream
+
+```nix
+users.users = lib.optionalAttrs (cfg.user != null) {
+```
+
+Our own splash, in the theme directory upstream's occupies -- upstream
+installs it by copying into /usr/share/plymouth/themes from
+omarchy-refresh-plymouth. Nothing was doing that here, so plymouth came
+up with NixOS' default theme -- the one screen every boot shows,
+unbranded. The artwork in it is nixarchy's; see the option's description
+and pkgs/omarchy/default.nix.
+
+Theme and themePackages always move together, at whatever priority
+bootSplash asks for. NixOS asserts the named theme exists in the package
+list, so setting one without the other fails the build -- which is what
+anyone reaching for `lib.mkForce boot.plymouth.theme = "omarchy"` on a
+stylix machine hits, because stylix sets themePackages at normal priority
+and wins it.
+The one thing upstream's installer does that needs a name.
+
+install/hardware/input-group.sh runs `usermod -aG input`, and without it
+the dictation tools and controllers Omarchy offers cannot read their
+devices. Skipped entirely when programs.nixarchy.user is unset, because
+the alternative is guessing which of a machine's users logs into the
+desktop.
+
+<a id="docker-is-enabled-above-at-mkdefault-for-every-mac"></a>
+### Docker is enabled above, at mkDefault, for every machine
+
+```nix
+++ lib.optional config.virtualisation.docker.enable "docker";
+```
+
+Docker is enabled above, at mkDefault, for every machine. Enabled and
+unusable, until now: without this group every command wants sudo, and
+`docker ps` answers "permission denied while trying to connect to the
+Docker daemon socket" -- which reads like a broken install rather than
+a missing group.
+
+The installer has always put its user in `docker` directly
+(installer/host.nix), so this was only ever wrong for someone adding
+nixarchy to a machine they already run: they got the daemon and not
+the access. Conditioned on the option rather than set unconditionally,
+so turning Docker off does not leave a group behind that grants root
+to whatever installs a socket there later.
+
+<a id="default-fontconfig-conf-avail-50-omarchy-conf-whic"></a>
+### default/fontconfig/conf.avail/50-omarchy.conf, which upstream symlinks
+
+```nix
+fonts.fontconfig.localConf = lib.mkDefault (
+```
+
+default/fontconfig/conf.avail/50-omarchy.conf, which upstream symlinks
+into /etc/fonts/conf.d. Without it `fc-match monospace` on a live
+session answered Adwaita Mono, so every application asking for the
+generic family got a font Omarchy never chose -- and half the file's
+rules had nothing to resolve to anyway, because Liberation was not
+installed (see fonts.packages below).
+
+The whole file rather than fonts.fontconfig.defaultFonts, which covers
+the three generic families and nothing else: this also carries the
+system-ui / -apple-system / BlinkMacSystemFont aliases that Electron and
+web apps ask for by name, the emoji and Nerd Font fallback chains, and
+the Arabic script rules.
+
+localConf, not a package in fontconfig's conf.d, for two reasons:
+fonts.conf includes local.conf last, so these rules win the ties they
+are meant to win, and it is one mkDefault a user can take back whole.
+Read from the flake input rather than from cfg.package, because
+readFile on a derivation output is import-from-derivation and would
+make this module unevaluatable without building Omarchy first.
+
+<a id="default-environment-d-10-omarchy-fcitx-conf-plus-t"></a>
+### default/environment.d/10-omarchy-fcitx.conf, plus the daemon that reads
+
+```nix
+i18n.inputMethod = {
+```
+
+default/environment.d/10-omarchy-fcitx.conf, plus the daemon that reads
+it -- fcitx5 was not installed at all. i18n.inputMethod rather than
+dropping fcitx5 into systemPackages: it is what builds fcitx5 with its
+addons, writes the Qt plugin path, and sets XMODIFIERS and the GTK/Qt IM
+modules. The unit that starts it is above.
+Priority 1250, which is neither of the two names lib gives you, because
+this option is squeezed between them. GNOME's desktop-manager module sets
+type to "ibus" at mkDefault (1000) and two mkDefaults tie rather than
+yield, so a host running GNOME beside this session failed to evaluate at
+all -- not the wrong input method, no evaluation. One step lower is not
+available either: nixpkgs' own module defines type as null at
+mkOptionDefault (1500) to carry the deprecated `enabled` across, and
+nullOr refuses to merge null with a value, so matching that ties in the
+other direction. Sitting between the two loses to anyone with a real
+opinion and still beats nixpkgs' placeholder, which is exactly the rule
+this module follows everywhere else: arrive beside what is installed.
+
+<a id="fcitx5-says-this-itself-in-a-notification-on-every"></a>
+### fcitx5 says this itself, in a notification on every login
+
+```nix
+i18n.inputMethod.fcitx5.waylandFrontend = lib.mkIf usingFcitx5 (lib.mkDefault true);
+```
+
+fcitx5 says this itself, in a notification on every login:
+
+  Wayland Diagnose -- Detect GTK_IM_MODULE being set and Wayland Input
+  method frontend is working. It is recommended to unset GTK_IM_MODULE.
+
+nixpkgs sets GTK_IM_MODULE and QT_IM_MODULE only when waylandFrontend is
+off, which is its default (i18n/input-method/fcitx5.nix). Those two are
+the X11-era route: with them set, GTK sends input through the legacy
+module instead of the Wayland input-method protocol, which is both worse
+and, in GTK4 and Electron apps, sometimes nothing at all.
+
+Nixarchy is Wayland-only -- there is no session here where the X11
+default is the right one -- so this is set rather than left to the user.
+
+## `modules/home.nix`
+
+<a id="what-omarchy-path-points-at-and-the-source-of-ever"></a>
+### What OMARCHY_PATH points at, and the source of every file seeded below
+
+```nix
+omarchyPath = osConfig.programs.nixarchy.tree or "${cfg.package}/share/omarchy";
+```
+
+What OMARCHY_PATH points at, and the source of every file seeded below.
+
+Read across from the NixOS module when there is one, the same way localAi
+is: it is the package's own tree with the files nixarchy generates for THIS
+machine in it, and the app selection those are built from is only visible
+over there. The menu's defaults file is the one that matters -- it carries
+the Install-row rewrites, which is how the Install menu stays off pacman
+without nixarchy taking ~/.config/omarchy/extensions/omarchy-menu.jsonc,
+the file upstream documents as the user's and points plugins at (#210).
+
+A standalone home-manager configuration has no NixOS module and therefore
+no selection, so it falls back to the package's tree -- the same menu
+Omarchy ships, which is the honest answer when there is no selection for
+the Install rows to reach.
+
+<a id="each-declared-plugin-checked-at-build-time-against"></a>
+### Each declared plugin, checked at build time against the schema the shell
+
+```nix
+validatedPlugins = lib.mapAttrs (
+```
+
+Each declared plugin, checked at build time against the schema the shell
+enforces, and carrying the id its own manifest claims.
+
+Validated with upstream's own omarchy-plugin-validate rather than a
+reimplementation of it here: that script exists precisely to refuse what
+the running shell would silently reject, and a second copy of those rules
+in Nix would drift from it at the first upstream bump. A plugin that would
+not load now fails the rebuild, with the reason, instead of being installed
+and doing nothing.
+
+The id comes out of manifest.json rather than the attribute name. It is
+what the shell, the menu and every omarchy-plugin-* command key on, and a
+directory named anything else would be a plugin the user cannot enable,
+disable or remove by the name they see on screen.
+
+<a id="a-plugin-that-shells-out-to-pacman-fails-the-rebui"></a>
+### A plugin that shells out to pacman fails the REBUILD, not the click
+
+```nix
+hits=$(
+```
+
+A plugin that shells out to pacman fails the REBUILD, not the click.
+
+omarchy-plugin-validate above checks the manifest and the shape the
+shell requires. It does not read what the plugin RUNS, and the
+marketplace is written for Arch: a widget whose QML calls
+`pacman -S` or `yay -S` installs cleanly here, appears in the bar,
+and fails the first time somebody presses it -- on a machine where
+pacman does not exist and could not be allowed to.
+
+This is build.yml's "no bin touches pacman outside the allowlist"
+applied one layer out. That scan walks Omarchy's own bins in this
+repository; nothing looked at code a USER brings in.
+
+No allowlist here, deliberately. build.yml has one because upstream's
+own Arch-only plumbing legitimately calls pacman and has to keep
+working on Arch. A third-party plugin installed on a NixOS machine
+has no such case: there is nothing for it to be right about.
+
+COMMENT STRIPPING, and why it is not the shell scanner's `s/#.*//`:
+QML comments with // and stripping that naively eats `https://...`,
+which would hide anything after a URL on the same line. So only
+WHOLE-LINE comments are removed -- `//` or `#` at the start of a
+line, after optional whitespace. A trailing `// mentions pacman`
+after real code still trips this, which is the safe direction for a
+check about what a machine will execute.
+
+<a id="declares-which-plugins-are-present-and-deliberatel"></a>
+### Declares which plugins are *present*, and deliberately not which are on
+
+```nix
+plugins = lib.mkOption {
+```
+
+Declares which plugins are *present*, and deliberately not which are on.
+
+Upstream already splits the two: a plugin's code lives in
+~/.config/omarchy/plugins/<id>/, while whether it is enabled, and where
+it sits in the bar, is recorded separately in ~/.config/omarchy/shell.json
+by the running shell. Content and state are already different files, so
+the content can come from the store without freezing the state.
+
+Enablement is therefore left alone on purpose. Managing shell.json here
+would mean a plugin you turned off in Setup > Plugins came back at the
+next rebuild, which is the sort of thing that makes people stop using the
+menu. Declare the plugin, enable it once, and your choice persists.
+
+<a id="omarchys-desktop-is-its-hyprland-config"></a>
+### Omarchy's desktop is its Hyprland config
+
+```nix
+warnings =
+```
+
+Omarchy's desktop is its Hyprland config: hyprland.lua requires
+autostart.lua, which is what starts the bar, and bindings.lua, which is
+every keybinding the manual documents. The seed below is --no-clobber, so
+a hyprland.lua that Home Manager already owns is kept and the other seven
+files land beside it, loaded by nothing.
+
+That failure is silent and total: every Omarchy binary, menu and theme
+installs, `nixarchy` looks like it worked, and the session that comes up
+is the user's own with no bar and none of the keybindings. Worth a
+warning rather than leaving someone to work it out from an empty bar.
+
+<a id="whether-there-is-an-omarchy-session-entry-to-log-i"></a>
+### Whether there is an Omarchy session entry to log into
+
+```nix
+hasOmarchySession =
+```
+
+Whether there is an Omarchy session entry to log into.
+
+When there is, a home-manager-owned ~/.config/hypr is not a problem:
+it is the arrangement this module is built for, and the session runs
+Omarchy's config with --config regardless. Warning anyway meant every
+rebuild on a machine already doing the right thing printed twelve
+lines telling it to do the right thing.
+
+Only the case that actually loses the desktop is worth a warning: no
+session entry, and a hypr directory that will never load Omarchy. The
+informational half is one line from the seed instead, and the doctor
+says it before anyone installs at all.
+
+`or true` is the option's default; `or false` on enable because a
+standalone home-manager install has no NixOS module registering
+sessions at all.
+
+<a id="the-hyprland-toggles-tree-and-deliberately-only-fl"></a>
+### The Hyprland toggles tree, and deliberately only flags.lua out of it
+
+```nix
+seed_file "${omarchyPath}/default/hypr/toggles/flags.lua" \
+```
+
+The Hyprland toggles tree, and deliberately only flags.lua out of it.
+
+These flags are state, not config: a flag is *on* because its file is
+there, so copying all of default/hypr/toggles would bring the session
+up with no window gaps and every single window forced square.
+omarchy-hyprland-toggle copies the other two out of $OMARCHY_PATH the
+moment you ask for one, so nothing is lost by leaving them there --
+upstream's own omarchy-refresh-hyprland seeds exactly this one file.
+
+flags.lua is what makes the directory exist, and it has to exist
+before the shell starts rather than before the first toggle: the bar
+watches ~/.local/state/omarchy/toggles with a FileView to notice
+bar-off appearing, and a watch on a directory that is not there never
+fires. Hiding the bar wrote the flag and changed nothing on screen
+until the shell was restarted.
+
+<a id="and-the-two-files-that-belong-in-it-which-upstream"></a>
+### And the two files that belong in it, which upstream seeds from
+
+```nix
+seed_file "${omarchyPath}/icon.txt" \
+```
+
+And the two files that belong in it, which upstream seeds from
+/etc/skel. Without them the About window opens with an empty logo
+column -- fastfetch's config sources about.txt as its logo -- and the
+screensaver dies on the spot, because omarchy-screensaver hands
+screensaver.txt to ttfx as the art to animate.
+
+The same two sources `omarchy branding <about|screensaver> reset`
+copies back, so a reset returns to exactly what was seeded. logo.txt
+is this repo's NIXARCHY banner rather than upstream's, by the same
+reasoning as the menu's snowflake.
+
+<a id="the-extensions-directory-and-one-thing-to-undo-in-"></a>
+### The extensions directory, and one thing to undo in it
+
+```nix
+run mkdir -p "${config.xdg.configHome}/omarchy/extensions"
+```
+
+The extensions directory, and one thing to undo in it.
+
+This file is the user's: upstream documents it as theirs, and
+shell/plugins/README.md tells third-party plugins to write it.
+Nixarchy's rows are in the DEFAULTS this session reads (see
+omarchyPath), so nothing here writes it and nothing arbitrates.
+
+Except on a machine an older nixarchy already took it on, where
+it is a symlink into /etc and therefore into a read-only store
+path. Leaving that behind would keep the file unwritable forever
+on exactly the machines this is meant to fix, and nothing would
+ever say so -- which is the bug, not the symlink. So it is
+removed, once, and Omarchy's own commented example seeded in its
+place. Only a link into /etc/nixarchy is touched: a file, or a
+link somebody else made, is theirs. #210.
+
+<a id="agent-skills-relinked-on-every-activation"></a>
+### Agent skills, relinked on every activation
+
+```nix
+${
+```
+
+Agent skills, relinked on every activation.
+
+Upstream does this in omarchy-provision-user, which is guarded by a
+`finalize-user` marker and therefore runs exactly once, ever. That is
+fine on Arch, where the skill directory is a fixed path that gets
+overwritten in place. Here every bump moves the package to a new store
+path, so a once-only link points at the previous one -- still resolving
+until it is garbage-collected, then dangling. Renaming the `omarchy`
+skill to `nixarchy` made it worse than stale: the machine kept serving
+the old Arch skill from a path nothing would update again.
+
+provision-user's own --force would fix the links and also replay
+/etc/skel over $HOME, which is not a thing to do for four symlinks.
+So: the same loop, declaratively, on every rebuild.
+
+Only symlinks whose target is itself a skills directory in the store
+are removed. That is what distinguishes a link this module or
+provision-user planted from a skill the user wrote by hand, which is a
+real directory and is never touched.
+
+<a id="declared-plugins-linked-in-by-the-id-their-manifes"></a>
+### Declared plugins, linked in by the id their manifest claims
+
+```nix
+run mkdir -p "${config.xdg.configHome}/omarchy/plugins"
+```
+
+Declared plugins, linked in by the id their manifest claims.
+
+A symlink rather than a copy, and that is a supported shape rather
+than a trick: upstream's scan globs "$dir"/*/ , which matches a
+symlink to a directory, and omarchy-plugin-remove has an explicit
+branch for one -- it offers to "Unlink" and prints where it pointed.
+Its picker globs -type d -o -type l for the same reason.
+
+Only links this module planted are cleaned up, tracked in a
+.nixarchy-managed file beside them. A plugin you added yourself with
+`omarchy plugin add` is a real directory that this never touches, so
+the two ways of installing one live side by side.
+
+<a id="the-first-run-theme-above-is-applied-headless-whic"></a>
+### The first-run theme above is applied headless, which by design skips…
+
+```nix
+systemd.user.services.omarchy-theme-gnome = {
+```
+
+The first-run theme above is applied headless, which by design skips every
+post-theme command -- including omarchy-theme-set-gnome, the one that
+tells GTK and the settings portal whether this theme is light or dark.
+Upstream never notices: on Arch that command runs during install with a
+live session, and dconf keeps the answer forever after. Here the first
+session would come up dark-themed with light GTK apps until the user
+switched themes by hand.
+
+Unlike the shell below, this needs only the session bus, not a running
+compositor, so a graphical-session unit is the right shape for it. It is
+a no-op on every later login, because it writes what dconf already holds.
+
+<a id="provider-files-for-the-local-model-when-the-system"></a>
+### Provider files for the local model, when the system module turned it on
+
+```nix
+home.activation.nixarchyOpencodeProvider =
+```
+
+Provider files for the local model, when the system module turned it on.
+
+Written here rather than in modules/local-ai.nix because only the home
+module knows where a user's home is, and read back out of osConfig so the
+address the server binds and the address the agents dial cannot drift.
+Guarded by `or null` throughout: home.nix is usable on its own, without
+the NixOS module, and then there is no osConfig to read.
+
+Both agents get a file whether or not either is the current default. They
+are a few hundred bytes, and the alternative is that switching agent in
+the menu silently produces one that cannot reach the model.
+opencode's provider, merged into the file rather than owning it.
+
+~/.config/opencode/opencode.json already exists on every Omarchy machine
+-- it is seeded with the theme and an autoupdate setting -- so declaring
+it as an xdg.configFile fails activation outright:
+
+  Existing file '~/.config/opencode/opencode.json' would be clobbered
+
+and takes the whole home-manager generation down with it, not just this
+file. `force = true` is worse: it would throw away the user's own opencode
+settings and Omarchy's theme wiring to install a provider block.
+
+So the provider is merged in with jq, on every activation, leaving every
+other key alone. Same reasoning as the pi settings below, arrived at the
+same way: both files already have an owner.
+
+<a id="pi-keeps-its-configuration-in-pi-agent-not-under-x"></a>
+### pi keeps its configuration in ~/.pi/agent, not under XDG
+
+```nix
+home.activation.nixarchyPiProvider =
+```
+
+pi keeps its configuration in ~/.pi/agent, not under XDG.
+
+supportsDeveloperRole is the field that has to be right. pi sends system
+instructions in the `developer` role to reasoning-capable models, and
+Ollama -- like vLLM and SGLang -- rejects a role it does not know. Every
+request then fails with an error that does not name the cause.
+pi's provider. Merged for the same reason, though less urgently: nothing
+in Omarchy writes models.json today. Doing it the same way means a future
+version that does cannot break activation, and means a user's own extra
+providers survive.
+
+<a id="same-extension-point-on-the-other-hook-omarchy-alr"></a>
+### Same extension point, on the other hook Omarchy already runs
+
+```nix
+xdg.configFile."omarchy/hooks/post-boot.d/config-repo" = {
+```
+
+Same extension point, on the other hook Omarchy already runs:
+default/hypr/autostart.lua ends its startup with `omarchy-hook post-boot`.
+
+A notification rather than a window. On a machine the installer built,
+/etc/nixos is a repository with one staged, never-committed tree -- so
+there is something real to say -- but a terminal that seizes the screen on
+a first-ever boot arrives before the user has signed in to anything, which
+makes the one answer they can give "dismiss". The nudge is a notification
+they can act on when they are ready, and the script's own --check decides
+whether there is any point showing it: already committed and pushed, no
+agent chosen yet, or already answered once, and it stays quiet.
+
+It stays quiet for one more reason now, and it is the important one. This
+module reaches every machine that imports it, including one where somebody
+added nixarchy to a configuration of their own -- and on that machine
+/etc/nixos is theirs. --check asks /etc/nixarchy/managed before anything
+else and answers "no nudge", so the hook exits 0 having said nothing.
+
+Two conditions, two messages. The first push is a different thing to say
+than the fortnight of changes that piled up after it, and a notification
+whose text does not match what clicking it will do is worse than none.
+
+<a id="left-at-home-managers-own-default-everywhere-else-"></a>
+### Left at Home Manager's own default everywhere else, which is
+
+```nix
+enableSystemdUnit = lib.mkDefault false;
+```
+
+Left at Home Manager's own default everywhere else, which is
+`cfg.containers != { } && cfg.package != null` -- true the instant
+`machines` is non-empty, so leaving this unset would turn it on.
+Refused outright: its ExecStart is
+`${cfg.package}/bin/distrobox-assemble create --file ...`, a literal
+/nix/store/... path baked straight into the unit file -- the exact
+GC-survival hazard (nixpkgs#478154) modules/services/boxes.nix's own
+comment documents distrobox itself must never be reached through.
+`nix-collect-garbage` can delete that path out from under this unit
+the same way it can out from under a running box. It also hardcodes
+uid 1000 in the cleanup it runs first
+(`rm -rf /tmp/storage-run-1000/...`), a second, independent reason to
+leave it off. `nixarchy box` (a later issue) is how a machine picks
+up a declared container -- by calling `distrobox-assemble` itself,
+by bare name, the way the module comment already requires.
+
+## `modules/apps.nix`
+
+<a id="the-command-each-app-puts-on-path-so-the-menu-can-"></a>
+### The command each app puts on PATH, so the menu can tell "you already…
+
+```nix
+appBinary =
+```
+
+The command each app puts on PATH, so the menu can tell "you already have
+this" from "you have not installed it".
+
+meta.mainProgram rather than the attribute name: it is right where the two
+differ, and they differ often -- obs-studio puts `obs` on PATH, not
+`obs-studio`. It is metadata, so this reads it without building anything.
+
+tryEval because an unfree package throws at *evaluation* when allowUnfree
+is off, and spotify and obsidian are both unfree. Without it, adding this
+would have broken evaluation for everyone who has not opted into unfree --
+a far worse outcome than the dim row it is here to draw. Falling back to
+the app's own name is the same guess omarchy-pkg-present already makes.
+
+`ours` apps are answered by cfg.apps.<name>.package -- the very derivation
+the row would install, including any override the user put on it -- and
+NOT by a lookup in `pkgs`, which cannot see them: this module's pkgs
+carries no nixarchy overlay (modules/services/default.nix says why), so
+the lookup returned null for every app this repo packages and the
+fallback answered with the app id. That was `command -v zen` for a
+package whose only binary is zen-beta, so the row never dimmed on a
+machine that HAS Zen. nixarchy-doctor hit the same trap and fixed its
+copy first, by probing final.nixarchy-apps (flake.nix); this is the
+menu's half, asserted by tests/coverage.py against the flake's packages.
+
+<a id="the-curated-list-as-search-rows"></a>
+### The curated list as search rows
+
+```nix
+optionsJsonPath =
+```
+
+The curated list as search rows: id, label, category, note. Notes are
+flattened because the index this feeds is tab-separated and a note with a
+newline in it would silently become three broken rows -- the same reason
+templateRow collapses them.
+The NixOS option index, or "" when this system has no manual to take it
+from. `system.build.manual` is defined under documentation.nixos.enable,
+which is on by default but off in every NixOS test node -- so a hard
+reference here evaluates fine on a real machine and fails the session
+check, which is exactly how it got through review.
+
+Built rather than fetched, but built by nixpkgs: it substitutes from
+cache.nixos.org, so it costs a 2.6 MiB download rather than an evaluation
+of every option on the machine.
+
+<a id="flatpaks-go-in-services-nix-rather-than-a-fourth-f"></a>
+### Flatpaks go in services.nix rather than a fourth file
+
+```nix
+flatpakIndexRows = pkgs.writeText "nixarchy-flatpak-rows.tsv" (
+```
+
+Flatpaks go in services.nix rather than a fourth file.
+
+They are applications, so apps.nix is the tempting home -- and the wrong
+one: that file's header promises "Applications available through the
+Omarchy menu, as NixOS configuration", meaning software from nixpkgs with
+everything that implies. A flatpak is a different tier with weaker
+promises, and mixing the two would make the file quietly dishonest.
+
+services.nix already holds things that are decisions about the machine
+rather than packages, which is what enabling a flatpak is: it turns on a
+daemon, adds a remote, and installs software the store does not hold.
+Curated flatpaks as picker rows, plus the one row that reaches the rest of
+Flathub. Written whole in Nix rather than transformed by awk at index time
+like the app rows: there are a handful of these and the preview text is
+prose, so a template is clearer than a transformation.
+
+Five tab-separated fields, matching every other source: kind, name,
+summary, option type (unused here), preview.
+
+<a id="services-and-system-settings-as-nixos-configuratio"></a>
+### Services and system settings, as NixOS configuration
+
+```nix
+{ ... }:
+```
+
+Services and system settings, as NixOS configuration.
+
+The companion to apps.nix. An app is a package; a service is a decision
+about the machine. Uncomment what you want -- or pick it from the menu --
+then run
+
+    nixarchy-apply
+
+Two kinds of line appear below and the difference is deliberate:
+
+  programs.nixarchy.services.X   nixarchy bundles several options here,
+                                 because turning the thing on usefully
+                                 takes more than one.
+
+  services.X.enable              the real NixOS option, because there was
+                                 nothing for nixarchy to add. This is the
+                                 line every wiki page will show you, and
+                                 it is the same line here.
+
+This file is a NixOS module and nothing stops you writing any option in
+it. Upstream's own settings work alongside ours -- if you enable
+syncthing below, `services.syncthing.settings.folders` still does what
+its documentation says.
+
+This file is yours. Nothing regenerates or overwrites it once created;
+the current full list is always at /etc/nixarchy/services-template.nix.
+
+<a id="anything-at-all"></a>
+### Anything at all
+
+```nix
+{ ... }:
+```
+
+Anything at all.
+
+apps.nix is a list nixarchy generated and services.nix is a catalogue it
+curated. This file has neither, because at some point the answer to "how
+do I do X on NixOS" is a NixOS option nobody put on a list, and a curated
+desktop that has no room for that is a cage.
+
+It is an ordinary NixOS module. Every option in nixpkgs is available:
+
+  services.openssh.settings.PermitRootLogin = "no";
+  boot.kernelParams = [ "quiet" ];
+  users.users.you.extraGroups = [ "dialout" ];
+
+`nixarchy-search` writes here when you pick an option from it. Nothing
+else touches this file.
+
+If you find yourself writing the same thing here on every machine, that
+is worth an issue -- it probably belongs in the catalogue.
+
+<a id="applications-available-through-the-omarchy-menu-as"></a>
+### Applications available through the Omarchy menu, as NixOS configuration
+
+```nix
+{ ... }:
+```
+
+Applications available through the Omarchy menu, as NixOS configuration.
+
+Every app is listed and every line is commented out. Uncomment what you
+want -- or pick it from the menu, which uncomments it for you -- then run
+
+    nixarchy-apply
+
+to copy this into your flake and `nixos-rebuild switch`. Enable as many as
+you like before applying; nothing is built until you do.
+
+This file is yours. Nothing regenerates or overwrites it once created;
+the current full list is always at /etc/nixarchy/apps-template.nix.
+
+The `#@ name` markers are how the menu finds a line to uncomment. Keep
+them and you can reformat, reorder and annotate this file freely.
+
+<a id="the-menu-defaults"></a>
+### ── The menu defaults ───────────────────────────────────────────────────
+
+```nix
+overrideSpec = pkgs.writeText "nixarchy-menu-overrides.json" (
+```
+
+── The menu defaults ───────────────────────────────────────────────────
+Rewrites Omarchy's Install menu, in the DEFAULTS rather than in the user's
+extension. Menu.qml reads two files and merges the second over the first:
+
+  defaults   $OMARCHY_PATH/default/omarchy/omarchy-menu.jsonc
+  user       ~/.config/omarchy/extensions/omarchy-menu.jsonc
+
+Nixarchy used to generate the second one and symlink it into /etc, which
+put the port in the slot upstream documents as the user's -- and which
+shell/plugins/README.md tells third-party plugins to write. A plugin's row,
+or a row somebody typed, could not survive there, and nothing said so.
+
+But we build the package OMARCHY_PATH points at, so the defaults are ours
+to write: `omarchyTree` below is that tree with this one file replaced.
+Then the user's file is free, upstream's merge does the rest in the
+direction it was designed for, and there is nothing to arbitrate. See #210.
+
+A failing `when:` hides a row outright (MenuModel.js isVisible); a
+succeeding `disabled:` leaves it listed but dim and unselectable, which is
+what upstream already uses for "you have this installed".
+The override rows, as data. Deliberately WITHOUT label or icon: those are
+copied from upstream's own menu at build time by the script below, so a
+rename upstream follows through instead of being frozen into this repo.
+
+<a id="beside-roll-back-because-they-are-the-two-halves-o"></a>
+### Beside Roll back, because they are the two halves of the same
+
+```nix
+"system.backup" = {
+```
+
+Beside Roll back, because they are the two halves of the same
+question: a generation brings this machine back on this disk, and a
+pushed configuration brings it back on any other one.
+
+Reachable deliberately rather than only by notification. The command
+existed for a while with no way to reach it except a nudge on a boot
+you happened to act on, or knowing its name -- which meant the answer
+to "I changed things, is that backed up?" was to remember a command.
+
+`when` rather than letting the row refuse when clicked: on a machine
+nixarchy did not write, nixarchy-config-repo declines and explains
+why, and a menu row whose only possible outcome is that explanation
+is not worth drawing. /etc/nixarchy/managed is the same predicate the
+command itself gates on -- see modules/nixos.nix.
+
+<a id="the-off-disk-half-beside-the-on-disk-one"></a>
+### The off-disk half, beside the on-disk one
+
+```nix
+"trigger.home-backup" = {
+```
+
+The off-disk half, beside the on-disk one.
+
+A snapshot and a backup read as the same thing to someone who has
+not lost a disk yet, so the two pairs sit together deliberately:
+snapshots are instant and local, these two survive the hardware.
+The descriptions are where that difference is actually said.
+
+`when` hides both rows on a machine nixarchy did not install --
+the same gate the script itself enforces, so an imported
+nixosModules.nixarchy is not offered a thing that will refuse.
+A row that exists to say no is worse than no row.
+
+<a id="the-sandboxes-group-226"></a>
+### The Sandboxes group (#226)
+
+```nix
+"trigger.vm" = {
+```
+
+The Sandboxes group (#226). A nested `trigger.vm`, not a new root
+section -- `trigger.ask` above is the same shape, a new parent
+under an upstream root, and there is no precedent here for a root
+of our own. `full = dict(upstream); full.update(out)` in
+menuDefaults above means a totally new id like this one is
+APPENDED, so it lands after System and About at the end of the
+list -- the ordering #226 documents, not something coded here.
+
+Two gates, both needed. This `lib.optionalAttrs cfg.enable` is the
+Nix-level one: belt-and-braces, since every row in this file
+already lives inside `config = lib.mkIf cfg.enable (...)` above --
+stated explicitly so a reader does not have to trace that back.
+The runtime one is the parent's own `when` below: whether *this
+login* can open /dev/kvm is only knowable now, not at rebuild
+time -- `nixarchy-vm --check` (pkgs/microvm.nix) always exits 0,
+so nothing here is actually gated on hardware; the fallback to a
+software CPU is what makes that true on every nixarchy machine.
+
+`nixarchy-vm` itself is installed unconditionally (this file,
+below -- same as `nixarchy dev init`), so there is no
+`programs.nixarchy.services.microvm.enable` to gate this on:
+#221 designed the disposable half to need no root and no rebuild,
+so nothing about it is opt-in.
+
+<a id="dim-when-the-app-is-in-the-selection-or-already-on"></a>
+### Dim when the app is in the selection *or* already on PATH
+
+```nix
+disabled =
+```
+
+Dim when the app is in the selection *or* already on PATH.
+
+The second half is the case nixarchy could not see before: an
+app the user installed themselves, in their own
+systemPackages or home.packages, which the selection knows
+nothing about. The row offered to install something they
+already had, and taking it would have written a second
+declaration for it.
+
+Remove rows deliberately do NOT gain this. They stay bound to
+the selection, because deselecting is the only removal
+nixarchy is allowed to perform -- an app that arrived from
+the user's own configuration is not this menu's to take away.
+
+<a id="the-services-catalogue-as-menu-rows"></a>
+### The services catalogue, as menu rows
+
+```nix
+// lib.listToAttrs (
+```
+
+The services catalogue, as menu rows.
+
+Most of these are ids upstream does not ship -- Omarchy's menu has no
+"turn on SSH" row because on Arch that is not a menu's business. The
+generator takes a new id as long as the override names the row itself,
+which is why label and icon are here; install.search arrived the same
+way. Where upstream DOES have a row, the catalogue entry carries its
+menuId and this overrides it in place -- tailscale is that case, and
+carrying the id across is what keeps the generator from failing on a
+row nothing maps.
+
+<a id="the-tree-omarchy-path-points-at"></a>
+### The tree OMARCHY_PATH points at
+
+```nix
+omarchyTree = pkgs.runCommand "nixarchy-omarchy-tree" { } ''
+```
+
+The tree OMARCHY_PATH points at: the package's own share/omarchy, with
+exactly one file replaced.
+
+Built here rather than in pkgs/omarchy because the rewrites depend on the
+machine's app selection, which is per-configuration, not per-package. The
+idiom is flake.nix's nixarchy-plymouth: mirror a subtree out of the omarchy
+package rather than rebuild the package for one file.
+
+Symlinks at the shallowest level that works, and real files in the one
+directory being changed. That matters for more than size: upstream's own
+scripts copy out of $OMARCHY_PATH at runtime (omarchy refresh, the
+migrations, omarchy-plugin-clone), and a symlink FARM would hand them
+links into a read-only store path where they expect files. Symlinking whole
+directories instead keeps everything inside them a real file, which is what
+`cp -r $OMARCHY_PATH/config/.` copies.
+
+<a id="the-doctor-and-verify-which-until-now-were-flake-a"></a>
+### The doctor and verify, which until now were flake apps only
+
+```nix
+(pkgs.extend inputs.self.overlays.default).nixarchy-doctor
+```
+
+The doctor and verify, which until now were flake apps only.
+
+`nixarchy doctor` has always been an advertised subcommand, and on
+every machine where you can type `nixarchy` it answered "The doctor
+is not installed". The dispatcher below already has
+`if command -v nixarchy-doctor` and routes to it -- a branch nothing
+could take, because nothing installed it.
+
+Running from the flake is unchanged: that entry point exists so the
+doctor can be run BEFORE nixarchy is an input anywhere, and
+installing it does not take that away.
+
+Through the overlay on the user's own pkgs, never
+inputs.self.packages -- see the note on programs.nixarchy.package in
+modules/nixos.nix for what mixing nixpkgs instances does to buildEnv.
+
+<a id="uncomments-one-app-in-config-nixarchy-apps-nix"></a>
+### Uncomments one app in ~/.config/nixarchy/apps.nix
+
+```nix
+(pkgs.writeShellApplication {
+```
+
+Uncomments one app in ~/.config/nixarchy/apps.nix. Matching is on
+the `#@ <id>` marker, not a line number or a label, so the file
+survives being reformatted, reordered or annotated by hand.
+What the catalogue offers that your file has never heard of.
+
+The seeded files are written once and never touched again, which is
+correct -- they are the user's, and overwriting one would silently
+undo a selection. The consequence is that an entry added after a
+machine was installed never appears on it: no `#@` marker, so
+nixarchy-app-enable answers "no app 'x' in $file" and the menu row
+is dead. Until now the only way to find that out was to diff
+against /etc/nixarchy/apps-template.nix by hand, and nothing said
+so.
+
+<a id="the-answer-to-i-want-a-package-the-menu-does-not-o"></a>
+### The answer to "I want a package the menu does not offer"
+
+```nix
+(pkgs.writeShellApplication {
+```
+
+The answer to "I want a package the menu does not offer". Upstream's
+`omarchy pkg add` runs pacman; there is no imperative equivalent
+here, so this does the declarative thing instead -- appends the
+attribute to a list in the same file the menu already edits, so
+one `nixarchy-apply` builds curated apps and extras together.
+
+It deliberately does NOT touch the user's own NixOS configuration,
+which nixarchy does not own. ~/.config/nixarchy/apps.nix is already
+a full NixOS module, so a systemPackages list can sit beside the
+app selection with no new file and no new option.
+
+<a id="search-everything-this-machine-could-install-and-r"></a>
+### Search everything this machine could install, and route the choice
+
+```nix
+(pkgs.writeShellApplication {
+```
+
+Search everything this machine could install, and route the choice
+to whichever writer is right for it.
+
+The three kinds are not interchangeable and the whole point of one
+picker over them is that you do not have to know which is which:
+an app becomes programs.<name>, a package becomes a systemPackages
+entry, an option becomes a line of its own. Picking Firefox from
+the app rows and picking `firefox` from the package rows are
+genuinely different configurations, and the rows say so.
+
+The index is built from this system's own nixpkgs and its own
+options, not from search.nixos.org. It is slower to build and it
+cannot go stale against the machine, which is the trade that
+matters: an index that offers a package nixarchy-pkg-add will then
+refuse is worse than no index.
+
+<a id="ask-flathub-org-directly"></a>
+### Ask flathub.org directly
+
+```nix
+flathub_search() {
+```
+
+Ask flathub.org directly.
+
+NOT `flatpak search`, which is columnar with no JSON output and
+needs both a configured remote and a downloaded appstream cache
+-- so it answers nothing on a machine that has not set flatpak
+up yet, which is exactly the machine asking.
+
+This is the one thing in the picker that needs a network. The
+index itself is still built entirely from local sources, so the
+other three kinds keep working on a machine with none; only
+this row fails, and it says so.
+
+<a id="one-name-for-the-commands-this-repo-adds-and-a-way"></a>
+### One name for the commands this repo adds, and a way through to
+
+```nix
+(pkgs.writeShellApplication {
+```
+
+One name for the commands this repo adds, and a way through to
+the 431 it vendors.
+
+Not a rename of Omarchy. Upstream's commands keep upstream's name,
+because they are upstream's -- `omarchy theme set` is the same
+script here as on Arch, and a bug in it is a bug to report there.
+What this names is the other half: the commands nixarchy wrote,
+which until now were binaries on PATH with nothing tying them
+together and no way to discover them.
+
+Anything this does not own falls through to omarchy unchanged, so
+`nixarchy theme set catppuccin` works and does exactly what
+`omarchy theme set catppuccin` does. The fallthrough is the point:
+you should not have to know which half of the desktop you are
+talking to before you can type a command.
+
+<a id="where-the-selection-lands"></a>
+### Where the selection lands
+
+```nix
+base="$flake"
+```
+
+Where the selection lands: this machine's directory when the
+flake has one, the flake root when it does not.
+
+That second case is every machine installed before the hosts/
+layout existed. Their flake is their own -- the README calls it
+"a flake you own" -- so nothing migrates it, and this one
+conditional is the entire cost of leaving them alone.
+
+Keyed on the directory existing rather than on the hostname
+matching anything: a repo that has hosts/ but not one for THIS
+machine is a repo being edited from somewhere else, and writing
+a stray directory into it would be worse than writing the file
+where it has always gone.
+
+<a id="a-flake-cannot-read-a-file-outside-its-own-tree-so"></a>
+### A flake cannot read a file outside its own tree, so the
+
+```nix
+srcdir="''${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy"
+```
+
+A flake cannot read a file outside its own tree, so the
+selection is copied in rather than imported from $HOME.
+
+Three files now, into $flake/nixarchy/, with nixarchy-apps.nix
+left as a module that imports them. That last part is the whole
+reason for the indirection: the README has been telling people
+to add `imports = [ ./nixarchy-apps.nix ];` since the beginning,
+and on a machine nixarchy does not own, asking them to add two
+more lines is not a thing this project gets to do. The name they
+already wrote keeps working and gains two files behind it.
+
+Safe to overwrite because nixarchy-apps.nix has always been a
+copy this script regenerates, never something the user wrote --
+and the copy it used to hold is written to nixarchy/apps.nix in
+the same run, before the stub replaces it.
+
+<a id="stage-what-was-written-or-a-flake-in-a-git-worktre"></a>
+### Stage what was written, or a flake in a git worktree cannot see
+
+```nix
+if [ -e "$flake/.git" ]; then
+```
+
+Stage what was written, or a flake in a git worktree cannot see
+it. This is not a nicety: git makes untracked files invisible to
+the evaluator, so a fresh nixarchy/services.nix fails with "path
+does not exist" -- the trap installer/mkFlake.nix documents and
+the installer works around by staging at install time.
+
+Guarded, and still guarded after #356 chowned /etc/nixos to the
+installed user. This no longer fires on a machine this
+installer wrote -- staging succeeds there now -- but it is not
+dead code: an own-flake adopter keeps whatever ownership their
+configuration already has, and `--from-repo` installs onto a
+tree somebody else created. A failure to stage should still
+print the fix rather than abort an apply that has already
+copied everything correctly.
+
+<a id="whether-anything-in-the-flake-actually-imports-it"></a>
+### Whether anything in the flake actually imports it
+
+```nix
+importers=$(grep -rl 'nixarchy-apps\.nix' "$flake" \
+```
+
+Whether anything in the flake actually imports it.
+
+Copying the selection in is only half the job: a flake cannot
+read a file outside its own tree, so the copy is necessary, and
+importing it is the user's. Nothing checked that, so a machine
+that never added the import got the full ceremony -- the menu
+marking apps enabled, this script reporting a copy, a rebuild
+running to completion -- and installed nothing, every time. It
+took someone asking why `dictation.enable = true` never
+installed anything to notice.
+
+Excludes the copy itself, which of course contains its own name
+nowhere but is matched by the filename glob.

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -16,29 +16,7 @@ let
   boxesEnabled = cfg.enable && cfg.services.boxes.enable;
   boxTemplates = import ../data/box-templates.nix;
 
-  # The command each app puts on PATH, so the menu can tell "you already have
-  # this" from "you have not installed it".
-  #
-  # meta.mainProgram rather than the attribute name: it is right where the two
-  # differ, and they differ often -- obs-studio puts `obs` on PATH, not
-  # `obs-studio`. It is metadata, so this reads it without building anything.
-  #
-  # tryEval because an unfree package throws at *evaluation* when allowUnfree
-  # is off, and spotify and obsidian are both unfree. Without it, adding this
-  # would have broken evaluation for everyone who has not opted into unfree --
-  # a far worse outcome than the dim row it is here to draw. Falling back to
-  # the app's own name is the same guess omarchy-pkg-present already makes.
-  #
-  # `ours` apps are answered by cfg.apps.<name>.package -- the very derivation
-  # the row would install, including any override the user put on it -- and
-  # NOT by a lookup in `pkgs`, which cannot see them: this module's pkgs
-  # carries no nixarchy overlay (modules/services/default.nix says why), so
-  # the lookup returned null for every app this repo packages and the
-  # fallback answered with the app id. That was `command -v zen` for a
-  # package whose only binary is zen-beta, so the row never dimmed on a
-  # machine that HAS Zen. nixarchy-doctor hit the same trap and fixed its
-  # copy first, by probing final.nixarchy-apps (flake.nix); this is the
-  # menu's half, asserted by tests/coverage.py against the flake's packages.
+  # Why: modules/AGENTS.md#the-command-each-app-puts-on-path-so-the-menu-can-
   appBinary =
     name: app:
     let
@@ -180,19 +158,7 @@ let
     )
   );
 
-  # The curated list as search rows: id, label, category, note. Notes are
-  # flattened because the index this feeds is tab-separated and a note with a
-  # newline in it would silently become three broken rows -- the same reason
-  # templateRow collapses them.
-  # The NixOS option index, or "" when this system has no manual to take it
-  # from. `system.build.manual` is defined under documentation.nixos.enable,
-  # which is on by default but off in every NixOS test node -- so a hard
-  # reference here evaluates fine on a real machine and fails the session
-  # check, which is exactly how it got through review.
-  #
-  # Built rather than fetched, but built by nixpkgs: it substitutes from
-  # cache.nixos.org, so it costs a 2.6 MiB download rather than an evaluation
-  # of every option on the machine.
+  # Why: modules/AGENTS.md#the-curated-list-as-search-rows
   optionsJsonPath =
     let
       manual = config.system.build.manual.optionsJSON or null;
@@ -222,24 +188,7 @@ let
   serviceCatalogue = import ../data/services.nix;
   flatpakCatalogue = import ../data/flatpaks.nix;
 
-  # Flatpaks go in services.nix rather than a fourth file.
-  #
-  # They are applications, so apps.nix is the tempting home -- and the wrong
-  # one: that file's header promises "Applications available through the
-  # Omarchy menu, as NixOS configuration", meaning software from nixpkgs with
-  # everything that implies. A flatpak is a different tier with weaker
-  # promises, and mixing the two would make the file quietly dishonest.
-  #
-  # services.nix already holds things that are decisions about the machine
-  # rather than packages, which is what enabling a flatpak is: it turns on a
-  # daemon, adds a remote, and installs software the store does not hold.
-  # Curated flatpaks as picker rows, plus the one row that reaches the rest of
-  # Flathub. Written whole in Nix rather than transformed by awk at index time
-  # like the app rows: there are a handful of these and the preview text is
-  # prose, so a template is clearer than a transformation.
-  #
-  # Five tab-separated fields, matching every other source: kind, name,
-  # summary, option type (unused here), preview.
+  # Why: modules/AGENTS.md#flatpaks-go-in-services-nix-rather-than-a-fourth-f
   flatpakIndexRows = pkgs.writeText "nixarchy-flatpak-rows.tsv" (
     lib.concatStrings (
       lib.mapAttrsToList (name: fp: ''
@@ -309,32 +258,7 @@ let
     header + lib.concatStrings (lib.mapAttrsToList serviceRow rows) + "\n";
 
   servicesTemplate = pkgs.writeText "nixarchy-services.nix" ''
-    # Services and system settings, as NixOS configuration.
-    #
-    # The companion to apps.nix. An app is a package; a service is a decision
-    # about the machine. Uncomment what you want -- or pick it from the menu --
-    # then run
-    #
-    #     nixarchy-apply
-    #
-    # Two kinds of line appear below and the difference is deliberate:
-    #
-    #   programs.nixarchy.services.X   nixarchy bundles several options here,
-    #                                  because turning the thing on usefully
-    #                                  takes more than one.
-    #
-    #   services.X.enable              the real NixOS option, because there was
-    #                                  nothing for nixarchy to add. This is the
-    #                                  line every wiki page will show you, and
-    #                                  it is the same line here.
-    #
-    # This file is a NixOS module and nothing stops you writing any option in
-    # it. Upstream's own settings work alongside ours -- if you enable
-    # syncthing below, `services.syncthing.settings.folders` still does what
-    # its documentation says.
-    #
-    # This file is yours. Nothing regenerates or overwrites it once created;
-    # the current full list is always at /etc/nixarchy/services-template.nix.
+    # Why: modules/AGENTS.md#services-and-system-settings-as-nixos-configuratio
     { ... }:
     {
     ${lib.concatStrings (map serviceCategoryBlock serviceCategories)}${flatpakBlock}}
@@ -342,45 +266,14 @@ let
 
   # No catalogue, on purpose.
   advancedTemplate = pkgs.writeText "nixarchy-advanced.nix" ''
-    # Anything at all.
-    #
-    # apps.nix is a list nixarchy generated and services.nix is a catalogue it
-    # curated. This file has neither, because at some point the answer to "how
-    # do I do X on NixOS" is a NixOS option nobody put on a list, and a curated
-    # desktop that has no room for that is a cage.
-    #
-    # It is an ordinary NixOS module. Every option in nixpkgs is available:
-    #
-    #   services.openssh.settings.PermitRootLogin = "no";
-    #   boot.kernelParams = [ "quiet" ];
-    #   users.users.you.extraGroups = [ "dialout" ];
-    #
-    # `nixarchy-search` writes here when you pick an option from it. Nothing
-    # else touches this file.
-    #
-    # If you find yourself writing the same thing here on every machine, that
-    # is worth an issue -- it probably belongs in the catalogue.
+    # Why: modules/AGENTS.md#anything-at-all
     { ... }:
     {
     }
   '';
 
   appsTemplate = pkgs.writeText "nixarchy-apps.nix" ''
-    # Applications available through the Omarchy menu, as NixOS configuration.
-    #
-    # Every app is listed and every line is commented out. Uncomment what you
-    # want -- or pick it from the menu, which uncomments it for you -- then run
-    #
-    #     nixarchy-apply
-    #
-    # to copy this into your flake and `nixos-rebuild switch`. Enable as many as
-    # you like before applying; nothing is built until you do.
-    #
-    # This file is yours. Nothing regenerates or overwrites it once created;
-    # the current full list is always at /etc/nixarchy/apps-template.nix.
-    #
-    # The `#@ name` markers are how the menu finds a line to uncomment. Keep
-    # them and you can reformat, reorder and annotate this file freely.
+    # Why: modules/AGENTS.md#applications-available-through-the-omarchy-menu-as
     { ... }:
     {
       programs.nixarchy.apps = {
@@ -389,29 +282,7 @@ let
 
     # Offered by the Omarchy menu but with no nixpkgs equivalent:
     ${unavailableNote}'';
-  # ── The menu defaults ───────────────────────────────────────────────────
-  # Rewrites Omarchy's Install menu, in the DEFAULTS rather than in the user's
-  # extension. Menu.qml reads two files and merges the second over the first:
-  #
-  #   defaults   $OMARCHY_PATH/default/omarchy/omarchy-menu.jsonc
-  #   user       ~/.config/omarchy/extensions/omarchy-menu.jsonc
-  #
-  # Nixarchy used to generate the second one and symlink it into /etc, which
-  # put the port in the slot upstream documents as the user's -- and which
-  # shell/plugins/README.md tells third-party plugins to write. A plugin's row,
-  # or a row somebody typed, could not survive there, and nothing said so.
-  #
-  # But we build the package OMARCHY_PATH points at, so the defaults are ours
-  # to write: `omarchyTree` below is that tree with this one file replaced.
-  # Then the user's file is free, upstream's merge does the rest in the
-  # direction it was designed for, and there is nothing to arbitrate. See #210.
-  #
-  # A failing `when:` hides a row outright (MenuModel.js isVisible); a
-  # succeeding `disabled:` leaves it listed but dim and unselectable, which is
-  # what upstream already uses for "you have this installed".
-  # The override rows, as data. Deliberately WITHOUT label or icon: those are
-  # copied from upstream's own menu at build time by the script below, so a
-  # rename upstream follows through instead of being frozen into this repo.
+  # Why: modules/AGENTS.md#the-menu-defaults
   overrideSpec = pkgs.writeText "nixarchy-menu-overrides.json" (
     builtins.toJSON (
       {
@@ -449,20 +320,7 @@ let
           description = "Switch to an earlier system generation. Your home directory is not touched";
         };
 
-        # Beside Roll back, because they are the two halves of the same
-        # question: a generation brings this machine back on this disk, and a
-        # pushed configuration brings it back on any other one.
-        #
-        # Reachable deliberately rather than only by notification. The command
-        # existed for a while with no way to reach it except a nudge on a boot
-        # you happened to act on, or knowing its name -- which meant the answer
-        # to "I changed things, is that backed up?" was to remember a command.
-        #
-        # `when` rather than letting the row refuse when clicked: on a machine
-        # nixarchy did not write, nixarchy-config-repo declines and explains
-        # why, and a menu row whose only possible outcome is that explanation
-        # is not worth drawing. /etc/nixarchy/managed is the same predicate the
-        # command itself gates on -- see modules/nixos.nix.
+        # Why: modules/AGENTS.md#beside-roll-back-because-they-are-the-two-halves-o
         "system.backup" = {
           icon = "󰆔";
           label = "Back up configuration";
@@ -490,17 +348,7 @@ let
           description = "Open an earlier version of your home directory and copy back what you want";
         };
 
-        # The off-disk half, beside the on-disk one.
-        #
-        # A snapshot and a backup read as the same thing to someone who has
-        # not lost a disk yet, so the two pairs sit together deliberately:
-        # snapshots are instant and local, these two survive the hardware.
-        # The descriptions are where that difference is actually said.
-        #
-        # `when` hides both rows on a machine nixarchy did not install --
-        # the same gate the script itself enforces, so an imported
-        # nixosModules.nixarchy is not offered a thing that will refuse.
-        # A row that exists to say no is worse than no row.
+        # Why: modules/AGENTS.md#the-off-disk-half-beside-the-on-disk-one
         "trigger.home-backup" = {
           icon = "󰁯";
           label = "Back up desktop config";
@@ -639,29 +487,7 @@ let
         ) boxTemplates
       )
       // lib.optionalAttrs cfg.enable {
-        # The Sandboxes group (#226). A nested `trigger.vm`, not a new root
-        # section -- `trigger.ask` above is the same shape, a new parent
-        # under an upstream root, and there is no precedent here for a root
-        # of our own. `full = dict(upstream); full.update(out)` in
-        # menuDefaults above means a totally new id like this one is
-        # APPENDED, so it lands after System and About at the end of the
-        # list -- the ordering #226 documents, not something coded here.
-        #
-        # Two gates, both needed. This `lib.optionalAttrs cfg.enable` is the
-        # Nix-level one: belt-and-braces, since every row in this file
-        # already lives inside `config = lib.mkIf cfg.enable (...)` above --
-        # stated explicitly so a reader does not have to trace that back.
-        # The runtime one is the parent's own `when` below: whether *this
-        # login* can open /dev/kvm is only knowable now, not at rebuild
-        # time -- `nixarchy-vm --check` (pkgs/microvm.nix) always exits 0,
-        # so nothing here is actually gated on hardware; the fallback to a
-        # software CPU is what makes that true on every nixarchy machine.
-        #
-        # `nixarchy-vm` itself is installed unconditionally (this file,
-        # below -- same as `nixarchy dev init`), so there is no
-        # `programs.nixarchy.services.microvm.enable` to gate this on:
-        # #221 designed the disposable half to need no root and no rebuild,
-        # so nothing about it is opt-in.
+        # Why: modules/AGENTS.md#the-sandboxes-group-226
         "trigger.vm" = {
           icon = "󰦛";
           label = "Sandbox";
@@ -715,19 +541,7 @@ let
             else
               {
                 action = "nixarchy-app-enable ${name}";
-                # Dim when the app is in the selection *or* already on PATH.
-                #
-                # The second half is the case nixarchy could not see before: an
-                # app the user installed themselves, in their own
-                # systemPackages or home.packages, which the selection knows
-                # nothing about. The row offered to install something they
-                # already had, and taking it would have written a second
-                # declaration for it.
-                #
-                # Remove rows deliberately do NOT gain this. They stay bound to
-                # the selection, because deselecting is the only removal
-                # nixarchy is allowed to perform -- an app that arrived from
-                # the user's own configuration is not this menu's to take away.
+                # Why: modules/AGENTS.md#dim-when-the-app-is-in-the-selection-or-already-on
                 disabled =
                   "grep -qE '^[[:space:]]*${name}\\.enable' $HOME/.config/nixarchy/apps.nix"
                   + " || command -v ${appBinary name app} >/dev/null 2>&1";
@@ -736,16 +550,7 @@ let
           )
         ) (lib.filterAttrs (_: a: a ? menuId) apps)
       )
-      # The services catalogue, as menu rows.
-      #
-      # Most of these are ids upstream does not ship -- Omarchy's menu has no
-      # "turn on SSH" row because on Arch that is not a menu's business. The
-      # generator takes a new id as long as the override names the row itself,
-      # which is why label and icon are here; install.search arrived the same
-      # way. Where upstream DOES have a row, the catalogue entry carries its
-      # menuId and this overrides it in place -- tailscale is that case, and
-      # carrying the id across is what keeps the generator from failing on a
-      # row nothing maps.
+      # Why: modules/AGENTS.md#the-services-catalogue-as-menu-rows
       // lib.listToAttrs (
         lib.mapAttrsToList (
           name: fp:
@@ -896,21 +701,7 @@ let
         PY
       '';
 
-  # The tree OMARCHY_PATH points at: the package's own share/omarchy, with
-  # exactly one file replaced.
-  #
-  # Built here rather than in pkgs/omarchy because the rewrites depend on the
-  # machine's app selection, which is per-configuration, not per-package. The
-  # idiom is flake.nix's nixarchy-plymouth: mirror a subtree out of the omarchy
-  # package rather than rebuild the package for one file.
-  #
-  # Symlinks at the shallowest level that works, and real files in the one
-  # directory being changed. That matters for more than size: upstream's own
-  # scripts copy out of $OMARCHY_PATH at runtime (omarchy refresh, the
-  # migrations, omarchy-plugin-clone), and a symlink FARM would hand them
-  # links into a read-only store path where they expect files. Symlinking whole
-  # directories instead keeps everything inside them a real file, which is what
-  # `cp -r $OMARCHY_PATH/config/.` copies.
+  # Why: modules/AGENTS.md#the-tree-omarchy-path-points-at
   omarchyTree = pkgs.runCommand "nixarchy-omarchy-tree" { } ''
     src=${cfg.package}/share/omarchy
     mkdir -p $out/default/omarchy
@@ -1013,37 +804,11 @@ in
         };
 
         environment.systemPackages = [
-          # The doctor and verify, which until now were flake apps only.
-          #
-          # `nixarchy doctor` has always been an advertised subcommand, and on
-          # every machine where you can type `nixarchy` it answered "The doctor
-          # is not installed". The dispatcher below already has
-          # `if command -v nixarchy-doctor` and routes to it -- a branch nothing
-          # could take, because nothing installed it.
-          #
-          # Running from the flake is unchanged: that entry point exists so the
-          # doctor can be run BEFORE nixarchy is an input anywhere, and
-          # installing it does not take that away.
-          #
-          # Through the overlay on the user's own pkgs, never
-          # inputs.self.packages -- see the note on programs.nixarchy.package in
-          # modules/nixos.nix for what mixing nixpkgs instances does to buildEnv.
+          # Why: modules/AGENTS.md#the-doctor-and-verify-which-until-now-were-flake-a
           (pkgs.extend inputs.self.overlays.default).nixarchy-doctor
           (pkgs.extend inputs.self.overlays.default).nixarchy-verify
 
-          # Uncomments one app in ~/.config/nixarchy/apps.nix. Matching is on
-          # the `#@ <id>` marker, not a line number or a label, so the file
-          # survives being reformatted, reordered or annotated by hand.
-          # What the catalogue offers that your file has never heard of.
-          #
-          # The seeded files are written once and never touched again, which is
-          # correct -- they are the user's, and overwriting one would silently
-          # undo a selection. The consequence is that an entry added after a
-          # machine was installed never appears on it: no `#@` marker, so
-          # nixarchy-app-enable answers "no app 'x' in $file" and the menu row
-          # is dead. Until now the only way to find that out was to diff
-          # against /etc/nixarchy/apps-template.nix by hand, and nothing said
-          # so.
+          # Why: modules/AGENTS.md#uncomments-one-app-in-config-nixarchy-apps-nix
           (pkgs.writeShellApplication {
             name = "nixarchy-catalogue-diff";
             runtimeInputs = [
@@ -1372,16 +1137,7 @@ in
             '';
           })
 
-          # The answer to "I want a package the menu does not offer". Upstream's
-          # `omarchy pkg add` runs pacman; there is no imperative equivalent
-          # here, so this does the declarative thing instead -- appends the
-          # attribute to a list in the same file the menu already edits, so
-          # one `nixarchy-apply` builds curated apps and extras together.
-          #
-          # It deliberately does NOT touch the user's own NixOS configuration,
-          # which nixarchy does not own. ~/.config/nixarchy/apps.nix is already
-          # a full NixOS module, so a systemPackages list can sit beside the
-          # app selection with no new file and no new option.
+          # Why: modules/AGENTS.md#the-answer-to-i-want-a-package-the-menu-does-not-o
           (pkgs.writeShellApplication {
             name = "nixarchy-pkg-add";
             runtimeInputs = [
@@ -1559,21 +1315,7 @@ in
             '';
           })
 
-          # Search everything this machine could install, and route the choice
-          # to whichever writer is right for it.
-          #
-          # The three kinds are not interchangeable and the whole point of one
-          # picker over them is that you do not have to know which is which:
-          # an app becomes programs.<name>, a package becomes a systemPackages
-          # entry, an option becomes a line of its own. Picking Firefox from
-          # the app rows and picking `firefox` from the package rows are
-          # genuinely different configurations, and the rows say so.
-          #
-          # The index is built from this system's own nixpkgs and its own
-          # options, not from search.nixos.org. It is slower to build and it
-          # cannot go stale against the machine, which is the trade that
-          # matters: an index that offers a package nixarchy-pkg-add will then
-          # refuse is worse than no index.
+          # Why: modules/AGENTS.md#search-everything-this-machine-could-install-and-r
           (pkgs.writeShellApplication {
             name = "nixarchy-search";
             runtimeInputs = [
@@ -1758,17 +1500,7 @@ in
                 scaffolded=$((scaffolded + 1))
               }
 
-              # Ask flathub.org directly.
-              #
-              # NOT `flatpak search`, which is columnar with no JSON output and
-              # needs both a configured remote and a downloaded appstream cache
-              # -- so it answers nothing on a machine that has not set flatpak
-              # up yet, which is exactly the machine asking.
-              #
-              # This is the one thing in the picker that needs a network. The
-              # index itself is still built entirely from local sources, so the
-              # other three kinds keep working on a machine with none; only
-              # this row fails, and it says so.
+              # Why: modules/AGENTS.md#ask-flathub-org-directly
               flathub_search() {
                 local query hits picked id line
                 read -r -p "Search Flathub for: " query || return 0
@@ -1882,21 +1614,7 @@ in
           # a /nix/store path.
           (pkgs.callPackage ../pkgs/box.nix { })
 
-          # One name for the commands this repo adds, and a way through to
-          # the 431 it vendors.
-          #
-          # Not a rename of Omarchy. Upstream's commands keep upstream's name,
-          # because they are upstream's -- `omarchy theme set` is the same
-          # script here as on Arch, and a bug in it is a bug to report there.
-          # What this names is the other half: the commands nixarchy wrote,
-          # which until now were binaries on PATH with nothing tying them
-          # together and no way to discover them.
-          #
-          # Anything this does not own falls through to omarchy unchanged, so
-          # `nixarchy theme set catppuccin` works and does exactly what
-          # `omarchy theme set catppuccin` does. The fallthrough is the point:
-          # you should not have to know which half of the desktop you are
-          # talking to before you can type a command.
+          # Why: modules/AGENTS.md#one-name-for-the-commands-this-repo-adds-and-a-way
           (pkgs.writeShellApplication {
             name = "nixarchy";
             runtimeInputs = [
@@ -2006,19 +1724,7 @@ in
               file="''${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/apps.nix"
               flake="''${NIXARCHY_FLAKE:-${cfg.flake}}"
 
-              # Where the selection lands: this machine's directory when the
-              # flake has one, the flake root when it does not.
-              #
-              # That second case is every machine installed before the hosts/
-              # layout existed. Their flake is their own -- the README calls it
-              # "a flake you own" -- so nothing migrates it, and this one
-              # conditional is the entire cost of leaving them alone.
-              #
-              # Keyed on the directory existing rather than on the hostname
-              # matching anything: a repo that has hosts/ but not one for THIS
-              # machine is a repo being edited from somewhere else, and writing
-              # a stray directory into it would be worse than writing the file
-              # where it has always gone.
+              # Why: modules/AGENTS.md#where-the-selection-lands
               base="$flake"
               # uname -n, not hostname(1): writeShellApplication builds a
               # strict PATH from runtimeInputs, and hostname lives in a package
@@ -2041,21 +1747,7 @@ in
               grep -E "^[[:space:]]*[a-z0-9_-]+\.enable" "$file" || echo "  (none)"
               echo
 
-              # A flake cannot read a file outside its own tree, so the
-              # selection is copied in rather than imported from $HOME.
-              #
-              # Three files now, into $flake/nixarchy/, with nixarchy-apps.nix
-              # left as a module that imports them. That last part is the whole
-              # reason for the indirection: the README has been telling people
-              # to add `imports = [ ./nixarchy-apps.nix ];` since the beginning,
-              # and on a machine nixarchy does not own, asking them to add two
-              # more lines is not a thing this project gets to do. The name they
-              # already wrote keeps working and gains two files behind it.
-              #
-              # Safe to overwrite because nixarchy-apps.nix has always been a
-              # copy this script regenerates, never something the user wrote --
-              # and the copy it used to hold is written to nixarchy/apps.nix in
-              # the same run, before the stub replaces it.
+              # Why: modules/AGENTS.md#a-flake-cannot-read-a-file-outside-its-own-tree-so
               srcdir="''${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy"
               mkdir -p "$base/nixarchy"
 
@@ -2091,20 +1783,7 @@ in
                 echo "$base is already up to date."
               fi
 
-              # Stage what was written, or a flake in a git worktree cannot see
-              # it. This is not a nicety: git makes untracked files invisible to
-              # the evaluator, so a fresh nixarchy/services.nix fails with "path
-              # does not exist" -- the trap installer/mkFlake.nix documents and
-              # the installer works around by staging at install time.
-              #
-              # Guarded, and still guarded after #356 chowned /etc/nixos to the
-              # installed user. This no longer fires on a machine this
-              # installer wrote -- staging succeeds there now -- but it is not
-              # dead code: an own-flake adopter keeps whatever ownership their
-              # configuration already has, and `--from-repo` installs onto a
-              # tree somebody else created. A failure to stage should still
-              # print the fix rather than abort an apply that has already
-              # copied everything correctly.
+              # Why: modules/AGENTS.md#stage-what-was-written-or-a-flake-in-a-git-worktre
               if [ -e "$flake/.git" ]; then
                 git -C "$flake" add -A nixarchy nixarchy-apps.nix 2>/dev/null || {
                   echo
@@ -2116,19 +1795,7 @@ in
                 }
               fi
 
-              # Whether anything in the flake actually imports it.
-              #
-              # Copying the selection in is only half the job: a flake cannot
-              # read a file outside its own tree, so the copy is necessary, and
-              # importing it is the user's. Nothing checked that, so a machine
-              # that never added the import got the full ceremony -- the menu
-              # marking apps enabled, this script reporting a copy, a rebuild
-              # running to completion -- and installed nothing, every time. It
-              # took someone asking why `dictation.enable = true` never
-              # installed anything to notice.
-              #
-              # Excludes the copy itself, which of course contains its own name
-              # nowhere but is matched by the filename glob.
+              # Why: modules/AGENTS.md#whether-anything-in-the-flake-actually-imports-it
               importers=$(grep -rl 'nixarchy-apps\.nix' "$flake" \
                 --include='*.nix' 2>/dev/null |
                 grep -v '/nixarchy-apps\.nix$' || true)

--- a/modules/home.nix
+++ b/modules/home.nix
@@ -12,20 +12,7 @@ inputs:
 let
   cfg = config.programs.nixarchy;
 
-  # What OMARCHY_PATH points at, and the source of every file seeded below.
-  #
-  # Read across from the NixOS module when there is one, the same way localAi
-  # is: it is the package's own tree with the files nixarchy generates for THIS
-  # machine in it, and the app selection those are built from is only visible
-  # over there. The menu's defaults file is the one that matters -- it carries
-  # the Install-row rewrites, which is how the Install menu stays off pacman
-  # without nixarchy taking ~/.config/omarchy/extensions/omarchy-menu.jsonc,
-  # the file upstream documents as the user's and points plugins at (#210).
-  #
-  # A standalone home-manager configuration has no NixOS module and therefore
-  # no selection, so it falls back to the package's tree -- the same menu
-  # Omarchy ships, which is the honest answer when there is no selection for
-  # the Install rows to reach.
+  # Why: modules/AGENTS.md#what-omarchy-path-points-at-and-the-source-of-ever
   omarchyPath = osConfig.programs.nixarchy.tree or "${cfg.package}/share/omarchy";
 
   # Upstream's user menu file, which nixarchy does not write -- named here
@@ -130,20 +117,7 @@ let
       ''
     );
 
-  # Each declared plugin, checked at build time against the schema the shell
-  # enforces, and carrying the id its own manifest claims.
-  #
-  # Validated with upstream's own omarchy-plugin-validate rather than a
-  # reimplementation of it here: that script exists precisely to refuse what
-  # the running shell would silently reject, and a second copy of those rules
-  # in Nix would drift from it at the first upstream bump. A plugin that would
-  # not load now fails the rebuild, with the reason, instead of being installed
-  # and doing nothing.
-  #
-  # The id comes out of manifest.json rather than the attribute name. It is
-  # what the shell, the menu and every omarchy-plugin-* command key on, and a
-  # directory named anything else would be a plugin the user cannot enable,
-  # disable or remove by the name they see on screen.
+  # Why: modules/AGENTS.md#each-declared-plugin-checked-at-build-time-against
   validatedPlugins = lib.mapAttrs (
     name: plugin:
     pkgs.runCommand "nixarchy-plugin-${name}"
@@ -180,31 +154,7 @@ let
           exit 1
         fi
 
-        # A plugin that shells out to pacman fails the REBUILD, not the click.
-        #
-        # omarchy-plugin-validate above checks the manifest and the shape the
-        # shell requires. It does not read what the plugin RUNS, and the
-        # marketplace is written for Arch: a widget whose QML calls
-        # `pacman -S` or `yay -S` installs cleanly here, appears in the bar,
-        # and fails the first time somebody presses it -- on a machine where
-        # pacman does not exist and could not be allowed to.
-        #
-        # This is build.yml's "no bin touches pacman outside the allowlist"
-        # applied one layer out. That scan walks Omarchy's own bins in this
-        # repository; nothing looked at code a USER brings in.
-        #
-        # No allowlist here, deliberately. build.yml has one because upstream's
-        # own Arch-only plumbing legitimately calls pacman and has to keep
-        # working on Arch. A third-party plugin installed on a NixOS machine
-        # has no such case: there is nothing for it to be right about.
-        #
-        # COMMENT STRIPPING, and why it is not the shell scanner's `s/#.*//`:
-        # QML comments with // and stripping that naively eats `https://...`,
-        # which would hide anything after a URL on the same line. So only
-        # WHOLE-LINE comments are removed -- `//` or `#` at the start of a
-        # line, after optional whitespace. A trailing `// mentions pacman`
-        # after real code still trips this, which is the safe direction for a
-        # check about what a machine will execute.
+        # Why: modules/AGENTS.md#a-plugin-that-shells-out-to-pacman-fails-the-rebui
         hits=$(
           find "$src" -type f \( -name '*.qml' -o -name '*.js' -o -name '*.sh' -o -name '*.bash' \) -print0 |
             xargs -0 -r grep -nHE '\bpacman\b|\byay\b' |
@@ -287,18 +237,7 @@ in
       description = "Theme applied on first login only. Switchable at runtime afterwards.";
     };
 
-    # Declares which plugins are *present*, and deliberately not which are on.
-    #
-    # Upstream already splits the two: a plugin's code lives in
-    # ~/.config/omarchy/plugins/<id>/, while whether it is enabled, and where
-    # it sits in the bar, is recorded separately in ~/.config/omarchy/shell.json
-    # by the running shell. Content and state are already different files, so
-    # the content can come from the store without freezing the state.
-    #
-    # Enablement is therefore left alone on purpose. Managing shell.json here
-    # would mean a plugin you turned off in Setup > Plugins came back at the
-    # next rebuild, which is the sort of thing that makes people stop using the
-    # menu. Declare the plugin, enable it once, and your choice persists.
+    # Why: modules/AGENTS.md#declares-which-plugins-are-present-and-deliberatel
     plugins = lib.mkOption {
       type = lib.types.attrsOf (
         lib.types.submodule {
@@ -341,38 +280,14 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    # Omarchy's desktop is its Hyprland config: hyprland.lua requires
-    # autostart.lua, which is what starts the bar, and bindings.lua, which is
-    # every keybinding the manual documents. The seed below is --no-clobber, so
-    # a hyprland.lua that Home Manager already owns is kept and the other seven
-    # files land beside it, loaded by nothing.
-    #
-    # That failure is silent and total: every Omarchy binary, menu and theme
-    # installs, `nixarchy` looks like it worked, and the session that comes up
-    # is the user's own with no bar and none of the keybindings. Worth a
-    # warning rather than leaving someone to work it out from an empty bar.
+    # Why: modules/AGENTS.md#omarchys-desktop-is-its-hyprland-config
     warnings =
       let
         ownsHyprConfig =
           (config.wayland.windowManager.hyprland.enable or false)
           || lib.any (n: lib.hasPrefix "hypr/" n) (lib.attrNames config.xdg.configFile);
 
-        # Whether there is an Omarchy session entry to log into.
-        #
-        # When there is, a home-manager-owned ~/.config/hypr is not a problem:
-        # it is the arrangement this module is built for, and the session runs
-        # Omarchy's config with --config regardless. Warning anyway meant every
-        # rebuild on a machine already doing the right thing printed twelve
-        # lines telling it to do the right thing.
-        #
-        # Only the case that actually loses the desktop is worth a warning: no
-        # session entry, and a hypr directory that will never load Omarchy. The
-        # informational half is one line from the seed instead, and the doctor
-        # says it before anyone installs at all.
-        #
-        # `or true` is the option's default; `or false` on enable because a
-        # standalone home-manager install has no NixOS module registering
-        # sessions at all.
+        # Why: modules/AGENTS.md#whether-there-is-an-omarchy-session-entry-to-log-i
         hasOmarchySession =
           (osConfig.programs.nixarchy.enable or false) && (osConfig.programs.nixarchy.session or true);
       in
@@ -493,21 +408,7 @@ in
 
                 run mkdir -p "${config.home.homeDirectory}/.local/state/omarchy/current"
 
-                # The Hyprland toggles tree, and deliberately only flags.lua out of it.
-                #
-                # These flags are state, not config: a flag is *on* because its file is
-                # there, so copying all of default/hypr/toggles would bring the session
-                # up with no window gaps and every single window forced square.
-                # omarchy-hyprland-toggle copies the other two out of $OMARCHY_PATH the
-                # moment you ask for one, so nothing is lost by leaving them there --
-                # upstream's own omarchy-refresh-hyprland seeds exactly this one file.
-                #
-                # flags.lua is what makes the directory exist, and it has to exist
-                # before the shell starts rather than before the first toggle: the bar
-                # watches ~/.local/state/omarchy/toggles with a FileView to notice
-                # bar-off appearing, and a watch on a directory that is not there never
-                # fires. Hiding the bar wrote the flag and changed nothing on screen
-                # until the shell was restarted.
+                # Why: modules/AGENTS.md#the-hyprland-toggles-tree-and-deliberately-only-fl
                 seed_file "${omarchyPath}/default/hypr/toggles/flags.lua" \
                   "${config.home.homeDirectory}/.local/state/omarchy/toggles/hypr/flags.lua"
 
@@ -525,36 +426,13 @@ in
                 # not ship it either.
                 run mkdir -p "${config.xdg.configHome}/omarchy/branding"
 
-                # And the two files that belong in it, which upstream seeds from
-                # /etc/skel. Without them the About window opens with an empty logo
-                # column -- fastfetch's config sources about.txt as its logo -- and the
-                # screensaver dies on the spot, because omarchy-screensaver hands
-                # screensaver.txt to ttfx as the art to animate.
-                #
-                # The same two sources `omarchy branding <about|screensaver> reset`
-                # copies back, so a reset returns to exactly what was seeded. logo.txt
-                # is this repo's NIXARCHY banner rather than upstream's, by the same
-                # reasoning as the menu's snowflake.
+                # Why: modules/AGENTS.md#and-the-two-files-that-belong-in-it-which-upstream
                 seed_file "${omarchyPath}/icon.txt" \
                   "${config.xdg.configHome}/omarchy/branding/about.txt"
                 seed_file "${omarchyPath}/logo.txt" \
                   "${config.xdg.configHome}/omarchy/branding/screensaver.txt"
 
-                # The extensions directory, and one thing to undo in it.
-                #
-                # This file is the user's: upstream documents it as theirs, and
-                # shell/plugins/README.md tells third-party plugins to write it.
-                # Nixarchy's rows are in the DEFAULTS this session reads (see
-                # omarchyPath), so nothing here writes it and nothing arbitrates.
-                #
-                # Except on a machine an older nixarchy already took it on, where
-                # it is a symlink into /etc and therefore into a read-only store
-                # path. Leaving that behind would keep the file unwritable forever
-                # on exactly the machines this is meant to fix, and nothing would
-                # ever say so -- which is the bug, not the symlink. So it is
-                # removed, once, and Omarchy's own commented example seeded in its
-                # place. Only a link into /etc/nixarchy is touched: a file, or a
-                # link somebody else made, is theirs. #210.
+                # Why: modules/AGENTS.md#the-extensions-directory-and-one-thing-to-undo-in-
                 run mkdir -p "${config.xdg.configHome}/omarchy/extensions"
                 case "$(readlink "${menuExtensionPath}" 2>/dev/null)" in
                   /etc/nixarchy/*)
@@ -565,25 +443,7 @@ in
                 seed_file "${omarchyPath}/config/omarchy/extensions/omarchy-menu.jsonc" \
                   "${menuExtensionPath}"
 
-                # Agent skills, relinked on every activation.
-                #
-                # Upstream does this in omarchy-provision-user, which is guarded by a
-                # `finalize-user` marker and therefore runs exactly once, ever. That is
-                # fine on Arch, where the skill directory is a fixed path that gets
-                # overwritten in place. Here every bump moves the package to a new store
-                # path, so a once-only link points at the previous one -- still resolving
-                # until it is garbage-collected, then dangling. Renaming the `omarchy`
-                # skill to `nixarchy` made it worse than stale: the machine kept serving
-                # the old Arch skill from a path nothing would update again.
-                #
-                # provision-user's own --force would fix the links and also replay
-                # /etc/skel over $HOME, which is not a thing to do for four symlinks.
-                # So: the same loop, declaratively, on every rebuild.
-                #
-                # Only symlinks whose target is itself a skills directory in the store
-                # are removed. That is what distinguishes a link this module or
-                # provision-user planted from a skill the user wrote by hand, which is a
-                # real directory and is never touched.
+                # Why: modules/AGENTS.md#agent-skills-relinked-on-every-activation
                 ${
                   let
                     skillsDir = "${omarchyPath}/default/agents/skills";
@@ -608,18 +468,7 @@ in
                   ''
                 }
 
-                # Declared plugins, linked in by the id their manifest claims.
-                #
-                # A symlink rather than a copy, and that is a supported shape rather
-                # than a trick: upstream's scan globs "$dir"/*/ , which matches a
-                # symlink to a directory, and omarchy-plugin-remove has an explicit
-                # branch for one -- it offers to "Unlink" and prints where it pointed.
-                # Its picker globs -type d -o -type l for the same reason.
-                #
-                # Only links this module planted are cleaned up, tracked in a
-                # .nixarchy-managed file beside them. A plugin you added yourself with
-                # `omarchy plugin add` is a real directory that this never touches, so
-                # the two ways of installing one live side by side.
+                # Why: modules/AGENTS.md#declared-plugins-linked-in-by-the-id-their-manifes
                 run mkdir -p "${config.xdg.configHome}/omarchy/plugins"
                 ${
                   let
@@ -698,17 +547,7 @@ in
       '';
     };
 
-    # The first-run theme above is applied headless, which by design skips every
-    # post-theme command -- including omarchy-theme-set-gnome, the one that
-    # tells GTK and the settings portal whether this theme is light or dark.
-    # Upstream never notices: on Arch that command runs during install with a
-    # live session, and dconf keeps the answer forever after. Here the first
-    # session would come up dark-themed with light GTK apps until the user
-    # switched themes by hand.
-    #
-    # Unlike the shell below, this needs only the session bus, not a running
-    # compositor, so a graphical-session unit is the right shape for it. It is
-    # a no-op on every later login, because it writes what dconf already holds.
+    # Why: modules/AGENTS.md#the-first-run-theme-above-is-applied-headless-whic
     systemd.user.services.omarchy-theme-gnome = {
       Unit = {
         Description = "Apply the current Omarchy theme's light/dark mode to GTK";
@@ -743,32 +582,7 @@ in
       '';
     };
 
-    # Provider files for the local model, when the system module turned it on.
-    #
-    # Written here rather than in modules/local-ai.nix because only the home
-    # module knows where a user's home is, and read back out of osConfig so the
-    # address the server binds and the address the agents dial cannot drift.
-    # Guarded by `or null` throughout: home.nix is usable on its own, without
-    # the NixOS module, and then there is no osConfig to read.
-    #
-    # Both agents get a file whether or not either is the current default. They
-    # are a few hundred bytes, and the alternative is that switching agent in
-    # the menu silently produces one that cannot reach the model.
-    # opencode's provider, merged into the file rather than owning it.
-    #
-    # ~/.config/opencode/opencode.json already exists on every Omarchy machine
-    # -- it is seeded with the theme and an autoupdate setting -- so declaring
-    # it as an xdg.configFile fails activation outright:
-    #
-    #   Existing file '~/.config/opencode/opencode.json' would be clobbered
-    #
-    # and takes the whole home-manager generation down with it, not just this
-    # file. `force = true` is worse: it would throw away the user's own opencode
-    # settings and Omarchy's theme wiring to install a provider block.
-    #
-    # So the provider is merged in with jq, on every activation, leaving every
-    # other key alone. Same reasoning as the pi settings below, arrived at the
-    # same way: both files already have an owner.
+    # Why: modules/AGENTS.md#provider-files-for-the-local-model-when-the-system
     home.activation.nixarchyOpencodeProvider =
       lib.mkIf (localAi.enable && builtins.elem "opencode" localAi.agents)
         (
@@ -807,16 +621,7 @@ in
           ''
         );
 
-    # pi keeps its configuration in ~/.pi/agent, not under XDG.
-    #
-    # supportsDeveloperRole is the field that has to be right. pi sends system
-    # instructions in the `developer` role to reasoning-capable models, and
-    # Ollama -- like vLLM and SGLang -- rejects a role it does not know. Every
-    # request then fails with an error that does not name the cause.
-    # pi's provider. Merged for the same reason, though less urgently: nothing
-    # in Omarchy writes models.json today. Doing it the same way means a future
-    # version that does cannot break activation, and means a user's own extra
-    # providers survive.
+    # Why: modules/AGENTS.md#pi-keeps-its-configuration-in-pi-agent-not-under-x
     home.activation.nixarchyPiProvider =
       lib.mkIf (localAi.enable && builtins.elem "pi" localAi.agents)
         (
@@ -886,27 +691,7 @@ in
           ''
         );
 
-    # Same extension point, on the other hook Omarchy already runs:
-    # default/hypr/autostart.lua ends its startup with `omarchy-hook post-boot`.
-    #
-    # A notification rather than a window. On a machine the installer built,
-    # /etc/nixos is a repository with one staged, never-committed tree -- so
-    # there is something real to say -- but a terminal that seizes the screen on
-    # a first-ever boot arrives before the user has signed in to anything, which
-    # makes the one answer they can give "dismiss". The nudge is a notification
-    # they can act on when they are ready, and the script's own --check decides
-    # whether there is any point showing it: already committed and pushed, no
-    # agent chosen yet, or already answered once, and it stays quiet.
-    #
-    # It stays quiet for one more reason now, and it is the important one. This
-    # module reaches every machine that imports it, including one where somebody
-    # added nixarchy to a configuration of their own -- and on that machine
-    # /etc/nixos is theirs. --check asks /etc/nixarchy/managed before anything
-    # else and answers "no nudge", so the hook exits 0 having said nothing.
-    #
-    # Two conditions, two messages. The first push is a different thing to say
-    # than the fortnight of changes that piled up after it, and a notification
-    # whose text does not match what clicking it will do is worse than none.
+    # Why: modules/AGENTS.md#same-extension-point-on-the-other-hook-omarchy-alr
     xdg.configFile."omarchy/hooks/post-boot.d/config-repo" = {
       executable = true;
       text = ''
@@ -968,21 +753,7 @@ in
       # /run/current-system/sw/bin, never a store path.
       package = lib.mkDefault null;
 
-      # Left at Home Manager's own default everywhere else, which is
-      # `cfg.containers != { } && cfg.package != null` -- true the instant
-      # `machines` is non-empty, so leaving this unset would turn it on.
-      # Refused outright: its ExecStart is
-      # `${cfg.package}/bin/distrobox-assemble create --file ...`, a literal
-      # /nix/store/... path baked straight into the unit file -- the exact
-      # GC-survival hazard (nixpkgs#478154) modules/services/boxes.nix's own
-      # comment documents distrobox itself must never be reached through.
-      # `nix-collect-garbage` can delete that path out from under this unit
-      # the same way it can out from under a running box. It also hardcodes
-      # uid 1000 in the cleanup it runs first
-      # (`rm -rf /tmp/storage-run-1000/...`), a second, independent reason to
-      # leave it off. `nixarchy box` (a later issue) is how a machine picks
-      # up a declared container -- by calling `distrobox-assemble` itself,
-      # by bare name, the way the module comment already requires.
+      # Why: modules/AGENTS.md#left-at-home-managers-own-default-everywhere-else-
       enableSystemdUnit = lib.mkDefault false;
     };
   };

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -17,22 +17,7 @@ let
   # write would be a way to hand root arbitrary git settings.
   safeDirInclude = "/var/lib/nixarchy/gitconfig-flake";
 
-  # Omarchy's session, launched from its own hyprland.lua in the store rather
-  # than from ~/.config/hypr/hyprland.lua. Hyprland's --config takes the entry
-  # point; the modules it requires still resolve through $HOME/.config, which
-  # is where the Home Manager seed puts them.
-  #
-  # Through start-hyprland rather than the Hyprland binary. Booting this on a
-  # real laptop logged
-  #
-  #   WARNING: Hyprland is being launched without start-hyprland.
-  #   This is highly advised against.
-  #
-  # start-hyprland is the watchdog Hyprland 0.56 wants supervising it, and it
-  # is what nixpkgs' own hyprland.desktop execs. Everything after its `--` is
-  # passed through to Hyprland, so --config still arrives where it was going.
-  # The VM never complained because a warning is not a failure -- it took
-  # somebody reading the journal on a machine that had actually logged in.
+  # Why: modules/AGENTS.md#omarchys-session-launched-from-its-own-hyprland-lu
   omarchySessionLauncher = pkgs.writeShellScript "omarchy-session" ''
     export OMARCHY_PATH=${cfg.tree}
     exec ${pkgs.uwsm}/bin/uwsm start -N Omarchy -D Hyprland -- \
@@ -95,26 +80,7 @@ in
   options.programs.nixarchy = {
     enable = lib.mkEnableOption "Nixarchy, the Omarchy desktop vendored for NixOS";
 
-    # "Nixarchy wrote this machine", as a property of the configuration rather
-    # than of the install event.
-    #
-    # Set in exactly one place -- installer/host.nix, which is imported only by
-    # a hosts/<name>/default.nix the installer generated. That is what makes a
-    # machine nixarchy-shaped: snapper, nh, the registry pin, the seeded user.
-    # So the question "did nixarchy build this?" is answered by whether that
-    # module is in the evaluation, and re-answered at every rebuild.
-    #
-    # Not /etc/nixos/.nixarchy-url, which used to look like the same signal and
-    # is not one any more. `git add -A` tracks it, so it is committed, pushed,
-    # and cloned onto every machine enrolled with `nixarchy install --from` --
-    # including a machine the installer never touched. And an admin-authored
-    # repo of the shape `--from` accepts carries no such file while being a
-    # perfectly good nixarchy install. Presence stopped meaning "here", absence
-    # stopped meaning "hands off". It survives as provenance of the *repo*.
-    #
-    # Not a heuristic either. Sniffing flake.lock's root inputs or testing for
-    # hosts/$(hostname) reads state the user is invited to edit, and would one
-    # day refuse a machine to its own owner.
+    # Why: modules/AGENTS.md#nixarchy-wrote-this-machine-as-a-property-of-the-c
     installerManaged = lib.mkOption {
       type = lib.types.bool;
       default = false;
@@ -147,20 +113,7 @@ in
 
     package = lib.mkOption {
       type = lib.types.package;
-      # Built from *your* nixpkgs through this flake's overlay, not from
-      # inputs.self.packages -- which is built from nixarchy's own nixpkgs.
-      #
-      # Those look identical and are not: every one of the ~80 runtime
-      # dependencies would come from a different nixpkgs instance than the
-      # rest of your system, and the first one you also install yourself makes
-      # buildEnv refuse the profile --
-      #
-      #   two given paths contain a conflicting subpath:
-      #     .../tesseract-5.5.3/bin/tesseract and .../tesseract-5.5.3/bin/tesseract
-      #
-      # -- two builds of the same version, which reads like a bug in nix until
-      # you notice the hashes differ. Found by building a real config that had
-      # tesseract of its own.
+      # Why: modules/AGENTS.md#built-from-your-nixpkgs-through-this-flakes-overla
       default = (pkgs.extend inputs.self.overlays.default).omarchy;
       defaultText = lib.literalExpression "pkgs.extend nixarchy.overlays.default).omarchy";
       description = "The vendored Omarchy tree providing OMARCHY_PATH.";
@@ -483,34 +436,7 @@ in
       }
     ];
 
-    # Most of what the Install menu offers is unfree: the browsers, the editors,
-    # Steam, the AI clients, several of the fonts. Leaving licence policy to the
-    # consumer sounded principled and in practice meant a new user picked an app,
-    # ran nixarchy-apply, and watched a rebuild die on a licence error partway
-    # through -- with nothing on screen explaining that the fix was a line in a
-    # file they had never opened.
-    #
-    # Behind an option rather than mkDefault, because mkDefault does not work
-    # here: nixpkgs.config is a free-form attribute set, so `mkDefault true` on
-    # one of its keys is stored as the override attrset itself and nixpkgs is
-    # handed { _type = "override"; ... } where it expects a bool. mkDefault on
-    # the whole set does resolve, but then any other nixpkgs.config key a user
-    # sets replaces our definition wholesale and unfree silently goes away.
-    #
-    # mkIf so that turning the option off removes the definition entirely rather
-    # than asserting false, and mkDefault so that ours is the one that yields
-    # wherever something else already owns nixpkgs.config. That is not
-    # hypothetical: a NixOS VM test takes its pkgs from outside and imports
-    # misc/nixpkgs/read-only.nix, which defines nixpkgs.config as a unique
-    # option -- so any definition of ours, at any priority above default, makes
-    # every runNixOSTest node fail to evaluate.
-    #
-    # The cost is that priorities filter before merging: a user who sets any
-    # other nixpkgs.config key, say permittedInsecurePackages, outranks this
-    # default and drops it, and unfree goes off again. That case is not silent,
-    # which is the only reason it is acceptable -- modules/apps.nix warns at
-    # evaluation time when an enabled app is unfree and allowUnfree is off, and
-    # names the fix.
+    # Why: modules/AGENTS.md#most-of-what-the-install-menu-offers-is-unfree
     nixpkgs.config = lib.mkIf cfg.allowUnfree (lib.mkDefault { allowUnfree = true; });
 
     nix.settings = {
@@ -543,64 +469,13 @@ in
     # flags a repeated top-level key, and it is right that they read better
     # together.
     programs = {
-      # /etc/nixos belongs to the installed user (installer/install.sh
-      # chown_flake_dir), and git refuses to open a repository owned by
-      # somebody else. So does nix: its flake fetcher goes through libgit2,
-      # which runs the same ownership check and fails the whole evaluation
-      # with
-      #
-      #   error: opening Git repository "/etc/nixos": repository path
-      #   '/etc/nixos' is not owned by current user (libgit2 error code = 7)
-      #   error: could not find a flake.nix file
-      #
-      # -- the second line being the one people actually read, which is why
-      # this was diagnosed three times before it was understood.
-      #
-      # NOT every root command needs this. git and libgit2 both exempt root
-      # when SUDO_UID names the repository's owner, so `sudo nixos-rebuild
-      # --flake /etc/nixos#...` -- the thing a user actually types -- was
-      # never broken by the chown. What needs the entry is root WITHOUT
-      # SUDO_UID: root systemd units, a root login shell, `nixos-install`
-      # from a live ISO during a rescue reinstall, and the VM test drivers,
-      # which are root by construction and never sudo.
-      #
-      # It has to be a real config file. Passing `-c safe.directory=...` on a
-      # git command line fixes that one git invocation and does not reach nix
-      # at all, and the environment variables are no use either: nix opens
-      # repositories with git_repository_open() rather than the _FROM_ENV
-      # variant, so libgit2 leaves use_env false and ignores
-      # GIT_CONFIG_SYSTEM and GIT_CONFIG_NOSYSTEM. libgit2 does read
-      # /etc/gitconfig -- verified by strace of a root `nix eval`, which
-      # opens exactly that one system path -- and that is what this writes.
-      #
-      # Via programs.git rather than environment.etc."gitconfig" because
-      # programs.git.config merges with a user's own git settings, where two
-      # environment.etc definitions of the same file collide.
-      #
-      # One limit worth knowing: the check runs against the RESOLVED path, so
-      # an adopter who points programs.nixarchy.flake at a symlink is not
-      # covered by this entry. Name the real directory instead. Machines this
-      # installer writes have a real /etc/nixos, so the default is fine.
+      # Why: modules/AGENTS.md#etc-nixos-belongs-to-the-installed-user-installer-
       git = {
         enable = lib.mkDefault true;
         config = {
           safe.directory = [ cfg.flake ];
 
-          # The literal path above is not always enough, because the ownership
-          # check runs against the RESOLVED directory: point
-          # programs.nixarchy.flake at a symlink -- /etc/nixos -> a repository
-          # in $HOME, which is how plenty of people arrange this -- and the
-          # entry never matches what libgit2 actually opened. Measured, not
-          # assumed: safe.directory naming the symlink is refused, naming the
-          # real directory is accepted.
-          #
-          # Resolving it needs the filesystem of the machine being configured,
-          # which evaluation cannot see (and reading it at eval time would mean
-          # IFD). So the resolved form is written at activation, and included
-          # from here. libgit2 does follow include.path when it collects
-          # safe.directory -- also measured -- and a missing include target is
-          # silently ignored, which is what makes the file safe to reference
-          # before the first activation has written it.
+          # Why: modules/AGENTS.md#the-literal-path-above-is-not-always-enough-becaus
           include.path = safeDirInclude;
         };
       };
@@ -622,17 +497,7 @@ in
         withUWSM = true;
       };
 
-      # mise is in Omarchy's base packages and its dev-env installers lean on
-      # it heavily. It downloads prebuilt runtimes, which cannot run against
-      # NixOS' non-standard loader, so it detects NixOS and falls back to
-      # compiling from source -- which then fails, because there is no compiler
-      # on the session PATH. mise's own message names the fix:
-      #
-      #   "The automatic all_compile=true default on NixOS caused python to
-      #    compile from source. Enable nix-ld to use precompiled binaries"
-      #
-      # This is what makes `omarchy install dev-env` work rather than print a
-      # wall of build errors.
+      # Why: modules/AGENTS.md#mise-is-in-omarchys-base-packages-and-its-dev-env-
       nix-ld.enable = lib.mkDefault true;
 
       # See programs.nixarchy.bashIntegration. This lands in /etc/bashrc, which
@@ -723,23 +588,7 @@ in
       systemPackages = [
         cfg.package
       ]
-      # Minus Hyprland itself.
-      #
-      # The package carries the compositor its Lua config is written against as
-      # a runtime dependency, and putting that in systemPackages made it the
-      # Hyprland on PATH -- so on a machine that already ran Hyprland, enabling
-      # nixarchy silently swapped the compositor behind the user's *existing*
-      # sessions. Its share/wayland-sessions/hyprland.desktop won the buildEnv
-      # collision too, so `hyprland.desktop` pointed at nixarchy's build rather
-      # than theirs. Found by building this against a real configuration; the
-      # doctor tells people to keep their own Hyprland, and this quietly did
-      # the opposite.
-      #
-      # programs.hyprland already puts the right one on PATH -- ours when
-      # nixarchy sets the option, theirs when they mkForce it -- so dropping it
-      # here changes nothing on a clean machine and stops overriding anyone
-      # else's. omarchy-session still runs the Lua config through
-      # config.programs.hyprland.package, which is the same binary either way.
+      # Why: modules/AGENTS.md#minus-hyprland-itself
       ++ builtins.filter (d: !(lib.hasPrefix "hyprland-" (d.name or ""))) cfg.package.passthru.runtimeDeps
       # sessionPackages alone does not populate
       # /run/current-system/sw/share/wayland-sessions, and that is where greetd
@@ -767,27 +616,7 @@ in
         # Yaru inherits from Adwaita for anything it does not draw itself.
         adwaita-icon-theme
 
-        # config/hypr/xdph.conf, which the package seeds into
-        # ~/.config/hypr, sets
-        # `custom_picker_binary = hyprland-preview-share-picker`.
-        # xdg-desktop-portal-hyprland execs that name for every ScreenCast
-        # request, so with nothing providing it the exec fails, the backend
-        # reads selection -1 and destroys the session -- screen sharing dies
-        # in every application, with no dialog and no error anywhere a user
-        # looks. Upstream declares it in install/omarchy-base.packages, which
-        # pacman honours and nothing on NixOS reads. (#202)
-        #
-        # From nixpkgs rather than the hyprland input that supplies the portal
-        # at programs.hyprland.portalPackage: that flake publishes only
-        # hyprland and xdg-desktop-portal-hyprland, so there is no picker
-        # there to match. Nothing is mismatched by taking it from nixpkgs
-        # either -- the picker links no Hyprland library (gtk4,
-        # gtk4-layer-shell, cairo, pango and nothing else), and the portal
-        # reaches it by exec plus a selection line on stdout, not an ABI.
-        #
-        # Editing the seeded xdph.conf was the other option and is the wrong
-        # one: the file is upstream's, so the edit is undone by the next
-        # Omarchy bump.
+        # Why: modules/AGENTS.md#config-hypr-xdph-conf-which-the-package-seeds-into
         hyprland-preview-share-picker
 
         # Omarchy sets a cursor size but never a cursor theme -- on Arch one
@@ -839,16 +668,7 @@ in
     # mkForce their way out one option at a time. Their setting wins now, and
     # they lose only the feature that depended on it.
     services = {
-      # Passed straight through: nix-flatpak's own option carries the
-      # behaviour, ours carries the decision and its reasoning. mkDefault so a
-      # user who sets services.flatpak.uninstallUnmanaged directly keeps their
-      # value -- this is a convenience over an upstream option, not a
-      # replacement for it.
-      #
-      # In this block rather than as its own `services.flatpak...` line
-      # because statix rejects a second `services` key in the same attribute
-      # set, and it is right to: two places setting services is two places to
-      # look.
+      # Why: modules/AGENTS.md#passed-straight-through
       flatpak.uninstallUnmanaged = lib.mkDefault cfg.flatpaks.uninstallUnmanaged;
 
       # See programs.nixarchy.displayManager for why this is an option of our
@@ -882,23 +702,7 @@ in
       # install/config/locate.sh
       locate.enable = lib.mkDefault true;
 
-      # cups, avahi and nss-mdns are all in base.packages. cups-browsed was
-      # too until 4.0.2 dropped it -- "Harden CUPS printer discovery and
-      # administration" -- along with the unit that started it, leaving only a
-      # hardened drop-in for machines that already had it. cups-pk-helper
-      # replaced it for the administration half, and NixOS' own cupsd module
-      # adds that wherever polkit is on, so nothing here has to name it.
-      #
-      # Turning it off is not just comment maintenance: NixOS defaults
-      # services.printing.browsed.enable to services.avahi.enable, which the
-      # lines below set, so `printing.enable` alone did leave cups-browsed
-      # running -- as root, with none of the User=/ProtectSystem= hardening
-      # upstream's drop-in adds, listening for mDNS printer announcements and
-      # creating queues from them. That is the daemon upstream deliberately
-      # removed, so it does not stay on here by inheritance.
-      #
-      # Only browsed goes: avahi stays on for driverless IPP discovery, which
-      # is how modern printers are found and is what cupsd does by itself.
+      # Why: modules/AGENTS.md#cups-avahi-and-nss-mdns-are-all-in-base-packages
       printing.enable = lib.mkDefault true;
       printing.browsed.enable = lib.mkDefault false;
       avahi = {
@@ -959,20 +763,7 @@ in
     # regenerated with the system and always points at the current package.
     environment.etc."omarchy/xcompose".source = "${cfg.package}/share/omarchy/default/xcompose";
 
-    # The ownership marker, for the shell tools that cannot ask the module
-    # system anything.
-    #
-    # Declarative on purpose: it is in the closure, it is rewritten by every
-    # rebuild, and a machine that stops descending from installer/host.nix
-    # loses it in the same switch that made that true. A file the installer
-    # wrote once could not say that -- it would survive being wrong, and a
-    # `--from` rebuild that never created it would leave the machine looking
-    # unmanaged for the rest of its life.
-    #
-    # The contents are for the person who finds the file and wonders. Nothing
-    # reads them, and nothing should start: the predicate is the file's
-    # existence, which is the only part that is cheap to get right in every
-    # shell script that needs it.
+    # Why: modules/AGENTS.md#the-ownership-marker-for-the-shell-tools-that-cann
     environment.etc."nixarchy/managed" = lib.mkIf cfg.installerManaged {
       text = ''
         This machine's configuration descends from the host module the Nixarchy
@@ -1005,55 +796,14 @@ in
       firewall = {
         enable = lib.mkDefault true;
 
-        # The other half of that script, which this module left behind.
-        # Upstream's is not merely "turn the firewall on":
-        #
-        #     ufw default deny incoming
-        #     ufw allow 53317/udp
-        #     ufw allow 53317/tcp   # "Allow ports for LocalSend."
-        #
-        # Porting only the deny half enables a firewall that blocks the one
-        # service Omarchy's manual promises works out of the box: "Omarchy's
-        # firewall is closed by default except for LocalSend's port, so this
-        # works out of the box on a fresh install." On a machine taking this
-        # module's firewall default it did not -- Share > Receive listened on
-        # 53317 and nothing on the network could reach it.
-        #
-        # Discovery was never the missing part: services.avahi above already
-        # opens 5353. Only LocalSend's own transfer port was closed.
-        #
-        # Not mkDefault: these are list options, so they merge with whatever
-        # the user opens rather than replacing it. A mkDefault list would be
-        # dropped whole the moment they opened a port of their own.
+        # Why: modules/AGENTS.md#the-other-half-of-that-script-which-this-module-le
         allowedTCPPorts = [ 53317 ];
         allowedUDPPorts = [ 53317 ];
       };
       networkmanager.enable = lib.mkDefault true;
     };
 
-    # install/config/lockscreen-pam.sh, whose one line is `omarchy-apply-lock`
-    # -- and that writes /etc/pam.d/omarchy-lock-password. Omarchy 4's lock
-    # screen is the Quickshell one, which names that stack itself
-    # (shell/plugins/lock/Service.qml: `config: "omarchy-lock-password"`), and
-    # watches the file's existence to decide whether locking is possible at
-    # all. hyprlock appears nowhere in the tree except omarchy-upgrade-to-
-    # quattro, which *removes* it -- so what was declared here was PAM for a
-    # program the desktop no longer runs. On a live session:
-    #
-    #   /etc/pam.d/omarchy-lock-password  ->  No such file or directory
-    #   omarchy-shell lock lock           ->  missing-pam, screen stayed up
-    #
-    # Five paths reach that no-op: SUPER + CTRL + L, Menu > System > Lock, the
-    # idle timeout, lid close, and suspend.
-    #
-    # An empty attrset is the whole fix. NixOS' generated stack is pam_unix
-    # auth plus an account section, which is upstream's file with faillock and
-    # pam_systemd_home taken out. faillock is deliberately not reproduced:
-    # NixOS' only handle on it is `logFailures`, which emits pam_faillock with
-    # no preauth/authfail/authsucc arguments, so nothing ever resets the
-    # counter -- three bad unlocks would lock a user out of their own screen
-    # for good. Upstream's deny=10 needs the raw `rules` interface, and a
-    # lockout is a worse failure than the logging it would buy.
+    # Why: modules/AGENTS.md#install-config-lockscreen-pam-sh-whose-one-line-is
     security.pam.services = {
       omarchy-lock-password = { };
     }
@@ -1089,43 +839,7 @@ in
         ]
       );
 
-      # $OMARCHY_PATH/default/systemd/user/, which upstream installs into
-      # /usr/lib/systemd/user and nothing here installed anywhere -- that
-      # directory is not a systemd search path. `systemctl --user status
-      # bt-agent.service` answered "could not be found" on a live session, and
-      # with it went the pairing agent, the crash watcher, the input method, the
-      # internal-monitor recovery, and -- the one that matters -- the sleep lock,
-      # so suspend did not lock even once the PAM stack above exists.
-      #
-      # Declared here rather than linked out of the package, because every
-      # shipped ExecStart is a /usr/bin path that resolves to nothing on NixOS
-      # and the package is not this module's to patch. The bodies are upstream's:
-      # same conditions, same ordering, same restart policy, binaries named by
-      # store path.
-      #
-      # omarchy-migrate-notify and omarchy-tailscale-receive are deliberately
-      # absent. Their conditions (ConditionPathIsDirectory=/usr/share/omarchy/
-      # migrations, ConditionPathExists=/usr/bin/tailscale) can never hold here,
-      # and both jobs belong elsewhere on NixOS: migrations arrive with a
-      # rebuild, and Taildrop with services.tailscale.
-      #
-      # Each omarchy-* unit gets /run/current-system/sw on its PATH. NixOS gives
-      # every unit a stub PATH of coreutils, findutils, grep, sed and systemd,
-      # and unlike the copies upstream drops in ~/.config/systemd/user that stub
-      # *overrides* the session PATH uwsm imported -- omarchy-system-sleep-
-      # monitor would not find dbus-monitor, and none of them would find the
-      # other omarchy-* commands they call. The system profile is where the
-      # package's runtimeDeps already live, by the package's own design: bin/ is
-      # a symlink farm rather than wrapped programs, so the CLI can still read
-      # the `# omarchy:summary=` metadata out of each script.
-      #
-      # omarchy-speaker-tuning is absent for a different reason: omarchy-audio-
-      # tuning installs it itself, by copying the unit into
-      # ~/.config/systemd/user and running `systemctl --user enable`. Declaring
-      # it would not race that copy -- the user directory outranks /etc -- but
-      # `omarchy audio tuning off` disables and deletes it, and `disable` cannot
-      # remove an [Install] symlink that lives in a read-only /etc, so the
-      # tuning would come back at the next login with the config it needs gone.
+      # Why: modules/AGENTS.md#omarchy-path-default-systemd-user-which-upstream-i
       user.services = {
         bt-agent = {
           description = "Bluetooth pairing agent (auto-accept)";
@@ -1242,22 +956,7 @@ in
         };
       };
 
-      # default/systemd/user/app.slice.d/10-oomd.conf. systemd-oomd is on by
-      # default in NixOS, and with no slice marked as a candidate it has nothing
-      # it is allowed to kill. Marking app.slice -- where uwsm-app puts every
-      # launched application -- leaves the compositor structurally ineligible:
-      # Hyprland runs in session.slice, so oomd takes the browser or terminal
-      # that caused the pressure and the session survives to report it.
-      #
-      # Deliberately not systemd.oomd.enableUserSlices, which is the obvious
-      # switch and the wrong one: it sets the same properties on user.slice and
-      # on the user manager's own root slice, which puts the compositor back in
-      # the candidate pool. asDropin rather than a systemd.user.slices entry so
-      # systemd's own app.slice definition is extended, not replaced.
-      #
-      # Upstream's oomd.conf.d also lowers the global thresholds to 50% over 20s
-      # from systemd's 60% over 30s. Not carried over: those are a tuning
-      # preference, and the defaults still fire.
+      # Why: modules/AGENTS.md#default-systemd-user-app-slice-d-10-oomd-conf
       user.units."app.slice" = {
         overrideStrategy = "asDropin";
         text = ''
@@ -1271,56 +970,15 @@ in
     # bin/omarchy-brightness-display-ddc talks to monitors over i2c
     hardware.i2c.enable = lib.mkDefault true;
 
-    # bluez, bluez-tools and bluez-utils are all in
-    # install/omarchy-base.packages, the bar has a Bluetooth widget, and
-    # omarchy-bluetooth-device and omarchy-bluetooth-power are two of the
-    # commands the menu offers -- but none of it works without the service,
-    # and nothing here was starting it. Every session logged
-    #
-    #   quickshell.dbus.objectmanager: Failed to create
-    #   DBusObjectManagerInterface for "org.bluez" "/"
-    #
-    # which was written off as a VM artefact for as long as this was in the
-    # README's known gaps. It is the same shape as UPower: the tools were
-    # installed, the daemon was not.
+    # Why: modules/AGENTS.md#bluez-bluez-tools-and-bluez-utils-are-all-in
     hardware.bluetooth.enable = lib.mkDefault true;
 
-    # Our own splash, in the theme directory upstream's occupies -- upstream
-    # installs it by copying into /usr/share/plymouth/themes from
-    # omarchy-refresh-plymouth. Nothing was doing that here, so plymouth came
-    # up with NixOS' default theme -- the one screen every boot shows,
-    # unbranded. The artwork in it is nixarchy's; see the option's description
-    # and pkgs/omarchy/default.nix.
-    #
-    # Theme and themePackages always move together, at whatever priority
-    # bootSplash asks for. NixOS asserts the named theme exists in the package
-    # list, so setting one without the other fails the build -- which is what
-    # anyone reaching for `lib.mkForce boot.plymouth.theme = "omarchy"` on a
-    # stylix machine hits, because stylix sets themePackages at normal priority
-    # and wins it.
-    # The one thing upstream's installer does that needs a name.
-    #
-    # install/hardware/input-group.sh runs `usermod -aG input`, and without it
-    # the dictation tools and controllers Omarchy offers cannot read their
-    # devices. Skipped entirely when programs.nixarchy.user is unset, because
-    # the alternative is guessing which of a machine's users logs into the
-    # desktop.
+    # Why: modules/AGENTS.md#our-own-splash-in-the-theme-directory-upstreams-oc
     users.users = lib.optionalAttrs (cfg.user != null) {
       ${cfg.user}.extraGroups = [
         "input"
       ]
-      # Docker is enabled above, at mkDefault, for every machine. Enabled and
-      # unusable, until now: without this group every command wants sudo, and
-      # `docker ps` answers "permission denied while trying to connect to the
-      # Docker daemon socket" -- which reads like a broken install rather than
-      # a missing group.
-      #
-      # The installer has always put its user in `docker` directly
-      # (installer/host.nix), so this was only ever wrong for someone adding
-      # nixarchy to a machine they already run: they got the daemon and not
-      # the access. Conditioned on the option rather than set unconditionally,
-      # so turning Docker off does not leave a group behind that grants root
-      # to whatever installs a socket there later.
+      # Why: modules/AGENTS.md#docker-is-enabled-above-at-mkdefault-for-every-mac
       ++ lib.optional config.virtualisation.docker.enable "docker";
     };
 
@@ -1338,25 +996,7 @@ in
       })
     ];
 
-    # default/fontconfig/conf.avail/50-omarchy.conf, which upstream symlinks
-    # into /etc/fonts/conf.d. Without it `fc-match monospace` on a live
-    # session answered Adwaita Mono, so every application asking for the
-    # generic family got a font Omarchy never chose -- and half the file's
-    # rules had nothing to resolve to anyway, because Liberation was not
-    # installed (see fonts.packages below).
-    #
-    # The whole file rather than fonts.fontconfig.defaultFonts, which covers
-    # the three generic families and nothing else: this also carries the
-    # system-ui / -apple-system / BlinkMacSystemFont aliases that Electron and
-    # web apps ask for by name, the emoji and Nerd Font fallback chains, and
-    # the Arabic script rules.
-    #
-    # localConf, not a package in fontconfig's conf.d, for two reasons:
-    # fonts.conf includes local.conf last, so these rules win the ties they
-    # are meant to win, and it is one mkDefault a user can take back whole.
-    # Read from the flake input rather than from cfg.package, because
-    # readFile on a derivation output is import-from-derivation and would
-    # make this module unevaluatable without building Omarchy first.
+    # Why: modules/AGENTS.md#default-fontconfig-conf-avail-50-omarchy-conf-whic
     fonts.fontconfig.localConf = lib.mkDefault (
       builtins.readFile "${inputs.omarchy}/default/fontconfig/conf.avail/50-omarchy.conf"
     );
@@ -1381,40 +1021,13 @@ in
       liberation_ttf
     ]);
 
-    # default/environment.d/10-omarchy-fcitx.conf, plus the daemon that reads
-    # it -- fcitx5 was not installed at all. i18n.inputMethod rather than
-    # dropping fcitx5 into systemPackages: it is what builds fcitx5 with its
-    # addons, writes the Qt plugin path, and sets XMODIFIERS and the GTK/Qt IM
-    # modules. The unit that starts it is above.
-    # Priority 1250, which is neither of the two names lib gives you, because
-    # this option is squeezed between them. GNOME's desktop-manager module sets
-    # type to "ibus" at mkDefault (1000) and two mkDefaults tie rather than
-    # yield, so a host running GNOME beside this session failed to evaluate at
-    # all -- not the wrong input method, no evaluation. One step lower is not
-    # available either: nixpkgs' own module defines type as null at
-    # mkOptionDefault (1500) to carry the deprecated `enabled` across, and
-    # nullOr refuses to merge null with a value, so matching that ties in the
-    # other direction. Sitting between the two loses to anyone with a real
-    # opinion and still beats nixpkgs' placeholder, which is exactly the rule
-    # this module follows everywhere else: arrive beside what is installed.
+    # Why: modules/AGENTS.md#default-environment-d-10-omarchy-fcitx-conf-plus-t
     i18n.inputMethod = {
       enable = lib.mkOverride 1250 true;
       type = lib.mkOverride 1250 "fcitx5";
     };
 
-    # fcitx5 says this itself, in a notification on every login:
-    #
-    #   Wayland Diagnose -- Detect GTK_IM_MODULE being set and Wayland Input
-    #   method frontend is working. It is recommended to unset GTK_IM_MODULE.
-    #
-    # nixpkgs sets GTK_IM_MODULE and QT_IM_MODULE only when waylandFrontend is
-    # off, which is its default (i18n/input-method/fcitx5.nix). Those two are
-    # the X11-era route: with them set, GTK sends input through the legacy
-    # module instead of the Wayland input-method protocol, which is both worse
-    # and, in GTK4 and Electron apps, sometimes nothing at all.
-    #
-    # Nixarchy is Wayland-only -- there is no session here where the X11
-    # default is the right one -- so this is set rather than left to the user.
+    # Why: modules/AGENTS.md#fcitx5-says-this-itself-in-a-notification-on-every
     i18n.inputMethod.fcitx5.waylandFrontend = lib.mkIf usingFcitx5 (lib.mkDefault true);
 
     # The two of upstream's four that the nixpkgs module does not set. It has

--- a/pkgs/AGENTS.md
+++ b/pkgs/AGENTS.md
@@ -1,0 +1,58 @@
+# pkgs/
+
+The Omarchy tree as a derivation, the commands this repository writes itself,
+and the packages nixpkgs does not carry.
+
+## Intent
+
+Omarchy's source is packaged, not reimplemented. `OMARCHY_PATH` points at it in
+the store and only the distro-coupled scripts — the ones that run `pacman` — are
+replaced or shimmed. Tracking an upstream release is a source bump, not a
+re-port, and that property is worth more than any individual fix.
+
+| path | what it is |
+|---|---|
+| `omarchy/` | the vendored tree, its patches, and `nix-bin/` — the replacements |
+| `omarchy/nix-bin/` | commands that replace an Arch-coupled upstream one |
+| `omarchy/skills/` | what an agent on a nixarchy machine reads |
+| `apps/` | packages with no nixpkgs equivalent |
+| `doctor.sh`, `verify.sh`, `review.sh` | scripts spliced into derivations at build time |
+| `box.nix`, `microvm.nix` | the container and guest runners |
+
+## The trap that has cost the most here
+
+**`writeShellApplication` builds a strict PATH from `runtimeInputs`.** A command
+a script calls and does not declare is a runtime failure no build catches — and
+it does not read as "missing command", it reads as whatever the script concludes
+from the failure.
+
+`doctor.sh` carries the canonical example in a comment on its `runtimeInputs`:
+an undeclared `vainfo` does not report "vainfo is missing", it reports "no VAAPI
+driver answered", which is a different and much worse answer to hand someone. It
+ran anyway during development, from the author's own PATH.
+
+Before adding a command to any script here, add it to that derivation's
+`runtimeInputs`. If the script parses JSON, that means `jq` — reaching for `sed`
+on JSON is how a check starts confidently reporting wrong things the first time
+nix reformats a file.
+
+## Patching upstream
+
+Everything is patched with `--replace-fail`, so an Omarchy bump that rewords a
+line a patch depends on **fails the build** rather than quietly restoring Arch
+instructions. Only `SKILL.md` and `contributing.md` are replaced outright, where
+the guidance is wrong here rather than merely misspelt.
+
+CI additionally asserts that no skill code block contains a `pacman`, `yay`,
+`/usr/share/omarchy` or Arch-debuginfod line. Prose may contrast with Arch on
+purpose; a fenced block is what an agent copies.
+
+## Tests
+
+| check | covers |
+|---|---|
+| `omarchy` | the tree builds, and the README's counts still match it |
+| `omarchy-runtime` | the replaced commands run |
+| `patched-files` | every `--replace-fail` patch still applies |
+| `doctor-graphics` | the doctor's GPU rules, against fixture machines |
+| `dashboard-clock` | the install dashboard against a rewound clock |

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,58 @@
+# tests/
+
+Every `checks.<name>` in `flake.nix` is a file here. 37 of them.
+
+## Intent
+
+A check exists to fail. The recurring failure in this repository is not a
+missing check but a check that runs, passes, and measures nothing — a coverage
+guard that extracted zero names, a merge gate that read absence-of-failure as
+green, a `cachix` step that printed "Nothing to push" at a 404.
+
+So the bar for adding one is: **run it against the unfixed code first and watch
+it fail.** A check that has never failed is a check nobody knows works.
+
+## The expensive ones, and what only they can prove
+
+| check | proves | where |
+|---|---|---|
+| `install` | the installer's output boots — a real disk, real bootloader | self-hosted |
+| `install-encrypted` | the LUKS path, unlocked over the serial console | self-hosted |
+| `install-iso` / `-net` | the real published image, installing with no network | self-hosted |
+| `free-space` | installing beside an existing OS without eating it | self-hosted |
+| `session` | a booted desktop; **does not run locally**, CI only | self-hosted |
+| `microvm-boot` | a guest actually boots, not just builds | `-tcg` runner |
+
+VM tests run from `/mnt/data/vmtest`, never `/tmp` — `/tmp` is a 32G tmpfs and
+a VM test that runs out of room does not fail cleanly, it wedges.
+
+## The cheap ones, which is where new checks usually belong
+
+`installer-ui`, `installer-wizard`, `installer-refusal`, `installer-lock`,
+`installer-store-space`, `try-preflight`, `doctor-graphics`, `dashboard-clock`,
+`options`, `review-pins`, `patched-files`, `doc-options`.
+
+These are `runCommand`s that finish in seconds and drive one decision with a
+stubbed environment. Prefer one of these over extending a VM test: they are the
+only way to reach a branch a VM cannot produce.
+
+Two branches only these can reach, as illustration:
+
+- `installer-store-space` — a live ISO's store is a RAM overlay at half the
+  machine's memory. `install` cannot see it filling, because it installs onto a
+  machine whose store fits.
+- `dashboard-clock` — a clock that goes backwards mid-install. Every VM's clock
+  is stable, so no install check can produce a negative duration.
+
+## Working here
+
+- **A check in `flake.nix` and in no workflow is not a check.** `build.yml` has
+  a step asserting every check is run by some workflow, because
+  `checks.installer-ui` shipped that way once and its PR went green without it
+  ever executing.
+- Assert the outcome, not the mechanism. `stat -c %U` asks the wrong machine
+  when the test driver's passwd is not the target's; compare numeric ids
+  against the target's own `/etc/passwd`.
+- A forbid-pattern matches prose too. Forbidding a bare package name failed
+  against correctly-gated code because the surrounding comment mentioned it —
+  match the call, not the string.


### PR DESCRIPTION
## The finding that matters most

This repository has **no `CLAUDE.md`**, and Claude Code reads `CLAUDE.md`, not `AGENTS.md`.

So the 274 lines of conventions in `AGENTS.md` — "prove your check fails", the module priority rules, the `runtimeInputs` trap — **have never been auto-loaded into a Claude Code session.** Every agent that has worked here followed them only if it happened to open the file.

```
ln -s AGENTS.md CLAUDE.md
```

That one line is worth more than the rest of this PR.

## The comment ratios

| file | before | after |
|---|---|---|
| `flake.nix` | 1784 lines, 48% comment | **1291, 28%** |
| `modules/nixos.nix` | 1435, 46% | **1048, 27%** |
| `modules/home.nix` | 989, 43% | **760, 26%** |
| `modules/apps.nix` | 2173, 31% | **1840, 18%** |

90 blocks of ten lines or more, 1,549 comment lines, each replaced by one `# Why: <path>#<anchor>` pointer.

## How it is safe to do in one pass

Not by reading 1,549 lines and hoping. Two mechanical proofs, run per file:

- **Nothing changed but comments** — every removed line matches `^\s*#`, every added line is a `# Why:` pointer. **0 exceptions across all four files.**
- **Nothing was lost** — every removed comment line is checked to reappear in its destination. **1,549 moved, 0 lost.**

`nix fmt -- --ci` clean, and `checks.options`, `doc-options` and `patched-files` all pass locally.

## Where things went

| destination | holds |
|---|---|
| `installer/AGENTS.md` | the ISO, wizard, phase chain, and the flake it writes |
| `modules/AGENTS.md` | option surface, Mode A, what each module owns + 61 moved blocks |
| `pkgs/AGENTS.md` | the vendored tree, patch rules, the `runtimeInputs` trap |
| `tests/AGENTS.md` | what each check covers, and what only a cheap check can reach |
| `docs/internals/flake.md` | the flake's 29 moved blocks |

Per-directory is the AGENTS.md standard's own answer — *"agents automatically read the nearest file in the directory tree"* — and Claude Code implements the equivalent: nested files load **on demand, when it reads a file in that directory**, so they cost no context until relevant.

`flake.nix`'s reasoning deliberately did **not** go in the root `AGENTS.md`: that file is the `CLAUDE.md` symlink and loads every session, so 539 lines of build reasoning there would cost context on every unrelated task.

## AGENTS.md §6 is rewritten in the same commit

Deliberately. It currently instructs every contributor to write the long inline comments, so leaving it would regrow them within a week and make this read as one person's preference rather than the convention.

What it asks for now is the split that survives:

- **short note at the line it protects** — an invariant, a gotcha, one to three lines
- **anything longer** — the directory's `AGENTS.md`, behind a pointer

The test is whether somebody editing *that line* needs it in front of them. The `runtimeInputs` note — that an undeclared command reads as a *wrong answer* rather than a missing one — earned its place twice this week. The history of why a package is not in nixpkgs did not.

Anthropic's own `/doctor` trim guidance draws the same line: it cuts what is derivable from the codebase and keeps "pitfalls, rationale, and conventions that differ from tool defaults."

## Review note

The extraction is **reproducible** — `MIN_LINES=10`, block replaced by pointer, body reproduced verbatim. If this conflicts with anything in flight, the resolution is to take the other side's file and re-run the tool, not to hand-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
