### PR TITLE
Two nightly checks were failing on their own assertions, not on the product

### DIFF
--- a/tests/install-encrypted.nix
+++ b/tests/install-encrypted.nix
@@ -384,9 +384,21 @@ pkgs.testers.runNixOSTest {
     hw_rc, hw_text = installer.execute(f"cat {hw}")
     if hw_rc == 0:
         print(hw_text)
+        # Anything between the attribute and its mkForce, because since #388
+        # there IS something: the pin is wrapped in a kernel guard, written
+        # across three lines,
+        #
+        #   boot.initrd.availableKernelModules =
+        #     lib.mkIf (config.boot.kernelPackages.kernel.version == "7.2.3")
+        #       (lib.mkForce [ ... ]);
+        #
+        # and the previous pattern required `= lib.mkForce [` adjacent, with
+        # no re.S. It stopped matching a pin that was there and correct, and
+        # reported "no mkForce pin at all" -- the branch whose message says the
+        # refusal path changed. It had not; this regex had gone stale.
         pinned = re.search(
-            r"^\s*boot\.initrd\.availableKernelModules\s*=\s*lib\.mkForce\s*\[([^]]*)\]",
-            hw_text, re.M)
+            r"boot\.initrd\.availableKernelModules\s*=.*?lib\.mkForce\s*\[([^]]*)\]",
+            hw_text, re.S)
         if pinned:
             missing = [m for m in "${toString encryptedOnlyModules}".split()
                        if f'"{m}"' not in pinned.group(1)]
@@ -398,6 +410,26 @@ pkgs.testers.runNixOSTest {
                 "cannot unlock its root on first boot. The install itself "
                 "may well have 'succeeded'.")
             print("the pin carries every LUKS-only module")
+
+            # And that it is still CONDITIONAL on the kernel. Loosening the
+            # pattern above to see past the guard also made it blind to the
+            # guard's absence -- a plain mkForce would now match happily, and
+            # that is exactly the shape #388 shipped: a list captured at 7.2
+            # forced onto a machine that later moved kernels, asking modprobe
+            # for xhci_pci_prom21 on a kernel that has no such module, so
+            # nixos-rebuild refuses to produce a system at all.
+            #
+            # checks.initrd-pin-guard asserts this on the installer's source.
+            # This asserts it on what the installer actually wrote, which is
+            # the thing the machine will read.
+            assert re.search(
+                r"boot\.initrd\.availableKernelModules\s*=\s*\n?\s*lib\.mkIf\s*\(",
+                hw_text), (
+                "the pin is not conditional on the kernel version: the "
+                "installer wrote a bare mkForce. A machine whose kernel later "
+                "moves will be handed a module list captured from a different "
+                "one, and cannot build an initrd at all.")
+            print("and it is conditional on the kernel it came from")
         else:
             # No pin at all is the legitimate other branch: something detected
             # was not on the medium and the install builds its own initrd. On

--- a/tests/install-iso.nix
+++ b/tests/install-iso.nix
@@ -157,8 +157,24 @@ let
         # And nothing was fetched. The image carries no substituter and the
         # machine has no interface, so a download here would mean every
         # assertion above is measuring something other than what it claims.
-        grep -q "unable to download" /var/log/nixarchy-install.log
-        step OFFLINE test $? -ne 0
+        #
+        # The scan runs INSIDE step, which is not a tidiness change.
+        #
+        # As two statements, the grep ran while the driver was already waiting
+        # for the marker -- and the marker cannot be printed until the grep
+        # returns. `grep -q` exits early only on a MATCH, so the passing case
+        # is the slow one: no match means reading the whole log, and that log
+        # carries a `copying path` line for every store path in a 6 GB image,
+        # on an emulated CPU. The driver timed out at 120s with the script
+        # still running, which reads as "the install downloaded something"
+        # when it means the opposite. FLAKE and ESP resolving in 0.00s while
+        # OFFLINE never appeared is the tell: the script was alive, not dead.
+        #
+        # Inside step, the wait covers the work, so the timeout is a real
+        # budget rather than a race. `! grep` also drops the `$?`-on-the-next-
+        # line idiom, where anything inserted between the two statements
+        # silently changes what is being tested.
+        step OFFLINE sh -c '! grep -q "unable to download" /var/log/nixarchy-install.log'
 
         # The removable fallback, asserted rather than taken on trust.
         #
@@ -405,7 +421,11 @@ pkgs.testers.runNixOSTest {
         step("INSTALLED", 3600, "the install completed")
         step("FLAKE", 120)
         step("ESP", 120, "it wrote a flake and an ESP")
-        step("OFFLINE", 120, "and downloaded nothing")
+        # 600, not 120: this step now includes the scan of the install log
+        # rather than racing it, and the passing case is the slow one -- no
+        # match means grep reads the whole file, which on a 6 GB offline
+        # install is every `copying path` line it printed.
+        step("OFFLINE", 600, "and downloaded nothing")
         step("FALLBACK", 120,
              "the ESP carries the removable fallback loader bootctl promises")
         step("SERIAL", 120)


### PR DESCRIPTION
Both failed for the first time on 2026-09-08, and both accuse the installer of
something it did not do.

## `install-encrypted` — the pin was there and the regex could not see it

```
AssertionError: hardware-configuration.nix carries no mkForce pin at all
```

The same log prints the file, and the pin is in it, correct, with every LUKS
module *and* the kernel guard:

```nix
boot.initrd.availableKernelModules =
  lib.mkIf (config.boot.kernelPackages.kernel.version == "7.2.3")
    (lib.mkForce [ "aes" … "dm_crypt" … ]);
```

The pattern required `= lib.mkForce [` **adjacent**, with no `re.S`. Since #388
there is a newline, a `mkIf` and an open paren between them. So a check written
to catch *"the installer pinned the wrong list"* started reporting *"there is no
pin"* — the branch whose own message says the refusal path must have changed. It
had not; the regex had gone stale when the guard landed.

Loosened to match across the guard — **and a second assertion added in the same
breath**, because widening the first one also made it blind to a *bare* mkForce.
That is exactly the shape #388 shipped: a list captured at 7.2 forced onto a
machine that later moves kernels, asking modprobe for `xhci_pci_prom21` where no
such module exists, so `nixos-rebuild` produces no system at all.
`checks.initrd-pin-guard` asserts that on the installer's *source*; this asserts
it on what the installer actually *wrote*.

## `install-iso` — the passing case is the slow one

```
waiting for OFFLINE-0-X ... timed out after 120.02 seconds
```

As two statements, the scan ran while the driver was already waiting, and the
marker cannot print until it returns:

```sh
grep -q "unable to download" /var/log/nixarchy-install.log
step OFFLINE test $? -ne 0
```

**`grep -q` exits early only on a match.** Nothing was downloaded, so there was
no match, so it read the whole log — and that log carries a `copying path` line
for every store path in a 6 GB offline install, on an emulated CPU. The timeout
then reads as *"it downloaded something"* when it means the opposite.

The tell is in the log: `FLAKE` and `ESP` resolved in **0.00 s** each, already
buffered, while `OFFLINE` never appeared at all. A dead script leaves no marker;
a live one that hasn't finished leaves no marker either — only the timing
separates them.

The scan now runs *inside* `step`, so the wait covers the work rather than
racing it, with a 600 s budget. `! grep` also retires the
`$?`-on-the-next-line idiom, where anything inserted between the two statements
silently changes what is asserted.

**Neither change touches the installer.** Both make a check measure what it says
it measures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5