### PR TITLE
The installer image boots the way NixOS's own does

### DIFF
--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -251,13 +251,31 @@ in
   boot = {
     loader.timeout = lib.mkForce 0;
 
-    plymouth = {
-      enable = true;
-      theme = "omarchy";
-      themePackages = [
-        inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.nixarchy-plymouth
-      ];
-    };
+    # OFF on the installer image, and this is a reversal worth reading.
+    #
+    # Two users could not boot v4.0.2-8 on real hardware -- a ThinkPad E15 --
+    # while the same published file boots to a login prompt in a VM. The
+    # difference between this image and the one NixOS ships is almost entirely
+    # here: stock installation-cd-minimal runs NO plymouth, and its kernel is
+    # the same 6.18.49 we use, so the kernel was never the variable.
+    #
+    # plymouth takes over KMS before the root filesystem exists. On a machine
+    # with real graphics that hand-off is a thing that can hang, and when it
+    # does there is nothing to see -- because nixpkgs' plymouth module adds
+    # `splash` and `loglevel=0` to the command line, so not even a panic
+    # prints. An installer image whose failures are invisible cannot be
+    # debugged by the person holding the laptop, which is the only person who
+    # can debug it.
+    #
+    # The branding cost is smaller than it looks. What a user sees during the
+    # install -- the wordmark, the bar, the tips -- is the installer's own TUI
+    # in installer/lib/ui.sh, not plymouth. plymouth only covered the few
+    # seconds of kernel boot before that starts.
+    #
+    # The INSTALLED machine keeps its splash: programs.nixarchy.bootSplash is
+    # untouched, and modules/nixos.nix still sets it. This is the boot medium
+    # only.
+    plymouth.enable = false;
 
     # `quiet` alone is not enough. It lowers the console log level but leaves
     # anything at KERN_ERR and above going straight to tty1, which is where the
@@ -265,17 +283,29 @@ in
     # progress bar and the screen never recovers. loglevel=3 keeps the console
     # for the installer; everything still reaches the journal and dmesg.
     kernelParams = [
-      "quiet"
-      "loglevel=3"
-      "udev.log_level=3"
-      "rd.systemd.show_status=false"
+      # loglevel=4 is what stock installation-cd-minimal uses: warnings and
+      # worse on the console, the rest in the journal. `quiet`, loglevel=3,
+      # udev.log_level=3 and rd.systemd.show_status=false all used to be here,
+      # to keep the console clean for the installer's own screen -- and the
+      # cost of that was a boot failure nobody could see. Two users hit one on
+      # real hardware and could report nothing but "it crashes".
+      #
+      # The installer still owns the screen once it starts: it clears it
+      # (installer/lib/ui.sh) and systemd's status list has stopped by then.
+      # What changes is that everything BEFORE that is now visible, which is
+      # exactly the window where an unbootable machine fails.
+      "loglevel=4"
       # Kernel messages to the serial line as well. tty0 is listed LAST and so
       # stays the primary console -- the installer keeps the screen, and a
       # headless run or a support request still has somewhere to read from.
       "console=ttyS0,115200"
       "console=tty0"
     ];
-    consoleLogLevel = 0;
+    # 4, as stock installation-cd-minimal has it. This is rendered as a
+    # `loglevel=` parameter and appended AFTER the list above, so a 0 here
+    # silently overrode the loglevel set there -- which is how an image meant
+    # to be quiet became an image that could not report a panic.
+    consoleLogLevel = 4;
   };
 
   # And the flag without which the splash above is dead weight.

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -1340,7 +1340,33 @@ pkgs.runCommand "nixarchy-options"
 
           splash_is_ours installed "$splashInstalledDir" \
             "$splashInstalledOn" "$splashInstalledTheme"
-          splash_is_ours iso "$splashIsoDir" "$splashIsoOn" "$splashIsoTheme"
+
+          # The ISO is asserted the other way round, and the reversal is the
+          # point of #383 rather than an exemption from this check.
+          #
+          # What the original issue was about is upstream Omarchy artwork
+          # appearing on a nixarchy boot. The live image now draws NO splash at
+          # all -- stock NixOS's installation image runs no plymouth either,
+          # and on real hardware plymouth takes over KMS before the root
+          # filesystem exists, which is where a ThinkPad E15 stopped with
+          # nothing on screen while every VM here booted fine.
+          #
+          # So the older promise is kept, more strongly than before: a splash
+          # that does not exist cannot draw somebody else's artwork. What has
+          # to be defended now is the opposite regression -- somebody turning
+          # plymouth back on for the boot medium, which is exactly the tidy-up
+          # that would undo #383 without anyone noticing.
+          [ "$splashIsoOn" = "false" ] || {
+            echo "iso: boot.plymouth.enable is $splashIsoOn on the BOOT MEDIUM" >&2
+            echo "  #383 turned it off there: plymouth grabs KMS before the" >&2
+            echo "  root filesystem exists, and on hardware that hand-off can" >&2
+            echo "  hang with nothing printed. Stock NixOS ships its installer" >&2
+            echo "  without plymouth for the same reason." >&2
+            echo "  The INSTALLED machine keeps its splash -- that is the" >&2
+            echo "  assertion above, and it is untouched." >&2
+            exit 1
+          }
+          echo "iso: the boot medium runs no plymouth, as NixOS's own does not"
 
           # ---- nixarchy only commits a configuration it wrote --------------
           #


### PR DESCRIPTION
Two users could not boot `v4.0.2-8` on real hardware — a ThinkPad E15 — while the same published file boots to a login prompt in a VM. Part of #382.

## What differs from the image NixOS ships

Evaluated side by side against `installation-cd-minimal`, which this image is built on:

| | stock NixOS installer | nixarchy `v4.0.2-8` |
|---|---|---|
| kernel | `6.18.49` | `6.18.49` — **identical** |
| `boot.plymouth.enable` | **false** | **true** |
| kernel params | `nohibernate root=fstab loglevel=4 lsm=…` | `quiet loglevel=3 udev.log_level=3 rd.systemd.show_status=false console=… splash **loglevel=0** lsm=…` |

**The kernel was never the variable.** Two things were.

### plymouth

It takes over KMS before the root filesystem exists. On a machine with real graphics that hand-off can hang; on `virtio-vga` it does not — which is exactly the split between the tester's laptop and every test that has ever run here. Stock NixOS runs no plymouth on its installer image.

### `loglevel=0`

Nothing printed. Not a panic, not a failed unit, nothing. It arrives **last** on the command line, from `boot.consoleLogLevel = 0`, and silently overrode the `loglevel=3` set four lines above it in the same block.

An installer image whose failures are invisible cannot be debugged by the only person able to debug it — the one holding the laptop. "It crashes when booting" is all a user can report, and it covers a bootloader that never starts, a kernel panic, and a service that dies. Those are three different bugs.

## The change

`installer/cd.nix` only:

- `boot.plymouth.enable = false` on the **boot medium**
- `consoleLogLevel = 4` and `loglevel=4`, dropping `quiet`, `udev.log_level=3`, `rd.systemd.show_status=false`

The **installed machine keeps its splash** — `programs.nixarchy.bootSplash` and `modules/nixos.nix` are untouched. This is the ISO only.

The branding cost is smaller than it looks: the wordmark, progress bar and tips a user sees during the install are the installer's own TUI in `installer/lib/ui.sh`, not plymouth. plymouth only covered the few seconds of kernel boot before that starts.

## Verification

| | |
|---|---|
| `iso` and `iso-net` toplevels evaluate | yes |
| resulting params | `loglevel=4 console=ttyS0,115200 console=tty0 nohibernate root=fstab loglevel=4 lsm=…` — both 4, consistent |
| the built image still boots | **yes** — reaches the installer greeter, screenshotted, identical to the published image's |
| `nix fmt -- --ci` | clean |

I caught one mistake mid-fix worth recording: the first edit set `loglevel=4` but left `consoleLogLevel = 0`, which appends `loglevel=0` *after* it — so the console would still have been silent. Only re-evaluating `boot.kernelParams` showed it.

## What this does NOT prove

**It is not demonstrated to fix the E15.** Real-hardware KMS cannot be reproduced here — the published image boots fine in every VM I have. What is demonstrated is that this image now behaves like the one NixOS ships, that it still boots, and that when it does fail it will say why.

That last part is the change I would want even if plymouth turns out to be innocent: the next report will carry a message instead of "it crashes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
