### PR TITLE
"maybe ship iwctl?" -- no: with no netdev every wireless UI shows the same nothing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,6 +166,19 @@ jobs:
       - name: The doctor reads a GPU correctly
         run: nix build .#checks.x86_64-linux.doctor-graphics --print-build-logs
 
+      # The doctor's wireless rules. The install VM has a virtio NIC and no
+      # radio, so not one of the three no-wlan0 cases can occur there -- the
+      # same gap that let the no-VAAPI-driver branch ship unreachable (#352).
+      - name: The doctor tells the three no-wlan0 cases apart
+        run: nix build .#checks.x86_64-linux.doctor-wireless --print-build-logs
+
+      # That an installed machine carries firmware without depending on a virt
+      # probe, and can still refuse it. Every guest reports a virt type, so
+      # every install check takes the branch where this is false and the branch
+      # real users are on is the one nothing covers.
+      - name: Installed systems carry firmware, and can still refuse it
+        run: nix build .#checks.x86_64-linux.firmware-guard --print-build-logs
+
       # The `nix run #try` front door, on the machines it will actually meet:
       # no KVM, no kvm group, 1 GB of RAM, a tmpfs working directory, a
       # declined binary cache, a disk left by a ctrl-C'd install. Each must

--- a/flake.nix
+++ b/flake.nix
@@ -1131,6 +1131,12 @@
             pkgs = pkgsFor.${system};
           };
 
+          # Why: tests/firmware-guard.nix
+          firmware-guard = import ./tests/firmware-guard.nix {
+            inherit inputs;
+            pkgs = pkgsFor.${system};
+          };
+
           # Why: installer/AGENTS.md#try-nixarchy-sh
           try-nixarchy = import ./tests/try-nixarchy.nix {
             inherit inputs;

--- a/flake.nix
+++ b/flake.nix
@@ -1052,6 +1052,15 @@
             inherit (self.packages.${system}) doctor;
           };
 
+          # The same argument for the Wireless section, and a sharper one: the
+          # install VM has a virtio NIC and no radio, so none of the three
+          # no-wlan0 cases can occur there at all. Two users hit them in one
+          # week and neither could tell which they had.
+          doctor-wireless = import ./tests/doctor-wireless.nix {
+            pkgs = pkgsFor.${system};
+            inherit (self.packages.${system}) doctor;
+          };
+
           # The `try` front door's refusals, each driven with a stubbed
           # environment that lies about KVM, RAM, disk and the build plan.
           # Building tryApp is itself half the assertion: the app evaluates

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -1004,11 +1004,38 @@ in
       };
     };
 
-    # bin/omarchy-brightness-display-ddc talks to monitors over i2c
-    hardware.i2c.enable = lib.mkDefault true;
+    hardware = {
+      # bin/omarchy-brightness-display-ddc talks to monitors over i2c
+      i2c.enable = lib.mkDefault true;
 
-    # Why: modules/AGENTS.md#bluez-bluez-tools-and-bluez-utils-are-all-in
-    hardware.bluetooth.enable = lib.mkDefault true;
+      # Why: modules/AGENTS.md#bluez-bluez-tools-and-bluez-utils-are-all-in
+      bluetooth.enable = lib.mkDefault true;
+
+      # Wireless, Bluetooth and most graphics need a firmware blob, and this is
+      # the option that puts one on the machine.
+      #
+      # It reads as belonging in hardware-configuration.nix, and nominally it is:
+      # nixos-generate-config imports installer/scan/not-detected.nix, whose
+      # entire content is `enableRedistributableFirmware = lib.mkDefault true`.
+      # But it imports it only inside `if ($virt eq "none")` -- bare metal only,
+      # nixos-generate-config.pl:321. So the installed system's firmware depends
+      # on a generated import, and the generated import depends on a virt probe.
+      #
+      # That is untestable here by construction. Every guest we install into
+      # reports a virt type, so every VM check takes the branch where this is
+      # FALSE and no test can ever exercise the branch real users are on. The ISO
+      # sets it (installation-device.nix), which is worse rather than better: the
+      # installer has wifi and the machine it installs may not, and the report
+      # that arrives is "it worked during the install".
+      #
+      # Redistributable, not All: this needs no allowUnfree and is what a desktop
+      # wants. hardware.enableAllFirmware adds b43, brcm, facetimehd and the Xbox
+      # dongles for ~2 MB more and does need it, so the doctor's Wireless section
+      # names it per-card instead of it being turned on for everyone.
+      #
+      # mkDefault, so an adopter who has a reason to ship no blobs still wins.
+      enableRedistributableFirmware = lib.mkDefault true;
+    };
 
     # Why: modules/AGENTS.md#our-own-splash-in-the-theme-directory-upstreams-oc
     users.users = lib.optionalAttrs (cfg.user != null) {

--- a/pkgs/doctor.sh
+++ b/pkgs/doctor.sh
@@ -710,6 +710,102 @@ elif [ -n "$igpu" ]; then
   finding "Single $igpu GPU" "$ok" "no hybrid setup needed"
 fi
 
+# ---- wireless ------------------------------------------------------------
+# Two users in one week could not see wlan0 at all -- not in nmtui, not after
+# rfkill unblock, not after restarting NetworkManager. One asked whether we
+# should ship iwctl. We should not, and that is the point of this section: if
+# there is no netdev, every wireless UI shows the same nothing, because they
+# all ask the kernel and the kernel has no interface to give. iwctl would have
+# been a second way to see the same absence, and the hour spent installing it
+# is an hour not spent on the driver.
+#
+# So the question worth answering is not "which tool" but "which of the three
+# is it": no PCI device, a device with no driver bound, or a driver bound with
+# no interface. Those have three different fixes and the user cannot tell them
+# apart from nmtui. sysfs can, and it is the same walk the Graphics section
+# above already does.
+say "${bold}Wireless${off}"
+
+# A wireless netdev is any interface with a `wireless` directory -- cfg80211
+# creates it for every driver that registers a wiphy, so this is the one test
+# that does not need a vendor table.
+: "${NIXARCHY_SYSFS_NET:=/sys/class/net}"
+wlan=""
+for n in "$NIXARCHY_SYSFS_NET"/*/; do
+  [ -d "$n/wireless" ] || [ -e "$n/phy80211" ] || continue
+  wlan="$(basename "$n")"
+  break
+done
+
+# PCI class 0x0280 is "network controller, other", which is where wifi lives.
+# 0x0200 is ethernet and is not this section's problem. The driver symlink is
+# the load-bearing part: present means a module claimed the card, absent means
+# this kernel has nothing for it.
+wifi_vendor="" wifi_id="" wifi_bound=""
+for d in "$NIXARCHY_SYSFS_PCI"/*/; do
+  [ -r "$d/class" ] && [ -r "$d/vendor" ] || continue
+  case "$(cat "$d/class")" in 0x0280*) ;; *) continue ;; esac
+  wifi_vendor="$(cat "$d/vendor")"
+  [ -r "$d/device" ] && wifi_id="$(cat "$d/device")"
+  [ -e "$d/driver" ] && wifi_bound="$(basename "$(readlink -f "$d/driver")")"
+  break
+done
+
+# Only the vendors whose fix DIFFERS. Intel, MediaTek and Atheros ship their
+# firmware in the redistributable set the ISO already enables, so naming them
+# is how the user learns their card is not the problem. Broadcom and Realtek
+# are the two that need something the default does not give, and they need
+# different somethings -- which is the whole reason this is a table and not a
+# sentence.
+case "$wifi_vendor" in
+  0x8086) wifi_make="Intel" ;;
+  0x14e4) wifi_make="Broadcom" ;;
+  0x10ec) wifi_make="Realtek" ;;
+  0x14c3) wifi_make="MediaTek" ;;
+  0x168c | 0x1969 | 0x17cb) wifi_make="Qualcomm/Atheros" ;;
+  0x1814) wifi_make="Ralink" ;;
+  "") wifi_make="" ;;
+  *) wifi_make="PCI vendor $wifi_vendor" ;;
+esac
+
+if [ -n "$wlan" ]; then
+  finding "Wireless interface $wlan is up" "$ok" "${wifi_make:+$wifi_make, }driver ${wifi_bound:-in-kernel}"
+elif [ -z "$wifi_vendor" ]; then
+  # Says nothing about USB dongles on purpose. This walks PCI, so a USB card
+  # is invisible here, and "you have no wifi card" would be a confident wrong
+  # answer on a machine that has one on the other bus.
+  say "  ${dim}No PCI wireless card here. A desktop, a VM, or a USB adapter --"
+  say "  which this check does not see, because it reads the PCI bus.${off}"
+elif [ -z "$wifi_bound" ]; then
+  finding "A $wifi_make wireless card with no driver" "$warn" "device $wifi_id"
+  say "     Nothing in this kernel claimed it, so no interface exists and every"
+  say "     wireless tool -- nmtui, iwctl, wpa_cli -- will show the same nothing."
+  case "$wifi_make" in
+    Broadcom)
+      notes+=("Broadcom wireless needs firmware outside the redistributable set. hardware.enableAllFirmware pulls in b43 and brcm, and needs nixpkgs.config.allowUnfree. Older BCM43xx cards want boot.extraModulePackages = [ config.boot.kernelPackages.broadcom_sta ] instead, and that one conflicts with b43 -- pick one.")
+      snippet+=("  hardware.enableAllFirmware = true; # Broadcom wireless; needs allowUnfree")
+      ;;
+    Realtek)
+      notes+=("Several Realtek cards (8821CE, 8852BE, 8852BU) have no in-tree driver and need an out-of-tree module. nixpkgs packages them under config.boot.kernelPackages -- rtl8821ce, rtl8852bu, rtw88 -- and which one is right depends on device $wifi_id, not on the vendor.")
+      snippet+=("  # boot.extraModulePackages = [ config.boot.kernelPackages.rtl8821ce ]; # match to $wifi_id")
+      ;;
+    *)
+      notes+=("A $wifi_make card with no driver bound usually means the module is newer than this kernel. boot.kernelPackages is already linuxPackages_latest here, so the next nixpkgs bump is the fix, and journalctl -b -k will name the module it wanted.")
+      ;;
+  esac
+else
+  # Driver bound, no interface: the module loaded and then failed, and on
+  # wireless that is almost always the firmware blob it asked for and did not
+  # get. dmesg says exactly which file, which beats any guess this can make.
+  finding "$wifi_make driver $wifi_bound loaded, but no interface" "$warn" "device $wifi_id"
+  say "     The module claimed the card and then did not register an interface."
+  say "     That is nearly always a missing firmware file, and the kernel log"
+  say "     names it:"
+  say "       journalctl -b -k | grep -i firmware"
+  notes+=("$wifi_bound bound but registered no wiphy. If the log names a file the redistributable firmware set does not carry, hardware.enableAllFirmware = true (with nixpkgs.config.allowUnfree) is the next thing to try; if it names a file NEWER than nixpkgs' linux-firmware, only a nixpkgs bump fixes it.")
+fi
+say ""
+
 # ---- what a laptop or a shared machine will want to know ----------------
 say "${bold}Worth turning on${off}"
 if [ -d /sys/class/bluetooth ] && [ -n "$(ls -A /sys/class/bluetooth 2>/dev/null)" ]; then

--- a/tests/doctor-wireless.nix
+++ b/tests/doctor-wireless.nix
@@ -1,0 +1,137 @@
+{ pkgs, doctor }:
+# The doctor's Wireless section, driven against fixture machines.
+#
+# Written because two users in one week reported the same thing -- no wlan0 in
+# nmtui, rfkill unblocked, NetworkManager restarted -- and one of them asked
+# whether nixarchy should ship iwctl. It should not: with no netdev, iwctl
+# shows the same nothing nmtui does, because both ask the kernel and the kernel
+# has no interface to give. The section exists to say WHICH of the three cases
+# it is, and this test exists because none of the three can occur in a VM.
+#
+# checks.install's guest has a virtio NIC and no wireless anything, so every
+# branch here would otherwise be untested -- the shape that let the doctor's
+# no-VAAPI-driver branch ship unreachable (#352).
+#
+# Fixtures are real device ids: 0x8086/0x2725 is Intel AX200, 0x14e4/0x43a0 a
+# Broadcom BCM4360, 0x10ec/0xc821 a Realtek 8821CE -- the three cards behind
+# the overwhelming majority of "no wlan0 on NixOS" reports.
+pkgs.runCommand "nixarchy-doctor-wireless" { nativeBuildInputs = [ pkgs.gnugrep ]; } ''
+  # <root> <addr> <vendor> <device> [driver]
+  wifi() {
+    mkdir -p "$1/$2"
+    echo 0x028000 > "$1/$2/class"
+    echo "$3" > "$1/$2/vendor"
+    echo "$4" > "$1/$2/device"
+    if [ -n "$5" ]; then mkdir -p "$1/drv/$5"; ln -s "../drv/$5" "$1/$2/driver"; fi
+  }
+  # A netdev with a phy80211, which is what cfg80211 creates for every driver
+  # that successfully registers a wiphy. That link -- not the interface name --
+  # is what separates "the driver worked" from "the driver loaded".
+  netdev() { mkdir -p "$1/$2/phy80211"; }
+
+  # No wireless card at all: an ethernet controller, to prove the class filter
+  # does not count 0x0200 as wifi. Without this the "no card" branch passes on
+  # an empty directory, which proves only that the loop can find nothing.
+  mkdir -p fix/none/0000:00:1f.6
+  echo 0x020000 > fix/none/0000:00:1f.6/class
+  echo 0x8086 > fix/none/0000:00:1f.6/vendor
+
+  wifi fix/intel-nofw  "0000:00:14.3" 0x8086 0x2725 iwlwifi
+  wifi fix/broadcom    "0000:03:00.0" 0x14e4 0x43a0 ""
+  wifi fix/realtek     "0000:02:00.0" 0x10ec 0xc821 ""
+  wifi fix/working     "0000:00:14.3" 0x8086 0x2725 iwlwifi
+
+  # Only the working fixture gets an interface. The other three are the whole
+  # point: a card the user can see in lspci and cannot see in nmtui.
+  mkdir -p net/empty
+  netdev net/up wlan0
+  # `lo` in both, because a real machine always has one and a check that only
+  # passes on a machine with no interfaces at all is not checking much.
+  mkdir -p net/empty/lo net/up/lo
+
+  export HOME=$PWD/home USER=tester
+  mkdir -p "$HOME"
+
+  run() { # run <pci fixture> <net fixture>
+    ( export NIXARCHY_SYSFS_PCI="$PWD/fix/$1" NIXARCHY_SYSFS_NET="$PWD/net/$2"
+      ${doctor}/bin/nixarchy-doctor 2>&1 ) || true
+  }
+
+  fails=0
+  want() {
+    if printf '%s' "$2" | grep -q "$3"; then echo "  ok      $1"
+    else echo "  FAILED  $1: no /$3/ in the output"; fails=$((fails + 1)); fi
+  }
+  wantnot() {
+    if printf '%s' "$2" | grep -q "$3"; then
+      echo "  FAILED  $1: /$3/ present and should not be"; fails=$((fails + 1))
+    else echo "  ok      $1"; fi
+  }
+
+  up=$(run working up)
+  # Same guard as the graphics test: every assertion below fails identically
+  # when the doctor printed nothing, which reads like every rule being wrong.
+  printf '%s' "$up" | grep -q 'Wireless' || {
+    echo "the doctor printed no Wireless section at all:"; printf '%s\n' "$up"; exit 1; }
+  want    "a working card is named"    "$up" 'Wireless interface wlan0 is up'
+  want    "and its driver with it"     "$up" 'Intel, driver iwlwifi'
+  wantnot "no advice when it works"    "$up" 'enableAllFirmware'
+
+  n=$(run none empty)
+  want    "no card is said plainly"    "$n" 'No PCI wireless card here'
+  # Ethernet is not wireless. A class filter of 0x02* rather than 0x0280*
+  # would call this Intel NIC a wifi card with no driver and send the user
+  # after firmware for a cable.
+  wantnot "ethernet is not counted"    "$n" 'wireless card with no driver'
+  # The honest limit, stated in the output rather than only in a comment: this
+  # walks PCI, so a USB adapter is invisible and must not be denied.
+  want    "USB is not ruled out"       "$n" 'USB adapter'
+
+  b=$(run broadcom empty)
+  want    "broadcom named as unbound"  "$b" 'Broadcom wireless card with no driver'
+  want    "its device id is printed"   "$b" '0x43a0'
+  want    "the fix is pasteable"       "$b" 'hardware.enableAllFirmware = true'
+  want    "allowUnfree is mentioned"   "$b" 'allowUnfree'
+  # broadcom_sta and b43 cannot both load. Advice that omits the conflict is
+  # advice that produces a machine which builds and still has no wifi.
+  want    "the conflict is named"      "$b" 'pick one'
+
+  r=$(run realtek empty)
+  want    "realtek named as unbound"   "$r" 'Realtek wireless card with no driver'
+  want    "out-of-tree module named"   "$r" 'rtl8821ce'
+  # Realtek is not Broadcom. enableAllFirmware does nothing for an 8821CE, and
+  # offering it here would be a paste-in line that changes nothing and reads
+  # like the fix -- the same mistake as intel-media-driver on an NVIDIA box.
+  wantnot "no broadcom fix on realtek" "$r" 'enableAllFirmware = true'
+
+  i=$(run intel-nofw empty)
+  want    "bound-but-dead is distinct" "$i" 'driver iwlwifi loaded, but no interface'
+  want    "the log is where to look"   "$i" 'journalctl -b -k'
+  # This is NOT the no-driver case, and saying so is the entire value of
+  # splitting them: "install a driver" is wrong advice for a card whose driver
+  # is already loaded and merely could not find its firmware.
+  wantnot "not called driverless"      "$i" 'card with no driver'
+
+  # The question that prompted all of this: "maybe ship iwctl?". The doctor
+  # must never send someone after a second wireless UI for a missing netdev.
+  #
+  # Matched on a RECOMMENDATION, not on the string -- the same distinction the
+  # graphics test draws between intel-media-driver in prose and in the snippet.
+  # A first draft of this forbade the bare word and failed on the two branches
+  # that name iwctl in exactly the sentence that answers the question ("nmtui,
+  # iwctl, wpa_cli -- will show the same nothing"). Deleting that sentence to
+  # make an assertion pass would have removed the one line worth reading.
+  # `c`, not `out`: $out is the builder's own output path. Shadowing it let
+  # every assertion pass and then sent `touch $out` at /etc/nixos.
+  for c in "$b" "$r" "$i"; do
+    wantnot "iwctl is not prescribed" "$c" 'iwd\|install.*iwctl\|try iwctl'
+  done
+  # And the sentence itself is load-bearing, so it is asserted rather than
+  # merely tolerated: without it "no driver" reads as a NetworkManager fault
+  # and the next thing tried is another client.
+  want "why no UI will help" "$b" 'nmtui, iwctl, wpa_cli'
+
+  [ "$fails" = 0 ] || { echo "$fails case(s) failed"; exit 1; }
+  echo "the doctor tells the three no-wlan0 cases apart"
+  touch $out
+''

--- a/tests/firmware-guard.nix
+++ b/tests/firmware-guard.nix
@@ -1,0 +1,79 @@
+{ inputs, pkgs, ... }:
+# The installed system must carry firmware without depending on a virt probe.
+#
+# What this defends:
+#
+#   Wireless, Bluetooth and most graphics need a firmware blob.
+#   hardware.enableRedistributableFirmware is what puts one on the machine,
+#   and nominally it comes from hardware-configuration.nix -- but only there:
+#   nixos-generate-config imports installer/scan/not-detected.nix, whose whole
+#   content is that option, and it imports it inside
+#
+#     if ($virt eq "none") {          nixos-generate-config.pl:321
+#
+#   so an installed machine's firmware hangs on a generated import, which
+#   hangs on systemd-detect-virt.
+#
+#   That branch cannot be tested by any VM in this repo. Every guest reports a
+#   virt type, so every install check takes the path where the option is FALSE
+#   and the path real users are on is the one nothing covers. The ISO enables
+#   it (installation-device.nix), which makes the failure worse rather than
+#   better: wifi works while installing and is gone afterwards, and the report
+#   that arrives says "it worked during the install".
+#
+#   A user on an Intel AX201 hit exactly this shape -- iwlwifi bound, no
+#   wlan0 in nmtui -- and asked whether we should ship iwctl.
+#
+# Two things are asserted. The first is that the module sets it at all. The
+# second is the one that rots quietly: that it is a DEFAULT, not forced, so an
+# adopter who has a reason to ship no blobs can still say so. A guard that
+# only checked the value would pass on an mkForce that takes their choice away.
+pkgs.runCommand "nixarchy-firmware-guard" { } (
+  let
+    inherit (inputs.self.nixosConfigurations) reference iso;
+
+    # A configuration with the option explicitly off. If the module used
+    # mkForce, or plain assignment at the same priority, this would either
+    # evaluate to true anyway or fail to evaluate at all -- and the whole
+    # point of mkDefault is that it does neither.
+    overridden = reference.extendModules {
+      modules = [ { hardware.enableRedistributableFirmware = false; } ];
+    };
+
+    b = v: if v then "true" else "false";
+  in
+  ''
+    fail=0
+    check() { # check <name> <actual> <wanted>
+      if [ "$2" = "$3" ]; then echo "  ok      $1"
+      else echo "  FAILED  $1: got $2, wanted $3"; fail=1; fi
+    }
+
+    # The installed system. This is the assertion that was false before the
+    # module set it, on every machine whose hardware-configuration.nix did not
+    # happen to be generated on bare metal.
+    check "installed systems get firmware" \
+      ${b reference.config.hardware.enableRedistributableFirmware} true
+
+    # The ISO already had it, from installation-device.nix. Asserted so that
+    # the day someone trims the image, the installer does not quietly lose the
+    # wifi it needs to reach a binary cache.
+    check "the ISO keeps firmware" \
+      ${b iso.config.hardware.enableRedistributableFirmware} true
+
+    # Still overridable.
+    check "an adopter can turn it off" \
+      ${b overridden.config.hardware.enableRedistributableFirmware} false
+
+    # NOT enableAllFirmware: that one needs allowUnfree, and turning it on for
+    # everyone would make every adopter's build fail on an unfree licence to
+    # fix a Broadcom card most of them do not have. The doctor's Wireless
+    # section names it per-card instead.
+    check "all-firmware stays opt-in" \
+      ${b reference.config.hardware.enableAllFirmware} false
+
+    [ "$fail" = 0 ] || exit 1
+    echo "the installed system carries firmware, and can still refuse it"
+    touch $out
+  ''
+)


### PR DESCRIPTION
Two users this week: no `wlan0` in nmtui, rfkill unblocked, NetworkManager
restarted. One asked whether we should ship `iwctl`.

We should not. nmtui, iwctl and wpa_cli all ask the kernel for interfaces.
With no netdev they all show the same nothing, so iwctl is a second way to
see the same absence — and the time spent installing it is time not spent on
the driver.

## What this adds

A **Wireless** section in `nixarchy doctor` that says *which of three cases*
the user has, because they cannot tell from nmtui:

| what sysfs shows | what it means | what it prints |
| --- | --- | --- |
| no PCI class `0x0280` | USB adapter, or no card | says so, and does **not** deny a USB card it cannot see |
| device, no `driver` link | this kernel has no module | vendor + device id + the right option |
| `driver` bound, no `phy80211` | module loaded, firmware missing | `journalctl -b -k` |

Per-vendor, because the fixes differ:

- **Broadcom** → `hardware.enableAllFirmware = true` (+ `allowUnfree`), and it
  names the `broadcom_sta`/`b43` conflict. Advice that omits that produces a
  machine which builds and still has no wifi.
- **Realtek** → the out-of-tree `rtl8821ce`/`rtl8852bu`/`rtw88` modules, keyed
  to the device id. `enableAllFirmware` does nothing for an 8821CE, so it is
  deliberately **not** offered there — a paste-in line that changes nothing
  reads like the fix.
- **Intel / MediaTek / Atheros** → named, so the user learns their firmware is
  already in the redistributable set the ISO enables and the card is not the
  problem.

## The test

`checks.install`'s guest has a virtio NIC and no radio, so **not one of these
branches can occur in a VM** — the same gap that let the no-VAAPI-driver branch
ship unreachable (#352). `tests/doctor-wireless.nix` drives all four shapes
against fixture sysfs, with real device ids (AX200, BCM4360, 8821CE).

Two of its assertions are about not over-correcting: an ethernet controller
must not be counted as wireless, and the Broadcom snippet must not appear on
a Realtek card.

One assertion caught itself: forbidding the bare string `iwctl` failed on the
sentence *"nmtui, iwctl, wpa_cli — will show the same nothing"*, which is the
line that actually answers the question. It now forbids a recommendation and
asserts the explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5