### PR TITLE
nixpkgs: 3 app version(s) move

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -527,11 +527,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1788614874,
-        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
+        "lastModified": 1788752844,
+        "narHash": "sha256-VaWGJ6+cIYN2erfSecbRV+4ljI185Ty2wUrXyvQbgOw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
+        "rev": "dc5d91f840324650bac8c379428c7037a416959a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Nightly bump of the `nixpkgs` input. Only that input: the others
are left where they are, because at least one of them is pinned on
purpose.

| app | was | now |
|---|---|---|
| `brave` | 1.94.117 | 1.94.121 |
| `codex` | 0.151.0 | 0.153.4 |
| `opencode` | 1.18.28 | 1.18.29 |

Verified before this PR was opened:

- `.#checks.x86_64-linux.vm-toplevel` evaluates
- `.#checks.x86_64-linux.reference-toplevel` evaluates

That is an evaluation check, not a build. **The gate is the CI on
this pull request**, which runs because the PR was opened with
`BUMP_TOKEN`; it merges when the required contexts report green and
not before.

What CI does not cover: an app that builds and then misbehaves at
runtime. If a package here is one you rely on, launch it before
this lands, or roll back afterwards with `nixos-rebuild --rollback`.