### PR TITLE
Adding a check now runs it, instead of failing until someone writes YAML

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,110 +113,16 @@ jobs:
       - name: deadnix
         run: nix run nixpkgs#deadnix -- --fail .
 
-      # Cheap, and it belongs with the other things that are checked before
-      # anything is built: it reads files rather than making them. `nix run
-      # .#review` watches every hand-pinned package; this watches that it can
-      # still see them, which is how that script rots.
-      - name: The nightly review can still read every pin
-        run: nix build .#checks.x86_64-linux.review-pins --print-build-logs
 
-      # The lock the installer writes, checked for the fields nix would have
-      # written itself. installer/mkFlake.nix assembles that node by hand, and a
-      # hand-assembled node can be missing a field without failing: the flake
-      # evaluates and whatever reads it takes a fallback. `lastModified` went
-      # missing exactly that way, which changed the omarchy derivation on the
-      # installed machine, which made an offline install build what it meant to
-      # copy -- surfacing 25 minutes later as a missing ESP.
-      - name: The installer's generated lock has the fields nix would write
-        run: nix build .#checks.x86_64-linux.installer-lock --print-build-logs
 
-      # Whether the live store can hold what the install must fetch. A live
-      # ISO's store is a RAM-backed overlay at half the machine's memory, and
-      # when it fills the install dies several levels under an error naming
-      # none of it -- reaching one user as a machine with no bootloader.
-      # checks.install cannot see this: it installs onto a machine whose store
-      # fits, which is the only shape that does not fail. So the decision is
-      # unit-tested here instead, in seconds.
-      - name: The installer refuses a build the live store cannot hold
-        run: nix build .#checks.x86_64-linux.installer-store-space --print-build-logs
 
-      # Every attribute nixos-generate-config can emit, against what the ISO
-      # bakes. #382: an Intel NPU made the tool write
-      # hardware.cpu.intel.npu.enable, which added a package no reference
-      # closure carried, which the offline image then tried to BUILD -- into
-      # the stdenv source bootstrap, after partitioning the disk. qemu exposes
-      # no NPU, so every install check in this file passed while that shipped.
-      #
-      # Pure evaluation, seconds of wall clock, and it goes red on the nixpkgs
-      # bump that introduces the next such attribute rather than on the user
-      # who owns the hardware.
-      - name: Every generate-config attribute is one the image can satisfy
-        run: nix build .#checks.x86_64-linux.generate-config-surface --print-build-logs
 
-      # The initrd pin install.sh writes must stay conditional on the kernel
-      # its module lists came from. An unguarded pin makes `omarchy update`
-      # fail outright on any machine whose kernel has moved -- nixos-rebuild
-      # cannot build the initrd, so it produces no system at all. Seconds of
-      # wall clock; it greps the built installer.
-      - name: The initrd pin names the kernel it was captured from
-        run: nix build .#checks.x86_64-linux.initrd-pin-guard --print-build-logs
 
-      # The doctor's GPU rules, against fixture machines. checks.install's VM
-      # has no PCI display controller, so nothing else can reach these branches.
-      - name: The doctor reads a GPU correctly
-        run: nix build .#checks.x86_64-linux.doctor-graphics --print-build-logs
 
-      # The doctor's wireless rules. The install VM has a virtio NIC and no
-      # radio, so not one of the three no-wlan0 cases can occur there -- the
-      # same gap that let the no-VAAPI-driver branch ship unreachable (#352).
-      - name: The doctor tells the three no-wlan0 cases apart
-        run: nix build .#checks.x86_64-linux.doctor-wireless --print-build-logs
 
-      # That an installed machine carries firmware without depending on a virt
-      # probe, and can still refuse it. Every guest reports a virt type, so
-      # every install check takes the branch where this is false and the branch
-      # real users are on is the one nothing covers.
-      - name: Installed systems carry firmware, and can still refuse it
-        run: nix build .#checks.x86_64-linux.firmware-guard --print-build-logs
-      # Which nixos-hardware modules the installer picks, against four fixture
-      # machines. The install VM is one machine and these rules are about being
-      # on many -- and it is the one shape that reaches none of the interesting
-      # branches: virtio GPU, no battery, and a squashfs loop that a naive
-      # rotational test reads as an SSD.
-      - name: The installer picks the right hardware modules
-        run: nix build .#checks.x86_64-linux.hardware-modules --print-build-logs
 
-      # And that the offline image can satisfy them. common-gpu-intel pulls
-      # intel-media-driver, intel-compute-runtime and vpl-gpu-rt, and an
-      # offline Intel laptop selects it without asking -- #382's failure mode,
-      # made reachable again and wider.
-      - name: The offline image carries those modules' packages
-        run: nix build .#checks.x86_64-linux.offline-hardware-packages --print-build-logs
 
-      # The `nix run #try` front door, on the machines it will actually meet:
-      # no KVM, no kvm group, 1 GB of RAM, a tmpfs working directory, a
-      # declined binary cache, a disk left by a ctrl-C'd install. Each must
-      # refuse in a sentence naming the number and the way out, and a
-      # preflight nobody has seen fail is a preflight nobody knows works --
-      # so every path is driven here with a stubbed environment, in seconds.
-      # The happy path (a bootable UEFI window) needs KVM and a display no
-      # sandbox has; what CAN be asserted cheaply is asserted on every PR.
-      - name: The try front door refuses in sentences, not stack traces
-        run: nix build .#checks.x86_64-linux.try-preflight --print-build-logs
 
-      # --from-repo, the install mode that clones the user's OWN configuration
-      # repository and installs the host it finds there. Both of its branches
-      # -- host already in the repo, host added to it -- had zero coverage
-      # until now, and it is the only mode that writes to something the user
-      # owns as well as to a disk.
-      #
-      # Wired here rather than left for a follow-up. #323 makes this file's
-      # coverage guard actually work; a check in the flake that no workflow
-      # runs fails that guard on main and on every PR after it, which is the
-      # empty-`box:` deadlock from another direction. An unrun check is worse
-      # than no check -- it occupies the slot.
-      - name: --from-repo installs the host the repository names
-        run: nix build .#checks.x86_64-linux.installer-from-repo --print-build-logs
 
       # Where a crash report goes. The prose said Nixarchy and every `gh`
       # command said Basecamp, so an agent read the rule, concluded correctly,
@@ -248,52 +154,13 @@ jobs:
           nix shell nixpkgs#actionlint -c \
             actionlint -ignore 'SC[0-9]+:(info|style):'
 
-      - name: Crash reports route to the repository the rule names
-        run: nix build .#checks.x86_64-linux.crash-report-repo --print-build-logs
 
-      # The bus room is public, permanent and undeletable, so the redaction
-      # hook's dangerous failure is passing something it claimed to catch --
-      # and its other dangerous failure is blocking ordinary messages until
-      # agents route around it. Both directions are asserted, which is why
-      # this runs here rather than being trusted.
-      - name: The bus redaction hook blocks what it claims, and only that
-        run: nix build .#checks.x86_64-linux.bus-redact --print-build-logs
 
-      # The vendored MCP server is a copy of a file in a repo CI cannot see,
-      # so drift cannot be diffed away -- instead the copy is started over
-      # real stdio and held to the tool contract SKILL.md documents. The
-      # failure this defends against is a re-vendored copy that is subtly
-      # behind and still runs. Seconds of wall clock, so it runs per-PR.
-      - name: The vendored bus server still honours its documented contract
-        run: nix build .#checks.x86_64-linux.bus-mcp --print-build-logs
 
-      # Same shape, same reason: its dangerous failure is reporting nothing.
-      - name: The Omarchy package delta still sees a change
-        run: nix build .#checks.x86_64-linux.package-delta --print-build-logs
 
-      # The rest of the bump PR body. The config delta scans the seeded tree
-      # for the executables it names -- the class of bug #202 was -- and the
-      # patched-files intersection derives what this port has its hands on by
-      # grepping four statements the repo makes about itself. Both fail by
-      # falling quiet, so both are fed a known answer here.
-      - name: The seeded-config delta still sees a change
-        run: nix build .#checks.x86_64-linux.config-delta --print-build-logs
 
-      - name: The patched-file intersection still finds what this port patches
-        run: nix build .#checks.x86_64-linux.patched-files --print-build-logs
 
-      # And the release notes those deltas go into, which have four scans to
-      # rot rather than one -- the Omarchy pin, the pinned versions, the
-      # mkDefault lines, and the option set -- and where reporting nothing
-      # reaches every person deciding whether to upgrade.
-      - name: The release notes still see what changed
-        run: nix build .#checks.x86_64-linux.release-notes --print-build-logs
 
-      # Prose, checked the way the app and subcommand counts already are: an
-      # option path in the README or the manual is a claim about the option
-      # set, and #214 shipped one that had been false for a release.
-      - name: The documentation only quotes options that exist
-        run: nix build .#checks.x86_64-linux.doc-options --print-build-logs
 
   # Every preset in data/devenv-presets.nix, scaffolded with the real
   # `nixarchy dev init` and handed to a real devenv to evaluate.
@@ -465,7 +332,46 @@ jobs:
           # entry is an `inherit` of the package, so building the package IS
           # building the check. The old awk-based extraction could never see it
           # at all, which is why it was not listed here before.)
+          # WHO claims each check, rather than "is it named anywhere".
+          #
+          # This list is the opt-OUT. Everything not on it is built by the next
+          # step, which derives its targets from the flake -- so adding a check
+          # now runs it, with no YAML to write and nothing to forget. That
+          # inversion is the point: `checks.<name> is defined but no workflow
+          # runs it` fired four times in one day, every time because a check was
+          # added and a step was not, and the gate can only ever report that
+          # after the fact.
+          #
+          # These are the checks another job runs for a reason the generated
+          # step cannot satisfy -- a bigger runner, KVM, a 90-minute budget, a
+          # disk-free step, or a Hyprland closure that wants its own concurrency
+          # group. Naming them here is a claim that is CHECKED below in both
+          # directions, so the list cannot rot into fiction.
+          claimed="install free-space installer-refusal
+            install-encrypted install-iso install-iso-net iso-budget microvm-boot
+            box-boot box-template coexist dashboard-clock installer-ui
+            installer-wizard integration microvm-template options plugin
+            reference-toplevel session try-nixarchy vm-toplevel"
+
+          # Two are covered by a path the grep below cannot see, and are listed
+          # here rather than left to look accidental:
+          #   omarchy                        built as `nix build .#omarchy`
+          #   reference-unencrypted-toplevel pulled in by checks.install
+          #   omarchy-runtime                built as `nix build .#omarchy-runtime`
+          # (omarchy-runtime is the same derivation either way -- the checks
+          # entry is an `inherit` of the package, so building the package IS
+          # building the check.)
           exempt="omarchy omarchy-runtime reference-unencrypted-toplevel"
+
+          # Collapsed to single spaces before anything tests membership.
+          # `case " $claimed " in *" $c "*)` wants a space on BOTH sides, and
+          # the list above is written across lines for readability -- so the
+          # last name on every line was followed by a newline and matched
+          # nothing. Four checks (installer-refusal, microvm-boot, installer-ui,
+          # plugin) were silently added to the generated set while another job
+          # already built them, and only the count not adding up showed it:
+          # 24 generated + 22 claimed against 45 checks.
+          claimed=$(printf '%s' "$claimed" | tr -s ' \n' ' ')
 
           # And the same hole one level up, which is #164. "Some workflow names
           # it" was never the whole question: a check named only by nightly.yml
@@ -474,26 +380,15 @@ jobs:
           # sat in exactly this position for most of this repo's life, and #123
           # shipped straight through it, green.
           #
-          # These two stay there deliberately, and the cost is the reason:
-          #   install-iso  builds a 5.6 GB image and installs it -- ~3h
+          # These stay there deliberately, and the cost is the reason:
+          #   install-iso  builds a 6 GB image and installs it -- ~3h
           #   iso-budget   measures that same image, so pays the same build
-          # Per-push, an hour of wall clock each makes the queue the bottleneck.
-          # Written down here rather than arrived at by omission, which is the
-          # argument the guard above already rests on.
-          #   install-iso-net  the same image build plus a closure fetch; it is
-          #                    install-iso's sibling and belongs in the same
-          #                    bucket. Measured 483s warm, so promoting it to
-          #                    per-PR is affordable if the appetite is there --
-          #                    see the note above about this list's cost
-          #                    argument being stale.
+          #   install-iso-net  the same image build plus a closure fetch
           #   install-encrypted  an install-class VM with the same 85-minute
-          #                    driver budget as checks.install. install-check.yml
-          #                    already runs two of those concurrently against its
-          #                    90-minute job on the one big runner, and that pair
-          #                    grazed the timeout under load on 2026-09-03; a
-          #                    third has no budget to fit in. nightly.yml's job
-          #                    prints its timings -- promote per-PR with those in
-          #                    hand, since encryption is the default answer.
+          #                    driver budget as checks.install; install-check.yml
+          #                    already runs two of those against a 90-minute job
+          #                    and that pair grazed the timeout on 2026-09-03
+          #   microvm-boot     a nested VM on the -tcg runner
           nightly_only="install-iso iso-budget microvm-boot install-iso-net install-encrypted"
 
           # Ask Nix, do not parse the file.
@@ -502,9 +397,7 @@ jobs:
           # EIGHT spaces of indentation. #299 added a `let ... in` around the
           # checks block, every entry moved to TEN, and the grep silently
           # matched nothing from that commit onward: the guard printed its
-          # success line having extracted zero names. checks.installer-refusal
-          # and checks.install-iso-net both merged unwired while it stood dead,
-          # which is #133 twice over with the tripwire built for it switched off.
+          # success line having extracted zero names.
           #
           # A guard that reads the source's LAYOUT rather than its VALUE fails
           # this way. `nix eval` cannot go stale when someone adds a binding.
@@ -512,14 +405,7 @@ jobs:
             ".#checks.x86_64-linux" \
             --apply 'c: builtins.concatStringsSep "\n" (builtins.attrNames c)')
 
-          # A floor, because the interesting failure of this guard is not a
-          # wrong answer but an EMPTY one. It has now passed-while-checking-
-          # nothing twice: once when the awk indentation went stale, and it
-          # would do so again if `nix eval` ever returned an empty set for a
-          # reason nobody predicted. AGENTS.md 1 says prove your check fails;
-          # that was never applied to the guard itself.
-          #
-          # 20 is well under the current 33 and well over zero -- it catches
+          # 20 is well under the current 45 and well over zero -- it catches
           # "extracted nothing" without needing maintenance every time a check
           # is added or removed.
           count=$(printf '%s\n' "$names" | grep -c . || true)
@@ -529,35 +415,95 @@ jobs:
             exit 1
           fi
 
-          missing=""
+          # Every CLAIM, in both directions. A claimed check that no longer
+          # exists is a stale list; a claimed check no workflow names is a job
+          # that was deleted and a check that now runs nowhere -- and unlike
+          # before, that one would be silent, because the generated step below
+          # skips exactly what this list names.
+          bad=""
           ungated=""
-          for c in $names; do
-            case " $exempt " in *" $c "*) continue ;; esac
+          for c in $claimed $exempt; do
+            printf '%s\n' "$names" | grep -qx "$c" ||
+              { bad="$bad $c:not-a-check"; continue; }
+          done
+          for c in $claimed; do
+            # Already reported as not being a check at all; a second error
+            # saying no workflow names it is true and adds nothing.
+            case " $bad " in *" $c:"*) continue ;; esac
 
             # Not \b, which counts `-` as a boundary: `install` would match a
-            # line naming `install-iso`, and a nightly-only check could borrow
-            # the pull-request coverage of a longer-named sibling.
+            # line naming `install-iso`.
             named=$(grep -rlE "checks\.x86_64-linux\.$c([^a-z0-9-]|\$)" .github/workflows/ || true)
-            if [ -z "$named" ]; then missing="$missing $c"; continue; fi
-
+            if [ -z "$named" ]; then bad="$bad $c:claimed-but-unrun"; continue; fi
             case " $nightly_only " in *" $c "*) continue ;; esac
             # Top-level `on:` key only. `pull_request` also appears in
-            # install-check.yml as `github.event_name == 'pull_request'`, and a
-            # loose grep would read that expression as a trigger.
+            # install-check.yml as `github.event_name == 'pull_request'`.
             echo "$named" | xargs grep -lE '^  pull_request:' >/dev/null 2>&1 ||
               ungated="$ungated $c"
           done
 
-          if [ -n "$missing$ungated" ]; then
-            for c in $missing; do
-              echo "::error::checks.$c is defined but no workflow runs it"
+          if [ -n "$bad$ungated" ]; then
+            for c in $bad; do
+              case $c in
+                *:not-a-check)
+                  echo "::error::${c%%:*} is in the claimed list and is not a check in the flake" ;;
+                *:claimed-but-unrun)
+                  echo "::error::${c%%:*} is claimed by the list and named by no workflow --" \
+                       "the generated step skips it, so it now runs nowhere" ;;
+              esac
             done
             for c in $ungated; do
-              echo "::error::checks.$c is run by no workflow that triggers on a pull request"
+              echo "::error::checks.$c is claimed but run by no workflow that triggers on a pull request"
             done
             exit 1
           fi
-          echo "every check in the flake is built by a workflow that runs on pull requests"
+
+          # What the next step builds: everything nobody claimed. Written to a
+          # file rather than recomputed there, so the lists above are the single
+          # place either step reads.
+          : > /tmp/generated-checks
+          for c in $names; do
+            case " $claimed $exempt " in *" $c "*) continue ;; esac
+            echo ".#checks.x86_64-linux.$c" >> /tmp/generated-checks
+          done
+          gen=$(grep -c . /tmp/generated-checks || true)
+          if [ "${gen:-0}" -lt 5 ]; then
+            echo "::error::only $gen checks would be built by the generated step;" \
+                 "the claimed list has swallowed the flake" >&2
+            exit 1
+          fi
+          echo "$gen checks are generated, $(printf '%s' "$claimed" | wc -w) are claimed elsewhere"
+
+      - name: Build every check no other job claims
+        run: |
+          # The 20 steps this replaces were byte-identical except for the name:
+          # `nix build .#checks.x86_64-linux.<x> --print-build-logs`, no setup,
+          # no runner of their own. Maintaining that list by hand is what made
+          # "checks.<name> is defined but no workflow runs it" the most repeated
+          # CI failure in the repo -- four times in one day.
+          #
+          # One `nix build`, not a job matrix. A 20-job matrix pays 20 runner
+          # spin-ups, 20 nix installs and 20 cachix setups to parallelise work
+          # nix already parallelises internally, and turns four required status
+          # contexts into twenty-four. --keep-going reports every failure in one
+          # run rather than stopping at the first, which is what the matrix would
+          # have been bought for.
+          #
+          # The list comes from the previous step, which owns the claimed/exempt
+          # lists and has already verified them.
+          mapfile -t targets < /tmp/generated-checks
+          # mapfile returns 0 whatever the redirect did; an empty array here
+          # would make this `nix build` with no installables, which builds
+          # .#default and passes having checked nothing. The step before has a
+          # floor of its own, and this is the second half of the same guard --
+          # cheap, and the failure it prevents is a green run over no checks.
+          if [ "${#targets[@]}" -eq 0 ]; then
+            echo "::error::no generated targets; refusing to build .#default and call it a pass" >&2
+            exit 1
+          fi
+          printf 'building %s checks:\n' "${#targets[@]}"
+          printf '  %s\n' "${targets[@]}"
+          nix build --keep-going --print-build-logs "${targets[@]}"
 
       - name: The README's roadmap still matches the open epics
         env:


### PR DESCRIPTION
`checks.<name> is defined but no workflow runs it` fired **four times in one
day** — `doctor-wireless`, `firmware-guard`, `hardware-modules`,
`offline-hardware-packages` — every time because a check was added and a
hand-written step was not. The gate is correct, and it can only ever report this
*after the fact*.

## Inverting the default

The `lint` job's twenty steps were byte-identical except for the name:

```yaml
run: nix build .#checks.x86_64-linux.<x> --print-build-logs
```

No setup, no runner of their own. They are replaced by **one** step that derives
its targets from the flake: everything no other job claims. **Adding a check now
runs it with no YAML at all**; only opting *out* is an edit, and that edit is
guarded.

## The gate becomes a claim, checked both ways

`claimed` names the 22 checks another job runs for a reason the generated step
cannot satisfy — a bigger runner, KVM, a 90-minute budget, a disk-free step, a
Hyprland closure wanting its own concurrency group. Every entry must **exist in
the flake** *and* **be named by some workflow**.

That second direction matters more than before: a claimed check whose job was
deleted now runs **nowhere**, silently, because the generated step skips exactly
what the list claims.

```
20 generated + 22 claimed + 3 exempt = 45 checks
```

**That arithmetic caught a real bug in this change.** The first version leaked
`installer-refusal`, `microvm-boot`, `installer-ui` and `plugin` into the
generated set while another job already built them — they are the *last name on
each line* of the multi-line `claimed` string, and `case " $claimed " in
*" $c "*)` wants a space on both sides; a newline is not one. Collapsed with
`tr -s ' \n' ' '` before any membership test. `24 + 22` against 45 didn't add up,
which is the only reason it was seen.

## One `nix build --keep-going`, not a job matrix

Twenty jobs would pay twenty runner spin-ups, twenty nix installs and twenty
cachix setups to parallelise what nix already parallelises internally, and turn
four required status contexts into twenty-four. `--keep-going` reports every
failure in one run — which is what the matrix would have been bought for.

## Proven red

Both failure modes fire with one clear message each:

```
::error::no-such-check is in the claimed list and is not a check in the flake
::error::doctor-graphics is claimed by the list and named by no workflow --
         the generated step skips it, so it now runs nowhere
```

**The first attempt at proving them was itself worthless** — the `sed` meant to
inject a bad entry matched nothing, so both "proofs" ran the unmodified gate and
passed. Verified the modification landed before trusting the result; not doing so
is the same mistake as a check that cannot fail.

Error tokens carry no spaces: `bad` is word-split, so `"$c(no such check)"`
became three entries and printed `::error::check)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5