### PR TITLE
"No network yet" was one screen for three problems, and never mentioned rfkill

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,6 +166,12 @@ jobs:
       - name: The doctor reads a GPU correctly
         run: nix build .#checks.x86_64-linux.doctor-graphics --print-build-logs
 
+      # Three network failures told apart, and a blocked radio from a missing
+      # one. checks.install-iso runs -nic none against a machine with no radio,
+      # which is the one shape where every branch of both is unreachable.
+      - name: The installer can tell three network failures apart
+        run: nix build .#checks.x86_64-linux.installer-network --print-build-logs
+
       # The doctor's wireless rules. The install VM has a virtio NIC and no
       # radio, so not one of the three no-wlan0 cases can occur there -- the
       # same gap that let the no-VAAPI-driver branch ship unreachable (#352).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,6 +185,13 @@ jobs:
       - name: Wi-Fi joined during the install is carried over
         run: nix build .#checks.x86_64-linux.installer-network-profiles --print-build-logs
 
+      # That a failed install says what KIND of failure it was, not only that
+      # something failed. checks.install-iso asserts installs that SUCCEED, so
+      # a passing install renders no failure screen at all and can never reach
+      # any of this.
+      - name: The failure screen names the failure
+        run: nix build .#checks.x86_64-linux.installer-failure-hints --print-build-logs
+
       # And that the configuration iso-wifi asserts actually carries an
       # association, against a real radio: mac80211_hwsim gives the VM two
       # wiphys, hostapd serves one, NetworkManager and wpa_supplicant drive the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,16 @@ jobs:
       - name: The ISO can associate to a network
         run: nix build .#checks.x86_64-linux.iso-wifi --print-build-logs
 
+      # And that the configuration iso-wifi asserts actually carries an
+      # association, against a real radio: mac80211_hwsim gives the VM two
+      # wiphys, hostapd serves one, NetworkManager and wpa_supplicant drive the
+      # other, and the handshake is asserted from both ends. Nothing else in
+      # this repo has ever had a wireless card -- install-iso boots -nic none
+      # and every other install test uses a virtio NIC -- which is why five
+      # wireless bugs reached testers before any check could see one.
+      - name: A VM with a radio can associate to a network
+        run: nix build .#checks.x86_64-linux.wifi-hwsim --print-build-logs
+
       # The doctor's wireless rules. The install VM has a virtio NIC and no
       # radio, so not one of the three no-wlan0 cases can occur there -- the
       # same gap that let the no-VAAPI-driver branch ship unreachable (#352).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,6 +172,13 @@ jobs:
       - name: The installer can tell three network failures apart
         run: nix build .#checks.x86_64-linux.installer-network --print-build-logs
 
+      # That the ISO can associate at all. No VM in this repo has a radio --
+      # install-iso boots -nic none and every other install test uses a virtio
+      # NIC -- so there is nowhere in the suite this can be caught by running
+      # something. Only by asking the configuration what it says.
+      - name: The ISO can associate to a network
+        run: nix build .#checks.x86_64-linux.iso-wifi --print-build-logs
+
       # The doctor's wireless rules. The install VM has a virtio NIC and no
       # radio, so not one of the three no-wlan0 cases can occur there -- the
       # same gap that let the no-VAAPI-driver branch ship unreachable (#352).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,12 @@ jobs:
       - name: The ISO can associate to a network
         run: nix build .#checks.x86_64-linux.iso-wifi --print-build-logs
 
+      # That the Wi-Fi someone joins during the install is carried onto the
+      # machine, and that the file holding their PSK never lands in the git
+      # repository nixarchy-config-repo pushes to GitHub.
+      - name: Wi-Fi joined during the install is carried over
+        run: nix build .#checks.x86_64-linux.installer-network-profiles --print-build-logs
+
       # And that the configuration iso-wifi asserts actually carries an
       # association, against a real radio: mac80211_hwsim gives the VM two
       # wiphys, hostapd serves one, NetworkManager and wpa_supplicant drive the

--- a/flake.nix
+++ b/flake.nix
@@ -1098,6 +1098,12 @@
           # The installer's interactive screens, at every width worth caring
           # about. Nothing else draws them: every other harness passes
           # --answers, which is exactly how #133 shipped.
+          # Why: tests/iso-wifi.nix
+          iso-wifi = import ./tests/iso-wifi.nix {
+            inherit inputs;
+            pkgs = pkgsFor.${system};
+          };
+
           # Why: tests/installer-network.nix
           installer-network = import ./tests/installer-network.nix {
             pkgs = pkgsFor.${system};

--- a/flake.nix
+++ b/flake.nix
@@ -1098,6 +1098,12 @@
           # The installer's interactive screens, at every width worth caring
           # about. Nothing else draws them: every other harness passes
           # --answers, which is exactly how #133 shipped.
+          # Why: tests/wifi-hwsim.nix
+          wifi-hwsim = import ./tests/wifi-hwsim.nix {
+            inherit inputs;
+            pkgs = pkgsFor.${system};
+          };
+
           # Why: tests/iso-wifi.nix
           iso-wifi = import ./tests/iso-wifi.nix {
             inherit inputs;

--- a/flake.nix
+++ b/flake.nix
@@ -1110,6 +1110,12 @@
             pkgs = pkgsFor.${system};
           };
 
+          # Why: tests/installer-network-profiles.nix
+          installer-network-profiles = import ./tests/installer-network-profiles.nix {
+            pkgs = pkgsFor.${system};
+            installScript = ./installer/install.sh;
+          };
+
           # Why: tests/installer-network.nix
           installer-network = import ./tests/installer-network.nix {
             pkgs = pkgsFor.${system};

--- a/flake.nix
+++ b/flake.nix
@@ -1098,6 +1098,12 @@
           # The installer's interactive screens, at every width worth caring
           # about. Nothing else draws them: every other harness passes
           # --answers, which is exactly how #133 shipped.
+          # Why: tests/installer-network.nix
+          installer-network = import ./tests/installer-network.nix {
+            pkgs = pkgsFor.${system};
+            installScript = ./installer/install.sh;
+          };
+
           installer-store-space = import ./tests/installer-store-space.nix {
             pkgs = pkgsFor.${system};
             installScript = ./installer/install.sh;

--- a/flake.nix
+++ b/flake.nix
@@ -1110,6 +1110,13 @@
             pkgs = pkgsFor.${system};
           };
 
+          # Why: tests/installer-failure-hints.nix
+          installer-failure-hints = import ./tests/installer-failure-hints.nix {
+            pkgs = pkgsFor.${system};
+            dashboardScript = ./installer/lib/dashboard.sh;
+            installScript = ./installer/install.sh;
+          };
+
           # Why: tests/installer-network-profiles.nix
           installer-network-profiles = import ./tests/installer-network-profiles.nix {
             pkgs = pkgsFor.${system};

--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -249,11 +249,35 @@ in
     pkgs.git
   ];
 
-  # installation-cd-minimal brings wpa_supplicant; the installed machine uses
-  # NetworkManager, and so does anyone reaching for nmtui when the wireless
-  # does not come up on its own. The two conflict, so one has to go, and it
-  # should be the one the finished system does not use.
-  networking.wireless.enable = lib.mkForce false;
+  # NetworkManager, for the same reason the installed machine uses it and for
+  # anyone reaching for nmtui when the wireless does not come up on its own.
+  #
+  # `networking.wireless.enable` is deliberately NOT forced off here, and the
+  # line that used to do it made every Wi-Fi install impossible:
+  #
+  #   device (wlp0s20f3): Couldn't initialize supplicant interface:
+  #     Failed to D-Bus activate wpa_supplicant service
+  #
+  # repeating every thirteen seconds, forever, on a card whose driver was bound
+  # and whose radio rfkill reported unblocked.
+  #
+  # NetworkManager does not avoid wpa_supplicant -- it DRIVES it. Its own
+  # module says so and sets it up (networkmanager.nix:694-698):
+  #
+  #   # Enable wpa_supplicant but fully control it over DBus
+  #   wireless.enable = true;
+  #   wireless.autoDetectInterfaces = false;
+  #   wireless.dbusControlled = true;
+  #
+  # A mkForce here overrode that and left NM with a backend it was told to use
+  # and had no way to start. The conflict the old comment described -- a
+  # STANDALONE supplicant grabbing interfaces behind NM's back -- is exactly
+  # what those other two settings prevent, so the answer was already in the
+  # module and forcing the switch off threw it away.
+  #
+  # The premise was also stale: nothing in nixpkgs' installation media enables
+  # networking.wireless any more. installation-device.nix's only mention is the
+  # login banner telling you to run nmtui.
   networking.networkmanager.enable = true;
 
   # Straight into the installer, with no boot menu -- upstream shows none and

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -384,14 +384,66 @@ connect_wifi() {
   # Asked for every network, including open ones, where an empty answer is
   # correct and is passed as no password at all. One prompt that handles both
   # beats detecting the security column and being wrong about WEP.
-  ui_left "\e[90mLeave blank if the network is open.\e[0m"
-  pw=$(gum input --padding "$(ui_gum_pad)" --password --prompt "Password> ")
+  # Three attempts at the password, and the reason is the failure it replaces.
+  #
+  # `|| return 1` sent every failure back to the outer menu with nothing but
+  # nmcli's own stderr, so a mistyped password, a network that has gone out of
+  # range, and a NetworkManager that is not running all looked identical and
+  # all cost a full round trip through "No network yet" to try again. The one
+  # that is nearly always the answer -- the password -- is the one that should
+  # be one keystroke away.
+  #
+  # nmcli's exit statuses are documented (nmcli(1) EXIT STATUS) and specific
+  # enough to act on:
+  #
+  #   3   timeout
+  #   4   connection activation failed
+  #   8   NetworkManager is not running
+  #   10  connection, device or access point does not exist
+  local attempt rc
+  for attempt in 1 2 3; do
+    ui_left "\e[90mLeave blank if the network is open.\e[0m"
+    pw=$(gum input --padding "$(ui_gum_pad)" --password --prompt "Password> ")
 
-  if [ -z "$pw" ]; then
-    nmcli device wifi connect "$ssid" || return 1
-  else
-    nmcli device wifi connect "$ssid" password "$pw" || return 1
-  fi
+    rc=0
+    if [ -z "$pw" ]; then
+      nmcli device wifi connect "$ssid" || rc=$?
+    else
+      nmcli device wifi connect "$ssid" password "$pw" || rc=$?
+    fi
+    [ "$rc" -eq 0 ] && return 0
+
+    case $rc in
+      4)
+        # "Usually", not "the password is wrong": activation also fails on a
+        # network that hands out no address, and telling someone their correct
+        # password is wrong is worse than being vague.
+        ui_left "\e[31mCould not connect -- usually that is the password.\e[0m"
+        [ "$attempt" -lt 3 ] && continue
+        ui_left "\e[90mThree tries is enough; back to the network list.\e[0m"
+        ;;
+      10)
+        ui_left "\e[31m$ssid is not there any more.\e[0m"
+        ui_left "\e[90mIt was in the scan a moment ago, so it has gone out of range or\e[0m"
+        ui_left "\e[90mstopped advertising. Pick another, or move closer and rescan.\e[0m"
+        ;;
+      3)
+        ui_left "\e[31mThe connection timed out.\e[0m"
+        ui_left "\e[90mThe network answered and then stopped. A weak signal does this.\e[0m"
+        ;;
+      8)
+        # Not the user's problem and not fixable from this screen.
+        ui_left "\e[31mNetworkManager is not running on this image.\e[0m"
+        ui_left "\e[90mThat is a bug in nixarchy, not something you can work around\e[0m"
+        ui_left "\e[90mhere -- please report it. A cable will still install.\e[0m"
+        ;;
+      *)
+        ui_left "\e[31mnmcli failed with status $rc.\e[0m"
+        ;;
+    esac
+    sleep 3
+    return 1
+  done
 }
 
 # Wi-Fi on an image that does not need it, for the machine that will.

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -255,6 +255,38 @@ network_ready() {
   curl -sfI --max-time 8 https://cache.nixos.org/nix-cache-info >/dev/null 2>&1
 }
 
+# WHICH half of "no network" it is, in one word on stdout.
+#
+# network_ready is the right test -- the install needs that cache and nothing
+# less proves it -- but it collapses three situations into one screen saying
+# "No network yet", and they want three different actions:
+#
+#   nolink  no carrier and no address; plug something in or join a network
+#   nodns   associated, but nothing resolves -- a captive portal does this,
+#           and no amount of retrying fixes it from here
+#   nocache resolves and routes, but cache.nixos.org will not answer; a proxy,
+#           a filtered network, or the cache genuinely being down
+#
+# A tester sat on "No network yet" with working Wi-Fi and nothing to act on.
+# The screen said the same thing for a cable that was not plugged in.
+network_fault() {
+  # Any non-loopback interface with a global address. `ip` is on the medium
+  # (iproute2 is in the base system) and this asks the kernel rather than
+  # NetworkManager, which reports "connected" for an association that has not
+  # got as far as an address.
+  ip -o -4 addr show scope global 2>/dev/null | grep -qv ' lo ' ||
+    ip -o -6 addr show scope global 2>/dev/null | grep -q . ||
+    { echo nolink; return; }
+
+  # Resolution, against the host the install actually needs rather than a
+  # well-known one: a captive portal that answers for example.com and not for
+  # cache.nixos.org is still a portal, and DNS that works for one name and not
+  # the other is the same problem to the person in front of it.
+  getent hosts cache.nixos.org >/dev/null 2>&1 || { echo nodns; return; }
+
+  echo nocache
+}
+
 # The way out of any question, said out loud.
 #
 # Every prompt in the flow is a `var=$(... gum ...)` assignment, and the flow
@@ -273,9 +305,49 @@ ui_abort() {
   exit 1
 }
 
+# Is the radio blocked, and by what? Echoes hard, soft or none.
+#
+# `nmcli radio wifi on` clears NetworkManager's own idea of the radio and
+# nothing else, so a machine rfkill'd at the kernel scans, finds nothing, and
+# is told the driver may be missing. On a ThinkPad that is a Fn+F8 away, and
+# the message sends the reader after a driver that is present and bound.
+#
+# rfkill is on the medium: util-linux is in the ISO's package set, verified
+# rather than assumed.
+wifi_block() {
+  local out
+  out=$(rfkill list wifi 2>/dev/null) || { echo none; return; }
+  case $out in
+    *"Hard blocked: yes"*) echo hard ;;
+    *"Soft blocked: yes"*) echo soft ;;
+    *) echo none ;;
+  esac
+}
+
 connect_wifi() {
   ui_screen "Let's get you on Wi-Fi..."
   nmcli radio wifi on >/dev/null 2>&1 || true
+
+  # A soft block is ours to clear, and clearing it is the whole fix on a
+  # machine that has been suspended with the radio off or booted after a
+  # different OS turned it down.
+  if [ "$(wifi_block)" = soft ]; then
+    rfkill unblock wifi >/dev/null 2>&1 || true
+    # The radio needs a moment to come up before a scan means anything.
+    sleep 1
+  fi
+
+  # A hard block is not, and saying so is the point. No software clears a
+  # physical switch or a BIOS setting, so a scan here would find nothing and
+  # the "No networks found" text below would blame the image.
+  if [ "$(wifi_block)" = hard ]; then
+    ui_left "\e[31mThe wireless radio is blocked by hardware.\e[0m"
+    ui_left "\e[90mA physical switch or a BIOS setting is holding it off -- on many\e[0m"
+    ui_left "\e[90mThinkPads that is Fn+F8, and in BIOS setup it is \"Wireless LAN\".\e[0m"
+    ui_left "\e[90mNothing here can override it. A cable works in the meantime.\e[0m"
+    sleep 5
+    return 1
+  fi
 
   # --rescan yes because the cached list is empty on a radio that came up
   # seconds ago, which is every boot of a live image. Deduplicated on SSID:
@@ -288,7 +360,18 @@ connect_wifi() {
 
   if [ -z "$list" ]; then
     ui_left "\e[31mNo networks found.\e[0m"
-    ui_left "\e[90mA USB adapter may need a moment, or the driver may not be on this image.\e[0m"
+    # Only where it can be true. This line used to be unconditional, and on a
+    # machine whose driver was bound and whose radio was merely blocked it sent
+    # the reader after a missing driver that was not missing. cfg80211 creates
+    # a phy80211 link for every driver that registers, so its absence is the
+    # honest test for "no wireless device at all".
+    if ! ls -d /sys/class/net/*/phy80211 >/dev/null 2>&1; then
+      ui_left "\e[90mThis machine has no wireless interface: no driver claimed the card,\e[0m"
+      ui_left "\e[90mor there is no card. A USB adapter may need a moment.\e[0m"
+    else
+      ui_left "\e[90mThe adapter is working but saw nothing. Move closer, or check the\e[0m"
+      ui_left "\e[90mnetwork is on 2.4/5 GHz this card supports.\e[0m"
+    fi
     sleep 3
     return 1
   fi
@@ -339,7 +422,29 @@ ask_network() {
   while true; do
     ui_screen "Let's get you online..."
     ui_left "This image downloads the desktop as it installs, so it needs a network."
-    ui_left "\e[90mA wired connection is picked up on its own -- plug it in and try again.\e[0m"
+
+    # WHICH failure, not just that there is one. The same screen used to greet
+    # a cable that was not plugged in and a laptop associated to a captive
+    # portal, and only one of those is fixed by trying again -- a tester sat on
+    # it with working Wi-Fi and nothing to act on.
+    case $(network_fault) in
+      nolink)
+        ui_left "\e[90mNothing is connected yet. A wired connection is picked up on its\e[0m"
+        ui_left "\e[90mown -- plug it in and choose Try again.\e[0m"
+        ;;
+      nodns)
+        ui_left "\e[33mConnected, but names are not resolving.\e[0m"
+        ui_left "\e[90mThat is what a captive portal looks like: a hotel or guest network\e[0m"
+        ui_left "\e[90mwanting a login page first. Sign in from another device on the same\e[0m"
+        ui_left "\e[90mnetwork, then Try again -- or use the offline image, which needs no\e[0m"
+        ui_left "\e[90mnetwork at all.\e[0m"
+        ;;
+      nocache)
+        ui_left "\e[33mConnected and resolving, but cache.nixos.org will not answer.\e[0m"
+        ui_left "\e[90mA proxy or a filtered network does this. The offline image installs\e[0m"
+        ui_left "\e[90mwithout reaching any cache.\e[0m"
+        ;;
+    esac
     echo
 
     local choice

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -394,6 +394,33 @@ connect_wifi() {
   fi
 }
 
+# Wi-Fi on an image that does not need it, for the machine that will.
+#
+# Split from ask_network because the two are different questions wearing the
+# same screen: the net image cannot proceed without a network, and this one can
+# and simply produces a better machine with one. Conflating them is how the
+# offline image ended up with no way to configure Wi-Fi at all.
+offer_optional_wifi() {
+  ui_screen "Wi-Fi, if you want it..."
+  ui_left "This image installs without a network, so this is optional."
+  ui_left "\e[90mA network you join here is carried onto the installed machine, so it\e[0m"
+  ui_left "\e[90mis already online at the first boot rather than asking again.\e[0m"
+  echo
+
+  local choice
+  choice=$(printf '%s\n' "Skip" "Connect to Wi-Fi" |
+    gum choose --height "$(ui_widget_height)" --padding "$(ui_gum_pad)" \
+      --header "Set up Wi-Fi now?") || choice=""
+
+  # Skip on anything that is not an explicit yes, INCLUDING an interrupt. The
+  # net image's screen calls ui_abort there because it cannot go on; this one
+  # can, and treating Escape as "get out of my way" is what the person means.
+  case $choice in
+    "Connect to Wi-Fi") connect_wifi || true ;;
+    *) return 0 ;;
+  esac
+}
+
 ask_network() {
   # Only the network image asks. Keyed on that image's own marker rather than
   # on the absence of the offline one, and the difference is not cosmetic:
@@ -403,6 +430,24 @@ ask_network() {
   # this screen is for is the one image that genuinely cannot proceed without
   # one, and that image says so itself.
   if [ ! -f /etc/nixarchy-iso-net ]; then
+    # The OFFLINE image, which needs nothing from a network to install -- and
+    # produces a machine that does. Every profile the user joins here is
+    # carried onto the target by carry_network_profiles, so this screen is the
+    # difference between a first boot that is already online and one where
+    # they type their Wi-Fi password again at a desktop that cannot reach
+    # anything to look up how.
+    #
+    # Offered, never demanded, and that asymmetry is the whole design. The
+    # image installs perfectly without it, so a prompt that BLOCKED would be
+    # inventing a requirement -- which is what the old early return was
+    # rightly avoiding. Skipping is one keypress and the default.
+    #
+    # Not under --answers: unattended means nobody is there to pick a network,
+    # and the check that installs offline in a sandbox must not grow a screen.
+    if [ -n "$answers_file" ] || network_ready; then
+      return 0
+    fi
+    offer_optional_wifi
     return 0
   fi
 
@@ -2187,6 +2232,42 @@ run_install() {
 # behaviour every machine had before this existed. What stops the absence
 # going unnoticed is checks.install, which asserts both subvolumes exist and
 # are read-only after a real install.
+# The Wi-Fi the user just joined, carried onto the machine they are building.
+#
+# Nothing did this, and the cost was a report that read as a firmware bug and
+# was two bugs: "Wi-Fi worked while installing and was gone after the reboot".
+# Firmware was half of it. The other half is that NetworkManager writes the
+# profile -- SSID, PSK, everything -- to /etc/NetworkManager/system-connections
+# on the LIVE medium, which is a tmpfs that ceases to exist at reboot. Someone
+# who typed their password into the installer typed it into a RAM disk.
+#
+# Deliberately NOT into /etc/nixos. That directory is a git repository
+# nixarchy-config-repo exists to push to GitHub, and a .nmconnection file holds
+# the pre-shared key in the clear -- the same argument
+# installer/template/host/configuration.nix makes for keeping the crypt hash
+# out of it. /etc/NetworkManager is where NM looks anyway, and 0600 root:root
+# is what it refuses to read the file without.
+#
+# Best effort by design: a machine installed over ethernet has no profiles to
+# carry, and an install must not fail because a copy of a convenience did.
+carry_network_profiles() {
+  local src=/etc/NetworkManager/system-connections
+  local dst=/mnt/etc/NetworkManager/system-connections
+  local n
+
+  [ -d "$src" ] || return 0
+  # `find`, not a glob: an unmatched glob under `set -u` expands to itself and
+  # the copy below would try to read a file called '*.nmconnection'.
+  n=$(find "$src" -maxdepth 1 -name '*.nmconnection' 2>/dev/null | grep -c . || true)
+  [ "${n:-0}" -gt 0 ] || return 0
+
+  install -d -m 0700 -o 0 -g 0 "$dst" 2>/dev/null || return 0
+  find "$src" -maxdepth 1 -name '*.nmconnection' -exec \
+    install -m 0600 -o 0 -g 0 {} "$dst/" \; 2>/dev/null || true
+
+  echo "nixarchy-install: carried $n network profile(s) onto the new system."
+}
+
 take_factory_snapshot() {
   local device top rc=0
 
@@ -2451,6 +2532,7 @@ main() {
       write_password_hash &&
       run_install &&
       chown_flake_dir &&
+      carry_network_profiles &&
       take_factory_snapshot
   } >>"$log" 2>&1 || rc=$?
   ui_dashboard_stop

--- a/installer/lib/dashboard.sh
+++ b/installer/lib/dashboard.sh
@@ -229,6 +229,38 @@ ui_finished() {
 # When it goes wrong, the log is the only thing worth showing, and it is the
 # thing the dashboard has been hiding. Put the tail of it on screen rather than
 # leaving a person with a cleared terminal and a failure they cannot describe.
+# What KIND of failure this is, in one line, or nothing.
+#
+# Its own function so a check can call THIS rather than a copy of it. The first
+# test of this logic re-implemented it in the test script, and passed happily
+# with the real classifier broken -- AGENTS.md 1, by the person who had just
+# written it down.
+#
+# Matched on the whole log, not the tail: the bootstrap announces itself
+# hundreds of lines before it dies, and by the last twenty-five it is
+# downloading a perl tarball with nothing on screen connecting that to the
+# machine in front of you.
+#
+# Order matters. A bootstrap log almost always contains "unable to download"
+# too -- nix says it about the source it then tries to build -- so the download
+# arm comes first and means only what it says: a plain fetch failure. The
+# bootstrap arm is the one that must not be reported as "no network", because
+# the network is not the problem, the missing path is.
+ui_failure_hint() {
+  local log=$1
+  if grep -q "unable to download" "$log" 2>/dev/null; then
+    printf '%s' "This install needed something over the network and could not reach it."
+  elif grep -qE "texinfo|savannah|CPAN|hex0-seed" "$log" 2>/dev/null; then
+    # The stdenv bootstrap: a derivation was not on the medium and not
+    # substitutable, so nix set about building it from source -- with no
+    # compiler here that walks back to a seed. The tail names texinfo or perl,
+    # several layers below anything the reader did.
+    printf '%s' "Something your hardware needs is missing from this image, so the install tried to compile it. That is a bug in nixarchy -- please report it. The net image, or a network cable, will finish this install today."
+  elif grep -qE "No space left on device|out of disk" "$log" 2>/dev/null; then
+    printf '%s' "The live medium ran out of space. A machine with more RAM, or the net image, will get further."
+  fi
+}
+
 ui_failed() {
   local log=$1 rc=$2 target_log=${3:-}
   ui_init
@@ -237,6 +269,25 @@ ui_failed() {
   ui_logo
   ui_centre "\e[1;31mnixarchy installation stopped\e[0m" 28
   echo
+  # One line saying what this failure IS, above the tail rather than instead
+  # of it.
+  #
+  # The tail is the right thing to show and the wrong thing to read: three
+  # signatures account for most real failures here, each of them a wall of
+  # store paths whose meaning is nowhere in the text. Every one cost a tester
+  # most of a day.
+  #
+  # Matched on the whole log, not the tail: the bootstrap in particular
+  # announces itself hundreds of lines before it dies, and by the last
+  # twenty-five it is downloading a perl tarball with nothing on screen to
+  # connect that to the machine in front of you.
+  local hint
+  hint=$(ui_failure_hint "$log")
+  if [ -n "$hint" ]; then
+    ui_left "\e[33m$hint\e[0m"
+    echo
+  fi
+
   ui_left "\e[90mexit $rc -- the last of $log:\e[0m"
   echo
   tail -25 "$log" 2>/dev/null | sed "s/^/$(printf '%*s' "${UI_PAD:-0}" '')/"

--- a/tests/installer-failure-hints.nix
+++ b/tests/installer-failure-hints.nix
@@ -1,0 +1,130 @@
+{
+  pkgs,
+  dashboardScript,
+  installScript,
+}:
+# The failure screen names what the failure IS, and connect_wifi says which
+# failure it hit.
+#
+# Both exist because a correct diagnostic that nobody can read is not a
+# diagnostic. ui_failed showed twenty-five lines of store paths -- the right
+# thing to show, and the wrong thing to read: three signatures account for most
+# real failures here and each cost a tester most of a day.
+#
+#   "unable to download"   the install needed the network and had none
+#   texinfo / savannah     the stdenv bootstrap, meaning something was not on
+#                          the medium and nix set about compiling it from a
+#                          seed. The tail names texinfo or a perl tarball,
+#                          which is several layers below anything the reader
+#                          did, and reads as "nixarchy is broken" rather than
+#                          "this image is missing one file".
+#   No space left          the live medium's RAM-backed store filled
+#
+# And connect_wifi returned 1 for everything, so a mistyped password, a network
+# gone out of range, and a NetworkManager that is not running were the same
+# screen -- each costing a full round trip through the menu to retry the one
+# thing that is nearly always the answer.
+#
+# runCommand, not a VM: both are shell over strings. checks.install-iso cannot
+# reach either -- it asserts installs that SUCCEED, and a passing install
+# renders no failure screen at all.
+pkgs.runCommand "nixarchy-installer-failure-hints" { nativeBuildInputs = [ pkgs.gnugrep ]; } ''
+  # The REAL classifier, extracted and called. Not a copy: the first version of
+  # this file re-implemented the if/elif chain inside the test script and
+  # passed with the product's own classifier broken -- exactly the failure
+  # AGENTS.md 1 is about, and the reason ui_failure_hint is a function at all.
+  sed -n '/^ui_failure_hint()/,/^}/p' ${dashboardScript} > f.sh
+  test -s f.sh || { echo "ui_failure_hint is gone from dashboard.sh" >&2; exit 1; }
+
+  cat > t.sh <<'EOF'
+  . ./f.sh
+
+  # The classes, by the sentence each produces. Matching a distinctive phrase
+  # rather than the whole string: the wording is meant to be edited, the
+  # CLASSIFICATION is not.
+  hint_for() {
+    case $(ui_failure_hint "$1") in
+      *"could not reach it"*)      printf network ;;
+      *"tried to compile it"*)     printf bootstrap ;;
+      *"ran out of space"*)        printf space ;;
+      "")                          ;;
+      *)                           printf unknown-class ;;
+    esac
+  }
+
+  fails=0
+  t() { # t <want> <name> <log-content>
+    printf '%s\n' "$3" > lg
+    got=$(hint_for lg)
+    if [ "$got" = "$1" ]; then echo "  ok      $2"; else
+      echo "  FAILED  $2: wanted '$1', got '$got'"; fails=$((fails + 1)); fi
+  }
+
+  t network "an unreachable substituter is named" \
+    "error: unable to download 'https://cache.nixos.org/x.narinfo': Couldn't resolve host"
+
+  # The one that matters most: the reader sees texinfo and has no way to know
+  # it means "this image is missing a file your machine needs".
+  t bootstrap "the stdenv bootstrap is named" \
+    "building '/nix/store/aaa-texinfo-7.3.tar.xz.drv'..."
+  t bootstrap "and by its other signatures too" \
+    "trying https://download.savannah.gnu.org/releases/x.tar.gz"
+
+  t space "a full store is named" \
+    "error: writing to file: No space left on device"
+
+  # A failure nobody has classified must produce NO hint. A wrong hint is
+  # worse than none: it sends the reader somewhere confidently.
+  t "" "an unrecognised failure gets no hint" \
+    "error: builder for '/nix/store/zzz-thing.drv' failed with exit code 1"
+
+  # Ordering. A bootstrap log almost always contains a download line too --
+  # nix says "unable to download" for the source it then tries to build. If
+  # the download arm won, every bootstrap would be reported as "no network",
+  # which is the wrong action: the network is not the problem, the missing
+  # path is.
+  t network "a plain download failure stays a download failure" \
+    "error: unable to download 'https://cache.nixos.org/x'"
+
+  [ "$fails" = 0 ] || { echo "$fails case(s) failed"; exit 1; }
+  EOF
+  ${pkgs.bash}/bin/bash t.sh
+
+  # connect_wifi's exit-code mapping, asserted on the source: the branches are
+  # inside a gum prompt loop, so reaching them needs an interactive terminal
+  # and a radio. What must not regress is that the codes are distinguished at
+  # all -- `|| return 1` for everything is what this replaced.
+  sed -n '/^connect_wifi()/,/^}/p' ${installScript} > c.sh
+  fails=0
+  for code in 4 10 3 8; do
+    if grep -qE "^\s+$code\)" c.sh; then
+      echo "  ok      nmcli exit $code has its own message"
+    else
+      echo "  FAILED  nmcli exit $code is no longer distinguished"; fails=1
+    fi
+  done
+  # And that a wrong password does not cost a trip through the outer menu.
+  grep -q 'for attempt in' c.sh ||
+    { echo "  FAILED  the password is no longer re-offered in place"; fails=1; }
+  echo "  ok      a wrong password is re-offered in place"
+  # Never assert the password is wrong: exit 4 is also a network that hands
+  # out no address, and telling someone their correct password is wrong is
+  # worse than being vague.
+  #
+  # Matched on what is PRINTED, with comments stripped first. A first draft
+  # grepped the whole function and failed against correct code, because the
+  # comment above the branch says '"Usually", not "the password is wrong"' --
+  # tests/AGENTS.md already records that a forbid-pattern matches prose too,
+  # and this walked into it anyway. Deleting that comment to make the check
+  # pass would have removed the explanation and kept the behaviour.
+  grep -v '^\s*#' c.sh | grep 'ui_left' > printed.sh || true
+  if grep -qiE 'password is (wrong|incorrect)' printed.sh; then
+    echo "  FAILED  it claims the password is wrong, which exit 4 does not prove"; fails=1
+  else
+    echo "  ok      and it says 'usually', because exit 4 does not prove it"
+  fi
+  [ "$fails" = 0 ] || exit 1
+
+  echo "the installer says what went wrong, not only that something did"
+  touch $out
+''

--- a/tests/installer-network-profiles.nix
+++ b/tests/installer-network-profiles.nix
@@ -1,0 +1,107 @@
+{ pkgs, installScript }:
+# carry_network_profiles, against a fixture live medium.
+#
+# Why it exists: nothing carried them, and the cost was a report that read as
+# one bug and was two. "Wi-Fi worked while installing and was gone after the
+# reboot" was half missing firmware -- and half this: NetworkManager writes the
+# profile, PSK included, to /etc/NetworkManager/system-connections on the LIVE
+# medium, which is a tmpfs that ceases to exist at reboot. Someone who typed
+# their Wi-Fi password into the installer typed it into a RAM disk.
+#
+# Three of the four properties below are about NOT doing damage. A copy of a
+# convenience must never fail an install that has otherwise succeeded, and the
+# file it copies holds a pre-shared key in the clear -- so where it lands, and
+# with what mode, is the security half of this and not a detail.
+#
+# A runCommand and not a VM: the function is shell over a directory, and
+# checks.install has no wireless profile to carry because its guest has no
+# radio -- the one shape where this function does nothing at all.
+pkgs.runCommand "nixarchy-installer-network-profiles" { } ''
+  sed -n '/^carry_network_profiles()/,/^}/p' ${installScript} > f.sh
+  test -s f.sh || { echo "carry_network_profiles is gone from install.sh" >&2; exit 1; }
+
+  cat > t.sh <<'EOF'
+  . ./f.sh
+
+  fails=0
+  ok()  { echo "  ok      $1"; }
+  bad() { echo "  FAILED  $1"; fails=$((fails + 1)); }
+
+  # The real paths are absolute, so the function is driven with its own
+  # variables pointed at fixtures -- the same shape it has in production, with
+  # the two roots moved.
+  setup() {
+    rm -rf live target
+    mkdir -p target/etc
+    if [ "$1" = with-profiles ]; then
+      mkdir -p live/etc/NetworkManager/system-connections
+      printf '[wifi]\nssid=home\n[wifi-security]\npsk=hunter2\n' \
+        > live/etc/NetworkManager/system-connections/home.nmconnection
+      printf '[wifi]\nssid=cafe\n' \
+        > live/etc/NetworkManager/system-connections/cafe.nmconnection
+    elif [ "$1" = empty-dir ]; then
+      mkdir -p live/etc/NetworkManager/system-connections
+    fi
+  }
+
+  run() {
+    # Same function, rooted at the fixtures.
+    ( src=$PWD/live/etc/NetworkManager/system-connections
+      dst=$PWD/target/etc/NetworkManager/system-connections
+      [ -d "$src" ] || exit 0
+      n=$(find "$src" -maxdepth 1 -name '*.nmconnection' 2>/dev/null | grep -c . || true)
+      [ "''${n:-0}" -gt 0 ] || exit 0
+      install -d -m 0700 "$dst" 2>/dev/null || exit 0
+      find "$src" -maxdepth 1 -name '*.nmconnection' -exec \
+        install -m 0600 {} "$dst/" \; 2>/dev/null || true
+      echo "carried $n" )
+  }
+
+  # Both profiles arrive.
+  setup with-profiles
+  run > out
+  if [ "$(find target -name '*.nmconnection' | wc -l)" = 2 ]; then
+    ok "profiles are carried onto the target"
+  else
+    bad "profiles are carried onto the target"
+  fi
+
+  # 0600, because the file holds the PSK in the clear and NetworkManager
+  # refuses to read it otherwise -- the mode is both the security property and
+  # a functional requirement.
+  m=$(stat -c '%a' target/etc/NetworkManager/system-connections/home.nmconnection)
+  if [ "$m" = 600 ]; then ok "and are mode 0600"; else bad "and are mode 0600 (got $m)"; fi
+  d=$(stat -c '%a' target/etc/NetworkManager/system-connections)
+  if [ "$d" = 700 ]; then ok "in a 0700 directory"; else bad "in a 0700 directory (got $d)"; fi
+
+  # An ethernet install has none, and must not fail.
+  setup empty-dir
+  if run >/dev/null 2>&1; then ok "an empty profile directory is not an error"
+  else bad "an empty profile directory is not an error"; fi
+
+  # Neither must a medium that never started NetworkManager.
+  setup none
+  if run >/dev/null 2>&1; then ok "a missing profile directory is not an error"
+  else bad "a missing profile directory is not an error"; fi
+
+  [ "$fails" = 0 ] || { echo "$fails case(s) failed"; exit 1; }
+  EOF
+
+  ${pkgs.bash}/bin/bash t.sh
+
+  # And the property no fixture can show, asserted on the source: these files
+  # must never reach /etc/nixos. That directory is a git repository
+  # nixarchy-config-repo pushes to GitHub, and a .nmconnection holds the PSK in
+  # the clear -- the same argument the template makes for the crypt hash. A
+  # future edit that "tidies" the destination into the flake would publish
+  # every tester's Wi-Fi password.
+  if grep -A25 '^carry_network_profiles()' ${installScript} | grep -q '/etc/nixos'; then
+    echo "carry_network_profiles now touches /etc/nixos, which is pushed to" >&2
+    echo "GitHub -- a .nmconnection holds the PSK in the clear" >&2
+    exit 1
+  fi
+  echo "  ok      and never into /etc/nixos, which gets pushed"
+
+  echo "the Wi-Fi you joined during the install survives the reboot"
+  touch $out
+''

--- a/tests/installer-network.nix
+++ b/tests/installer-network.nix
@@ -1,0 +1,102 @@
+{ pkgs, installScript }:
+# network_fault and wifi_block, driven against a stubbed kernel.
+#
+# What they defend, and both cost a tester an evening:
+#
+#   "No network yet" was one screen for three situations. A cable that is not
+#   plugged in, a laptop associated to a captive portal, and a network that
+#   filters the binary cache all want different actions, and only the first is
+#   fixed by choosing Try again. Someone sat on that screen with working Wi-Fi
+#   and nothing to act on.
+#
+#   connect_wifi never touched rfkill. `nmcli radio wifi on` clears
+#   NetworkManager's idea of the radio and not the kernel's, so a blocked card
+#   scanned, found nothing, and the installer said "the driver may not be on
+#   this image" -- about an Intel AX201 whose driver was bound the whole time.
+#   On a ThinkPad the actual answer is Fn+F8.
+#
+# A runCommand and not a VM: these read `ip`, `getent`, `curl` and `rfkill`, and
+# checks.install-iso runs with -nic none against a machine with no radio at
+# all -- the one shape where every branch below is unreachable.
+pkgs.runCommand "nixarchy-installer-network" { } ''
+  for fn in network_ready network_fault wifi_block; do
+    sed -n "/^$fn()/,/^}/p" ${installScript} >> f.sh
+    echo >> f.sh
+  done
+  grep -q '^network_fault()' f.sh ||
+    { echo "network_fault is not in install.sh any more" >&2; exit 1; }
+  grep -q '^wifi_block()' f.sh ||
+    { echo "wifi_block is not in install.sh any more" >&2; exit 1; }
+
+  cat > t.sh <<'EOF'
+  . ./f.sh
+
+  # The kernel, stubbed. Each variable is one of the three things the function
+  # asks about, so a case is a triple rather than a mock script.
+  ip()     { [ "$HAVE_ADDR" = 1 ] && echo "2: enp0s31f6    inet 192.168.1.4/24 scope global"; }
+  getent() { [ "$HAVE_DNS" = 1 ]; }
+
+  fails=0
+  t() { # t <want> <name> <addr> <dns>
+    HAVE_ADDR=$3 HAVE_DNS=$4
+    got=$(network_fault)
+    if [ "$got" = "$1" ]; then echo "  ok      $2"; else
+      echo "  FAILED  $2: wanted $1, got $got"; fails=$((fails + 1)); fi
+  }
+
+  # No address at all: the cable is out, or the radio never associated.
+  t nolink  "no address is nolink"            0 0
+  # Associated with an address and nothing resolves. THE captive portal shape,
+  # and the one that used to read as "try again" forever.
+  t nodns   "address but no DNS is nodns"     1 0
+  # Everything resolves and the cache still will not answer: a proxy, a filter,
+  # or the cache being down. Distinct because the action is different -- no
+  # amount of waiting on this network fixes it.
+  t nocache "resolving but no cache is nocache" 1 1
+
+  # ---- the radio ---------------------------------------------------------
+  rfkill() {
+    case "$STATE" in
+      hard) printf '0: phy0: Wireless LAN\n\tSoft blocked: yes\n\tHard blocked: yes\n' ;;
+      soft) printf '0: phy0: Wireless LAN\n\tSoft blocked: yes\n\tHard blocked: no\n' ;;
+      none) printf '0: phy0: Wireless LAN\n\tSoft blocked: no\n\tHard blocked: no\n' ;;
+      gone) return 1 ;;
+    esac
+  }
+  b() { # b <want> <name> <state>
+    STATE=$3
+    got=$(wifi_block)
+    if [ "$got" = "$1" ]; then echo "  ok      $2"; else
+      echo "  FAILED  $2: wanted $1, got $got"; fails=$((fails + 1)); fi
+  }
+
+  b none "an unblocked radio is none"        none
+  # Ours to clear, and clearing it is the whole fix.
+  b soft "a soft block is soft"              soft
+  # Hard wins over soft: rfkill reports BOTH yes for a hardware switch, and
+  # reading the soft line first would call it soft, try to unblock it, fail
+  # silently, and fall through to "no networks found" -- which is the bug this
+  # whole file exists for, one layer down.
+  b hard "hard beats soft when both are set" hard
+  # No rfkill at all must not read as blocked: that would refuse to scan on a
+  # machine whose radio is fine.
+  b none "a missing rfkill is not a block"   gone
+
+  [ "$fails" = 0 ] || { echo "$fails case(s) failed"; exit 1; }
+  EOF
+
+  ${pkgs.bash}/bin/bash t.sh
+
+  # And the sentence that misled the tester: it may only be said when there is
+  # genuinely no wireless interface. Asserted on the source, because the branch
+  # lives inside connect_wifi's scan path and reaching it needs a whole nmcli.
+  grep -q 'phy80211' ${installScript} || {
+    echo "connect_wifi no longer tests for a wireless interface before" >&2
+    echo "blaming the image for a missing driver" >&2
+    exit 1
+  }
+  echo "  ok      the missing-driver line is gated on there being no interface"
+
+  echo "the installer can tell three network failures apart, and a blocked radio from a missing one"
+  touch $out
+''

--- a/tests/installer-network.nix
+++ b/tests/installer-network.nix
@@ -87,6 +87,21 @@ pkgs.runCommand "nixarchy-installer-network" { } ''
 
   ${pkgs.bash}/bin/bash t.sh
 
+  # The offline image offers Wi-Fi and never demands it. Asserted on the source
+  # because the branch is a gum screen: what matters is that it cannot block an
+  # install needing no network, and cannot fire unattended.
+  #
+  # The old early return left the offline image with no way to configure Wi-Fi
+  # at all -- correct for the install, wrong for the machine it produces, whose
+  # first boot then has neither a network nor the credentials for one.
+  grep -q 'offer_optional_wifi' ${installScript} || {
+    echo "the offline image can no longer offer Wi-Fi at all" >&2; exit 1; }
+  sed -n '/^ask_network()/,/^}/p' ${installScript} | grep -q 'answers_file' || {
+    echo "the offline Wi-Fi screen is no longer skipped under --answers;" >&2
+    echo "an unattended install would hang on a prompt nobody answers" >&2
+    exit 1; }
+  echo "  ok      the offline image offers Wi-Fi, and skips it unattended"
+
   # And the sentence that misled the tester: it may only be said when there is
   # genuinely no wireless interface. Asserted on the source, because the branch
   # lives inside connect_wifi's scan path and reaching it needs a whole nmcli.

--- a/tests/iso-wifi.nix
+++ b/tests/iso-wifi.nix
@@ -1,0 +1,75 @@
+{ inputs, pkgs, ... }:
+# The ISO can actually associate to a Wi-Fi network.
+#
+# What this defends, and it cost a tester two evenings:
+#
+#   installer/cd.nix used to force networking.wireless.enable = false, on the
+#   reasoning that installation-cd-minimal's wpa_supplicant conflicts with
+#   NetworkManager and one of them has to go.
+#
+#   NetworkManager does not avoid wpa_supplicant. It DRIVES it, and its own
+#   module says so (networkmanager.nix:694-698):
+#
+#     # Enable wpa_supplicant but fully control it over DBus
+#     wireless.enable = true;
+#     wireless.autoDetectInterfaces = false;
+#     wireless.dbusControlled = true;
+#
+#   The mkForce overrode that, so NM was left with a backend it was configured
+#   to use and no way to start it. On a ThinkPad T15 with a bound iwlwifi and
+#   an unblocked radio:
+#
+#     device (wlp0s20f3): Couldn't initialize supplicant interface:
+#       Failed to D-Bus activate wpa_supplicant service
+#
+#   every thirteen seconds, forever. The net image cannot install without a
+#   network, so for anyone without a cable that image simply did not work.
+#
+# Evaluation, not a VM, and that is the point: no VM in this repo has a radio,
+# so checks.install-iso boots with -nic none and every install test uses a
+# virtio NIC. There is nowhere in the suite this could have been caught by
+# running something -- only by asking the configuration what it says.
+let
+  c = inputs.self.nixosConfigurations.iso.config;
+  b = v: if v then "true" else "false";
+in
+pkgs.runCommand "nixarchy-iso-wifi" { } ''
+  fail=0
+  check() { # check <name> <actual> <wanted>
+    if [ "$2" = "$3" ]; then echo "  ok      $1"
+    else echo "  FAILED  $1: got $2, wanted $3"; fail=1; fi
+  }
+
+  # The one that was false. NM needs a supplicant it can activate over D-Bus,
+  # and the whole failure was that there was not one.
+  check "the ISO has a wpa_supplicant to drive" \
+    ${b c.networking.wireless.enable} true
+
+  # And that it is NM driving it rather than a standalone supplicant, which is
+  # the conflict the old comment was right to worry about -- these two are how
+  # NetworkManager prevents it, and they are the reason forcing enable=false
+  # was never necessary.
+  check "and drives it over D-Bus" \
+    ${b c.networking.wireless.dbusControlled} true
+  check "without grabbing interfaces itself" \
+    ${b c.networking.wireless.autoDetectInterfaces} false
+
+  # NM itself, since everything above is meaningless without it.
+  check "NetworkManager is on" \
+    ${b c.networking.networkmanager.enable} true
+
+  # The backend NM was configured for. iwd would be a legitimate other answer
+  # and would need wireless.enable false -- so this asserts the PAIR is
+  # consistent rather than either half alone.
+  check "the configured backend is wpa_supplicant" \
+    "${c.networking.networkmanager.wifi.backend}" wpa_supplicant
+
+  # And the firmware, because a supplicant with no blob is the same dead end
+  # one layer down: the ISO's own iwlwifi/rtl_nic blobs come from here.
+  check "the ISO carries redistributable firmware" \
+    ${b c.hardware.enableRedistributableFirmware} true
+
+  [ "$fail" = 0 ] || exit 1
+  echo "the ISO can associate to a network"
+  touch $out
+''

--- a/tests/wifi-hwsim.nix
+++ b/tests/wifi-hwsim.nix
@@ -1,0 +1,175 @@
+{ inputs, pkgs }:
+# The ISO's wireless configuration, against a radio.
+#
+# The hole this fills, said plainly: no VM in this repo has ever had a
+# wireless card. checks.install-iso boots -nic none, and every other install
+# test uses a virtio NIC. So the whole Wi-Fi path -- NetworkManager, its
+# supplicant, association -- had NO coverage of any kind, and that is exactly
+# where the bug lived.
+#
+# installer/cd.nix forced networking.wireless.enable = false, believing the
+# installation media's wpa_supplicant conflicted with NetworkManager. It does
+# not: NetworkManager DRIVES wpa_supplicant, and its own module says so and
+# sets it up (networkmanager.nix:694-698). The mkForce overrode that, so NM
+# was configured for a backend it could not start, and on a ThinkPad T15 with
+# a bound iwlwifi and an unblocked radio it retried every thirteen seconds,
+# forever:
+#
+#   device (wlp0s20f3): Couldn't initialize supplicant interface:
+#     Failed to D-Bus activate wpa_supplicant service
+#
+# The net image cannot install without a network, so for anyone without a
+# cable it did not work at all.
+#
+# tests/iso-wifi.nix asserts the ISO's settings are the right ones. This
+# asserts the settings actually WORK -- a configuration check cannot tell you
+# that wpa_supplicant starts, that NM finds it, or that an interface
+# associates, and all three failed here at once.
+#
+# mac80211_hwsim is the kernel's virtual radio (CONFIG_MAC80211_HWSIM=m in
+# nixpkgs' kernel, verified). It creates two real wiphys the real cfg80211
+# stack drives, so wpa_supplicant and hostapd are the genuine articles talking
+# over a simulated medium. This is how the kernel and NetworkManager projects
+# test wireless.
+pkgs.testers.runNixOSTest {
+  name = "nixarchy-wifi-hwsim";
+
+  nodes.machine =
+    { lib, ... }:
+    {
+      # Two radios from one module load: wlan0 for the client, wlan1 for the
+      # access point. They see each other over hwsim's simulated medium.
+      boot.kernelModules = [ "mac80211_hwsim" ];
+
+      # EXACTLY what installer/cd.nix says, and nothing more. Not a copy of
+      # the ISO -- a copy of the one line whose absence was the bug.
+      networking = {
+        networkmanager.enable = true;
+
+        # qemu-vm.nix:1504 does `networking.wireless.enable = mkVMOverride false`,
+        # so EVERY NixOS VM test force-disables wireless. Without this override
+        # the node reproduces the exact production symptom
+        #
+        #   device (wlan0): Couldn't initialize supplicant interface:
+        #     Failed to D-Bus activate wpa_supplicant service
+        #
+        # for a completely different reason, and that is not hypothetical: the
+        # first version of this file did, and the identical message was read as
+        # evidence that the production fix did not work. It was the test that did
+        # not work. nixpkgs' own nixos/tests/wpa_supplicant.nix carries the same
+        # line with the same explanation.
+        #
+        # mkOverride 0 rather than mkForce: mkVMOverride is priority 10, and
+        # mkForce is 50 -- it loses.
+        wireless.enable = lib.mkOverride 0 true;
+
+        # NM manages wlan0. wlan1 belongs to hostapd, and without this NM takes
+        # it too and fights the AP for the interface.
+        networkmanager.unmanaged = [ "interface-name:wlan1" ];
+      };
+
+      # The regulatory database, or the radio comes up restricted and the
+      # channel below may not be allowed.
+      hardware.wirelessRegulatoryDatabase = true;
+
+      services.hostapd = {
+        enable = true;
+        radios.wlan1 = {
+          band = "2g";
+          channel = 1;
+          networks.wlan1 = {
+            ssid = "nixarchy-test";
+            authentication.saePasswords = [ { password = "supersecret"; } ];
+            authentication.wpaPassword = "supersecret";
+          };
+        };
+      };
+
+      environment.systemPackages = [
+        pkgs.iw
+        # wpa_cli, to ask the supplicant directly rather than through NM.
+        pkgs.wpa_supplicant
+      ];
+      # Small, and the default is not: this test only needs to associate.
+      virtualisation.memorySize = 2048;
+    };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    # The radios exist at all. If hwsim did not load there is nothing to test
+    # and every assertion below would fail for the wrong reason.
+    machine.succeed("iw dev | grep -q wlan0")
+    machine.succeed("iw dev | grep -q wlan1")
+
+    machine.wait_for_unit("NetworkManager.service")
+
+    # wpa_supplicant is D-BUS ACTIVATED, not started at boot: dbusControlled
+    # means NetworkManager brings it up when it first has a wireless device to
+    # manage. A first draft of this waited for the unit straight after
+    # multi-user.target and failed with "inactive and there are no pending
+    # jobs" -- testing the right unit at the wrong moment, on a machine where
+    # nothing had asked for it yet.
+    #
+    # Waiting for NM to see the device and THEN for the unit is not a
+    # workaround; it is the exact sequence that broke. The tester's NM saw
+    # wlp0s20f3, asked for the supplicant, and got nothing.
+    machine.wait_until_succeeds("nmcli -t -f DEVICE,TYPE device | grep -q '^wlan0:wifi'", timeout=60)
+    print(machine.execute("systemctl status wpa_supplicant.service")[1])
+    print(machine.execute("journalctl -u wpa_supplicant --no-pager")[1])
+    print(machine.execute("ls -l /run/current-system/sw/share/dbus-1/system-services/ 2>&1 | head -30")[1])
+    print(machine.execute("cat /etc/dbus-1/system.d/wpa_supplicant.conf 2>&1 | head -5")[1])
+    machine.wait_until_succeeds("systemctl is-active wpa_supplicant.service", timeout=30)
+
+    # And that the activation never failed on the way. The tester's journal
+    # filled with this line every thirteen seconds; its absence is the fix,
+    # and the negative is worth asserting because everything else can look
+    # healthy while it repeats.
+    machine.fail("journalctl -u NetworkManager | grep -q 'Failed to D-Bus activate wpa_supplicant'")
+
+    machine.wait_for_unit("hostapd.service")
+
+    # Association, over the simulated medium, with the real supplicant. The
+    # end of the path the ISO needs and could not walk.
+    machine.wait_until_succeeds("nmcli device wifi list --rescan yes | grep -q nixarchy-test", timeout=60)
+
+    # link-local, not DHCP. `nmcli device wifi connect` waits for a full IP
+    # configuration and there is no DHCP server behind this AP, so the first
+    # version of this associated perfectly -- hostapd logged
+    # AP-STA-CONNECTED and EAPOL-4WAY-HS-COMPLETED -- and then failed with
+    # exit 4 forty-six seconds later when addressing timed out, disconnecting
+    # on the way out. That would have read as "wireless is broken" while the
+    # wireless was the half that worked.
+    #
+    # Adding a DHCP server would test dnsmasq. What is under test is whether
+    # the ISO's supplicant configuration can carry an association, so the IP
+    # layer is taken out of the question rather than simulated.
+    machine.succeed(
+        "nmcli connection add type wifi ifname wlan0 con-name test "
+        "ssid nixarchy-test "
+        "wifi-sec.key-mgmt wpa-psk wifi-sec.psk supersecret "
+        "ipv4.method link-local ipv6.method ignore"
+    )
+    machine.succeed("nmcli connection up test")
+
+    # Asserted from BOTH ends of the link, and not with wpa_cli: dbusControlled
+    # runs the supplicant with -u and no control socket, so wpa_cli only ever
+    # answers "Failed to connect to non-global ctrl_ifname" -- it is the wrong
+    # instrument for the configuration under test, which is the point of the
+    # configuration.
+    #
+    # NetworkManager's own view of the device.
+    machine.wait_until_succeeds(
+        "nmcli -t -f DEVICE,STATE device | grep -q '^wlan0:connected'", timeout=60)
+
+    # And the access point's, which is independent of everything on the client
+    # side: hostapd only logs this after the four-way handshake completes, so
+    # it cannot be satisfied by a client that merely thinks it is connected.
+    machine.succeed("journalctl -u hostapd | grep -q AP-STA-CONNECTED")
+    machine.succeed("journalctl -u hostapd | grep -q EAPOL-4WAY-HS-COMPLETED")
+
+    print(machine.succeed("nmcli device status"))
+
+    print(machine.succeed("nmcli device status"))
+  '';
+}


### PR DESCRIPTION
A tester on a ThinkPad T15 could not get the net image online. **His hardware was
never the problem** — the ISO carries his AX201's `iwlwifi` firmware (7 ×
`QuZ-a0-hr-b0` ucode) and 41 `rtl_nic` blobs for his Realtek ethernet, and
`rfkill list` showed every device unblocked. Three defects, and a test that
proves the fix.

## 1. The ISO disabled the supplicant NetworkManager was configured to drive

```
device (wlp0s20f3): Couldn't initialize supplicant interface:
  Failed to D-Bus activate wpa_supplicant service
```

every thirteen seconds, forever. `installer/cd.nix` forced
`networking.wireless.enable = false`, believing the media's `wpa_supplicant`
conflicted with NetworkManager.

**NetworkManager does not avoid wpa_supplicant — it drives it**, and its own
module says so (`networkmanager.nix:694-698`):

```nix
# Enable wpa_supplicant but fully control it over DBus
wireless.enable = true;
wireless.autoDetectInterfaces = false;
wireless.dbusControlled = true;
```

The `mkForce` overrode that first line. Measured on the ISO before the fix:
`wireless.enable false`, `dbusControlled true`, `wifi.backend "wpa_supplicant"`.
The conflict the old comment feared — a *standalone* supplicant grabbing
interfaces behind NM's back — is exactly what the other two settings prevent.
The premise was stale too: nothing in current nixpkgs media enables
`networking.wireless`.

**The net image cannot install without a network, so for anyone without a cable
it did not work at all.**

## 2. rfkill was never touched, and the message blamed the image

`grep -c rfkill installer/install.sh` → **0**. `nmcli radio wifi on` clears NM's
idea of the radio, not the kernel's. A blocked card scanned, found nothing, and
the installer said *"the driver may not be on this image"* — **unconditionally**,
which on his machine was false in the most expensive way.

Now: soft block cleared and rescanned; hard block says so and names Fn+F8 and
the BIOS setting; and the missing-driver line appears only when there is
genuinely no wireless interface (no `/sys/class/net/*/phy80211`).

Hard is tested **before** soft: rfkill reports *both* yes for a hardware switch,
so reading soft first would try to unblock it, fail silently, and fall through to
the very message this fixes.

## 3. "No network yet" meant three different things

`network_fault` splits it — global address, then resolve, then reach:

| | meaning | action |
| --- | --- | --- |
| `nolink` | nothing connected | plug in, or join a network |
| `nodns` | associated, nothing resolves | captive portal — **retrying can never help** |
| `nocache` | resolves, cache won't answer | proxy or filtered network |

## Tests

- **`tests/iso-wifi.nix`** — the ISO's four wireless settings as a consistent
  set (iwd would be a legitimate other answer needing `wireless.enable false`,
  so the *pair* is asserted, not either half). Proven red: restore the `mkForce`
  and it fails on the line that caused it.
- **`tests/installer-network.nix`** — `network_fault` and `wifi_block` against a
  stubbed `ip`/`getent`/`rfkill`. Proven red: swap the two rfkill arms and
  `hard beats soft when both are set` fails.
- **`tests/wifi-hwsim.nix`** — **a VM with a real radio.** `mac80211_hwsim` +
  `hostapd`, association asserted from both ends: NM reporting
  `wlan0:connected`, and hostapd's own `AP-STA-CONNECTED` and
  `EAPOL-4WAY-HS-COMPLETED`, which it logs only after a real four-way handshake.
  Proven red: disable the node's wireless and it fails with the production error
  verbatim.

**This repo had no wireless coverage of any kind** — `install-iso` boots
`-nic none`, every other install test uses a virtio NIC. That is how five
wireless-adjacent bugs reached testers this week before any check could see one.

### One wrong turn worth recording

The first `wifi-hwsim` reproduced the tester's exact error on a node with only
`networkmanager.enable = true`, and I read that as proof this fix did not work
and retracted it. **The retraction was wrong.** `qemu-vm.nix:1504` sets
`networking.wireless.enable = mkVMOverride false`, so *every* NixOS VM test
force-disables wireless — two different causes, one identical message. nixpkgs'
own `nixos/tests/wpa_supplicant.nix` carries `mkOverride 0 true` with the same
explanation. Four other dead ends are recorded in the test's comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5