### PR TITLE
Every attribute generate-config can emit is one the image can satisfy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,19 @@ jobs:
       - name: The installer refuses a build the live store cannot hold
         run: nix build .#checks.x86_64-linux.installer-store-space --print-build-logs
 
+      # Every attribute nixos-generate-config can emit, against what the ISO
+      # bakes. #382: an Intel NPU made the tool write
+      # hardware.cpu.intel.npu.enable, which added a package no reference
+      # closure carried, which the offline image then tried to BUILD -- into
+      # the stdenv source bootstrap, after partitioning the disk. qemu exposes
+      # no NPU, so every install check in this file passed while that shipped.
+      #
+      # Pure evaluation, seconds of wall clock, and it goes red on the nixpkgs
+      # bump that introduces the next such attribute rather than on the user
+      # who owns the hardware.
+      - name: Every generate-config attribute is one the image can satisfy
+        run: nix build .#checks.x86_64-linux.generate-config-surface --print-build-logs
+
       # The doctor's GPU rules, against fixture machines. checks.install's VM
       # has no PCI display controller, so nothing else can reach these branches.
       - name: The doctor reads a GPU correctly

--- a/flake.nix
+++ b/flake.nix
@@ -875,6 +875,28 @@
         # present, and on an image with no network the difference between
         # having them and not is a source bootstrap.
         reference-unencrypted = self.lib.mkReference { encrypt = false; };
+
+        # The same machine again, with every hardware attribute
+        # nixos-generate-config can emit that ADDS A PACKAGE turned on. It is
+        # not a machine anyone installs; it exists so installer/cd.nix can put
+        # those packages on the image.
+        #
+        # #382: an Intel NPU made the tool write hardware.cpu.intel.npu.enable
+        # into hardware-configuration.nix, which put intel-npu-driver into
+        # environment.systemPackages, which no baked closure carried, so the
+        # target had to BUILD it -- and building a cmake package with no
+        # compiler on the image is the stdenv source bootstrap, which is where
+        # two users' installs died, after the disk was partitioned.
+        #
+        # boot.swraid.enable is the one that matters most and was found by
+        # tests/generate-config-surface.nix rather than by a user: a machine
+        # whose root is on mdraid gets it written, and it pulls mdadm. That
+        # one cannot be worked around by commenting it out either -- without
+        # it the installed machine does not boot at all.
+        reference-hardware = self.lib.mkReference {
+          encrypt = false;
+          hardware = true;
+        };
       };
 
       devShells = eachSystem (system: {
@@ -885,7 +907,10 @@
       # modes come from here so they cannot drift apart, and so installer/cd.nix
       # can bake each one onto the image without restating the host.
       lib.mkReference =
-        { encrypt }:
+        {
+          encrypt,
+          hardware ? false,
+        }:
         nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
           specialArgs = { inherit inputs; };
@@ -907,7 +932,21 @@
                 })
               ];
             }
-          ];
+          ]
+          ++ nixpkgs.lib.optional hardware {
+            # Kept in step with tests/generate-config-surface.nix, which fails
+            # if this list stops covering what nixos-generate-config emits.
+            # Two of the tool's package-adding attributes are deliberately NOT
+            # here, and the check states why: hardware.parallels.enable pulls
+            # a proprietary Parallels disk image that cannot be redistributed
+            # on an ISO, and boot.isNspawnContainer is emitted only when the
+            # tool runs INSIDE an nspawn container, which an installer that
+            # partitions a physical disk never is.
+            hardware.cpu.intel.npu.enable = true;
+            boot.swraid.enable = true;
+            virtualisation.hypervGuest.enable = true;
+            virtualisation.virtualbox.guest.enable = true;
+          };
         };
 
       # Why: docs/internals/flake.md#one-closure-per-template-shared-by-every-vm-a-user
@@ -1046,6 +1085,12 @@
           };
 
           installer-ui = import ./tests/installer-ui.nix {
+            inherit inputs;
+            pkgs = pkgsFor.${system};
+          };
+
+          # Why: installer/AGENTS.md#generate-config-surface
+          generate-config-surface = import ./tests/generate-config-surface.nix {
             inherit inputs;
             pkgs = pkgsFor.${system};
           };

--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -96,9 +96,20 @@ let
   # offline image ends in the source bootstrap, this list is the place it is
   # wrong, and checks.free-space -- which seeds the free-mode toplevels the
   # way this would -- is the shape of the fix.
+  # Kept in step with tests/generate-config-surface.nix, which reads the same
+  # three and fails if a generate-config attribute adds a package none of them
+  # carries.
   referenceConfigs = map (c: c.config) [
     inputs.self.nixosConfigurations.reference
     inputs.self.nixosConfigurations.reference-unencrypted
+
+    # The hardware the reference machine does not have. #382: a real laptop's
+    # hardware-configuration.nix is not the reference's, and where the
+    # difference is a PACKAGE the argument above -- "a few dozen text
+    # derivations" -- stops holding, because building a package with no
+    # compiler on the image is the source bootstrap. This one exists so those
+    # packages are on the medium; it is not a machine anyone installs.
+    inputs.self.nixosConfigurations.reference-hardware
   ];
 
   references = map (c: c.system.build) referenceConfigs;

--- a/tests/generate-config-surface.nix
+++ b/tests/generate-config-surface.nix
@@ -1,0 +1,221 @@
+{ inputs, pkgs, ... }:
+# Every attribute `nixos-generate-config` can emit, against what the ISO bakes.
+#
+# The failure this exists for, in full, because it cost two users an install
+# and most of a day to find:
+#
+#   nixpkgs c043004 added Intel NPU detection. nixos-generate-config.pl matches
+#   PCI 8086:7d1d and friends and writes `hardware.cpu.intel.npu.enable = true`
+#   into hardware-configuration.nix. hardware/cpu/intel-npu.nix turns that into
+#   pkgs.intel-npu-driver.validation in environment.systemPackages. That
+#   package is not in either reference closure, so the ISO does not carry it;
+#   it is a cmake build, so building it pulls cmake, libarchive and acl, none
+#   of which are baked either; and the offline image could not substitute. The
+#   install walked back to the source bootstrap and died fetching
+#   acl-2.4.0.tar.gz -- after partitioning the disk.
+#
+# qemu exposes no NPU, so no VM has ever emitted that attribute, and every
+# install check passed throughout.
+#
+# The general shape: installer/cd.nix bakes the closures of two reference
+# systems plus inputDerivation for their toplevel, initrd and etc, on the
+# argument that a real machine differs from them only by "a few dozen text
+# derivations". That argument holds right up until generate-config adds a
+# PACKAGE. Then the difference is a compiler.
+#
+# So this asserts the argument rather than trusting it: for every attribute
+# that tool can emit, either the package set is unchanged, or the packages it
+# adds are ones the image carries.
+#
+# The list is not invented. It is `push @attrs` in nixos-generate-config.pl of
+# the pinned nixpkgs, read out in full. When nixpkgs adds the next one, this
+# check goes red on the pin bump that introduces it -- which is the whole
+# point, and roughly a year earlier than a user finding it.
+let
+  inherit (pkgs) lib;
+
+  reference = inputs.self.nixosConfigurations.reference;
+
+  # What the ISO actually carries, which is the question -- not what the
+  # encrypted reference alone carries. installer/cd.nix bakes these three and
+  # this list is kept in step with it by hand; if they drift, this check gets
+  # stricter than the image, which fails loudly rather than quietly.
+  baked = [
+    reference
+    inputs.self.nixosConfigurations.reference-unencrypted
+    inputs.self.nixosConfigurations.reference-hardware
+  ];
+
+  # Comparing the PATHS rather than the closure keeps this an evaluation
+  # rather than a build.
+  #
+  # unsafeDiscardStringContext, or this check BUILDS what it is complaining
+  # about: a store path interpolated into `report` is a build input of the
+  # runCommand, so the first run compiled prl-tools, VirtualBox additions and
+  # a Parallels .dmg in order to print their names. The text is all this needs.
+  pathsOf =
+    c: map (p: builtins.unsafeDiscardStringContext "${p}") (c.config.system.path.paths or [ ]);
+
+  onImage = lib.unique (lib.concatMap pathsOf baked);
+
+  # Every attribute the tool can write, with a value that turns it on. Two are
+  # deliberately absent: nixpkgs.hostPlatform and
+  # nixpkgs.config.allowUnfreePackages are already set by the flake, and
+  # setting them again asserts nothing about packages.
+  candidates = [
+    {
+      name = "hardware.cpu.intel.npu.enable";
+      module = {
+        hardware.cpu.intel.npu.enable = true;
+      };
+    }
+    {
+      name = "hardware.cpu.amd.updateMicrocode";
+      module = {
+        hardware.cpu.amd.updateMicrocode = true;
+      };
+    }
+    {
+      name = "hardware.cpu.intel.updateMicrocode";
+      module = {
+        hardware.cpu.intel.updateMicrocode = true;
+      };
+    }
+    {
+      name = "boot.swraid.enable";
+      module = {
+        boot.swraid.enable = true;
+      };
+    }
+    {
+      name = "networking.enableIntel2200BGFirmware";
+      module = {
+        networking.enableIntel2200BGFirmware = true;
+      };
+    }
+    {
+      name = "networking.enableIntel3945ABGFirmware";
+      module = {
+        networking.enableIntel3945ABGFirmware = true;
+      };
+    }
+    {
+      name = "services.xserver.videoDrivers";
+      module = {
+        services.xserver.videoDrivers = [ "modesetting" ];
+      };
+    }
+    {
+      name = "virtualisation.hypervGuest.enable";
+      module = {
+        virtualisation.hypervGuest.enable = true;
+      };
+    }
+    {
+      name = "virtualisation.virtualbox.guest.enable";
+      module = {
+        virtualisation.virtualbox.guest.enable = true;
+      };
+    }
+    {
+      name = "hardware.parallels.enable";
+      module = {
+        hardware.parallels.enable = true;
+        nixpkgs.config.allowUnfree = true;
+      };
+      # prl-tools is built from a Parallels Desktop .dmg fetched from
+      # Parallels, unfree and not redistributable. It cannot go on an image
+      # this project publishes, so there is nothing to bake. What covers it
+      # instead is #384: both images now carry substituters, and a machine
+      # running under Parallels is a desktop VM with a working network by
+      # definition -- the case this check exists for is the laptop with an
+      # NPU and a hotel wifi, not a guest that cannot reach the internet.
+      excused = "unfree and undistributable; a Parallels guest has a network";
+    }
+    {
+      name = "boot.isNspawnContainer";
+      module = {
+        boot.isNspawnContainer = true;
+      };
+      # nixos-generate-config.pl:317 emits this only when $virt is
+      # "systemd-nspawn" -- when the tool is running INSIDE a container. This
+      # installer boots a kernel and partitions a physical disk, so it is
+      # never in that state and the attribute is never written. Excused
+      # because it is unreachable, not because it is inconvenient.
+      excused = "only emitted inside an nspawn container; the installer never is";
+    }
+  ];
+
+  added =
+    c:
+    let
+      v = reference.extendModules { modules = [ c.module ]; };
+      # Against the union of what is BAKED, not against the reference alone:
+      # an attribute that adds intel-npu-driver is fine once the image
+      # carries intel-npu-driver, and that is the whole fix.
+      new = lib.subtractLists onImage (pathsOf v);
+    in
+    {
+      inherit (c) name;
+      excused = c.excused or null;
+      packages = map (p: baseNameOf p) new;
+    };
+
+  results = map added candidates;
+  offenders = lib.filter (r: r.packages != [ ] && r.excused == null) results;
+
+  report = lib.concatMapStrings (
+    r: "  ${r.name}\n${lib.concatMapStrings (p: "      + ${p}\n") r.packages}"
+  ) offenders;
+
+  clean = lib.concatMapStrings (r: "  ${r.name}\n") (
+    lib.filter (r: r.packages == [ ] && r.excused == null) results
+  );
+
+  # Printed on success too. An exclusion nobody can see is an allowlist.
+  excusedReport = lib.concatMapStrings (r: "  ${r.name}\n      ${r.excused}\n") (
+    lib.filter (r: r.excused != null) results
+  );
+in
+pkgs.runCommand "nixarchy-generate-config-surface"
+  {
+    inherit report clean excusedReport;
+    offenderCount = builtins.length offenders;
+  }
+  ''
+    echo "attributes the image already satisfies:"
+    printf '%s' "$clean"
+    echo
+    echo "attributes excused, with the reason:"
+    printf '%s' "$excusedReport"
+    echo
+
+    if [ "$offenderCount" -eq 0 ]; then
+      echo "every generate-config attribute is one this image can satisfy"
+      touch $out
+      exit 0
+    fi
+
+    echo "these attributes need packages NO baked reference carries:" >&2
+    printf '%s' "$report" >&2
+    cat >&2 <<'WHY'
+
+    nixos-generate-config writes these into hardware-configuration.nix when it
+    finds the hardware. The offline image bakes two reference closures; a
+    package that is not in either is one the machine must BUILD, and building
+    it needs a compiler the image does not carry, which is the source
+    bootstrap.
+
+    Two ways to make this green, and both are real fixes:
+
+      - bake the packages, by turning the attribute on in
+        nixosConfigurations.reference-hardware (flake.nix), which
+        installer/cd.nix bakes for exactly this reason; or
+      - have installer/install.sh comment the attribute out of the generated
+        hardware-configuration.nix, the way reuse_baked_initrd already rewrites
+        the initrd lines, so it applies at the first update instead.
+
+    Adding the attribute to this check's allowlist is not one of them.
+    WHY
+    exit 1
+  ''

--- a/tests/generate-config-surface.nix
+++ b/tests/generate-config-surface.nix
@@ -158,7 +158,7 @@ let
     {
       inherit (c) name;
       excused = c.excused or null;
-      packages = map (p: baseNameOf p) new;
+      packages = map baseNameOf new;
     };
 
   results = map added candidates;


### PR DESCRIPTION
The follow-up #384 promised. #382's install died fetching `acl-2.4.0.tar.gz` from savannah **after the disk had been partitioned**; #384 fixed the image's inability to fetch, and this fixes the thing that made it need to.

## The chain

`nixpkgs c043004` added Intel NPU detection. `nixos-generate-config.pl:211` matches PCI `8086:{7d1d,ad1d,643e,b03e,fd3e,d71d}` and writes `hardware.cpu.intel.npu.enable` into `hardware-configuration.nix`. `hardware/cpu/intel-npu.nix:19` turns that into `intel-npu-driver.validation` in `environment.systemPackages`. No baked reference carried it → the target had to **build** it → it is a cmake package → building one with no compiler on the medium is the stdenv source bootstrap.

**qemu exposes no NPU.** No VM has ever emitted that attribute, so every install check in the repo passed throughout.

`installer/cd.nix` bakes two reference closures on the stated argument that a real machine differs from them by *"a few dozen text derivations"*. That argument holds right up until generate-config adds a **package**. Then the difference is a compiler.

## The check

`tests/generate-config-surface.nix` enumerates every attribute the tool can emit — the list is `push @attrs` in the pinned nixpkgs, **read out in full, not invented** — turns each on against the reference, and fails if it needs a store path no baked reference carries.

Against current `main` it found **six, not one**:

| attribute | packages no baked reference carries |
|---|---|
| `hardware.cpu.intel.npu.enable` | `intel-npu-driver`, `level-zero` ← the reported failure |
| **`boot.swraid.enable`** | **`mdadm`** |
| `virtualisation.hypervGuest.enable` | `hyperv-daemons` |
| `virtualisation.virtualbox.guest.enable` | `VirtualBox-GuestAdditions`, `mount.vboxsf` |
| `hardware.parallels.enable` | `prl-tools` |
| `boot.isNspawnContainer` | a rehashed `nixarchy-search` |

**`boot.swraid.enable` is the one that matters, and no user had to find it.** A machine whose root is on mdraid gets it written. It also cannot be deferred by commenting it out — the way `reuse_baked_initrd` rewrites the initrd lines — because without it the installed machine **does not boot at all**.

## The fix

`nixosConfigurations.reference-hardware`: the same machine with those attributes on. `installer/cd.nix` bakes it beside the other two, so the packages land on the medium. It shares everything else with them, so the marginal size is the packages themselves.

Two are excused, and the check **prints the reason on success** so an exclusion cannot hide:

- `hardware.parallels.enable` builds from a proprietary Parallels `.dmg` that cannot be redistributed on an ISO. #384 covers it instead — both images now carry substituters, and a Parallels guest is a desktop VM with a network by definition.
- `boot.isNspawnContainer` is emitted only when `nixos-generate-config.pl:317` finds `$virt eq "systemd-nspawn"` — when the tool runs *inside* a container. An installer that partitions a physical disk never is. Unreachable, not inconvenient.

## Verified in the order that makes it mean something

| | |
|---|---|
| **RED against current `main`** | names `intel-npu-driver`, `level-zero` and the five others |
| **GREEN with `reference-hardware` baked** | every attribute satisfied or excused-with-reason |
| wired into `build.yml` | which has a gate rejecting any check no workflow runs |
| `nix fmt -- --ci`, `checks.options` | clean |

One defect caught in my own check on its first run: it **built** `prl-tools`, VirtualBox additions and a Parallels `.dmg` in order to print their names — an interpolated store path is a build input. Paths now go through `unsafeDiscardStringContext`, and the run builds exactly one derivation.

The value is the next one, not this one: when nixpkgs adds the next package-adding attribute, this goes red on the pin bump that introduces it rather than on the user who owns the hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
