### PR TITLE
release.yml refuses a tag that is behind main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,56 @@ jobs:
           # the tags with it.
           fetch-depth: 0
 
+      # A tag behind main ships a release missing fixes that are already
+      # merged, and nothing here noticed.
+      #
+      # v4.0.2-7 is the measurement. It was tagged at 2aa2076 while the fix for
+      # a bug that draws sed's usage text over the installer was merged four
+      # commits later, so the published ISO had the bug, a tester hit it, and
+      # the fix had been on main the whole time. Everything about that release
+      # was green: CI passed, the assets published, the checksums matched. The
+      # only thing wrong with it was its age, and age was the one property
+      # nothing measured.
+      #
+      # Refused rather than warned. A warning in a ninety-minute job is read
+      # after the ISO is published, which is exactly too late -- and the cost
+      # of being wrong here is a release that has to be superseded, deleted or
+      # explained.
+      #
+      # RELEASE_ALLOW_BEHIND_MAIN is the way out, for a deliberate release of
+      # an older commit. It has to be set on the run, so it cannot be the
+      # thing that happens by default.
+      - name: The tag is not behind main
+        run: |
+          set -euo pipefail
+          tag="${{ inputs.tag || github.ref_name }}"
+          git fetch -q --depth=200 origin main || git fetch -q origin main
+          tagged=$(git rev-parse HEAD)
+          main=$(git rev-parse FETCH_HEAD)
+
+          if [ "$tagged" = "$main" ]; then
+            echo "$tag is the tip of main"
+            exit 0
+          fi
+
+          # Not an ancestor: a hotfix branch or a tag off something else. Not
+          # what this guard is about, and refusing it would block a real case.
+          if ! git merge-base --is-ancestor "$tagged" "$main"; then
+            echo "::notice::$tag is not on main; not a staleness question, continuing"
+            exit 0
+          fi
+
+          echo "::error::$tag is BEHIND main and would ship without these:"
+          git --no-pager log --oneline "$tagged..$main" | sed 's/^/  /'
+          if [ "${RELEASE_ALLOW_BEHIND_MAIN:-}" = "1" ]; then
+            echo "::warning::RELEASE_ALLOW_BEHIND_MAIN=1, publishing anyway"
+            exit 0
+          fi
+          echo ""
+          echo "Re-tag at main, or set RELEASE_ALLOW_BEHIND_MAIN=1 if this"
+          echo "older commit is genuinely the one to publish."
+          exit 1
+
       - name: The tag names the Omarchy the flake vendors
         run: |
           # v4.0.1-2 -> 4.0.1. The suffix counts our packaging revisions


### PR DESCRIPTION
## The defect this closes

`v4.0.2-7` was tagged at `2aa2076` while the fix for a bug that draws `sed`'s usage text over the installer sat **four commits ahead on main**. The ISO shipped with the bug, a tester hit it, and the fix had been merged the whole time.

**Everything about that release was green.** CI passed on the tagged commit, the build succeeded, all six assets published, the checksums matched, the release branch moved. The only thing wrong with it was its *age* — and age was the one property nothing measured.

That is the same shape as every other failure this week: a check that passes while measuring nothing, standing next to the thing that actually broke.

## The guard

Before building, compare the tag's commit against `main`:

| case | result |
|---|---|
| tag **is** the tip of main | proceed |
| tag is **behind** main | **refuse**, printing every commit it would ship without |
| tag is **not an ancestor** of main | proceed with a notice — a hotfix branch is not a staleness question, and refusing it would block a real case |

**Refused, not warned.** A warning in a ninety-minute job is read *after* the ISO is published, which is exactly too late. The cost of being wrong is a release that has to be superseded, deleted, and explained to somebody who already downloaded it — which is precisely what happened here, 11 downloads in.

`RELEASE_ALLOW_BEHIND_MAIN=1` is the escape for a deliberate release of an older commit. It must be set on the run, so it cannot be what happens by accident.

## Verification

`actionlint` clean. The logic is `git merge-base --is-ancestor` plus a tip comparison — no new dependency.

Against the actual incident: `v4.0.2-7` (`2aa2076`) versus main at the time would have hit the middle row and printed the four missing commits, including the dashboard fix.

## Already done outside this PR

- `v4.0.2-8` cut from current `main`, published, promoted to Latest
- `v4.0.2-7` release deleted (tag kept, so the build stays reproducible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5