### PR TITLE
A front door for people who do not have nix yet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1049,6 +1049,13 @@ jobs:
         # than no check, because it reads like coverage.
         run: nix build .#checks.x86_64-linux.installer-ui --print-build-logs
 
+      - name: The no-nix front door refuses in sentences
+        # installer/try-nixarchy.sh is for somebody on Ubuntu or Fedora with
+        # no nix, so almost all of it is refusals -- and a refusal nobody has
+        # watched fire is a refusal nobody knows works. Counterpart to
+        # try-preflight, which does this for the `nix run …#try` door.
+        run: nix build .#checks.x86_64-linux.try-nixarchy --print-build-logs
+
       - name: The install dashboard survives a rewound clock
         # The VM install checks cannot catch this: their clocks are stable, so
         # every duration they compute is positive. On a real machine the RTC is

--- a/README.md
+++ b/README.md
@@ -1269,6 +1269,26 @@ and whether `/dev/kvm` is usable -- without it the VM still runs, with a
 loud warning, several times slower. On a machine with no display it serves
 the screen over VNC on `127.0.0.1:5900` instead of dying.
 
+### No Nix yet? Try it from any Linux
+
+`#try` above is a `nix run` app, so it needs Nix installed. If you are on
+Ubuntu, Fedora, Arch or anything else and would rather look first, there is a
+script that needs only `qemu` and `curl` from your own package manager:
+
+```sh
+curl -fLO https://raw.githubusercontent.com/olafkfreund/nixarchy/main/installer/try-nixarchy.sh
+less try-nixarchy.sh          # it is going to download an image and start a VM
+bash try-nixarchy.sh
+```
+
+It fetches the latest release's installer image, checks it against the
+release's own `SHA256SUMS`, and boots it in a UEFI VM. `--boot` starts the
+machine you installed, `--fresh` wipes it and starts again, `--help` lists the
+rest.
+
+It takes the latest release and cannot resolve a particular commit — if you
+have Nix, `#try` is the better door and knows it.
+
 The two apps below are different animals: `#vm` boots a prebuilt smoke-test
 *of the installed system* -- no installer, no disk -- and is mainly a
 development tool.

--- a/docs/manual/getting-started.md
+++ b/docs/manual/getting-started.md
@@ -295,3 +295,24 @@ for Arch. For nixarchy-specific trouble, run
 `nix run github:olafkfreund/nixarchy#doctor`, read
 [troubleshooting](troubleshooting.md), and open an issue on the repository with
 the output of `omarchy debug --no-sudo --print`.
+
+## No Nix yet? Try it from any Linux
+
+`#try` above is a `nix run` app, so it needs Nix installed. If you are on
+Ubuntu, Fedora, Arch or anything else and would rather look first, there is a
+script that needs only `qemu` and `curl` from your own package manager:
+
+```sh
+curl -fLO https://raw.githubusercontent.com/olafkfreund/nixarchy/main/installer/try-nixarchy.sh
+less try-nixarchy.sh          # it is going to download an image and start a VM
+bash try-nixarchy.sh
+```
+
+It fetches the latest release's installer image, checks it against the
+release's own `SHA256SUMS`, and boots it in a UEFI VM. `--boot` starts the
+machine you installed, `--fresh` wipes it and starts again, `--help` lists the
+rest.
+
+It takes the latest release and cannot resolve a particular commit — if you
+have Nix, `#try` is the better door and knows it.
+

--- a/flake.nix
+++ b/flake.nix
@@ -1050,6 +1050,12 @@
             pkgs = pkgsFor.${system};
           };
 
+          # Why: installer/AGENTS.md#try-nixarchy-sh
+          try-nixarchy = import ./tests/try-nixarchy.nix {
+            inherit inputs;
+            pkgs = pkgsFor.${system};
+          };
+
           # The dashboard the installer draws while it works, against a clock
           # that goes backwards -- which is what NTP does to a machine whose
           # RTC was wrong, mid-install. Not covered by the VM checks: their

--- a/installer/AGENTS.md
+++ b/installer/AGENTS.md
@@ -22,6 +22,7 @@ the bugs have been. The README and the Pages docs say so to users.
 | `host.nix` | the installed machine's own configuration |
 | `lib/ui.sh`, `lib/dashboard.sh` | the screens; no gum widget without a pty |
 | `try.sh` | `nix run …#try` — boots the real ISO in a local VM |
+| `try-nixarchy.sh` | the same, for a machine with no nix — see below |
 
 ## The phase chain
 
@@ -67,3 +68,42 @@ before that resolves against the ISO's passwd, not the target's.
 | `installer-lock` | the generated lock has the fields nix would have written |
 | `dashboard-clock` | a clock that goes backwards mid-install |
 | `try-preflight` | every refusal path of the `#try` front door |
+
+<a id="try-nixarchy-sh"></a>
+## `try-nixarchy.sh` — the front door with no nix behind it
+
+`try.sh` is the better door and cannot serve everyone: it is a `nix run` app,
+its qemu and OVMF paths are substituted from the store at build time, and it
+makes fourteen `nix` calls. Somebody on Ubuntu who wants to look at nixarchy
+has to install Nix first, which is a larger commitment than the thing they
+were evaluating.
+
+So this one needs `qemu` and `curl` from the distribution and nothing else. It
+downloads the published release image, verifies it against the release's own
+`SHA256SUMS`, and boots it in a UEFI VM.
+
+What it does NOT do, and `try.sh` does: resolve the image from the commit you
+asked for. This one can only take the latest release, because that is all a
+machine without nix can fetch. Anybody who has nix is pointed at `#try`,
+including from the missing-firmware refusal — telling a NixOS user to
+`apt install ovmf` is the least useful thing it could say.
+
+Three things it must keep doing:
+
+- **Verify the download.** A truncated image does not announce itself; it boots
+  halfway and fails as something else. The verdict is asserted as an explicit
+  `: OK` line for that exact file, not by the exit status of a pipeline —
+  `sha256sum -c … | grep "$iso"` matches the `FAILED` line just as happily as
+  the `OK` one, and refuses only because `pipefail` carries the status out of
+  the pipe. That is one `set` away from silently accepting a corrupt image.
+- **Refuse in sentences, naming the number and the way out.** Missing tools
+  name the package for four distributions, because "install qemu" is not one
+  command anywhere. The memory refusal prints both numbers and a `--memory`
+  value that would work.
+- **Never silently reuse or wipe the disk.** It may hold an install somebody
+  spent twenty minutes on; `--boot` and `--fresh` are offered instead.
+
+`checks.try-nixarchy` drives every one of those refusals with stubs, in
+seconds. It invokes the script as `bash ./try-nixarchy.sh` throughout: the
+sandbox has no `/usr/bin/env`, so the shebang — which is correct for the
+machines this script is actually for — cannot resolve there.

--- a/installer/try-nixarchy.sh
+++ b/installer/try-nixarchy.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# Try nixarchy in a virtual machine, from any Linux, with no Nix installed.
+#
+# Why: installer/AGENTS.md#try-nixarchy-sh
+#
+#   ./try-nixarchy.sh            download the net image and install into a VM
+#   ./try-nixarchy.sh --full     the offline image instead (6 GB, no network)
+#   ./try-nixarchy.sh --boot     boot what you already installed
+#   ./try-nixarchy.sh --fresh    wipe the disk and install again
+#   ./try-nixarchy.sh --help     the rest
+#
+# Needs qemu and curl from your distribution, and nothing else. `nix run
+# github:olafkfreund/nixarchy#try` is the better front door if you HAVE nix --
+# it resolves the image from the commit you asked for rather than from the
+# latest release, and this script cannot.
+set -uo pipefail
+
+REPO=${NIXARCHY_REPO:-olafkfreund/nixarchy}
+API=${NIXARCHY_API:-https://api.github.com/repos/$REPO/releases/latest}
+WORK=${NIXARCHY_TRY_DIR:-$PWD}
+DISK="$WORK/nixarchy-try.qcow2"
+DISK_GB=${NIXARCHY_TRY_DISK:-24}
+MEM_MB=${NIXARCHY_TRY_MEM:-8192}
+CPUS=${NIXARCHY_TRY_CPUS:-4}
+
+bold=$(printf '\033[1m'); dim=$(printf '\033[2m')
+red=$(printf '\033[31m'); off=$(printf '\033[0m')
+say() { printf '%s\n' "$*"; }
+die() { printf '%s%s%s\n' "$red" "$*" "$off" >&2; exit 1; }
+
+full=false boot_only=false fresh=false
+while (($#)); do
+  case "$1" in
+    --full) full=true; shift ;;
+    --boot) boot_only=true; shift ;;
+    --fresh) fresh=true; shift ;;
+    --memory) MEM_MB=${2:?--memory needs a number in MB}; shift 2 ;;
+    -h | --help)
+      sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+      say ""
+      say "Environment: NIXARCHY_TRY_DIR (where the disk and image live),"
+      say "  NIXARCHY_TRY_MEM (MB, default $MEM_MB), NIXARCHY_TRY_DISK (GB,"
+      say "  default $DISK_GB), NIXARCHY_TRY_CPUS (default $CPUS)."
+      exit 0
+      ;;
+    *) die "Unknown option: $1 -- try --help" ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Refuse early, in sentences, naming the number and the way out.
+# ---------------------------------------------------------------------------
+
+# Named per distribution because "install qemu" is not one command anywhere,
+# and a person who has to search for it is a person who stops here.
+need() {
+  command -v "$1" >/dev/null 2>&1 && return 0
+  say "${red}$1 is not installed.${off}"
+  say ""
+  say "  Debian/Ubuntu   sudo apt install $2"
+  say "  Fedora          sudo dnf install $3"
+  say "  Arch            sudo pacman -S $4"
+  say "  openSUSE        sudo zypper install $3"
+  exit 1
+}
+need qemu-system-x86_64 qemu-system-x86 qemu-system-x86 qemu-full
+need qemu-img qemu-utils qemu-img qemu-full
+need curl curl curl curl
+need sha256sum coreutils coreutils coreutils
+
+# UEFI firmware, which every distribution puts somewhere different and none of
+# them puts on PATH. The machine boots UEFI-only -- systemd-boot, an ESP -- so
+# without this there is nothing to find the bootloader the installer writes.
+#
+# Overridable, because a distribution this list has not met -- or firmware
+# built by hand -- is a worse reason to stop than a missing package.
+OVMF_CODE=${NIXARCHY_TRY_OVMF_CODE:-} OVMF_VARS=${NIXARCHY_TRY_OVMF_VARS:-}
+[ -n "$OVMF_CODE" ] && [ -n "$OVMF_VARS" ] || for pair in \
+  "/usr/share/OVMF/OVMF_CODE_4M.fd:/usr/share/OVMF/OVMF_VARS_4M.fd" \
+  "/usr/share/OVMF/OVMF_CODE.fd:/usr/share/OVMF/OVMF_VARS.fd" \
+  "/usr/share/edk2/ovmf/OVMF_CODE.fd:/usr/share/edk2/ovmf/OVMF_VARS.fd" \
+  "/usr/share/edk2/x64/OVMF_CODE.4m.fd:/usr/share/edk2/x64/OVMF_VARS.4m.fd" \
+  "/usr/share/edk2-ovmf/x64/OVMF_CODE.fd:/usr/share/edk2-ovmf/x64/OVMF_VARS.fd" \
+  "/usr/share/qemu/ovmf-x86_64-code.bin:/usr/share/qemu/ovmf-x86_64-vars.bin"; do
+  c=${pair%%:*}; v=${pair##*:}
+  if [ -r "$c" ] && [ -r "$v" ]; then OVMF_CODE=$c; OVMF_VARS=$v; break; fi
+done
+if [ -z "$OVMF_CODE" ]; then
+  say "${red}No UEFI firmware (OVMF) found.${off}"
+  say ""
+  say "nixarchy installs UEFI-only, so a BIOS VM has nothing to boot."
+  say ""
+  # NixOS keeps OVMF in the store, not /usr/share, so the search above finds
+  # nothing on the one distribution that has a better answer anyway. Sending a
+  # NixOS user to `apt install ovmf` is the least useful thing this could say.
+  if [ -e /etc/NIXOS ] || command -v nix >/dev/null 2>&1; then
+    say "${bold}You have nix. Use the front door instead -- it needs none of this:${off}"
+    say ""
+    say "  nix run github:$REPO#try"
+    say ""
+    say "It resolves the image from the commit you ask for, brings its own"
+    say "qemu and firmware, and refuses in sentences the way this does."
+  else
+    say "  Debian/Ubuntu   sudo apt install ovmf"
+    say "  Fedora          sudo dnf install edk2-ovmf"
+    say "  Arch            sudo pacman -S edk2-ovmf"
+    say "  openSUSE        sudo zypper install qemu-ovmf-x86_64"
+  fi
+  exit 1
+fi
+
+# KVM is a warning, not a refusal: it still runs without it, several times
+# slower. Saying nothing would leave somebody wondering why an install that
+# takes minutes here is taking an hour for them.
+ACCEL="tcg" CPUOPT="max"
+if [ -w /dev/kvm ]; then
+  ACCEL="kvm" CPUOPT="host"
+elif [ -e /dev/kvm ]; then
+  say "${bold}/dev/kvm exists but is not writable by you.${off}"
+  say "  Usually: sudo usermod -aG kvm $USER   (then log out and back in)"
+  say "  Continuing without it -- expect this to be several times slower."
+  say ""
+else
+  say "${bold}No /dev/kvm on this machine.${off}"
+  say "  A VM inside a VM often has none. Continuing without it, slowly."
+  say ""
+fi
+
+# Memory. The installer builds a system; 4 GB is where it starts to struggle
+# and 2 GB is where it fails in ways that look like something else.
+total_mb=$(awk '/MemTotal/ {print int($2/1024)}' /proc/meminfo 2>/dev/null || echo 0)
+if [ "$total_mb" -gt 0 ] && [ "$MEM_MB" -gt $((total_mb - 1024)) ]; then
+  die "Asked for ${MEM_MB}MB of guest memory; this machine has ${total_mb}MB.
+Leave at least 1GB for the host: --memory $((total_mb - 2048))"
+fi
+[ "$MEM_MB" -lt 3072 ] && say "${bold}${MEM_MB}MB is below the 4GB the install wants. Expect trouble.${off}"
+
+mkdir -p "$WORK" || die "Cannot write to $WORK"
+avail_gb=$(df -BG --output=avail "$WORK" 2>/dev/null | tail -1 | tr -dc '0-9')
+avail_gb=${avail_gb:-0}
+if $full; then image_gb=7; else image_gb=2; fi
+want_gb=$((DISK_GB + image_gb))
+if [ "$avail_gb" -gt 0 ] && [ "$avail_gb" -lt "$want_gb" ]; then
+  die "$WORK has ${avail_gb}GB free; this needs about ${want_gb}GB (a ${DISK_GB}GB
+disk plus the image). Set NIXARCHY_TRY_DIR to somewhere with room."
+fi
+
+# ---------------------------------------------------------------------------
+# The image
+# ---------------------------------------------------------------------------
+
+run_vm() {
+  local -a args=(
+    -machine "q35,accel=$ACCEL" -cpu "$CPUOPT"
+    -m "$MEM_MB" -smp "$CPUS"
+    -drive "if=pflash,format=raw,readonly=on,file=$OVMF_CODE"
+    -drive "if=pflash,format=raw,file=$WORK/OVMF_VARS.fd"
+    -drive "file=$DISK,if=virtio,format=qcow2"
+    -netdev "user,id=n0" -device "virtio-net-pci,netdev=n0"
+    -device virtio-vga -device qemu-xhci -device usb-tablet
+    -name "nixarchy"
+  )
+  [ -n "${1:-}" ] && args+=(-cdrom "$1" -boot order=d)
+  # No display is not a failure: serve the screen over VNC rather than dying,
+  # which is what a headless host or an ssh session needs.
+  if [ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ]; then
+    args+=(-display "gtk" )
+  else
+    say "${bold}No display. Serving the VM over VNC on 127.0.0.1:5900.${off}"
+    say "  Connect with any VNC client, e.g.  vncviewer 127.0.0.1:5900"
+    say ""
+    args+=(-display "vnc=127.0.0.1:0")
+  fi
+  say "${dim}qemu-system-x86_64 ${args[*]}${off}"
+  say ""
+  qemu-system-x86_64 "${args[@]}"
+}
+
+# A fresh copy of the firmware variables per disk: they hold the boot entries
+# the installer writes, and a read-only or shared VARS file loses them.
+[ -f "$WORK/OVMF_VARS.fd" ] || cp "$OVMF_VARS" "$WORK/OVMF_VARS.fd"
+
+if $boot_only; then
+  [ -f "$DISK" ] || die "No $DISK to boot. Run without --boot to install first."
+  say "${bold}Booting the machine you installed.${off}"
+  run_vm ""
+  exit $?
+fi
+
+if $fresh && [ -f "$DISK" ]; then
+  rm -f "$DISK" "$WORK/OVMF_VARS.fd"
+  cp "$OVMF_VARS" "$WORK/OVMF_VARS.fd"
+  say "Wiped $DISK."
+fi
+
+if [ -f "$DISK" ]; then
+  die "$DISK already exists.
+  --boot   start the machine you installed into it
+  --fresh  wipe it and install again"
+fi
+
+say "${bold}Finding the latest nixarchy release...${off}"
+json=$(curl -fsSL "$API") || die "Could not reach $API. Are you online?"
+tag=$(printf '%s' "$json" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)
+[ -n "$tag" ] || die "Could not read a release tag from $API."
+say "  $tag"
+
+base="https://github.com/$REPO/releases/download/$tag"
+fetch() {
+  local name=$1
+  [ -f "$WORK/$name" ] && { say "  have $name"; return 0; }
+  say "  downloading $name"
+  curl -fL --progress-bar -o "$WORK/$name.part" "$base/$name" ||
+    die "Download failed: $base/$name"
+  mv "$WORK/$name.part" "$WORK/$name"
+}
+
+fetch SHA256SUMS
+if $full; then
+  iso="nixarchy-$tag.iso"
+  for p in aa ab ac ad; do fetch "$iso.part-$p"; done
+  if [ ! -f "$WORK/$iso" ]; then
+    say "  joining the parts"
+    cat "$WORK/$iso".part-* > "$WORK/$iso.tmp" && mv "$WORK/$iso.tmp" "$WORK/$iso"
+  fi
+else
+  iso="nixarchy-$tag-net.iso"
+  fetch "$iso"
+fi
+
+# Verified against the release's own checksums. A truncated download does not
+# announce itself -- it boots halfway and fails as something else entirely.
+say "${bold}Checking the image against the release's checksums...${off}"
+# Asserted as an explicit ": OK" for this exact file, rather than by the exit
+# status of a pipeline. `sha256sum -c ... | grep "$iso"` matches the FAILED
+# line just as happily as the OK one, and only refuses at all because pipefail
+# happens to carry sha256sum's status out of the pipe -- which is one `set`
+# away from silently accepting a corrupt image.
+verdict=$(cd "$WORK" && sha256sum -c --ignore-missing SHA256SUMS 2>/dev/null |
+  grep -F "$iso:" || true)
+case "$verdict" in
+  *": OK") say "  $verdict" ;;
+  *)
+    die "$iso does not match the published checksum.
+
+  ${verdict:-it is not listed in SHA256SUMS at all}
+
+Delete $WORK/$iso and run this again. If it fails a second time, say so on
+the issue tracker rather than booting it -- a mismatch is either a truncated
+download or an image that is not the one the release published."
+    ;;
+esac
+say ""
+
+qemu-img create -f qcow2 "$DISK" "${DISK_GB}G" >/dev/null ||
+  die "Could not create $DISK"
+
+say "${bold}Starting the installer.${off}"
+$full || say "  The net image downloads the desktop as it installs, so this VM needs"
+$full || say "  the network it already has through qemu's user networking."
+say "  When the install finishes, close the window and run:  $0 --boot"
+say ""
+run_vm "$WORK/$iso"

--- a/tests/try-nixarchy.nix
+++ b/tests/try-nixarchy.nix
@@ -1,0 +1,148 @@
+{ pkgs, ... }:
+# installer/try-nixarchy.sh, on the machines it will actually meet.
+#
+# The script exists for somebody on Ubuntu or Fedora with no nix, so almost
+# everything it does is refuse: no qemu, no UEFI firmware, not enough memory, a
+# disk left by a previous run, an image that does not match the release's
+# checksum. Those refusals ARE the script -- the qemu line at the end is four
+# lines -- and a refusal nobody has watched fire is a refusal nobody knows
+# works.
+#
+# checks.try-preflight does the same job for the `nix run …#try` front door.
+# This is its counterpart for the front door that has no nix behind it.
+#
+# Runs in seconds: no VM is started. The happy path ends in a qemu window,
+# which no sandbox has, so what is asserted here is everything up to it.
+let
+  script = ../installer/try-nixarchy.sh;
+in
+pkgs.runCommand "nixarchy-try-nixarchy"
+  {
+    nativeBuildInputs = [
+      pkgs.bash
+      pkgs.coreutils
+      pkgs.gnugrep
+      pkgs.gnused
+      pkgs.gawk
+      pkgs.shellcheck
+    ];
+  }
+  ''
+    export HOME=$PWD
+    cp ${script} ./try-nixarchy.sh
+    chmod +x ./try-nixarchy.sh
+    fail=0
+
+    # ---- it is valid shell ------------------------------------------------
+    # First, because every assertion below is worthless against a script that
+    # does not parse.
+    # Invoked as `bash ./try-nixarchy.sh` throughout, never as ./try-nixarchy.sh:
+    # the sandbox has no /usr/bin/env, so the shebang -- which is right for the
+    # Ubuntu and Fedora machines this script is FOR -- cannot resolve here.
+    shellcheck ./try-nixarchy.sh || { echo "shellcheck rejected it" >&2; fail=1; }
+    echo "  shellcheck clean"
+
+    # ---- a missing tool names the package, per distribution ---------------
+    # "install qemu" is not one command anywhere, and somebody who has to go
+    # and search for it is somebody who stops here.
+    res=$(PATH=/nonexistent ${pkgs.bash}/bin/bash ./try-nixarchy.sh 2>&1 || true)
+    case "$res" in
+      *"apt install"*"dnf install"*"pacman -S"*) echo "  a missing tool names all four" ;;
+      *) echo "a missing tool did not name the distribution packages" >&2; printf %s\\n "$res" | sed "s/^/    | /" >&2; fail=1 ;;
+    esac
+
+    # ---- no UEFI firmware -------------------------------------------------
+    # UEFI-only is not negotiable: the installer writes systemd-boot to an ESP,
+    # so a BIOS machine has nothing to find.
+    stub=$PWD/stub; mkdir -p "$stub"
+    for b in qemu-system-x86_64 qemu-img curl; do
+      printf '#!/bin/sh\nexit 0\n' > "$stub/$b"; chmod +x "$stub/$b"
+    done
+    export PATH="$stub:$PATH"
+
+    res=$(NIXARCHY_TRY_DIR=$PWD/w1 bash ./try-nixarchy.sh 2>&1 || true)
+    case "$res" in
+      *"No UEFI firmware"*) echo "  missing OVMF refuses" ;;
+      *) echo "a machine with no OVMF did not refuse" >&2; printf %s\\n "$res" | sed "s/^/    | /" >&2; fail=1 ;;
+    esac
+    # A sandbox has no nix on PATH, which is exactly the branch a Debian user
+    # takes: name the package for each distribution.
+    case "$res" in
+      *"apt install ovmf"*) echo "  and names the package per distribution" ;;
+      *) echo "the OVMF refusal did not name the packages" >&2; printf %s\\n "$res" | sed "s/^/    | /" >&2; fail=1 ;;
+    esac
+
+    # The other branch, and the one worth having: somebody who HAS nix should
+    # be sent to `nix run …#try`, not told to `apt install ovmf` -- useless
+    # advice on the single distribution with a better answer. Reached with a
+    # stub, because a sandbox has no nix of its own.
+    printf '#!/bin/sh\nexit 0\n' > "$stub/nix"; chmod +x "$stub/nix"
+    res=$(NIXARCHY_TRY_DIR=$PWD/w1b bash ./try-nixarchy.sh 2>&1 || true)
+    rm -f "$stub/nix"
+    case "$res" in
+      *"nix run github:"*) echo "  and points a nix user at #try instead" ;;
+      *) echo "did not offer #try to somebody who has nix" >&2; printf %s\\n "$res" | sed "s/^/    | /" >&2; fail=1 ;;
+    esac
+
+    # Firmware from here on, so the later refusals are reachable at all.
+    : > "$PWD/code.fd"; : > "$PWD/vars.fd"
+    export NIXARCHY_TRY_OVMF_CODE=$PWD/code.fd NIXARCHY_TRY_OVMF_VARS=$PWD/vars.fd
+
+    # ---- more memory than the machine has ---------------------------------
+    # Named with BOTH numbers and a flag that would work. A refusal that says
+    # only "not enough memory" leaves somebody guessing what would do.
+    res=$(NIXARCHY_TRY_DIR=$PWD/w2 bash ./try-nixarchy.sh --memory 999999999 2>&1 || true)
+    case "$res" in
+      *"this machine has"*"--memory "*) echo "  too much memory refuses with both numbers" ;;
+      *) echo "the memory refusal did not name the numbers" >&2; printf %s\\n "$res" | sed "s/^/    | /" >&2; fail=1 ;;
+    esac
+
+    # ---- a disk left by a previous run ------------------------------------
+    # Never silently reused and never silently wiped: it holds an install
+    # somebody may have spent twenty minutes on.
+    mkdir -p "$PWD/w3"; : > "$PWD/w3/nixarchy-try.qcow2"
+    res=$(NIXARCHY_TRY_DIR=$PWD/w3 bash ./try-nixarchy.sh 2>&1 || true)
+    case "$res" in
+      *"already exists"*"--boot"*"--fresh"*) echo "  an existing disk offers both ways out" ;;
+      *) echo "an existing disk was not handled" >&2; printf %s\\n "$res" | sed "s/^/    | /" >&2; fail=1 ;;
+    esac
+
+    res=$(NIXARCHY_TRY_DIR=$PWD/w4 bash ./try-nixarchy.sh --boot 2>&1 || true)
+    case "$res" in
+      *"to boot"*) echo "  --boot with no disk refuses" ;;
+      *) echo "--boot with no disk did not refuse" >&2; printf %s\\n "$res" | sed "s/^/    | /" >&2; fail=1 ;;
+    esac
+
+    # ---- an image that is not what the release published -------------------
+    # The one refusal with a security argument behind it, and the one that was
+    # briefly right by accident: `sha256sum -c | grep "$iso"` matches the
+    # FAILED line as happily as the OK one, and refused only because pipefail
+    # carried sha256sum's status out of the pipe. Both directions are asserted
+    # here so that a rewrite cannot quietly start accepting a bad image.
+    mkdir -p "$PWD/w5"
+    printf 'not an iso' > "$PWD/w5/nixarchy-vTEST-net.iso"
+    printf '%s  nixarchy-vTEST-net.iso\n' "$(printf 0123456789abcdef | sha256sum | cut -d' ' -f1)" \
+      > "$PWD/w5/SHA256SUMS"
+    printf '#!/bin/sh\necho \x27{ "tag_name": "vTEST" }\x27\n' > "$stub/curl"
+    chmod +x "$stub/curl"
+
+    res=$(NIXARCHY_TRY_DIR=$PWD/w5 bash ./try-nixarchy.sh 2>&1 || true)
+    case "$res" in
+      *"does not match the published checksum"*) echo "  a corrupt image refuses" ;;
+      *) echo "a corrupt image was NOT refused -- this is the one that matters" >&2; printf %s\\n "$res" | sed "s/^/    | /" >&2; fail=1 ;;
+    esac
+
+    # And the same file with a checksum that genuinely matches must get past it.
+    printf '%s  nixarchy-vTEST-net.iso\n' "$(sha256sum "$PWD/w5/nixarchy-vTEST-net.iso" | cut -d' ' -f1)" \
+      > "$PWD/w5/SHA256SUMS"
+    res=$(NIXARCHY_TRY_DIR=$PWD/w5 bash ./try-nixarchy.sh 2>&1 || true)
+    case "$res" in
+      *"does not match the published checksum"*)
+        echo "a MATCHING image was refused; the check tests the wrong thing" >&2; printf %s\\n "$res" | sed "s/^/    | /" >&2; fail=1 ;;
+      *) echo "  a matching image passes" ;;
+    esac
+
+    [ "$fail" = 0 ] || { echo "try-nixarchy.sh does not refuse the way it claims" >&2; exit 1; }
+    echo "the no-nix front door refuses in sentences"
+    touch $out
+  ''


### PR DESCRIPTION
## The gap

`nix run …#try` is the better front door and cannot serve the person who most needs it. It is a nix app: its qemu and OVMF paths are substituted from the store at build time, and it makes fourteen `nix` calls. Somebody on Ubuntu who wants to *look* at nixarchy has to install Nix first — a larger commitment than the thing they were evaluating.

## What this adds

`installer/try-nixarchy.sh` — needs `qemu` and `curl` from the user's own package manager and nothing else.

```sh
curl -fLO https://raw.githubusercontent.com/olafkfreund/nixarchy/main/installer/try-nixarchy.sh
less try-nixarchy.sh          # it downloads an image and starts a VM
bash try-nixarchy.sh
```

Takes the latest release's image, verifies it against the release's own `SHA256SUMS`, boots it in a UEFI VM. `--boot` starts what you installed, `--fresh` wipes it, `--full` takes the offline image instead of the 1.7 GB net one.

Documented as download-then-read, **not** `curl | bash` — it is about to write a disk image and start a VM, and the user should be able to see that first.

## Almost all of it is refusals, so almost all of the check is too

| refusal | shape |
|---|---|
| missing tool | names the package for **four** distributions — "install qemu" is not one command anywhere |
| no UEFI firmware | names the package, or points a nix user at `#try` |
| too much memory | prints both numbers *and* a `--memory` value that would work |
| existing disk | never silently reused or wiped — offers `--boot` and `--fresh` |
| bad checksum | refuses, and says not to boot it |

`checks.try-nixarchy` drives every one of these with stubs, in seconds. **Every assertion was watched failing before it passed** — the first run had 7 of 10 red.

## One refusal was right by accident

The checksum verdict was:

```bash
sha256sum -c --ignore-missing SHA256SUMS | grep -F "$iso"
```

`grep` matches the `FAILED` line exactly as happily as the `OK` one. It refused a corrupt image **only because `pipefail` carried `sha256sum`'s status out of the pipe** — one `set` away from silently accepting a bad download.

It now asserts an explicit `: OK` for that exact file, and the check asserts **both directions** (corrupt must fail, matching must pass) so a rewrite cannot quietly start accepting one.

## Testing found the advice was wrong on one distribution

NixOS keeps OVMF in the store, so the firmware search finds nothing — and the script told a NixOS user to `apt install ovmf`. The least useful thing it could possibly say to the one person who has a better door available. That branch now points at `nix run …#try`, and the check drives both sides.

## Note for reviewers

The check invokes the script as `bash ./try-nixarchy.sh` throughout. A nix sandbox has no `/usr/bin/env`, so the shebang — correct for every machine this script is actually *for* — cannot resolve there. That cost two debugging rounds and is commented in place.

Registered in `flake.nix` **and** wired into `build.yml`, because the repo's own gate rejects a check no workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
