### PR TITLE
Releases say they are experimental, in words a click cannot undo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,36 @@ jobs:
           # release would be a tag from the future.
           previous=$(git describe --tags --abbrev=0 "$TAG^" 2>/dev/null || true)
           : > notes.md
+
+          # The banner goes in FIRST, above the changelog, because it is the
+          # thing a person needs before they decide to write the image to a
+          # stick -- not a footnote under a list of merged PRs.
+          #
+          # Why it is text and not only the --prerelease flag: v4.0.2-8 shipped
+          # with --prerelease and was later promoted to a full release, because
+          # /releases/latest omits pre-releases and the try scripts resolved
+          # their download through it. The flag was a single click away from
+          # gone and nothing recorded that it had been. Prose in the body
+          # cannot be un-clicked, and the try scripts now read /releases.
+          cat >> notes.md <<'BANNER'
+          > ## ⚠️ Experimental — not yet verified on hardware
+          >
+          > This release is **published untested on real machines**. CI installs
+          > it in a VM; a VM exposes no NPU, one graphics device and no firmware
+          > quirks, so a VM install passing says very little about a laptop.
+          > Real installs have failed where every check was green.
+          >
+          > The **flake route** (`nixos-rebuild` against this repo, see the
+          > README) is the mature one and is what to use on a machine you care
+          > about. The **ISO installer is the least mature part of the project**
+          > and it partitions the disk before it can fail.
+          >
+          > If you install from this image, please say how it went on the
+          > release discussion — success as much as failure. The experimental
+          > label comes off a release only once someone has reported a
+          > successful install on physical hardware.
+
+          BANNER
           if [ -z "$previous" ]; then
             echo "::warning::no tag before $TAG; publishing without notes"
           elif nix run .#release-notes -- "$previous" "$TAG" > derived.md; then
@@ -313,6 +343,17 @@ jobs:
       # Pre-release, deliberately, and it stays that way until there is a 1.0.
       # The README says there is not one yet; a release page should not imply
       # otherwise.
+      #
+      # It is also experimental in the stronger sense, marked in the title and
+      # in the body: nothing here has been installed on a physical machine at
+      # the moment it is published. Taking that off is a deliberate human act
+      # after someone reports a successful hardware install --
+      #
+      #   gh release edit "$TAG" --title "$TAG"     # and drop the banner
+      #
+      # -- and it does NOT mean --latest. Promoting a release to latest is what
+      # lost the pre-release flag on v4.0.2-8; the try scripts read /releases
+      # now, so nothing needs it.
       - name: Publish
         env:
           GH_TOKEN: ${{ github.token }}
@@ -328,7 +369,7 @@ jobs:
           # reading "cups-browsed was running as root and is now off" belongs
           # under it rather than in a new issue.
           gh release create "$TAG" out/* \
-            --title "$TAG" \
+            --title "$TAG (experimental)" \
             --notes-file notes.md \
             --generate-notes \
             --discussion-category announcements \

--- a/installer/try-nixarchy.sh
+++ b/installer/try-nixarchy.sh
@@ -16,7 +16,10 @@
 set -uo pipefail
 
 REPO=${NIXARCHY_REPO:-olafkfreund/nixarchy}
-API=${NIXARCHY_API:-https://api.github.com/repos/$REPO/releases/latest}
+# /releases rather than /releases/latest: see installer/try.sh. Releases
+# are pre-releases until verified on hardware, and /releases/latest hides
+# those, so it would 404 on a repo whose only releases are experimental.
+API=${NIXARCHY_API:-https://api.github.com/repos/$REPO/releases?per_page=1}
 WORK=${NIXARCHY_TRY_DIR:-$PWD}
 DISK="$WORK/nixarchy-try.qcow2"
 DISK_GB=${NIXARCHY_TRY_DISK:-24}

--- a/installer/try.sh
+++ b/installer/try.sh
@@ -31,7 +31,12 @@
 # them the same way tests/installer-store-space.nix lies to install.sh.
 
 REV="@rev@"
-GH_API="${TRY_GH_API:-https://api.github.com/repos/olafkfreund/nixarchy/releases/latest}"
+# /releases, not /releases/latest: releases ship as pre-releases until a
+# human has installed one on real hardware, and /releases/latest omits
+# those entirely -- it answered 404 for the whole repo. This list is
+# newest-first and includes them; read_tag/read_urls take the first match,
+# so the array costs no parsing change.
+GH_API="${TRY_GH_API:-https://api.github.com/repos/olafkfreund/nixarchy/releases?per_page=1}"
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/nixarchy-try"
 QEMU="@qemu@"
 QEMU_IMG="@qemu_img@"


### PR DESCRIPTION
`v4.0.2-8` was published with `--prerelease` and was a **full release** by the time users downloaded it. Nothing recorded that it had been promoted, and nothing on the page said the image had never been installed on a physical machine — which it had not, and two users then found out the hard way.

## Why the flag kept coming off

Not carelessness. `GET /releases/latest` **omits pre-releases**, and both `installer/try.sh` and `installer/try-nixarchy.sh` resolve their download through it:

```
GH_API="…/releases/latest"     # try.sh:34
API=${NIXARCHY_API:-…/releases/latest}   # try-nixarchy.sh:19
```

A repo whose only releases are experimental answers **404** there. So the flag had to be taken off for `try` to work at all — the label and the tooling were in direct conflict, and the tooling won every time.

Both now read `/releases?per_page=1`, which is newest-first and includes pre-releases. They parse with `sed`/`grep … head -1` rather than a JSON object accessor, so the array costs **no parsing change** — one word each.

## With that pressure gone, the label can be real

| | before | after |
|---|---|---|
| `--prerelease` | passed, then clicked off | passed, and nothing needs it off |
| title | `v4.0.2-8` | `v4.0.2-8 (experimental)` |
| notes | nothing about maturity | banner, **above** the changelog |
| how it comes off | undocumented | written next to the flag that sets it |

The banner says the image is unverified on hardware, that the **flake route is the mature one**, that the ISO installer is the least mature part of the project and partitions the disk before it can fail, and that the label comes off only once someone reports a successful install on physical hardware.

A flag is one click from gone and leaves no trace. Prose in the body cannot be un-clicked.

## Verification

| | |
|---|---|
| `checks.try-preflight` (sources `try.sh`) | **0** |
| `checks.try-nixarchy` (shellcheck) | **0** |
| notes step rendered as Actions renders it | banner lands as a markdown blockquote at column 0, not a code block |
| `nix fmt -- --ci` | clean |

The rendering check was worth doing: the banner uses `<<'BANNER'` (quoted), so unlike the existing `<<EOF` preamble it expands nothing — which is why the pre-existing `${{ github.repository }}` in that preamble is the only thing my simulation could not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
