### PR TITLE
Hyprland comes from nixpkgs, because nixpkgs caught up

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,11 +46,12 @@ jobs:
           #   warning: ignoring untrusted flake configuration setting
           #   'extra-substituters'. Pass '--accept-flake-config' to trust it
           #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
+          # and the nixarchy cache flake.nix declares is simply not used.
+          # There used to be a second one, hyprland.cachix.org, re-added by
+          # hand in ONE job because "without this the runner compiles a
+          # compositor from source and times out" -- a workaround for a
+          # setting the flake already carried. Both the cache and the
+          # workaround are gone: Hyprland comes from nixpkgs now.
           #
           # Scoped to the flake being invoked, which is this repository's
           # own. It does not extend trust to inputs.
@@ -251,11 +252,12 @@ jobs:
           #   warning: ignoring untrusted flake configuration setting
           #   'extra-substituters'. Pass '--accept-flake-config' to trust it
           #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
+          # and the nixarchy cache flake.nix declares is simply not used.
+          # There used to be a second one, hyprland.cachix.org, re-added by
+          # hand in ONE job because "without this the runner compiles a
+          # compositor from source and times out" -- a workaround for a
+          # setting the flake already carried. Both the cache and the
+          # workaround are gone: Hyprland comes from nixpkgs now.
           #
           # Scoped to the flake being invoked, which is this repository's
           # own. It does not extend trust to inputs.
@@ -284,11 +286,12 @@ jobs:
           #   warning: ignoring untrusted flake configuration setting
           #   'extra-substituters'. Pass '--accept-flake-config' to trust it
           #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
+          # and the nixarchy cache flake.nix declares is simply not used.
+          # There used to be a second one, hyprland.cachix.org, re-added by
+          # hand in ONE job because "without this the runner compiles a
+          # compositor from source and times out" -- a workaround for a
+          # setting the flake already carried. Both the cache and the
+          # workaround are gone: Hyprland comes from nixpkgs now.
           #
           # Scoped to the flake being invoked, which is this repository's
           # own. It does not extend trust to inputs.
@@ -955,11 +958,12 @@ jobs:
           #   warning: ignoring untrusted flake configuration setting
           #   'extra-substituters'. Pass '--accept-flake-config' to trust it
           #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
+          # and the nixarchy cache flake.nix declares is simply not used.
+          # There used to be a second one, hyprland.cachix.org, re-added by
+          # hand in ONE job because "without this the runner compiles a
+          # compositor from source and times out" -- a workaround for a
+          # setting the flake already carried. Both the cache and the
+          # workaround are gone: Hyprland comes from nixpkgs now.
           #
           # Scoped to the flake being invoked, which is this repository's
           # own. It does not extend trust to inputs.
@@ -978,16 +982,6 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
             /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
           df -h /
-
-      - name: Add hyprland binary cache
-        # Nixarchy pins Hyprland ahead of nixpkgs, so without this the runner
-        # compiles a compositor from source and times out.
-        run: |
-          sudo tee -a /etc/nix/nix.conf >/dev/null <<'EOF'
-          extra-substituters = https://hyprland.cachix.org
-          extra-trusted-public-keys = hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE=
-          EOF
-          sudo systemctl restart nix-daemon || true
 
       - name: Build the VM system closure
         run: nix build .#checks.x86_64-linux.vm-toplevel --print-build-logs
@@ -1100,11 +1094,12 @@ jobs:
           #   warning: ignoring untrusted flake configuration setting
           #   'extra-substituters'. Pass '--accept-flake-config' to trust it
           #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
+          # and the nixarchy cache flake.nix declares is simply not used.
+          # There used to be a second one, hyprland.cachix.org, re-added by
+          # hand in ONE job because "without this the runner compiles a
+          # compositor from source and times out" -- a workaround for a
+          # setting the flake already carried. Both the cache and the
+          # workaround are gone: Hyprland comes from nixpkgs now.
           #
           # Scoped to the flake being invoked, which is this repository's
           # own. It does not extend trust to inputs.

--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -75,11 +75,12 @@ jobs:
           #   warning: ignoring untrusted flake configuration setting
           #   'extra-substituters'. Pass '--accept-flake-config' to trust it
           #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
+          # and the nixarchy cache flake.nix declares is simply not used.
+          # There used to be a second one, hyprland.cachix.org, re-added by
+          # hand in ONE job because "without this the runner compiles a
+          # compositor from source and times out" -- a workaround for a
+          # setting the flake already carried. Both the cache and the
+          # workaround are gone: Hyprland comes from nixpkgs now.
           #
           # Scoped to the flake being invoked, which is this repository's
           # own. It does not extend trust to inputs.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -214,11 +214,12 @@ jobs:
           #   warning: ignoring untrusted flake configuration setting
           #   'extra-substituters'. Pass '--accept-flake-config' to trust it
           #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
+          # and the nixarchy cache flake.nix declares is simply not used.
+          # There used to be a second one, hyprland.cachix.org, re-added by
+          # hand in ONE job because "without this the runner compiles a
+          # compositor from source and times out" -- a workaround for a
+          # setting the flake already carried. Both the cache and the
+          # workaround are gone: Hyprland comes from nixpkgs now.
           #
           # Scoped to the flake being invoked, which is this repository's
           # own. It does not extend trust to inputs.
@@ -315,11 +316,12 @@ jobs:
           #   warning: ignoring untrusted flake configuration setting
           #   'extra-substituters'. Pass '--accept-flake-config' to trust it
           #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
+          # and the nixarchy cache flake.nix declares is simply not used.
+          # There used to be a second one, hyprland.cachix.org, re-added by
+          # hand in ONE job because "without this the runner compiles a
+          # compositor from source and times out" -- a workaround for a
+          # setting the flake already carried. Both the cache and the
+          # workaround are gone: Hyprland comes from nixpkgs now.
           #
           # Scoped to the flake being invoked, which is this repository's
           # own. It does not extend trust to inputs.

--- a/.github/workflows/omarchy.yml
+++ b/.github/workflows/omarchy.yml
@@ -41,11 +41,12 @@ jobs:
           #   warning: ignoring untrusted flake configuration setting
           #   'extra-substituters'. Pass '--accept-flake-config' to trust it
           #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
+          # and the nixarchy cache flake.nix declares is simply not used.
+          # There used to be a second one, hyprland.cachix.org, re-added by
+          # hand in ONE job because "without this the runner compiles a
+          # compositor from source and times out" -- a workaround for a
+          # setting the flake already carried. Both the cache and the
+          # workaround are gone: Hyprland comes from nixpkgs now.
           #
           # Scoped to the flake being invoked, which is this repository's
           # own. It does not extend trust to inputs.
@@ -304,19 +305,6 @@ jobs:
       # pure black while every other check here passed, because a wallpaper
       # wider than GL_MAX_TEXTURE_SIZE draws nothing at all and Qt still
       # reports the image Ready.
-      - name: Add hyprland binary cache
-        if: steps.rel.outputs.changed == 'true'
-        # Nixarchy pins Hyprland ahead of nixpkgs, so without this the runner
-        # compiles a compositor from source. build.yml has had this since it
-        # started building the same closure; this job never did, which is the
-        # other half of why it kept running out of its budget.
-        run: |
-          sudo tee -a /etc/nix/nix.conf >/dev/null <<'EOF'
-          extra-substituters = https://hyprland.cachix.org
-          extra-trusted-public-keys = hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE=
-          EOF
-          sudo systemctl restart nix-daemon || true
-
       - name: Boot a session and check the desktop renders
         if: steps.rel.outputs.changed == 'true'
         run: |

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -44,11 +44,12 @@ jobs:
           #   warning: ignoring untrusted flake configuration setting
           #   'extra-substituters'. Pass '--accept-flake-config' to trust it
           #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
+          # and the nixarchy cache flake.nix declares is simply not used.
+          # There used to be a second one, hyprland.cachix.org, re-added by
+          # hand in ONE job because "without this the runner compiles a
+          # compositor from source and times out" -- a workaround for a
+          # setting the flake already carried. Both the cache and the
+          # workaround are gone: Hyprland comes from nixpkgs now.
           #
           # Scoped to the flake being invoked, which is this repository's
           # own. It does not extend trust to inputs.

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -36,11 +36,12 @@ jobs:
           #   warning: ignoring untrusted flake configuration setting
           #   'extra-substituters'. Pass '--accept-flake-config' to trust it
           #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
+          # and the nixarchy cache flake.nix declares is simply not used.
+          # There used to be a second one, hyprland.cachix.org, re-added by
+          # hand in ONE job because "without this the runner compiles a
+          # compositor from source and times out" -- a workaround for a
+          # setting the flake already carried. Both the cache and the
+          # workaround are gone: Hyprland comes from nixpkgs now.
           #
           # Scoped to the flake being invoked, which is this repository's
           # own. It does not extend trust to inputs.

--- a/README.md
+++ b/README.md
@@ -876,13 +876,11 @@ added, so nixarchy lists what is actually installed and takes the labels from
 
 ## Binary cache
 
-Enabling nixarchy otherwise means compiling a compositor, because it pins
-Hyprland ahead of nixpkgs. The module adds both caches for you:
+Enabling nixarchy otherwise means building the whole vendored Omarchy tree.
+The module adds one cache for you:
 
 ```
-https://nixarchy.cachix.org   the vendored tree, this flake's own packages,
-                              and Hyprland at whatever commit is pinned
-https://hyprland.cachix.org   hyprwm's own builds
+https://nixarchy.cachix.org   the vendored tree and this flake's own packages
 ```
 
 `programs.nixarchy.binaryCaches = false` if you would rather trust neither and

--- a/docs/internals/flake.md
+++ b/docs/internals/flake.md
@@ -11,7 +11,7 @@ it. This page is read when somebody follows a pointer.
 
 ## What the flake is for
 
-- **inputs** — nixpkgs is the package set; hyprland, zen-browser, microvm and
+- **inputs** — nixpkgs is the package set; zen-browser, microvm and
   the rest are pinned separately because they publish on their own schedule.
   Some pins are deliberate and must not be bumped by an automated job; the
   nightly review reports them and `flake-update.yml` names `nixpkgs` explicitly
@@ -61,14 +61,14 @@ themselves are not pushed to cachix -- they ship as release assets --
 so `#try` detects that case with a dry-run and falls back to the
 release download instead of leaning on these substituters.
 
-<a id="deliberately-unpinned-unlike-hyprland-sops-nix-and"></a>
-### Deliberately UNPINNED, unlike hyprland, sops-nix and microvm below, and
+<a id="deliberately-unpinned-unlike-sops-nix-and-microvm-b"></a>
+### Deliberately UNPINNED, unlike sops-nix and microvm below, and
 
 ```nix
 home-manager = {
 ```
 
-Deliberately UNPINNED, unlike hyprland, sops-nix and microvm below, and
+Deliberately UNPINNED, unlike sops-nix and microvm below, and
 not for lack of tags (home-manager has none; its releases are
 `release-XX.XX` branches that pair with STABLE nixpkgs, which is not
 what this flake tracks). master is co-developed against
@@ -79,32 +79,51 @@ skew -- a frozen home-manager evaluating renamed and removed nixpkgs
 attrs a few updates from now -- which is the exact failure pinning is
 supposed to prevent. Pin this the day nixpkgs is pinned, and not before.
 
-<a id="omarchy-4-x-configures-hyprland-through-the-lua-ap"></a>
-### Omarchy 4.x configures Hyprland through the Lua API that landed in
+<a id="hyprland-comes-from-nixpkgs-because-nixpkgs-caught-up"></a>
+### Hyprland comes from nixpkgs, because nixpkgs caught up
+
+There is no `hyprland` input. `programs.hyprland.package` is left unset in
+modules/nixos.nix so nixpkgs' own module decides, and the overlay passes
+`final.hyprland` to pkgs/omarchy.
+
+It used to be a separate flake input pinned to a hyprwm commit:
 
 ```nix
 hyprland.url = "github:hyprwm/Hyprland/0bd11c7a04a63d2785abd53363f09d552175d67d";
 ```
 
-Omarchy 4.x configures Hyprland through the Lua API that landed in
-0.55; nixpkgs is still on 0.54.3.
+with the reason that Omarchy 4.x configures Hyprland through the Lua API that
+landed in 0.55, while nixpkgs was still on 0.54.3. That reason expired.
+Measured 2026-09-07:
 
-Pinned to a COMMIT, not the v0.56.2 tag, because that tag does not build
-against its own flake.lock: its CMakeLists asks for
-`find_package(glaze 7...<8)` while nix/overlays.nix feeds it the
-glaze 8.0.0 from its locked nixpkgs. find_package fails, CMake falls
-back to cloning glaze over the network, and the sandbox has none.
-Upstream dropped the version bound after tagging, and v0.56.2 is the
-newest tag, so there is no fixed tag to move to.
+| | version |
+|---|---|
+| the pin | 0.56.0, dated 2026-08-24 |
+| nixpkgs | **0.56.2** |
+| Arch `extra` | **0.56.2-2** |
 
-A commit is just as reproducible as a tag. Bump it deliberately; never
-track a branch here, or `nix flake update` could break the bar on its
-own while the Lua bindings are still moving.
+Arch matters because it is what upstream Omarchy actually installs.
+`install/omarchy-base.packages` names `hyprland` with **no version at all** --
+zero version pins in the entire file -- so "the Hyprland Omarchy uses" is
+whatever Arch shipped on the day someone ran the installer. Tracking nixpkgs
+tracks the same thing.
 
-Deliberately NOT `inputs.nixpkgs.follows = "nixpkgs"`: hyprwm asks
-consumers not to override it, and doing so forfeits their binary cache
-and rebuilds the compositor from source. See nix.settings in
-modules/nixos.nix for the matching substituter.
+The pin was also invisible to every tool that exists to catch drift. The
+revision lived in the input URL, so `nix flake update` could not move it and
+the nightly bump silently skipped it; `nix run .#review` watches six pins and
+hyprland was not among them. Two weeks of drift looked exactly like none, and
+would have looked the same at two years.
+
+`hyprland.cachix.org` went with it. That cache only ever substituted because
+this flake took hyprwm's nixpkgs unmodified -- their own request, and the
+reason `inputs.nixpkgs.follows` was deliberately not set. From nixpkgs the
+compositor comes from cache.nixos.org, so the second cache, its key, and the
+`Add hyprland binary cache` step CI wrote into /etc/nix/nix.conf are all gone.
+
+The 0.55 floor is still asserted in modules/nixos.nix, because the Lua API is
+a real requirement rather than a preference. If nixpkgs ever goes backwards,
+that assertion fires with the reason rather than the desktop failing to
+configure itself.
 
 <a id="declarative-flatpaks-for-the-software-nixpkgs-genu"></a>
 ### Declarative Flatpaks, for the software nixpkgs genuinely does not carry

--- a/flake.lock
+++ b/flake.lock
@@ -1,38 +1,5 @@
 {
   "nodes": {
-    "aquamarine": {
-      "inputs": {
-        "hyprutils": [
-          "hyprland",
-          "hyprutils"
-        ],
-        "hyprwayland-scanner": [
-          "hyprland",
-          "hyprwayland-scanner"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787400831,
-        "narHash": "sha256-H3MEkFDZf+UH+QrVgW8TdKrssPFltF8fBg/rh0J1zIc=",
-        "owner": "hyprwm",
-        "repo": "aquamarine",
-        "rev": "7ce889cb78b97979b83a4648509fc3ef405c3286",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "aquamarine",
-        "type": "github"
-      }
-    },
     "disko": {
       "inputs": {
         "nixpkgs": [
@@ -51,22 +18,6 @@
         "owner": "nix-community",
         "ref": "latest",
         "repo": "disko",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1767039857,
-        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "flake-compat",
         "type": "github"
       }
     },
@@ -132,326 +83,6 @@
         "type": "github"
       }
     },
-    "hyprcursor": {
-      "inputs": {
-        "hyprlang": [
-          "hyprland",
-          "hyprlang"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786464181,
-        "narHash": "sha256-2alOMkLjXANh7unkZnYnCF2K2rApZaOLMoQ3o+VX2CY=",
-        "owner": "hyprwm",
-        "repo": "hyprcursor",
-        "rev": "e4ed7c08123df5af460a0a70961380cbfb872f76",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprcursor",
-        "type": "github"
-      }
-    },
-    "hyprgraphics": {
-      "inputs": {
-        "hyprutils": [
-          "hyprland",
-          "hyprutils"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786464367,
-        "narHash": "sha256-k58p4wbzIXWyRWrW84pP8tD+iaZSSYiiM+fr0Auk4oU=",
-        "owner": "hyprwm",
-        "repo": "hyprgraphics",
-        "rev": "7c895c44e3ca6d28ed68ddd80ec02b02b925e7fc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprgraphics",
-        "type": "github"
-      }
-    },
-    "hyprland": {
-      "inputs": {
-        "aquamarine": "aquamarine",
-        "hyprcursor": "hyprcursor",
-        "hyprgraphics": "hyprgraphics",
-        "hyprland-guiutils": "hyprland-guiutils",
-        "hyprland-protocols": "hyprland-protocols",
-        "hyprlang": "hyprlang",
-        "hyprutils": "hyprutils",
-        "hyprwayland-scanner": "hyprwayland-scanner",
-        "hyprwire": "hyprwire",
-        "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": "pre-commit-hooks",
-        "systems": "systems",
-        "xdph": "xdph"
-      },
-      "locked": {
-        "lastModified": 1787612295,
-        "narHash": "sha256-K7sUeS1tKTSDu+aQK0ZwCxJCls+JzDj1qeTJRGk+CV8=",
-        "owner": "hyprwm",
-        "repo": "Hyprland",
-        "rev": "0bd11c7a04a63d2785abd53363f09d552175d67d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "Hyprland",
-        "rev": "0bd11c7a04a63d2785abd53363f09d552175d67d",
-        "type": "github"
-      }
-    },
-    "hyprland-guiutils": {
-      "inputs": {
-        "aquamarine": [
-          "hyprland",
-          "aquamarine"
-        ],
-        "hyprgraphics": [
-          "hyprland",
-          "hyprgraphics"
-        ],
-        "hyprlang": [
-          "hyprland",
-          "hyprlang"
-        ],
-        "hyprtoolkit": "hyprtoolkit",
-        "hyprutils": [
-          "hyprland",
-          "hyprutils"
-        ],
-        "hyprwayland-scanner": [
-          "hyprland",
-          "hyprwayland-scanner"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786464504,
-        "narHash": "sha256-7sHwM86KILQyHDHDuE2SDBlQ2jvZ0EW3hY7sW009/cg=",
-        "owner": "hyprwm",
-        "repo": "hyprland-guiutils",
-        "rev": "4c30cf3097ea963c0e250749ee0c59f8b08816d6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprland-guiutils",
-        "type": "github"
-      }
-    },
-    "hyprland-protocols": {
-      "inputs": {
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1772460177,
-        "narHash": "sha256-/6G/MsPvtn7bc4Y32pserBT/Z4SUUdBd4XYJpOEKVR4=",
-        "owner": "hyprwm",
-        "repo": "hyprland-protocols",
-        "rev": "1cb6db5fd6bb8aee419f4457402fa18293ace917",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprland-protocols",
-        "type": "github"
-      }
-    },
-    "hyprlang": {
-      "inputs": {
-        "hyprutils": [
-          "hyprland",
-          "hyprutils"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786464129,
-        "narHash": "sha256-339AkTlpMYSIvFuG0rnR+8Yg4/AZKeJalshJavlnKfg=",
-        "owner": "hyprwm",
-        "repo": "hyprlang",
-        "rev": "9508458be316a0d70d37ebed1ab725ccd10411ff",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprlang",
-        "type": "github"
-      }
-    },
-    "hyprtoolkit": {
-      "inputs": {
-        "aquamarine": [
-          "hyprland",
-          "hyprland-guiutils",
-          "aquamarine"
-        ],
-        "hyprgraphics": [
-          "hyprland",
-          "hyprland-guiutils",
-          "hyprgraphics"
-        ],
-        "hyprlang": [
-          "hyprland",
-          "hyprland-guiutils",
-          "hyprlang"
-        ],
-        "hyprutils": [
-          "hyprland",
-          "hyprland-guiutils",
-          "hyprutils"
-        ],
-        "hyprwayland-scanner": [
-          "hyprland",
-          "hyprland-guiutils",
-          "hyprwayland-scanner"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "hyprland-guiutils",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "hyprland-guiutils",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1785930473,
-        "narHash": "sha256-DitTu625BhEYpZjtjxtGpjrEJwPwW+X/+jJvhSZNSJM=",
-        "owner": "hyprwm",
-        "repo": "hyprtoolkit",
-        "rev": "af515b69dfbe366dc7873aa1475cb2f4db3ebad7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprtoolkit",
-        "type": "github"
-      }
-    },
-    "hyprutils": {
-      "inputs": {
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786903207,
-        "narHash": "sha256-QTwMqLLONRhv9iz6CVeuX6BqQNQCIqI8hL/cPYlR/24=",
-        "owner": "hyprwm",
-        "repo": "hyprutils",
-        "rev": "6cf50415e06dc6bd9f1252f1b745eac6b4a1cc39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprutils",
-        "type": "github"
-      }
-    },
-    "hyprwayland-scanner": {
-      "inputs": {
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786464033,
-        "narHash": "sha256-QM8Qe4/L8lpdVN4bgwahmi+jyyc4fisseDMe4afcDxA=",
-        "owner": "hyprwm",
-        "repo": "hyprwayland-scanner",
-        "rev": "62e62c1ca23da17612c6890d4ad2064f575643db",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprwayland-scanner",
-        "type": "github"
-      }
-    },
-    "hyprwire": {
-      "inputs": {
-        "hyprutils": [
-          "hyprland",
-          "hyprutils"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786464294,
-        "narHash": "sha256-ZQsZ2WvBdkboCIyh8LStDPdAIARmxzn0XMNxxoOhjPE=",
-        "owner": "hyprwm",
-        "repo": "hyprwire",
-        "rev": "4ce7cd6b6128c1ac41caf23c58a30a26b327f9dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprwire",
-        "type": "github"
-      }
-    },
     "microvm": {
       "inputs": {
         "nixpkgs": [
@@ -492,22 +123,6 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787360063,
-        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
         "lastModified": 1788614874,
         "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "NixOS",
@@ -539,40 +154,17 @@
         "type": "github"
       }
     },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1784288435,
-        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "disko": "disko",
         "home-manager": "home-manager",
         "hypr-rdp": "hypr-rdp",
-        "hyprland": "hyprland",
         "microvm": "microvm",
         "nix-flatpak": "nix-flatpak",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "omarchy": "omarchy",
         "sops-nix": "sops-nix",
-        "systems": "systems_2",
+        "systems": "systems",
         "zen-browser": "zen-browser"
       }
     },
@@ -625,62 +217,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default-linux",
-        "type": "github"
-      }
-    },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1689347949,
-        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
-        "owner": "nix-systems",
-        "repo": "default-linux",
-        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default-linux",
-        "type": "github"
-      }
-    },
-    "xdph": {
-      "inputs": {
-        "hyprland-protocols": [
-          "hyprland",
-          "hyprland-protocols"
-        ],
-        "hyprlang": [
-          "hyprland",
-          "hyprlang"
-        ],
-        "hyprutils": [
-          "hyprland",
-          "hyprutils"
-        ],
-        "hyprwayland-scanner": [
-          "hyprland",
-          "hyprwayland-scanner"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786988229,
-        "narHash": "sha256-frEFLVRj8xXvBBDs44IRiqHo6R2PxsRpluygL7abjjI=",
-        "owner": "hyprwm",
-        "repo": "xdg-desktop-portal-hyprland",
-        "rev": "59d429bf45aed4e2209043c0c36565ad8e2859a5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "xdg-desktop-portal-hyprland",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,11 +5,9 @@
   nixConfig = {
     extra-substituters = [
       "https://nixarchy.cachix.org"
-      "https://hyprland.cachix.org"
     ];
     extra-trusted-public-keys = [
       "nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM="
-      "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE="
     ];
   };
 
@@ -18,14 +16,11 @@
 
     systems.url = "github:nix-systems/default-linux";
 
-    # Why: docs/internals/flake.md#deliberately-unpinned-unlike-hyprland-sops-nix-and
+    # Why: docs/internals/flake.md#deliberately-unpinned-unlike-sops-nix-and-microvm-b
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-
-    # Why: docs/internals/flake.md#omarchy-4-x-configures-hyprland-through-the-lua-ap
-    hyprland.url = "github:hyprwm/Hyprland/0bd11c7a04a63d2785abd53363f09d552175d67d";
 
     omarchy = {
       url = "github:basecamp/omarchy/v4.0.2";
@@ -78,7 +73,6 @@
       nixpkgs,
       systems,
       home-manager,
-      hyprland,
       omarchy,
       zen-browser,
       ...
@@ -306,8 +300,21 @@
           src = omarchy;
           version = omarchyVersion;
           inherit nixarchyRev nixarchyDate;
-          # The compositor the Lua config is written against, not nixpkgs'.
-          inherit (hyprland.packages.${final.stdenv.hostPlatform.system}) hyprland;
+          # Why: docs/internals/flake.md#hyprland-comes-from-nixpkgs-because-nixpkgs-caught-up
+          # The compositor the Lua config is written against.
+          #
+          # nixpkgs', since it caught up: this was a separate flake input
+          # pinned to a hyprwm commit because nixpkgs sat on 0.54.3 while
+          # Omarchy 4.x needs the Lua API that landed in 0.55. nixpkgs now
+          # ships the same version Arch does -- and Arch is what upstream
+          # Omarchy actually installs, since install/omarchy-base.packages
+          # names `hyprland` with no version at all.
+          #
+          # The pin was also unreachable by tooling: the rev lived in the
+          # input URL, so `nix flake update` could not move it and the nightly
+          # bump silently skipped it. Two weeks of drift looked exactly like
+          # none.
+          inherit (final) hyprland;
 
           # The desktop shell. nixpkgs' own, since #35: it was overridden to
           # 0.3.1 while nixpkgs sat on 0.3.0, whose session lock reaches

--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -614,20 +614,23 @@ in
     download-attempts = 1;
   }
   // {
-    # The same two caches install.sh already knows about and modules/nixos.nix
+    # The same caches install.sh already knows about and modules/nixos.nix
     # gives every installed machine. They are not a nicety here: CI builds
     # checks.reference-toplevel inside a cachix job, so the whole 15.3 GiB
     # desktop is on nixarchy.cachix.org. Without these the install still
-    # succeeds and takes hours, because it compiles Hyprland.
+    # succeeds and takes hours.
+    #
+    # hyprland.cachix.org is gone with the flake input it existed for. It
+    # served hyprwm's own build of the compositor, which only substituted
+    # while this flake took their nixpkgs unmodified; Hyprland comes from
+    # nixpkgs now, so cache.nixos.org has it.
     substituters = [
       "https://cache.nixos.org"
       "https://nixarchy.cachix.org"
-      "https://hyprland.cachix.org"
     ];
     trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
       "nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM="
-      "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE="
     ];
   };
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -44,10 +44,10 @@ NIX_FLAGS=(--extra-experimental-features "nix-command flakes")
 
 # The live ISO's nix.conf knows only cache.nixos.org. programs.nixarchy.binaryCaches
 # applies to the installed system, not to the installer's own daemon, so without
-# these the first install compiles Hyprland from source. Keys copied from
-# nix.settings in modules/nixos.nix -- do not retype them.
-SUBSTITUTERS="https://nixarchy.cachix.org https://hyprland.cachix.org"
-TRUSTED_KEYS="nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM= hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE="
+# this the first install builds the whole vendored tree from source. Key copied
+# from nix.settings in modules/nixos.nix -- do not retype it.
+SUBSTITUTERS="https://nixarchy.cachix.org"
+TRUSTED_KEYS="nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM="
 
 # ...unless we are the offline image, which carries the whole closure.
 #

--- a/installer/vm.nix
+++ b/installer/vm.nix
@@ -45,16 +45,14 @@
       "flakes"
     ];
     # The same caches the installer passes to nixos-install, so a run here is
-    # not an hour of compiling Hyprland.
+    # not an hour of building the desktop.
     substituters = [
       "https://cache.nixos.org"
       "https://nixarchy.cachix.org"
-      "https://hyprland.cachix.org"
     ];
     trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
       "nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM="
-      "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE="
     ];
   };
 

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -59,7 +59,6 @@ let
 in
 {
   imports = [
-    inputs.hyprland.nixosModules.default
     (import ./apps.nix inputs)
     ./local-ai.nix
     ./fleet.nix
@@ -259,8 +258,9 @@ in
       type = lib.types.bool;
       default = true;
       description = ''
-        Add nixarchy.cachix.org and hyprland.cachix.org as substituters.
-        Without them, enabling nixarchy means compiling a compositor.
+        Add nixarchy.cachix.org as a substituter. It carries the vendored
+        Omarchy tree and the packages this flake builds itself; without it,
+        enabling nixarchy means building all of them locally.
 
         This is the one thing here that changes a machine without any chance
         of a conflict to warn you: substituters and trusted-public-keys are
@@ -431,7 +431,12 @@ in
         message = ''
           Nixarchy needs Hyprland >= 0.55 for the Lua config API that
           Omarchy 4.x is written against (hl.bind / hl.window_rule / hl.on).
-          Use inputs.hyprland's package, not nixpkgs'.
+
+          The compositor comes from nixpkgs. If this fires, the nixpkgs pin
+          has gone backwards or programs.hyprland.package has been overridden
+          with something older; check what upstream Omarchy installs, which is
+          whatever Arch ships -- install/omarchy-base.packages names
+          `hyprland` with no version.
         '';
       }
     ];
@@ -447,9 +452,11 @@ in
         "flakes"
       ];
 
-      # hyprland.cachix.org covers Hyprland when the pinned commit is one
-      # hyprwm built; nixarchy.cachix.org covers it when it is not, plus the
-      # vendored Omarchy tree and the packages this flake builds itself.
+      # nixarchy.cachix.org covers the vendored Omarchy tree and the packages
+      # this flake builds itself. Hyprland is not among them: it comes from
+      # nixpkgs now, so cache.nixos.org serves it and hyprland.cachix.org --
+      # which only ever helped because the compositor came from hyprwm's own
+      # flake, unmodified -- has nothing left to offer.
       #
       # Behind an option rather than mkForce: these are lists, so they merge
       # into a user's existing trust with no conflict and no warning, which
@@ -457,11 +464,9 @@ in
       # silently. See programs.nixarchy.binaryCaches.
       substituters = lib.mkIf cfg.binaryCaches [
         "https://nixarchy.cachix.org"
-        "https://hyprland.cachix.org"
       ];
       trusted-public-keys = lib.mkIf cfg.binaryCaches [
         "nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM="
-        "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE="
       ];
     };
 
@@ -490,9 +495,13 @@ in
         # means lib.mkForce, which is the honest signal for replacing the
         # compositor an entire desktop is written against.
         enable = true;
-        package = inputs.hyprland.packages.${pkgs.stdenv.hostPlatform.system}.hyprland;
-        portalPackage =
-          inputs.hyprland.packages.${pkgs.stdenv.hostPlatform.system}.xdg-desktop-portal-hyprland;
+        # `package` and `portalPackage` are deliberately NOT set. They used to
+        # point at a hyprland flake input pinned to a hyprwm commit, because
+        # nixpkgs sat on 0.54.3 and Omarchy 4.x needs the Lua API from 0.55.
+        # nixpkgs caught up and passed it, so the override became a way to
+        # ship something OLDER than the default -- and older than what Arch,
+        # and therefore upstream Omarchy, actually installs. The assertion
+        # above still holds the floor at 0.55.
         # Omarchy's session and its user units are started through uwsm.
         withUWSM = true;
       };

--- a/tests/review-pins.nix
+++ b/tests/review-pins.nix
@@ -98,7 +98,12 @@ pkgs.runCommand "nixarchy-review-pins"
 
     # One of each shape, because the review asks a different question of each
     # and a classifier that has collapsed to one answer is the bug.
-    for want_line in "omarchy	tag" "hyprland	rev" "nixpkgs	ref"; do
+    # sops-nix is the `rev` example rather than hyprland, which used to be
+    # pinned by commit and is now taken from nixpkgs. That swap is the whole
+    # reason this loop names three specific inputs instead of counting shapes:
+    # when one disappears the check fails loudly, rather than quietly testing
+    # two shapes and calling it three.
+    for want_line in "omarchy	tag" "sops-nix	rev" "nixpkgs	ref"; do
       name=''${want_line%%	*}
       kind=''${want_line##*	}
       got=$(grep -E "^$name	" pins-flake.txt | cut -f2)


### PR DESCRIPTION
There is no `hyprland` input any more. `programs.hyprland.package` is left unset so nixpkgs' own module decides, and the overlay passes `final.hyprland` to `pkgs/omarchy`.

## The pin's reason expired

It was a separate flake input pinned to a hyprwm commit, justified in `docs/internals/flake.md` by *"Omarchy 4.x configures Hyprland through the Lua API that landed in 0.55; nixpkgs is still on 0.54.3."* Measured today:

| | version |
|---|---|
| the pin | 0.56.0, dated 2026-08-24 |
| **nixpkgs** | **0.56.2** |
| **Arch `extra`** | **0.56.2-2** |

**Arch is what upstream Omarchy actually installs.** `install/omarchy-base.packages` names `hyprland` with **no version at all** — zero version pins in the entire file — so "the Hyprland Omarchy uses" is whatever Arch shipped the day someone ran the installer. Tracking nixpkgs tracks the same thing.

The override had quietly become a way to ship something **older** than the default.

## The pin was invisible to everything meant to catch drift

- its revision lived in the **input URL**, so `nix flake update` could not move it and the nightly bump skipped it silently
- `nix run .#review` watches six pins; hyprland was not among them, and `checks.review-pins` asserts that list

Two weeks of drift looked exactly like none. It would look the same at two years.

## `hyprland.cachix.org` goes with it

Removed from `flake.nix`'s `nixConfig`, `modules/nixos.nix`, `installer/cd.nix`, `installer/vm.nix`, `install.sh`, and the two `Add hyprland binary cache` steps CI wrote into `/etc/nix/nix.conf`.

That cache only ever substituted because this flake took hyprwm's nixpkgs **unmodified** — their own request, and the reason `inputs.nixpkgs.follows` was deliberately not set on it. Verified before removing anything:

| | `hyprland.cachix.org` | `cache.nixos.org` |
|---|---|---|
| the old pin, 0.56.0 | ✅ | ❌ |
| nixpkgs' 0.56.2 | — | ✅ |

Neither is ever built; the compositor is a download either way. This just stops us maintaining a second cache and a CI workaround for it.

## What the checks caught

`checks.review-pins` failed, correctly: it asserts **one pin of each shape** (`tag` / `rev` / `ref`) and used `hyprland` as its `rev` example. It now names `sops-nix`, with a comment recording why the loop names three specific inputs rather than counting shapes — so the next disappearance also fails loudly instead of testing two shapes and calling it three.

## Verification

| | |
|---|---|
| `reference` and `iso` | **0.56.2** |
| `flake.lock` | −468 lines; a dozen transitive `hypr*` inputs gone |
| no references to `inputs.hyprland` remain | confirmed by grep |
| `options`, `review-pins`, `doc-options`, `installer-ui`, `patched-files`, `config-delta` | **RC=0** |
| `statix`, `nix fmt -- --ci` | clean |
| every `# Why:` pointer still resolves | checked after renaming home-manager's anchor |

The `>= 0.55` assertion stays — the Lua API is a requirement, not a preference. Its message no longer says *"use inputs.hyprland's package"*, which is now backwards.

## One thing deliberately left

`tests/install-iso-net.nix` still serves `hyprland.cachix.org` as an nginx alias and a fake DNS entry in its offline-cache simulation. It asserts nothing about it, and that check runs on a self-hosted runner I cannot exercise locally — so removing a name from a test I can't run is a worse trade than leaving a harmless alias. Worth tidying by someone who can run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
