### PR TITLE
nixpkgs ships the quickshell that does not strand a locked machine

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -309,14 +309,14 @@
           # The compositor the Lua config is written against, not nixpkgs'.
           inherit (hyprland.packages.${final.stdenv.hostPlatform.system}) hyprland;
 
-          # Why: docs/internals/flake.md#nixpkgs-is-on-0-3-0-whose-session-lock-aborts-on-d
-          quickshell = final.quickshell.overrideAttrs (_: rec {
-            version = "0.3.1";
-            src = final.fetchzip {
-              url = "https://git.outfoxxed.me/quickshell/quickshell/archive/refs/tags/v${version}.tar.gz";
-              hash = "sha256-CLX2Zp5i5BuLbOxNOkwRd9YY84IOrACNxBV79o9/F9Y=";
-            };
-          });
+          # The desktop shell. nixpkgs' own, since #35: it was overridden to
+          # 0.3.1 while nixpkgs sat on 0.3.0, whose session lock reaches
+          # qFatal when screens sleep and wake while locked -- and the
+          # Wayland protocol keeps the compositor locked when its lock client
+          # dies, so the machine is left blank with nowhere to type a
+          # password. nixpkgs now ships 0.3.1 from the same tag and the same
+          # URL the override fetched, so the override had become a no-op.
+          inherit (final) quickshell;
           # The screensaver's text-effects engine, packaged in this repo rather
           # than nixpkgs. Passed explicitly for the same reason hyprland is: it
           # lives under nixarchy-apps, which callPackage does not search.


### PR DESCRIPTION
Closes #35.

## The pin, and why it mattered

nixpkgs sat on quickshell **0.3.0**, whose session lock reaches `qFatal` when screens sleep and wake while locked:

```
FATAL: Tried to show lockscreen surfaces without active lock
```

The Wayland session-lock protocol **deliberately keeps the compositor locked when its lock client disappears** — so quickshell dying leaves a blank machine with nowhere to type a password, and a reboot as the only way out. #35 records it happening three times in one night on a real machine.

## Why it can go now

nixpkgs ships 0.3.1 — and not merely the same version *string*. It fetches:

```
https://git.outfoxxed.me/quickshell/quickshell/archive/refs/tags/v0.3.1.tar.gz
```

which is the same tag, from the same URL, that the override fetched. I checked that before dropping it: `0.3.1` appearing in two places is not evidence they are the same 0.3.1, and the thing being protected is whether somebody can get back into their laptop.

## Verification

| | |
|---|---|
| nixpkgs quickshell version | `0.3.1` |
| nixpkgs quickshell src | same tag + URL as the override |
| **reference machine after this change** | **`quickshell 0.3.1`** |
| `checks.options` | pass |
| `checks.omarchy` | pass |
| `nix fmt -- --ci` | clean |

The reference-machine version is the assertion that matters — it is the property #35 exists to protect, checked on the machine the installer actually writes.

## Worth noting

This arrived through the nightly nixpkgs bump in #369. The pin was waiting on upstream, upstream moved, and the bump that carried it was proposed and merged without anybody watching for it — the automation doing exactly what it is for.

`inherit (final) quickshell` rather than dropping the argument entirely: `pkgs/omarchy` takes `quickshell` as a parameter, and it is the session's shell — worth being able to see which one it gets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
