### PR TITLE
Teach the USB path with no trap in it

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,23 +924,37 @@ sudo dd if=nixarchy.iso of=/dev/sdX bs=4M status=progress oflag=sync
 `--ignore-missing` because one `SHA256SUMS` covers both images and nobody
 downloads both.
 
-**From Windows**, take the network image instead — it is one file and needs no
-reassembly. If you want the offline one, join the parts with `copy /b`, and the
-`/b` is load-bearing: without it `copy` treats them as text and truncates at
-the first `0x1A` byte, leaving an image that looks complete and is not.
+### Writing the stick from Windows or macOS
+
+**Use [balenaEtcher](https://etcher.balena.io/), and take the network image.**
+That combination has no wrong answer in it: Etcher only ever writes an image
+byte-for-byte -- no filesystem to choose, no partition scheme, no mode prompt --
+and the network image is one file that needs no reassembly.
+
+If you want the offline image on Windows, join the parts first. The `/b` is
+load-bearing: without it `copy` treats them as text and stops at the first
+`0x1A` byte, leaving a file that looks complete and is not.
 
 ```
 copy /b PART-aa + PART-ab + PART-ac + PART-ad nixarchy.iso
 certutil -hashfile nixarchy.iso SHA256
 ```
 
-substituting the real names — they carry the version, so
-`nixarchy-v4.0.2-10.iso.part-aa` and so on — and comparing the hash against
-`SHA256SUMS` by eye, since `certutil` does not check a sums file for you.
+substituting the real names, and comparing that hash against `SHA256SUMS`
+yourself -- `certutil` will not read a sums file for you.
 
-Then write it with **Rufus in DD Image mode** — read the next caveat before
-you press START, because Rufus's *recommended* answer is the one that breaks
-this — or with balenaEtcher, which never asks.
+**If you use Rufus instead**, it will ask one question and its recommended
+answer is the wrong one here; the next caveat explains why. Choose **DD Image
+mode**.
+
+**Turn Secure Boot off** in your firmware before booting the stick. This
+project does not sign its bootloader, which is
+[a decision rather than an oversight](#status).
+
+**Keeping Windows on the same disk?** Free the space from inside Windows
+first, and read [the dual boot page](docs/manual/dual-boot-install.md) --
+it covers Shrink Volume, the 32 GiB floor the installer enforces, and why
+BitLocker has to come off before you start.
 
 Or build it yourself, which is the same image from the same commit:
 
@@ -1058,10 +1072,12 @@ default.** Rufus asks once:
 > This image is an ISOHybrid image … Write in ISO Image mode (Recommended)
 > / Write in DD Image mode
 
-**ISO Image mode is the default and it is the wrong answer here.** It copies
-the image's files onto a FAT32 partition and installs *Rufus's own* GRUB to
-boot them. That GRUB then tries to load this image's GRUB modules, cannot
-parse them, and stops with:
+**ISO Image mode is the default and it is the wrong answer here**, and the
+reason is a file size. The offline image contains one 5.8 GB file, the Nix
+store it installs from, which is larger than FAT32 can hold -- so ISO mode
+falls back to NTFS, and because UEFI firmware cannot boot NTFS, Rufus adds its
+own bootloader to chain-load from it. *That* bootloader then tries to load this
+image's GRUB modules, cannot parse them, and stops with:
 
 ```
 kern/x86_64/dl.c:grub_arch_dl_relocate_symbols:114:
@@ -1096,18 +1112,9 @@ it refuses rather than shrinking anything itself.
 Full-disk mode is one file, `installer/disk-config.nix`, run against the disk
 you name. Anything already there is gone.
 
-**Making that free space, from Windows**, before you boot the stick:
-
-1. **Disk Management** → right-click the Windows partition → **Shrink Volume**.
-2. Leave what it frees **unallocated**. Do not create a partition in it — the
-   installer looks for unallocated space, and a formatted partition is not it.
-3. Free at least **32 GiB contiguous**, or the first screen refuses with
-   `the largest free region on /dev/… is under 32 GiB`.
-4. Turn off **Fast Startup** (Control Panel → Power Options → *Choose what the
-   power buttons do*). With it on, shutting down hibernates instead, and the
-   partition table is not safely readable from another system.
-5. If the drive is **BitLocker**-encrypted, suspend protection before
-   repartitioning, or Windows asks for the recovery key on its next boot.
+Making that space is a Windows job and is done before you boot the stick:
+[the dual boot page](docs/manual/dual-boot-install.md) covers Shrink Volume,
+the 32 GiB floor, Fast Startup, and BitLocker.
 
 It is **UEFI only** — the layout is an ESP with systemd-boot, and there is no
 BIOS path.

--- a/README.md
+++ b/README.md
@@ -922,8 +922,25 @@ sudo dd if=nixarchy.iso of=/dev/sdX bs=4M status=progress oflag=sync
 ```
 
 `--ignore-missing` because one `SHA256SUMS` covers both images and nobody
-downloads both. `dd` — or Rufus in **DD mode**, or Etcher — and not a
-multiboot tool; see the caveat below for why the difference is not cosmetic.
+downloads both.
+
+**From Windows**, take the network image instead — it is one file and needs no
+reassembly. If you want the offline one, join the parts with `copy /b`, and the
+`/b` is load-bearing: without it `copy` treats them as text and truncates at
+the first `0x1A` byte, leaving an image that looks complete and is not.
+
+```
+copy /b PART-aa + PART-ab + PART-ac + PART-ad nixarchy.iso
+certutil -hashfile nixarchy.iso SHA256
+```
+
+substituting the real names — they carry the version, so
+`nixarchy-v4.0.2-10.iso.part-aa` and so on — and comparing the hash against
+`SHA256SUMS` by eye, since `certutil` does not check a sums file for you.
+
+Then write it with **Rufus in DD Image mode** — read the next caveat before
+you press START, because Rufus's *recommended* answer is the one that breaks
+this — or with balenaEtcher, which never asks.
 
 Or build it yourself, which is the same image from the same commit:
 
@@ -1035,10 +1052,16 @@ themselves current, is [many machines, one repo](docs/manual/many-machines.md).
 
 **Five caveats worth knowing before you write the stick.**
 
-**Write the image literally.** Ventoy, unetbootin, and "boot an ISO from my
-existing GRUB" all work by loading the ISO with *their* bootloader rather than
-the one on it. This image carries its own GRUB, and an older GRUB core trying
-to load its modules fails like this:
+**In Rufus, answer the ISOHybrid question with DD — not the recommended
+default.** Rufus asks once:
+
+> This image is an ISOHybrid image … Write in ISO Image mode (Recommended)
+> / Write in DD Image mode
+
+**ISO Image mode is the default and it is the wrong answer here.** It copies
+the image's files onto a FAT32 partition and installs *Rufus's own* GRUB to
+boot them. That GRUB then tries to load this image's GRUB modules, cannot
+parse them, and stops with:
 
 ```
 kern/x86_64/dl.c:grub_arch_dl_relocate_symbols:114:
@@ -1046,11 +1069,21 @@ kern/x86_64/dl.c:grub_arch_dl_relocate_symbols:114:
 Aborted. Press any key to exit.
 ```
 
-That number is not a real relocation type — they are small integers — which is
-what tells you the loader is reading modules it does not understand, rather
-than that the download is corrupt. Nothing is wrong with the image: it boots
-under UEFI when the firmware runs its own bootloader. `dd`, Rufus in DD mode,
-or Etcher all do that. Ventoy does not.
+`0x18d570` is not a relocation type — real ones are small integers, and
+`R_X86_64_64` is 1 — which is how you know the loader is reading modules from
+a different build rather than that the download is corrupt. **Nothing is wrong
+with the image.** It boots under UEFI whenever the firmware runs the
+bootloader that is on it.
+
+So: **DD Image mode**. The stick then looks empty or unreadable to Windows,
+which is correct. [balenaEtcher](https://etcher.balena.io/) never asks — it
+only does raw writes — so it is the safer choice if you would rather not have
+to catch a dialog. On Linux, `dd` as above.
+
+Anything that boots the image with its own loader fails the same way, for the
+same reason: **Ventoy**, unetbootin, YUMI, multiboot sticks, and "loopback
+this ISO" entries in an existing GRUB. Windows' own *Burn disc image* is for
+optical media and will not make a bootable stick at all.
 
 **It asks how to use the disk, and one of the answers erases it.** The first
 screen offers a free-space install -- it keeps what is already on the drive and
@@ -1062,6 +1095,19 @@ it refuses rather than shrinking anything itself.
 
 Full-disk mode is one file, `installer/disk-config.nix`, run against the disk
 you name. Anything already there is gone.
+
+**Making that free space, from Windows**, before you boot the stick:
+
+1. **Disk Management** → right-click the Windows partition → **Shrink Volume**.
+2. Leave what it frees **unallocated**. Do not create a partition in it — the
+   installer looks for unallocated space, and a formatted partition is not it.
+3. Free at least **32 GiB contiguous**, or the first screen refuses with
+   `the largest free region on /dev/… is under 32 GiB`.
+4. Turn off **Fast Startup** (Control Panel → Power Options → *Choose what the
+   power buttons do*). With it on, shutting down hibernates instead, and the
+   partition table is not safely readable from another system.
+5. If the drive is **BitLocker**-encrypted, suspend protection before
+   repartitioning, or Windows asks for the recovery key on its next boot.
 
 It is **UEFI only** — the layout is an ESP with systemd-boot, and there is no
 BIOS path.

--- a/README.md
+++ b/README.md
@@ -922,7 +922,8 @@ sudo dd if=nixarchy.iso of=/dev/sdX bs=4M status=progress oflag=sync
 ```
 
 `--ignore-missing` because one `SHA256SUMS` covers both images and nobody
-downloads both.
+downloads both. `dd` — or Rufus in **DD mode**, or Etcher — and not a
+multiboot tool; see the caveat below for why the difference is not cosmetic.
 
 Or build it yourself, which is the same image from the same commit:
 
@@ -1032,13 +1033,35 @@ install builds nothing, because everything it did is described there.
 Installing a second machine from that same repository, and letting them keep
 themselves current, is [many machines, one repo](docs/manual/many-machines.md).
 
-**Four caveats worth knowing before you write the stick.**
+**Five caveats worth knowing before you write the stick.**
 
-It takes **the whole drive**. There is no partition picker and there is not
-going to be one: the layout is one file, `installer/disk-config.nix`, and the
-installer runs it against the disk you name. Anything already there is gone.
-Sharing a disk with Windows means editing that file and running `disko` by hand
-first, which is a thing you can do and not a thing this walks you through.
+**Write the image literally.** Ventoy, unetbootin, and "boot an ISO from my
+existing GRUB" all work by loading the ISO with *their* bootloader rather than
+the one on it. This image carries its own GRUB, and an older GRUB core trying
+to load its modules fails like this:
+
+```
+kern/x86_64/dl.c:grub_arch_dl_relocate_symbols:114:
+  relocation 0x18d570 is not implemented yet
+Aborted. Press any key to exit.
+```
+
+That number is not a real relocation type — they are small integers — which is
+what tells you the loader is reading modules it does not understand, rather
+than that the download is corrupt. Nothing is wrong with the image: it boots
+under UEFI when the firmware runs its own bootloader. `dd`, Rufus in DD mode,
+or Etcher all do that. Ventoy does not.
+
+**It asks how to use the disk, and one of the answers erases it.** The first
+screen offers a free-space install -- it keeps what is already on the drive and
+takes only unallocated space, which is how you put this beside Windows -- and a
+full-disk install, which does exactly what it says. There is still no partition
+*editor*: free-space mode needs at least 32 GiB of contiguous unallocated space
+that you made beforehand, with Windows' own Disk Management or `gparted`, and
+it refuses rather than shrinking anything itself.
+
+Full-disk mode is one file, `installer/disk-config.nix`, run against the disk
+you name. Anything already there is gone.
 
 It is **UEFI only** — the layout is an ESP with systemd-boot, and there is no
 BIOS path.

--- a/README.md
+++ b/README.md
@@ -1096,10 +1096,23 @@ which is correct. [balenaEtcher](https://etcher.balena.io/) never asks — it
 only does raw writes — so it is the safer choice if you would rather not have
 to catch a dialog. On Linux, `dd` as above.
 
-Anything that boots the image with its own loader fails the same way, for the
-same reason: **Ventoy**, unetbootin, YUMI, multiboot sticks, and "loopback
-this ISO" entries in an existing GRUB. Windows' own *Burn disc image* is for
-optical media and will not make a bootable stick at all.
+Tools that boot the image with their own loader are a different question, and
+the honest answer is "sometimes". **Ventoy** does boot the offline image: a
+tester's install log shows `NIXARCHY_4_0_2` mounted at `/iso` from Ventoy's
+exfat partition, with the installer running and disko partitioning the disk.
+So it is not in the same category as the NTFS shim above, and this text used to
+say it was.
+
+It is still not what to reach for first. Ventoy, unetbootin, YUMI, multiboot
+sticks and "loopback this ISO" entries in an existing GRUB all interpose their
+own loader between the firmware and ours, which is one more thing that can
+differ between your machine and the one this was tested on -- and when it does
+go wrong it goes wrong at boot, before there is anything to read a log from.
+A raw write has no such layer. If Ventoy is already how you keep your sticks,
+it is reasonable to try; if you are choosing now, choose the raw write.
+
+Windows' own *Burn disc image* is for optical media and will not make a
+bootable stick at all.
 
 **It asks how to use the disk, and one of the answers erases it.** The first
 screen offers a free-space install -- it keeps what is already on the drive and


### PR DESCRIPTION
A tester's install died at:

```
kern/x86_64/dl.c:grub_arch_dl_relocate_symbols:114:
  relocation 0x18d570 is not implemented yet
```

He used **Rufus**, accepted its recommended answer, and lost. This PR removes the choice rather than warning about it.

## Why it happens — a file size, not a corrupt download

The offline image contains one **5.83 GiB** file, `nix-store.squashfs`. FAT32's per-file limit is 4 GiB. So Rufus's ISO mode falls back to **NTFS**, and because UEFI firmware cannot boot NTFS, Rufus adds **its own bootloader** to chain-load from it. *That* bootloader then tries to load this image's GRUB modules and cannot parse them.

`0x18d570` is not a relocation type — real ones are small integers — which is how you know it's a loader mismatch, not corruption. **Nothing is wrong with the image**: it boots under UEFI whenever the firmware runs the bootloader that's on it, which is every boot of it in this repo's testing.

## What upstream does — checked, not assumed

Omarchy has the same problem. Their ISO carries an offline pacman mirror inside the image, so it's large, which is why Rufus picks NTFS for theirs too. Their guidance names **balenaEtcher** and **caligula**, never Rufus, and a [discussion asking them to add Rufus instructions](https://github.com/omacom/omarchy/discussions/5871) has been open since May 2026.

There is nothing to copy. The thing they do right is **name a tool that cannot be got wrong**.

## So: Etcher and the net image, first

| | measured |
|---|---|
| offline ISO, largest file | **5.83 GiB** → forces NTFS → forces Rufus's shim |
| **net ISO, largest file** | **1.54 GiB** → **0 files over 4 GiB** → FAT32 works, no shim |

balenaEtcher has no filesystem dropdown, no partition scheme, and no ISO/DD prompt. The net image is one file needing no `copy /b`. Together there is no wrong answer available.

**This is where we can beat upstream rather than match it.** Omarchy's mirror is always inside the image; ours is a separate 1.6 GB download that fits FAT32 — and we were burying it under the 5.8 GB one.

Rufus stays documented for people who already have it, with **DD Image mode** and the reason.

## Two things this stops saying twice

- The Windows dual-boot steps I first added **already existed, better**, in `docs/manual/dual-boot-install.md` — which knows the installer *refuses* a free-space install on a BitLocker-held disk, which my version did not. Now a link.
- **Secure Boot** is already explained under Status as a deliberate decision, so the install section gets the practical line and a pointer, not a second explanation.

## And a correction the README needed anyway

It said *"It takes the whole drive. There is no partition picker and there is not going to be one… Sharing a disk with Windows means editing that file and running `disko` by hand first."*

Not true since free-space mode — the installer's **first** question offers it, and a dual-boot install through that path was driven by hand today on both images. Same audience as the GRUB error: two wrong instructions aimed at one person.

## Verification

- Sizes measured from the published `v4.0.2-8` images with `bsdtar`.
- `FREE_MIN_GIB=32` read out of `installer/install.sh`.
- Five caveats, counted. Both cross-links resolve.
- The README's app-count assertions still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5