### PR TITLE
The offline image can fetch what it does not carry

### DIFF
--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -551,7 +551,28 @@ in
     # It also means the image's completeness is tested by everyone who uses
     # it, rather than silently patched over on machines that happen to have a
     # network.
-    substituters = lib.mkForce [ ];
+    # NOT mkForce [ ]. This line is what turned "needs one derivation we did
+    # not bake" into "compile stdenv from source, offline, and die".
+    #
+    # Reported by two users on real hardware. Their machine needed one thing
+    # the image does not carry -- a real laptop's configuration can diverge
+    # from the baked reference in ways a qemu guest never does;
+    # `services.fwupd.enable` alone changes system-path, measured -- and with
+    # no substituter nix could not fetch it, so it tried to BUILD it, which
+    # needs build inputs that are also not baked, which walks back to stdenv
+    # and ends fetching acl's tarball from savannah with a one-second
+    # timeout. The install stops after the disk has been partitioned.
+    #
+    # A cache would have downloaded the difference in seconds.
+    #
+    # So `offline` now means what it should mean: the store is pre-populated,
+    # so a standard install needs no network. It does not mean the network is
+    # forbidden. This is also what NixOS itself does -- its installation ISO
+    # bakes no system closure at all and substitutes everything.
+    #
+    # The case this used to protect is still handled, by connect-timeout
+    # below: with no network the substituters fail fast and the local store
+    # answers, which is the behaviour the empty list was reaching for.
 
     # An indirect reference -- `nixpkgs#hello`, or any flake input that is not
     # already locked -- sends nix to channels.nixos.org for the global
@@ -585,10 +606,14 @@ in
     # Fail rather than hang, for anything that still tries. Five attempts at
     # fifteen seconds each is over a minute of silence per path on an image
     # that by construction has nothing to download.
-    connect-timeout = 1;
-    download-attempts = 0;
+    # Fail fast when there is no network, without failing a network that is
+    # merely slow. One second and zero retries was tuned for an image that
+    # could never download anything; now that it can, a laptop on hotel wifi
+    # has to be able to finish a TLS handshake.
+    connect-timeout = 5;
+    download-attempts = 1;
   }
-  // lib.optionalAttrs (!offline) {
+  // {
     # The same two caches install.sh already knows about and modules/nixos.nix
     # gives every installed machine. They are not a nicety here: CI builds
     # checks.reference-toplevel inside a cachix job, so the whole 15.3 GiB


### PR DESCRIPTION
Fixes the install failure in #382: two users on real hardware, installing from the published offline image, fell into the stdenv source bootstrap and died fetching `acl-2.4.0.tar.gz` from savannah — after the disk had been partitioned.

## The trigger, and the cause

**The trigger** is `nixos-generate-config`. The pinned nixpkgs (`c043004`) added Intel NPU detection: `nixos-generate-config.pl:211` matches PCI `8086:{7d1d,ad1d,643e,b03e,fd3e,d71d}` and emits

```nix
hardware.cpu.intel.npu.enable = true;
```

which `hardware/cpu/intel-npu.nix:19` turns into `pkgs.intel-npu-driver.validation` in `environment.systemPackages`. Verified: that derivation's build closure contains

```
cmake-4.3.4.drv        libarchive-3.8.9.drv
acl-2.4.0.drv          acl-2.4.0.tar.gz.drv    → mirror://savannah
```

Every package in the users' error, at the exact versions.

qemu exposes no NPU, so no VM has ever emitted that attribute. That is why every test passes.

**The cause** is this, in `installer/cd.nix`:

```nix
substituters = lib.mkForce [ ];
connect-timeout = 1;
download-attempts = 0;
```

An empty substituter list does not mean "prefer the local store". It means nix may **never** fetch anything — including from a network sitting right there. So a machine needing one un-baked package cannot download it, must build it, needs build inputs that are also not baked, walks back to stdenv, and dies at the first source fetch.

The NPU is this month's trigger. The next nixpkgs release will add another. **The cause is that the image had no way to close a gap of any size.**

## Reproduced and fixed, end to end

The published ISO booted **with a working network**, asked to realise the exact path from the user's screenshot:

| | published `v4.0.2-8` | with this PR |
|---|---|---|
| `substituters` | *(empty)* | `cache.nixos.org`, `nixarchy`, `hyprland` |
| `connect-timeout` | 1 | 5 |
| path present on image | no | no |
| `nix-store -r …-cmake-4.3.4` | **exit 1** | **exit 0** |

The published image's own words:

```
error: path '/nix/store/908kvhj…-cmake-4.3.4' is required,
       but there is no substituter that can build it
```

## The change

Do what NixOS does — its installation ISO bakes no system closure at all and substitutes everything. `offline` here now means *the store is pre-populated*, not *the network is forbidden*.

- both images get the three caches
- `connect-timeout` 1 → 5, `download-attempts` 0 → 1: one second was tuned for an image that could never download, and it is not enough for a TLS handshake on hotel wifi
- everything that made the image offline-capable is kept — the baked closures, `tarball-ttl` infinite so locked inputs resolve from the store, empty flake-registry

| | before | after |
|---|---|---|
| no network, standard config | works | works |
| **network, divergent config** | **source bootstrap, dies** | **downloads the difference** |
| no network, divergent config | dies confusingly | fails fast with a reason |

The comment defending the empty list worried that an unreachable substituter makes a working install look hung. `connect-timeout` is the answer to that and was already sitting beside it.

## Ruled out along the way

- **Encryption.** Encrypted install from the published image: exit 0, 6m32s, **zero downloads**. #382's original framing was wrong.
- **A corrupt download.** Both images verify against `SHA256SUMS`.
- **The kernel.** `6.18.49`, identical to stock `installation-cd-minimal`.
- **Most config divergence.** `keymap`, `timezone`, microcode, firmware, `videoDrivers`, `hardware.graphics`, bluetooth, thermald, `powerManagement` all leave `system-path` **unchanged**.

## Worth doing next, not in this PR

A check asserting that every attribute `nixos-generate-config` can emit either leaves `system-path` unchanged or has its outputs baked. That would have caught this before release, and will catch whatever nixpkgs adds next. Filed as follow-up on #382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
