### PR TITLE
A watchdog that cannot see one of its subjects, and a check that passes on nothing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -386,7 +386,14 @@ jobs:
   report:
     name: report a failure
     runs-on: ubuntu-latest
-    needs: [install, install-iso, microvm, cache, canary]
+    # install-encrypted was missing here, and the omission is the same class
+    # of bug as the cancelled() note below: a watchdog that cannot see one of
+    # its subjects. `if: failure()` observes only the jobs in `needs`, so on
+    # 2026-09-08 install-encrypted failed, this job ran, saw five green
+    # dependencies, and reported SUCCESS. The encrypted install is the DEFAULT
+    # answer to the installer's own question, and it was the one failure that
+    # filed no issue.
+    needs: [install, install-encrypted, install-iso, microvm, cache, canary]
     # cancelled() too. On 2026-09-02 install-iso hit its 180-minute timeout,
     # which GitHub records as cancelled rather than failed, and this job --
     # the one whose whole purpose is that a 03:00 failure does not cost a day
@@ -423,6 +430,16 @@ jobs:
             # themselves are green, though; a night where both broke is an
             # install problem first.
             title="nightly: tomorrow's flake update breaks a user's eval"
+          elif [ "${{ needs.microvm.result }}" != "success" ] &&
+            [ "${{ needs.install.result }}" = "success" ] &&
+            [ "${{ needs.install-encrypted.result }}" = "success" ] &&
+            [ "${{ needs.install-iso.result }}" = "success" ]; then
+            # microvm was in `needs` and in no branch of this ladder, so a
+            # MicroVM boot failure was titled "the install checks are failing"
+            # -- the #236 shape the comment above warns about, committed two
+            # jobs later. It also collides with the dedupe search, appending a
+            # sandbox failure to the install issue.
+            title="nightly: a sandbox will not boot"
           else
             title="nightly: the install checks are failing"
           fi

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -102,6 +102,25 @@ jobs:
           # repacks, and it avoids trusting a filename-to-attribute convention
           # nothing enforces.
           mapfile -t attrs < <(nix eval --json .#update.pinned | jq -r '.[] | ".#" + .')
+
+          # mapfile returns 0 whatever the process substitution did -- a failed
+          # eval, a renamed output, a jq that is not there -- and an empty
+          # array then makes the line below `nix build --impure
+          # --print-build-logs` with no installables, which builds .#default
+          # and exits GREEN. The one step that proves the rewritten packages
+          # still build would have built none of them and said nothing.
+          #
+          # Six is what .#update.pinned holds today (hey-cli, omacalc, omacut,
+          # omawrite, once, ttfx). The floor is 1 rather than 6 so removing a
+          # package from the set is an ordinary edit and not a CI break, while
+          # "the list came back empty" still stops the job.
+          if [ "${#attrs[@]}" -eq 0 ]; then
+            echo "::error::.#update.pinned produced no attributes, so this step" \
+                 "would build .#default and pass without checking the packages" \
+                 "the bump just rewrote" >&2
+            exit 1
+          fi
+
           echo "building: ${attrs[*]}"
           nix build --impure --print-build-logs "${attrs[@]}"
 


### PR DESCRIPTION
Three findings from a review of the workflows. Each verified against the file
before fixing; the first two are visible in last night's run.

## `nightly.yml` — `install-encrypted` filed no issue

`report` exists so a 03:00 failure does not cost a day, and `if: failure()`
observes **only the jobs in `needs`**. `install-encrypted` was not in that list.

On 2026-09-08 it failed, `report` ran, saw five green dependencies, and concluded
**success**. The encrypted install is the *default* answer to the installer's own
question, and it was the one failure that told nobody.

Same class as the `cancelled()` note already in that job: a watchdog that barks
at only some of the ways its subject can die.

## `nightly.yml` — `microvm` was titled as an install failure

`microvm` was added to `needs` and to **no branch of the title ladder**, so a
sandbox that will not boot got `nightly: the install checks are failing` — the
#236 mis-titling the comment *directly above it* warns against, committed two
jobs later. It also collides with the dedupe search, which keys on the title, so
a sandbox failure would append itself to the install issue.

Given its own title, gated on the three install jobs being green — the shape the
canary branch already uses.

## `update.yml` — the build step could pass having built nothing

```sh
mapfile -t attrs < <(nix eval --json .#update.pinned | jq -r ...)
nix build --impure --print-build-logs "${attrs[@]}"
```

`mapfile` returns 0 whatever the process substitution did — a failed eval, a
renamed output, a `jq` that isn't there. An empty array makes the second line
`nix build` with **no installables**, which builds `.#default` and exits green.
The one step that proves the rewritten packages still build would have built none
of them, and said so nowhere.

Guarded on the array being non-empty. Floor of 1 rather than the 6
`.#update.pinned` holds today (`hey-cli omacalc omacut omawrite once ttfx`), so
removing a package stays an ordinary edit while "the list came back empty" still
stops the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5