### PR TITLE
The newest kernel nixpkgs has, and an initrd pin that survives it moving

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,14 @@ jobs:
       - name: Every generate-config attribute is one the image can satisfy
         run: nix build .#checks.x86_64-linux.generate-config-surface --print-build-logs
 
+      # The initrd pin install.sh writes must stay conditional on the kernel
+      # its module lists came from. An unguarded pin makes `omarchy update`
+      # fail outright on any machine whose kernel has moved -- nixos-rebuild
+      # cannot build the initrd, so it produces no system at all. Seconds of
+      # wall clock; it greps the built installer.
+      - name: The initrd pin names the kernel it was captured from
+        run: nix build .#checks.x86_64-linux.initrd-pin-guard --print-build-logs
+
       # The doctor's GPU rules, against fixture machines. checks.install's VM
       # has no PCI display controller, so nothing else can reach these branches.
       - name: The doctor reads a GPU correctly

--- a/flake.nix
+++ b/flake.nix
@@ -1116,6 +1116,12 @@
             pkgs = pkgsFor.${system};
           };
 
+          # Why: tests/initrd-pin-guard.nix
+          initrd-pin-guard = import ./tests/initrd-pin-guard.nix {
+            inherit inputs;
+            pkgs = pkgsFor.${system};
+          };
+
           # Why: installer/AGENTS.md#try-nixarchy-sh
           try-nixarchy = import ./tests/try-nixarchy.nix {
             inherit inputs;

--- a/flake.nix
+++ b/flake.nix
@@ -419,6 +419,7 @@
                   "@initrdforced@"
                   "@initrdmodulesplain@"
                   "@initrdforcedplain@"
+                  "@initrdkernel@"
                 ]
                 [
                   "${self.packages.${system}.flake-template}"
@@ -446,6 +447,26 @@
                   # third.
                   (nixpkgs.lib.concatStringsSep " " self.nixosConfigurations.reference-unencrypted.config.boot.initrd.availableKernelModules)
                   (nixpkgs.lib.concatStringsSep " " self.nixosConfigurations.reference-unencrypted.config.boot.initrd.kernelModules)
+                  # The kernel those four lists were captured from.
+                  #
+                  # The pin install.sh writes is only VALID for this kernel.
+                  # nixpkgs gates entries in the default initrd module set on
+                  # the kernel version -- xhci_pci_prom21 appears only at 7.2
+                  # and later -- so a list captured here and forced onto a
+                  # machine running a different kernel asks modprobe for a
+                  # module that does not exist, and the initrd cannot build.
+                  #
+                  # That is not hypothetical: it is what `omarchy update`
+                  # produced on a machine installed from a 7.2 image whose
+                  # flake still resolved nixarchy to a revision with no kernel
+                  # policy, and the machine dropped back to 6.18.
+                  #
+                  # So the pin is conditional on this exact version. When the
+                  # kernel moves the pin evaporates, nixpkgs computes the list
+                  # its own kernel warrants, and the machine builds a new
+                  # initrd -- which it had to do anyway, because a different
+                  # kernel is a different initrd.
+                  self.nixosConfigurations.reference-unencrypted.config.boot.kernelPackages.kernel.version
                 ]
                 (builtins.readFile ./installer/install.sh);
           };

--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -317,6 +317,23 @@ in
     # silently overrode the loglevel set there -- which is how an image meant
     # to be quiet became an image that could not report a panic.
     consoleLogLevel = 4;
+
+    # The newest kernel nixpkgs has, and on the boot medium it matters more
+    # than it does on the installed system.
+    #
+    # An installed machine that is a kernel behind is slow or missing a
+    # feature. A LIVE IMAGE that is a kernel behind cannot be used at all:
+    # there is no screen to read the error on and no network to fetch the fix
+    # with. omacom/omarchy#6551 is that exact deadlock -- a Dell XPS 13 whose
+    # Intel BE213 wifi had no driver on the install media, on a machine with
+    # no other way to reach a network.
+    #
+    # Stock NixOS keeps its installer conservative because it installs servers
+    # too. This image installs laptops bought this year, so it takes the other
+    # side of that trade. modules/nixos.nix carries the same line and the
+    # longer argument; this is set separately because the live image
+    # deliberately does not import nixosModules.nixarchy.
+    kernelPackages = pkgs.linuxPackages_latest;
   };
 
   # And the flag without which the splash above is dead weight.

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1517,7 +1517,9 @@ reuse_baked_initrd() {
   # is concerned, and `boot.initrd.x = lib.mkForce [...]` reads to it as a
   # command called `boot.initrd.x` with a stray `=`. A quoted heredoc for the
   # prose and printf for the two generated lines keeps both readers happy.
-  local avail forced
+  local avail forced kernelversion
+  # The kernel the four lists above were captured from; see the guard below.
+  kernelversion="@initrdkernel@"
   # shellcheck disable=SC2086  # deliberate word splitting: a module per word
   avail=$(printf '"%s" ' $avail_src)
   # shellcheck disable=SC2086
@@ -1538,9 +1540,32 @@ reuse_baked_initrd() {
   #
   # Delete this block to use exactly what was detected on this machine. That
   # is a rebuild, and it needs a network the first time.
+  #
+  # Conditional on the kernel, and that guard is the whole reason this block
+  # is not a plain mkForce.
+  #
+  # nixpkgs gates entries in the default initrd module set on the kernel
+  # version: xhci_pci_prom21 is added only at 7.2 and later. A list captured
+  # from one kernel and forced onto a machine running another asks modprobe
+  # for a module that does not exist, and the initrd fails to build -- which
+  # is not a warning, it is `nixos-rebuild` refusing to produce a system.
+  #
+  # It happened: a machine installed from a 7.2 image, whose flake still
+  # resolved nixarchy to a revision with no kernel policy, dropped to 6.18 on
+  # its first `omarchy update` and could not build an initrd at all.
+  #
+  # When the kernel moves, this pin simply stops applying. nixpkgs then
+  # computes the list its own kernel warrants and the machine builds a fresh
+  # initrd -- which it had to do regardless, because a different kernel is a
+  # different initrd. The pin exists to skip a build that would produce an
+  # identical result; once the result would differ, there is nothing to skip.
 PIN
-    printf '  boot.initrd.availableKernelModules = lib.mkForce [ %s];\n' "$avail"
-    printf '  boot.initrd.kernelModules = lib.mkForce [ %s];\n' "$forced"
+    printf '  boot.initrd.availableKernelModules =\n'
+    printf '    lib.mkIf (config.boot.kernelPackages.kernel.version == "%s")\n' "$kernelversion"
+    printf '      (lib.mkForce [ %s]);\n' "$avail"
+    printf '  boot.initrd.kernelModules =\n'
+    printf '    lib.mkIf (config.boot.kernelPackages.kernel.version == "%s")\n' "$kernelversion"
+    printf '      (lib.mkForce [ %s]);\n' "$forced"
     tail -n 1 "$file"
   } >"$file.pinned" && mv "$file.pinned" "$file"
 }

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -982,6 +982,36 @@ in
       ++ lib.optional config.virtualisation.docker.enable "docker";
     };
 
+    # The newest kernel nixpkgs has, not the release default.
+    #
+    # This is a laptop distribution. NixOS defaults to an older, longer-lived
+    # kernel because it also has to serve machines that have been running for
+    # two years; nixarchy's problem is the opposite one, a machine bought last
+    # month whose graphics or wifi has no driver in a kernel from last spring.
+    #
+    # Concretely, and the reason this changed: Dell, Intel and Omarchy shipped
+    # `linux-ptl` for Panther Lake XPS machines -- roughly twenty backports
+    # taken from Linux 7.0 release candidates, carried on Omarchy's own mirror
+    # "until Linux 7.0 drops". nixarchy was shipping 6.18, older than the
+    # kernel they had to work around, on hardware that needed 7.0-rc.
+    #
+    # Porting those backports would be the wrong answer. Linux 7.0 dropped;
+    # nixpkgs carries 7.2 and will carry whatever is newest at the moment an
+    # image is built, so tracking `linuxPackages_latest` gets the same fixes
+    # from upstream with no patch set to maintain and nothing to forget to
+    # retire. That is the NixOS-shaped version of what linux-ptl did.
+    #
+    # mkDefault, so an adopter who needs an LTS -- an out-of-tree module that
+    # lags, a machine that is happy where it is -- sets boot.kernelPackages
+    # and wins without touching this file.
+    #
+    # The two known hazards were measured rather than assumed: nothing in this
+    # tree references ZFS, and the NVIDIA open driver evaluates against the
+    # newest kernel in the current pin. When a future pin breaks that, it
+    # breaks at evaluation with the package named, which is a better failure
+    # than a machine that cannot see its screen.
+    boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
+
     boot.plymouth = lib.mkMerge [
       (lib.mkIf (cfg.bootSplash != "off") {
         enable = lib.mkDefault true;

--- a/tests/initrd-pin-guard.nix
+++ b/tests/initrd-pin-guard.nix
@@ -1,0 +1,73 @@
+{ inputs, pkgs, ... }:
+# The initrd pin installer/install.sh writes must stay conditional on the
+# kernel it was captured from.
+#
+# What this defends, in full:
+#
+#   install.sh forces the installed machine's initrd module lists to the ones
+#   the image carries, so the install copies the baked initrd instead of
+#   spending minutes building a near-identical one. That pin is a frozen
+#   literal list.
+#
+#   nixpkgs gates entries in the default initrd module set on kernel version:
+#   kernel.nix and all-hardware.nix both add xhci_pci_prom21 under
+#   `versionAtLeast kernel.version "7.2"`. Force a list captured at 7.2 onto a
+#   machine running 6.18 and modprobe is asked for a module that does not
+#   exist, and linux-6.18.49-modules-shrunk fails to build. That is not a
+#   warning -- nixos-rebuild refuses to produce a system, so the machine's
+#   next `omarchy update` fails outright.
+#
+#   It happened, on a machine installed from a 7.2 image whose /etc/nixos
+#   still resolved nixarchy to a revision with no kernel policy.
+#
+# Two things are asserted, and the second is the one that rots quietly: that
+# the guard is there at all, and that the version inside it is the version the
+# module lists actually came from. A guard naming the wrong kernel is worse
+# than none -- it would never apply, and the pin would silently stop working
+# without anything failing.
+let
+  installer = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.install;
+
+  # The same attribute flake.nix substitutes into @initrdkernel@.
+  kernel =
+    inputs.self.nixosConfigurations.reference-unencrypted.config.boot.kernelPackages.kernel.version;
+in
+pkgs.runCommand "nixarchy-initrd-pin-guard"
+  {
+    inherit kernel;
+    script = "${installer}/bin/nixarchy-install";
+  }
+  ''
+    guard='lib.mkIf (config.boot.kernelPackages.kernel.version == "%s")'
+
+    grep -qF "$guard" "$script" || {
+      echo "installer/install.sh writes an UNGUARDED initrd pin." >&2
+      echo "" >&2
+      echo "  expected this line to be emitted:" >&2
+      echo "    $guard" >&2
+      echo "" >&2
+      echo "  A bare lib.mkForce of the baked module lists is only correct" >&2
+      echo "  while the machine runs the kernel they were captured from." >&2
+      echo "  nixpkgs adds xhci_pci_prom21 to the defaults at 7.2 and later;" >&2
+      echo "  forcing that list onto an older kernel makes modprobe fail and" >&2
+      echo "  the initrd underivable, so nixos-rebuild produces no system at" >&2
+      echo "  all and the machine cannot update." >&2
+      exit 1
+    }
+
+    grep -qF "kernelversion=\"$kernel\"" "$script" || {
+      echo "the initrd pin's guard does not name the kernel the lists came from." >&2
+      echo "" >&2
+      echo "  reference-unencrypted is on: $kernel" >&2
+      echo "  the installer says:          $(grep -o 'kernelversion="[^"]*"' "$script" || echo '<nothing>')" >&2
+      echo "" >&2
+      echo "  A guard naming the wrong kernel never applies, so the pin stops" >&2
+      echo "  working and every install builds an initrd it did not need to." >&2
+      echo "  Nothing fails; it just gets slower, which is why this is" >&2
+      echo "  checked rather than trusted." >&2
+      exit 1
+    }
+
+    echo "the initrd pin is guarded, and names $kernel -- the kernel its lists came from"
+    touch $out
+  ''


### PR DESCRIPTION
nixarchy shipped Linux **6.18.49** — NixOS's release default, chosen for machines that have been running for two years. This is a laptop distribution; its problem is the opposite one.

## Why now

Dell, Intel and Omarchy shipped **`linux-ptl`** for Panther Lake XPS machines: roughly twenty backports taken from Linux 7.0 release candidates, carried on Omarchy's own mirror *"until Linux 7.0 drops"*. nixarchy was shipping a kernel **older than the one they had to work around**, on hardware that needed 7.0-rc.

Porting those backports would be the wrong answer. Linux 7.0 dropped. The current pin carries **7.2.3**, and `linuxPackages_latest` resolves at build time — so an image gets whatever is newest when it is cut, the nightly flake update carries it forward, and there is no patch set to maintain and nothing to forget to retire. That is the NixOS-shaped version of what `linux-ptl` did.

## Set in two places, deliberately

The live image does not import `nixosModules.nixarchy`, and the two carry different arguments:

- **`modules/nixos.nix`**, at `mkDefault`. An installed machine a kernel behind is slow or missing a feature; an adopter who needs an LTS sets `boot.kernelPackages` and wins. (`hosts/p510` doing exactly that, for NVIDIA, is why this is a default and not a force.)
- **`installer/cd.nix`**, unconditionally. A live image a kernel behind **cannot be used at all**: no screen to read the error on, no network to fetch the fix with. omacom/omarchy#6551 is that deadlock exactly — a Dell XPS 13 whose Intel BE213 wifi had no driver on the install media and no other way to reach a network. Stock NixOS keeps its installer conservative because it installs servers too; this one installs laptops bought this year.

## The bug this introduced, and the fix

Raising the ISO's kernel broke `omarchy update` on machines installed from it, and it took a real install to find:

```
modprobe: FATAL: Module xhci_pci_prom21 not found in directory …/6.18.49
error: Cannot build '…-linux-6.18.49-modules-shrunk.drv'
```

`install.sh` pins the machine's initrd module lists to what the image carries, with `mkForce`, so the install copies the baked initrd instead of building a near-identical one. That pin is a **frozen literal list**, and nixpkgs gates entries in the default set on kernel version — `kernel.nix:371` and `all-hardware.nix:114` both add `xhci_pci_prom21` under `versionAtLeast kernel.version "7.2"`. Force a 7.2 list onto a 6.18 machine and modprobe is asked for a module that does not exist. That is not a warning: `nixos-rebuild` produces no system, so the update fails outright.

It happens because `omarchy update` resolves nixarchy to a published revision with no kernel policy, so the machine drops to 6.18 while the pin stays at 7.2.

**The pin is now conditional on the kernel it was captured from**, passed in as `@initrdkernel@` beside the four module lists it belongs to:

```nix
boot.initrd.availableKernelModules =
  lib.mkIf (config.boot.kernelPackages.kernel.version == "7.2.3")
    (lib.mkForce [ … ]);
```

When the kernel moves the pin stops applying, nixpkgs computes the list its own kernel warrants, and the machine builds a fresh initrd — which it had to do regardless, because a different kernel is a different initrd. **The pin exists to skip a build that would produce an identical result; once the result would differ, there is nothing left to skip.**

`mkForce` stays *inside* the guard — still load-bearing against `profiles/qemu-guest.nix`, which sets both lists itself and which a comment cannot undo. `hardware-configuration.nix` takes `config` in its argument list (`nixos-generate-config.pl:619`), so the guard has it in scope.

`xhci_pci_prom21` is the first instance, not a special case: any future nixpkgs that adds or renames a version-gated module would have done the same thing.

## Verification

| | |
|---|---|
| `iso`, `iso-net`, `reference`, `reference-unencrypted` | **7.2.3** (were 6.18.49) |
| **ISO size cost** | 5.89 GiB → 5.89 GiB — **none** |
| hazards measured, not assumed | **no ZFS** in the tree; **NVIDIA open driver evaluates** on 7.2.3 |
| reproduction, unguarded pin on 6.18 | **RC=1**, same derivation, same `modprobe: FATAL` |
| same expression, guarded | **RC=0** |
| install from the fixed ISO, username `lovelace` | `INSTALL-0`, `ESP-0`, `NOHASH-0` |
| installed machine boots | yes |
| **`omarchy update` on that machine** | **`✓ initrd-linux-6.18.49` in 3s**, 102 builds, `7.2.3 → 6.18.49` — the exact derivation that used to be underivable |
| `checks.options` / `doctor-graphics` / `installer-ui` / `review-pins` | RC=0 |
| `statix`, `nix fmt -- --ci` | clean |

## `checks.initrd-pin-guard`

Wired into `build.yml`. Asserts **both** halves, and the second is the one that rots quietly: that the guard is emitted, and that the version inside it is the version the lists actually came from — read from the same attribute `flake.nix` substitutes. A guard naming the wrong kernel never applies, so the pin silently stops working and every install rebuilds an initrd it did not need to. Nothing fails; it just gets slower, which is why it is checked rather than trusted.

Verified red and green: `0` on correct input, `1` on a bare `mkForce`, `2` on a guard naming the wrong kernel.

It needs a committed tree, because `packages.install` pulls `flake-template`, which pins nixarchy by commit and refuses to build from a dirty one.

## Not in this PR

`hardware.enableAllFirmware = true` on the ISO. It is the other half of omacom#6551 — that wifi failure was *firmware*, not kernel — but it requires `allowUnfree` on a published image, which is a licensing decision rather than a technical one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
