### PR TITLE
Document what v4.0.2-11 changed, where people will look for it

### DIFF
--- a/docs/manual/getting-started.md
+++ b/docs/manual/getting-started.md
@@ -28,10 +28,26 @@ want depends on whether the drive is blank.
 
 ## The ISO
 
+Two images are published with each
+[release](https://github.com/olafkfreund/nixarchy/releases): a **net** image of
+about 1.6 GB that downloads the desktop while it installs, and an **offline**
+image of about 6 GB that carries it. The offline one is split into `.part-*`
+files because GitHub refuses a single asset over 2 GiB; the release notes give
+the one command that joins them.
+
+Or build either yourself:
+
 ```
 nix build github:olafkfreund/nixarchy#iso
 sudo dd if=result/iso/nixarchy-*.iso of=/dev/sdX bs=4M status=progress oflag=sync
 ```
+
+**On Windows or macOS, how you write the stick matters**, and the way it fails
+is at boot with no explanation — the README's
+[USB section](https://github.com/olafkfreund/nixarchy#writing-the-stick-from-windows-or-macos)
+has the detail, including why Rufus' *recommended* answer to its ISOHybrid
+question is the wrong one for the offline image. On Linux, `dd` as above has no
+such trap.
 
 Boot it. There is no boot menu and no login prompt — the installer is what
 comes up, and it asks the same questions Omarchy asks, in the same order.

--- a/docs/manual/many-machines.md
+++ b/docs/manual/many-machines.md
@@ -23,6 +23,7 @@ could rebuild your machine from somewhere else is off unless you turn it on.
     │   ├── default.nix                username, disk, encryption
     │   ├── configuration.nix          timezone, keymap, and whatever you add
     │   ├── hardware-configuration.nix generated on that machine
+    │   ├── nixarchy-hardware.nix      what that machine IS, detected
     │   └── nixarchy-apps.nix          this machine's app selection
     └── laptop/…
 ```
@@ -62,8 +63,50 @@ repository beside the others.
 **3. Commit its hardware back.**
 
 `hardware-configuration.nix` is generated on the machine, because hardware is
-the one thing a repository written elsewhere cannot know. Run
-`nixarchy config repo` on the new machine to push it.
+the one thing a repository written elsewhere cannot know. So is
+`nixarchy-hardware.nix` beside it — see below. Run `nixarchy config repo` on the
+new machine to push both.
+
+### `nixarchy-hardware.nix`, and why it is per-machine
+
+Written by the installer from what it found on the machine: CPU vendor, GPU
+vendor, whether there is a battery, whether the disk spins. Each line is a
+module from [nixos-hardware](https://github.com/NixOS/nixos-hardware), which
+carries 439 of them:
+
+```nix
+{ inputs, ... }:
+{
+  imports = [
+    inputs.nixos-hardware.nixosModules.common-cpu-intel-cpu-only
+    inputs.nixos-hardware.nixosModules.common-gpu-intel
+    inputs.nixos-hardware.nixosModules.common-pc-laptop-ssd
+  ];
+}
+```
+
+That is CPU microcode, the Intel media stack, and `fstrim` — things you would
+otherwise have found out you needed one at a time. Everything they set is
+`lib.mkDefault`, so anything you write elsewhere wins, and the file is yours to
+edit: nothing regenerates it behind you.
+
+**Only the generic `common-*` modules are chosen for you**, and that is a
+deliberate line. The other 412 key on DMI product strings with no
+machine-readable table anywhere, so matching them automatically would mean
+guessing — and importing `dell-xps-13-9310` onto a 9315 is a machine that boots
+wrong in a way nobody traces back to us. `nixarchy doctor` prints what your
+machine calls itself so you can search for it; add any match to this file by
+hand. Plenty of machines have no module at all — there are thirteen ThinkPad T14
+modules and no T15 — and the generic ones are then the whole story.
+
+**NVIDIA is never chosen for you either.** The choice is between the open kernel
+modules and the `legacy_580` series, split at PCI device id `0x1e00`, and on a
+hybrid laptop it also needs both PRIME bus ids in decimal. Get any of that wrong
+and the machine has no screen, which is not a failure a first boot can explain.
+The doctor computes all of it and prints the lines for you to paste.
+
+Copying this file from another machine is the one thing not to do — it describes
+that machine's hardware, not this one's.
 
 **4. Let them keep themselves current.**
 

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -93,6 +93,64 @@ rebuild.
 Unchanged: *Update > Hardware* restarts the subsystem, and the
 `omarchy-restart-*` commands behind those rows are upstream's.
 
+### I can't see my Wi-Fi at all
+
+Different from the section above: that one is for a radio that worked and
+stopped. This is for one that never appeared.
+
+**Look for the right name first, because it is free and it is usually this.**
+There is no `wlan0` on a modern NixOS and there never will be — systemd renames
+every interface after the PCI slot it sits in, so an Intel card at `00:14.3`
+becomes `wlp0s20f3`. Someone searching nmtui for "wlan0" finds nothing on a
+machine whose Wi-Fi is working perfectly:
+
+```
+ip link
+```
+
+If a `wlp*` device is listed, the card is fine — connect with
+`nmcli device wifi list`, or pick it in nmtui.
+
+**If no wireless device is listed at all**, the kernel has no interface, and
+every wireless tool will show the same nothing, because they all ask the kernel.
+Reaching for a different client — iwctl instead of nmtui — is a second way to
+see the same absence. Ask what the driver did instead:
+
+```
+journalctl -b -k | grep -i firmware
+nixarchy doctor
+```
+
+The doctor's **Wireless** section names which of three cases you are in: no PCI
+device at all, a device with no driver bound, or a driver bound that registered
+no interface. Those have three different fixes, and nmtui cannot tell them
+apart.
+
+**On a machine installed before v4.0.2-11**, the likeliest answer is that it has
+no firmware at all. `hardware.enableRedistributableFirmware` was true on the ISO
+and false on the installed system, so `linux-firmware` — which carries every
+iwlwifi, ath, rtw and mt76 blob — was never installed. The symptom is
+distinctive: Wi-Fi works while you are installing and is gone once you reboot,
+and `lspci -nnk` still shows the driver bound, because a driver binds without
+firmware and only then fails to register a radio.
+
+Either update the machine, or add the line yourself to
+`/etc/nixos/hosts/<hostname>/configuration.nix` and rebuild:
+
+```nix
+hardware.enableRedistributableFirmware = true;
+```
+
+It needs no `allowUnfree`. From v4.0.2-11 it is the default and the line is
+redundant — harmless to keep, since it is only a default.
+
+If the kernel log names a firmware file still missing after that, it is outside
+the redistributable set: add `hardware.enableAllFirmware = true;` as well, which
+*does* need `nixpkgs.config.allowUnfree` (already set in that file). That covers
+Broadcom's `b43` and `brcm` blobs. Some Realtek cards — 8821CE, 8852BE — have no
+in-tree driver at all and need an out-of-tree module instead; the doctor names
+the right one for your device id.
+
 ### Why can't I login or sudo with my password?
 
 Upstream's answer is `faillock --reset`, and it applies here too: switch to a


### PR DESCRIPTION
Docs for the two firmware bugs and nixos-hardware detection. `docs/` is both the
manual and the gh-pages source, so this is one edit rather than two.

## `troubleshooting.md` — "I can't see my Wi-Fi at all"

Separate from the existing *"just stopped working"* section: this is for a radio
that never appeared.

Leads with the check that is free, and that turned out to be the actual answer
for a ThinkPad T15 tester: **there is no `wlan0` on a modern NixOS.** systemd
renames every interface after its PCI slot, so a card at `00:14.3` is
`wlp0s20f3`, and someone searching nmtui for "wlan0" finds nothing on a machine
whose Wi-Fi is working. `ip link` settles it in one line.

Then the firmware case, with the symptom spelled out because it is distinctive
and actively misleading: **Wi-Fi works while installing and is gone after the
reboot**, and `lspci -nnk` still shows the driver bound — a driver binds without
firmware and only then fails to register a radio. Includes the one-liner for
machines that will not be updated.

It also says why reaching for a different client is the wrong move: nmtui, iwctl
and wpa_cli all ask the kernel, so with no netdev they show the same nothing.

## `many-machines.md` — `nixarchy-hardware.nix`

Added to the layout tree, plus a section on what it is: detected at install time
from CPU vendor, GPU vendor, battery and rotational; every line `mkDefault`; the
file is yours and nothing regenerates it behind you.

Both deliberate omissions are stated with reasons, because a reader will
otherwise assume they are bugs:

- The other **412** nixos-hardware modules key on DMI product strings with no
  machine-readable table, so matching them automatically is guessing — and
  importing `dell-xps-13-9310` onto a 9315 is a machine that boots wrong in a way
  nobody traces back to us.
- **NVIDIA is never automatic**: open vs `legacy_580` splits at PCI device id
  `0x1e00`, and a hybrid needs both PRIME bus ids in decimal.

And that the database is incomplete — thirteen ThinkPad T14 modules, no T15, no
ThinkBook — so *"search for yours"* and *"there may not be one"* are both true.

## `getting-started.md` — the ISO section

It documented only building from source and `dd`. Most people download a
release, and **both** testers this week came unstuck on Windows before the
installer ever ran.

Now names the two published images and the `.part-*` split, and **links** the
README's USB section rather than restating it. The last time this content was
written twice, the copy was worse than `docs/manual/dual-boot-install.md`, which
already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5