### PR TITLE
OpenCode in the catalogue, and a default agent that reproduces

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | **`nixarchy` command** | this port's own commands, and a way through to Omarchy's 431 |
 | **Remove menu** | deselects apps, never touches your own config |
 | **Update menu** | `nh os switch --update <flake>` |
-| 59 apps in the selection | 45 from nixpkgs, 4 as NixOS modules, 8 built here, 2 with no equivalent |
+| 60 apps in the selection | 46 from nixpkgs, 4 as NixOS modules, 8 built here, 2 with no equivalent |
 | Learn menu | NixOS wiki, `search.nixos.org` packages and options |
 | Shell functions | bash and zsh source the chain; fish derives it from the same files |
 | RetroArch | 13 libretro cores, resolved from the store rather than `/usr/lib` |
@@ -1390,7 +1390,7 @@ done
 
 Almost nothing here waits on a maintainer.
 
-**49 of the 59 apps never touch this repo.** Brave, VSCode, Signal and the rest
+**50 of the 60 apps never touch this repo.** Brave, VSCode, Signal and the rest
 are installed as `pkgs.<name>` from **your** nixpkgs, and the five
 module-backed ones (Steam, 1Password, Tailscale, Firefox, Xbox controllers)
 come from there too — the module is NixOS', not this repo's. Your own
@@ -1449,7 +1449,7 @@ Most of it is not our job, and should not be:
 
 | where the app comes from | who updates it |
 |---|---|
-| nixpkgs (49 of 59 apps) | **nobody** — your own `nix flake update` |
+| nixpkgs (50 of 60 apps) | **nobody** — your own `nix flake update` |
 | pinned in this repo (2) | a nightly bot, opening a PR |
 | `zen` | upstream's own flake |
 | `retroarch` | nixpkgs, via this flake's own pin — it is a rebuild with cores |

--- a/data/apps.nix
+++ b/data/apps.nix
@@ -361,6 +361,18 @@
     # Apache-2.0. Not unfree, unlike the ChatGPT desktop app above, which is a
     # different piece of software from the same vendor.
   };
+
+  opencode = {
+    label = "OpenCode";
+    category = "AI";
+    attr = "opencode";
+    # Absent from this catalogue until now, which was an oversight rather than
+    # a decision: omarchy-default-agent already maps `opencode` to this exact
+    # attribute and installs it through nixarchy-pkg-add, and
+    # programs.nixarchy.localAi installs it too. It was reachable both ways and
+    # listed in neither menu -- the only agent in the tree that could not be
+    # browsed to, and the one modules/local-ai.nix calls "the better agent".
+  };
   gemini-cli = {
     label = "Gemini CLI";
     category = "AI";

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -808,6 +808,33 @@ in
           (pkgs.extend inputs.self.overlays.default).nixarchy-doctor
           (pkgs.extend inputs.self.overlays.default).nixarchy-verify
 
+        ]
+        # The default agent's own package, when the configuration names one.
+        #
+        # ids and attributes are omarchy-default-agent's `attr_for`, kept in
+        # step by hand. That command installs an agent through nixarchy-pkg-add
+        # when someone picks one from the menu; this is the same decision made
+        # in the configuration instead, so it reproduces on the next machine.
+        #
+        # `claude-code` is unfree, so defaultAgent = "claude" without
+        # programs.nixarchy.allowUnfree fails to evaluate with nixpkgs' own
+        # message naming the package. That is the right failure: the
+        # alternative is a missing agent and an Ask menu that never appears.
+        ++
+          lib.optional (cfg.defaultAgent != null)
+            {
+              # Three of the seven are named after their own command, which is
+              # the whole reason omarchy-agent can look for `$agent` on PATH.
+              inherit (pkgs) codex opencode crush;
+
+              claude = pkgs.claude-code;
+              gemini = pkgs.gemini-cli;
+              copilot = pkgs.github-copilot-cli;
+              grok = pkgs.grok-cli;
+            }
+            .${cfg.defaultAgent}
+        ++ [
+
           # Why: modules/AGENTS.md#uncomments-one-app-in-config-nixarchy-apps-nix
           (pkgs.writeShellApplication {
             name = "nixarchy-catalogue-diff";

--- a/modules/home.nix
+++ b/modules/home.nix
@@ -36,6 +36,11 @@ let
   }
   // (osConfig.programs.nixarchy.localAi or { });
 
+  # The coding agent the menu treats as default, when the configuration names
+  # one. Null on a standalone home-manager user, exactly like localAi above:
+  # there is no NixOS module to have set it.
+  defaultAgent = osConfig.programs.nixarchy.defaultAgent or null;
+
   # Same shape as localAi just above: declared on the NixOS side
   # (modules/services/boxes.nix), because `machines` names containers that
   # should exist regardless of which user's home-manager config is reading
@@ -581,6 +586,38 @@ in
         exec ${cfg.package}/bin/omarchy-cursor-set
       '';
     };
+
+    # The default agent, recorded where omarchy-agent and the menu read it.
+    #
+    # ~/.config/omarchy/defaults/agent is upstream's file, written by
+    # omarchy-default-agent when someone picks an agent from the menu. That
+    # makes the choice imperative: it does not survive a reinstall and does not
+    # travel to the next machine, which is the one thing this project exists to
+    # replace.
+    #
+    # Written on every activation rather than seeded once, and the difference
+    # matters: the option is the configuration's answer to "which agent", and a
+    # menu click that outlived a rebuild would be a second answer with no
+    # record. The menu still works -- it writes this file and takes effect
+    # immediately -- it just does not outlive the next rebuild on a machine
+    # that has declared one. programs.nixarchy.defaultAgent says so.
+    #
+    # Not an xdg.configFile, for the same reason the opencode provider below is
+    # not: a read-only symlink here would make omarchy-default-agent fail at
+    # the moment someone clicks the menu, which is worse than being overwritten
+    # later.
+    home.activation.nixarchyDefaultAgent = lib.mkIf (defaultAgent != null) (
+      lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        agentfile="''${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/defaults/agent"
+        run mkdir -p "$(dirname "$agentfile")"
+
+        # Temp file and move, so an interrupted activation cannot leave the
+        # menu reading half an agent name and launching nothing.
+        tmp=$(${pkgs.coreutils}/bin/mktemp)
+        printf '%s\n' ${lib.escapeShellArg defaultAgent} > "$tmp"
+        run mv "$tmp" "$agentfile"
+      ''
+    );
 
     # Why: modules/AGENTS.md#provider-files-for-the-local-model-when-the-system
     home.activation.nixarchyOpencodeProvider =

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -289,6 +289,43 @@ in
       '';
     };
 
+    defaultAgent = lib.mkOption {
+      type = lib.types.nullOr (
+        lib.types.enum [
+          "claude"
+          "codex"
+          "opencode"
+          "crush"
+          "gemini"
+          "copilot"
+          "grok"
+        ]
+      );
+      default = null;
+      example = "opencode";
+      description = ''
+        Which coding agent this machine's Omarchy menu treats as the default:
+        the one `omarchy-agent` launches, and the one the Ask menu's whole
+        group is gated on.
+
+        Setting this installs the agent and records the choice, so it survives
+        a rebuild and travels to the next machine installed from this flake.
+        Without it the choice exists only in
+        `~/.config/omarchy/defaults/agent`, written by the menu at runtime --
+        which is the one thing this project exists to replace.
+
+        The menu still works and still writes that file, so a machine can be
+        changed at a prompt. This option is authoritative on the next
+        activation: the configuration is the source of truth, and a menu click
+        that outlived a rebuild would be a second, invisible one.
+
+        The ids match `omarchy-default-agent`'s. Absent from the list are `pi`,
+        `omp` and `antigravity`, which nixpkgs has no package for -- that
+        command falls back to mise for those, and an imperative install is not
+        something an option should promise to reproduce.
+      '';
+    };
+
     bootSplash = lib.mkOption {
       type = lib.types.enum [
         "defer"


### PR DESCRIPTION
Two gaps, one small and one that matters.

## OpenCode was reachable two ways and listed in neither menu

`data/apps.nix` had no `opencode` entry — an oversight rather than a decision. `omarchy-default-agent` already maps `opencode` to that exact nixpkgs attribute and installs it through `nixarchy-pkg-add`, and `programs.nixarchy.localAi` installs it too. So it was installable by two paths and browsable by none: the only agent in the tree you couldn't find in Install → AI, and the one `modules/local-ai.nix` calls *"the better agent"*.

Now in the catalogue beside Claude Code, Codex and Gemini CLI.

## The default agent did not reproduce

Which agent is default lived **only** in `~/.config/omarchy/defaults/agent`, written by the menu at runtime. It did not survive a reinstall and did not travel to the next machine — the one thing this project exists to replace.

```nix
programs.nixarchy.defaultAgent = "opencode";
```

Setting it installs that agent and records the choice on every activation, so a machine installed from this flake comes up with the agent its configuration asked for.

| id | nixpkgs attr | | id | nixpkgs attr |
|---|---|---|---|---|
| `claude` | `claude-code` | | `copilot` | `github-copilot-cli` |
| `codex` | `codex` | | `grok` | `grok-cli` |
| `opencode` | `opencode` | | `gemini` | `gemini-cli` |
| `crush` | `crush` | | | |

The ids and attributes are `omarchy-default-agent`'s own `attr_for`, kept in step by hand — and three of the seven are named after their own command, which is why that command can look for `$agent` on `PATH` at all.

`pi`, `omp` and `antigravity` are **deliberately absent**: nixpkgs has no package for them, that command falls back to `mise`, and an imperative install is not something an option should promise to reproduce.

## Two decisions worth stating

**Written on every activation, not seeded once.** The option is the configuration's answer to "which agent", and a menu click that outlived a rebuild would be a second answer with no record. The menu still works and still takes effect immediately; it just does not outlive the next rebuild on a machine that has declared one. The option's description says so, rather than leaving someone to discover it.

**Not an `xdg.configFile`**, for the same reason the opencode provider beside it is not: a read-only symlink would make `omarchy-default-agent` fail at the moment someone clicks the menu, which is worse than being overwritten later. Temp file and move, so an interrupted activation cannot leave the menu reading half an agent name.

`claude-code` is unfree, so `defaultAgent = "claude"` without `programs.nixarchy.allowUnfree` fails to evaluate with nixpkgs' own message naming the package. That is the right failure — the alternative is a missing agent and an Ask menu that never appears, since `trigger.ask` is gated on a default agent being set.

## What already existed, for the reviewer

The menu row is upstream's and was already vendored (`setup.default.agent.opencode`), and nixarchy already replaces upstream's `omarchy-default-agent` — whose header documents three real failures of upstream's `mise use -g` path. This PR does not touch either. It adds the catalogue entry and the declarative option they were missing.

## Verification

| | |
|---|---|
| all seven attributes exist in the pin | `claude-code` 2.1.260, `codex` 0.151.0, `opencode` 1.18.28, `crush` 0.91.2, `gemini-cli` 0.47.0, `github-copilot-cli` 1.0.61, `grok-cli` 0.0.33 |
| `opencode` lands in `systemPackages` when set | **YES** |
| absent when unset | **correct** |
| the activation writes `opencode` | confirmed in the generated script |
| `options`, `doc-options`, `config-delta`, `installer-ui`, `review-pins` | **RC=0** |
| `statix`, `nix fmt -- --ci` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
