### PR TITLE
box-boot recognises distrobox's third way of failing offline

### DIFF
--- a/tests/box-boot.nix
+++ b/tests/box-boot.nix
@@ -129,6 +129,8 @@ pkgs.testers.runNixOSTest {
     #   "could not start entrypoint"  init aborted, and enter reports it
     #   "Error: An error occurred"    init died earlier, inside its
     #                                 "Installing basic packages" step
+    #   "Container Setup Failure!"    the container stopped while enter was
+    #                                 waiting for setup to finish
     #
     # Pinning only the first made this check flaky. On 2026-09-05 it went red
     # on a pull request that touched nothing but a workflow file, while
@@ -145,9 +147,24 @@ pkgs.testers.runNixOSTest {
     # failure mode -- or a silent one -- still goes red and gets read by a
     # person, which is what the original assertion was for.
     out = machine.fail(alice("distrobox enter scratch -- true 2>&1"), timeout=600)
+    # The third arrived on 2026-09-07, on main, with nothing in this repo
+    # touching distrobox. distrobox-enter:729 prints it from the poll loop it
+    # runs after "Starting container...": if the container is not `running`
+    # when it looks, it says so and exits 1. Which of the three you get is the
+    # same race the comment above describes -- how far init got before it
+    # needed a network -- so this is a third correct outcome, not a new bug.
+    #
+    # Verified as distrobox's own words rather than assumed:
+    #   distrobox-1.8.2.5/bin/distrobox-enter:729
+    #     printf >&2 "\nContainer Setup Failure!\n"
+    #
+    # The allowlist earned itself here. A truthiness check would have passed
+    # silently on a message nobody had ever seen; instead this went red on
+    # main and got read.
     aborts = [
         "could not start entrypoint",
         "Error: An error occurred",
+        "Container Setup Failure!",
     ]
     assert any(a in out for a in aborts), (
         "offline first enter failed in a way this check does not recognise.\n"


### PR DESCRIPTION
`checks.box-boot` went red on `main`:

```
AssertionError: offline first enter failed in a way this check does not recognise.
  Expected one of: ['could not start entrypoint', 'Error: An error occurred']
  Got:
  Starting container...
  Container Setup Failure!
```

Nothing in this repo touches distrobox. This is a **third** loud, named failure from the same race the check already documents — how far `distrobox-init` got before it needed a network it does not have.

Read out of the package rather than inferred:

```
distrobox-1.8.2.5/bin/distrobox-enter:729
  printf >&2 "\nContainer Setup Failure!\n"
```

It comes from the poll loop `distrobox-enter` runs after printing `Starting container...`: if the container is not `running` when it looks, it says so and exits 1.

The property the check exists for is unchanged and still holds — **the failure is loud and named, not a hang and not a half-initialised shell.** `machine.fail` already proves a non-zero exit; this proves the user was told something.

## Why it stays an allowlist

Worth stating, because it's the argument for the shape of this check: **the allowlist earned itself here.** A truthiness check — "it failed with *some* message" — would have passed silently on wording nobody had ever seen. Instead it went red on `main` and a person read it, which is exactly what the comment above the assertion promised would happen:

> *"so a genuinely new failure mode — or a silent one — still goes red and gets read by a person, which is what the original assertion was for."*

## Verification

`statix` and `nix fmt -- --ci` clean. `box-boot` is a VM test on a self-hosted runner, so CI is the place it actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5