### PR TITLE
Installer hardening and CI hardening, together

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,0 +1,46 @@
+name: Set up nix
+description: >-
+  nix-installer with this flake's own binary caches, written where the daemon
+  will actually honour them.
+
+# Why this exists: the block below was copied into eleven places, and they are
+# byte-identical today by luck rather than by design. build.yml:66-69 records
+# what a divergence already cost -- the `system` job survived an outage only
+# because it had a hand-written `sudo tee` step nobody had copied to the
+# others. Eleven copies of a security-relevant setting is eleven places to
+# forget when a key rotates.
+#
+# NOT included here: the cachix push step. It relies on `continue-on-error:
+# true` (#235 -- a cache upload that fails must not fail a build that
+# succeeded), and whether a composite action's `uses:` step honours that is not
+# something to find out from a broken pipeline. It stays in the workflows,
+# where it demonstrably works. This action covers the duplication that is
+# actually identical.
+
+runs:
+  using: composite
+  steps:
+    - uses: DeterminateSystems/nix-installer-action@main
+      with:
+        # extra-conf, not the flake's own nixConfig, and the difference is the
+        # whole reason this is written down.
+        #
+        # `accept-flake-config` promotes a flake's nixConfig to CLIENT-specified
+        # settings, and the daemon discards those for anyone not in
+        # trusted-users. The runner is not, so every `nix build` printed
+        #
+        #   warning: ignoring the client-specified setting
+        #   'trusted-public-keys', because it is a restricted setting and you
+        #   are not a trusted user
+        #
+        # and then compiled Hyprland from source. extra-conf is written into
+        # the SYSTEM nix.conf as root, so what is set here is trusted and
+        # actually applies.
+        #
+        # The store path nixarchy uses is byte-identical to the one hyprwm
+        # publish -- verified, not assumed -- so with this the compositor is a
+        # download.
+        extra-conf: |
+          accept-flake-config = true
+          extra-substituters = https://nixarchy.cachix.org https://hyprland.cachix.org
+          extra-trusted-public-keys = nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM= hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE=

--- a/.github/scripts/app-versions.sh
+++ b/.github/scripts/app-versions.sh
@@ -56,9 +56,26 @@ total=0
   while IFS= read -r attr; do
     [ -n "$attr" ] || continue
     total=$((total + 1))
-    # --impure so NIXPKGS_ALLOW_UNFREE from the caller is honoured; several
-    # catalogue entries are unfree and would otherwise all be "skipped".
-    if v=$(nix eval --impure --raw "github:NixOS/nixpkgs/${rev}#${attr}.version" 2>/dev/null); then
+    # PURE, and the comment that used to sit here was wrong twice over.
+    #
+    # It said --impure was needed so NIXPKGS_ALLOW_UNFREE "from the caller"
+    # would be honoured, or every unfree catalogue entry would be skipped.
+    # flake-update.yml is the only caller and never sets it -- build.yml and
+    # update.yml do, this workflow does not -- so the justification described
+    # something that was not happening.
+    #
+    # And it was unnecessary anyway. nixpkgs defers the unfree throw to
+    # outPath/drvPath, so `.version` on an unfree package never fails.
+    # Measured with NIXPKGS_ALLOW_UNFREE and NIXPKGS_CONFIG both unset:
+    # vscode 1.136.1, obsidian 1.13.4, steam 1.0.0.87.
+    #
+    # What --impure actually cost was the flake eval cache, for all 53 attrs
+    # twice per run -- before and after the bump -- so 106 evaluations of
+    # nixpkgs from scratch to answer a question the cache already had.
+    #
+    # The eval above keeps --impure and needs it: `import ./data/apps.nix` is
+    # a relative path, which pure mode forbids outright.
+    if v=$(nix eval --raw "github:NixOS/nixpkgs/${rev}#${attr}.version" 2>/dev/null); then
       [ "$first" = 1 ] || echo ","
       first=0
       printf '  "%s": "%s"' "$attr" "$v"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,44 +63,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Honour this flake's own nixConfig instead of warning and
-          # discarding it. Without this every `nix build` here prints
-          #
-          #   warning: ignoring untrusted flake configuration setting
-          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
-          #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
-          #
-          # Scoped to the flake being invoked, which is this repository's
-          # own. It does not extend trust to inputs.
-          # accept-flake-config alone is not enough, and the reason cost a
-          # day: the runner is not in the daemon's `trusted-users`, so every
-          # substituter and key the flake declares is DISCARDED with
-          #
-          #   warning: ignoring the client-specified setting
-          #   'trusted-public-keys', because it is a restricted setting and
-          #   you are not a trusted user
-          #
-          # and the job then BUILDS what it should have downloaded. On
-          # 2026-09-07 the `omarchy` and `box` jobs each compiled Hyprland to
-          # 55% and hit timeout-minutes, while `system` survived only because
-          # it had a hand-written `sudo tee -a /etc/nix/nix.conf` step nobody
-          # had copied to the others.
-          #
-          # extra-conf is written into the SYSTEM nix.conf as root, so what is
-          # set here is trusted and actually applies. The store path nixarchy
-          # uses is byte-identical to the one hyprwm publish -- verified, not
-          # assumed -- so with this the compositor is a download.
-          extra-conf: |
-            accept-flake-config = true
-            extra-substituters = https://nixarchy.cachix.org https://hyprland.cachix.org
-            extra-trusted-public-keys = nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM= hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE=
+      - uses: ./.github/actions/setup-nix
       - uses: cachix/cachix-action@v17
         # A failed cache upload must not fail a build that succeeded. #235: three
         # of four concurrent pull requests went red in `Post Run
@@ -191,44 +154,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Honour this flake's own nixConfig instead of warning and
-          # discarding it. Without this every `nix build` here prints
-          #
-          #   warning: ignoring untrusted flake configuration setting
-          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
-          #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
-          #
-          # Scoped to the flake being invoked, which is this repository's
-          # own. It does not extend trust to inputs.
-          # accept-flake-config alone is not enough, and the reason cost a
-          # day: the runner is not in the daemon's `trusted-users`, so every
-          # substituter and key the flake declares is DISCARDED with
-          #
-          #   warning: ignoring the client-specified setting
-          #   'trusted-public-keys', because it is a restricted setting and
-          #   you are not a trusted user
-          #
-          # and the job then BUILDS what it should have downloaded. On
-          # 2026-09-07 the `omarchy` and `box` jobs each compiled Hyprland to
-          # 55% and hit timeout-minutes, while `system` survived only because
-          # it had a hand-written `sudo tee -a /etc/nix/nix.conf` step nobody
-          # had copied to the others.
-          #
-          # extra-conf is written into the SYSTEM nix.conf as root, so what is
-          # set here is trusted and actually applies. The store path nixarchy
-          # uses is byte-identical to the one hyprwm publish -- verified, not
-          # assumed -- so with this the compositor is a download.
-          extra-conf: |
-            accept-flake-config = true
-            extra-substituters = https://nixarchy.cachix.org https://hyprland.cachix.org
-            extra-trusted-public-keys = nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM= hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE=
+      - uses: ./.github/actions/setup-nix
       - uses: cachix/cachix-action@v17
         # A cache upload failing must not fail a build that succeeded (#235).
         continue-on-error: true
@@ -245,44 +171,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Honour this flake's own nixConfig instead of warning and
-          # discarding it. Without this every `nix build` here prints
-          #
-          #   warning: ignoring untrusted flake configuration setting
-          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
-          #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
-          #
-          # Scoped to the flake being invoked, which is this repository's
-          # own. It does not extend trust to inputs.
-          # accept-flake-config alone is not enough, and the reason cost a
-          # day: the runner is not in the daemon's `trusted-users`, so every
-          # substituter and key the flake declares is DISCARDED with
-          #
-          #   warning: ignoring the client-specified setting
-          #   'trusted-public-keys', because it is a restricted setting and
-          #   you are not a trusted user
-          #
-          # and the job then BUILDS what it should have downloaded. On
-          # 2026-09-07 the `omarchy` and `box` jobs each compiled Hyprland to
-          # 55% and hit timeout-minutes, while `system` survived only because
-          # it had a hand-written `sudo tee -a /etc/nix/nix.conf` step nobody
-          # had copied to the others.
-          #
-          # extra-conf is written into the SYSTEM nix.conf as root, so what is
-          # set here is trusted and actually applies. The store path nixarchy
-          # uses is byte-identical to the one hyprwm publish -- verified, not
-          # assumed -- so with this the compositor is a download.
-          extra-conf: |
-            accept-flake-config = true
-            extra-substituters = https://nixarchy.cachix.org https://hyprland.cachix.org
-            extra-trusted-public-keys = nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM= hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE=
+      - uses: ./.github/actions/setup-nix
       - uses: cachix/cachix-action@v17
         # A cache upload failing must not fail a build that succeeded (#235).
         continue-on-error: true
@@ -1054,44 +943,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Honour this flake's own nixConfig instead of warning and
-          # discarding it. Without this every `nix build` here prints
-          #
-          #   warning: ignoring untrusted flake configuration setting
-          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
-          #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
-          #
-          # Scoped to the flake being invoked, which is this repository's
-          # own. It does not extend trust to inputs.
-          # accept-flake-config alone is not enough, and the reason cost a
-          # day: the runner is not in the daemon's `trusted-users`, so every
-          # substituter and key the flake declares is DISCARDED with
-          #
-          #   warning: ignoring the client-specified setting
-          #   'trusted-public-keys', because it is a restricted setting and
-          #   you are not a trusted user
-          #
-          # and the job then BUILDS what it should have downloaded. On
-          # 2026-09-07 the `omarchy` and `box` jobs each compiled Hyprland to
-          # 55% and hit timeout-minutes, while `system` survived only because
-          # it had a hand-written `sudo tee -a /etc/nix/nix.conf` step nobody
-          # had copied to the others.
-          #
-          # extra-conf is written into the SYSTEM nix.conf as root, so what is
-          # set here is trusted and actually applies. The store path nixarchy
-          # uses is byte-identical to the one hyprwm publish -- verified, not
-          # assumed -- so with this the compositor is a download.
-          extra-conf: |
-            accept-flake-config = true
-            extra-substituters = https://nixarchy.cachix.org https://hyprland.cachix.org
-            extra-trusted-public-keys = nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM= hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE=
+      - uses: ./.github/actions/setup-nix
       - uses: cachix/cachix-action@v17
         # A cache upload failing must not fail a build that succeeded (#235).
         continue-on-error: true
@@ -1107,15 +959,6 @@ jobs:
             /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
           df -h /
 
-      - name: Add hyprland binary cache
-        # Nixarchy pins Hyprland ahead of nixpkgs, so without this the runner
-        # compiles a compositor from source and times out.
-        run: |
-          sudo tee -a /etc/nix/nix.conf >/dev/null <<'EOF'
-          extra-substituters = https://hyprland.cachix.org
-          extra-trusted-public-keys = hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE=
-          EOF
-          sudo systemctl restart nix-daemon || true
 
       - name: Build the VM system closure
         run: nix build .#checks.x86_64-linux.vm-toplevel --print-build-logs
@@ -1220,44 +1063,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Honour this flake's own nixConfig instead of warning and
-          # discarding it. Without this every `nix build` here prints
-          #
-          #   warning: ignoring untrusted flake configuration setting
-          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
-          #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
-          #
-          # Scoped to the flake being invoked, which is this repository's
-          # own. It does not extend trust to inputs.
-          # accept-flake-config alone is not enough, and the reason cost a
-          # day: the runner is not in the daemon's `trusted-users`, so every
-          # substituter and key the flake declares is DISCARDED with
-          #
-          #   warning: ignoring the client-specified setting
-          #   'trusted-public-keys', because it is a restricted setting and
-          #   you are not a trusted user
-          #
-          # and the job then BUILDS what it should have downloaded. On
-          # 2026-09-07 the `omarchy` and `box` jobs each compiled Hyprland to
-          # 55% and hit timeout-minutes, while `system` survived only because
-          # it had a hand-written `sudo tee -a /etc/nix/nix.conf` step nobody
-          # had copied to the others.
-          #
-          # extra-conf is written into the SYSTEM nix.conf as root, so what is
-          # set here is trusted and actually applies. The store path nixarchy
-          # uses is byte-identical to the one hyprwm publish -- verified, not
-          # assumed -- so with this the compositor is a download.
-          extra-conf: |
-            accept-flake-config = true
-            extra-substituters = https://nixarchy.cachix.org https://hyprland.cachix.org
-            extra-trusted-public-keys = nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM= hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE=
+      - uses: ./.github/actions/setup-nix
       - uses: cachix/cachix-action@v17
         # A cache upload failing must not fail a build that succeeded (#235).
         continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -323,15 +323,6 @@ jobs:
           # it ever executing. checks.installer-ui shipped that way -- written
           # for #133, wired into the flake, run by nothing, green.
           #
-          # Two are covered by a path this grep cannot see, and are listed here
-          # rather than left to look accidental:
-          #   omarchy                        built as `nix build .#omarchy`
-          #   reference-unencrypted-toplevel pulled in by checks.install
-          #   omarchy-runtime                built as `nix build .#omarchy-runtime`
-          # (omarchy-runtime is the same derivation either way -- the checks
-          # entry is an `inherit` of the package, so building the package IS
-          # building the check. The old awk-based extraction could never see it
-          # at all, which is why it was not listed here before.)
           # WHO claims each check, rather than "is it named anywhere".
           #
           # This list is the opt-OUT. Everything not on it is built by the next
@@ -503,7 +494,14 @@ jobs:
           fi
           printf 'building %s checks:\n' "${#targets[@]}"
           printf '  %s\n' "${targets[@]}"
-          nix build --keep-going --print-build-logs "${targets[@]}"
+          # --no-link, and it is load-bearing rather than tidy. This step runs
+          # in the same job that builds .#omarchy into `result`, and later
+          # steps read result/share/omarchy/bin. Without it, `nix build`
+          # repoints `result` at the first of these checks and "Verify
+          # shebangs were patched" inspects a completely different tree --
+          # which is exactly how it failed. Nothing here wants an out-link;
+          # the build IS the assertion.
+          nix build --keep-going --no-link --print-build-logs "${targets[@]}"
 
       - name: The README's roadmap still matches the open epics
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,6 +166,14 @@ jobs:
       - name: The doctor reads a GPU correctly
         run: nix build .#checks.x86_64-linux.doctor-graphics --print-build-logs
 
+      # The offline image's network fallback: that it fires when the medium is
+      # incomplete and a network is there, that it refuses everywhere else, and
+      # that it is impossible to miss when it does. checks.install-iso runs
+      # -nic none against a complete image, which is the one shape that never
+      # rescues.
+      - name: The offline rescue fires only where it should, and never quietly
+        run: nix build .#checks.x86_64-linux.installer-offline-rescue --print-build-logs
+
       # The doctor's wireless rules. The install VM has a virtio NIC and no
       # radio, so not one of the three no-wlan0 cases can occur there -- the
       # same gap that let the no-VAAPI-driver branch ship unreachable (#352).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,16 @@ on:
     # user's update would.
     #
     # What this run DOES watch is everything the checks reach past the lock
-    # for: the live issue list the roadmap check reads, the registry nixpkgs
-    # that "every mapped app still evaluates" asks, the fetched upstream
-    # artefacts. Those move on their own schedule, so a scheduled run is
-    # what notices.
+    # for: the live issue list the roadmap check reads, and the fetched
+    # upstream artefacts. Those move on their own schedule, so a scheduled run
+    # is what notices -- and the roadmap check now runs ONLY here and on
+    # pushes to main, because a pull request cannot be responsible for an issue
+    # somebody closed while it was open.
+    #
+    # "the registry nixpkgs that every mapped app still evaluates asks" used to
+    # be on this list and is not any more: that check resolves `nixpkgs#`
+    # through --inputs-from . now, so it reads this repository's pin and moves
+    # only when the lock does.
     - cron: "0 6 * * 1"
 
 concurrency:
@@ -127,10 +133,10 @@ jobs:
         run: nix fmt -- --ci
 
       - name: statix
-        run: nix run nixpkgs#statix -- check .
+        run: nix run --inputs-from . nixpkgs#statix -- check .
 
       - name: deadnix
-        run: nix run nixpkgs#deadnix -- --fail .
+        run: nix run --inputs-from . nixpkgs#deadnix -- --fail .
 
 
 
@@ -165,7 +171,7 @@ jobs:
       # would fail a workflow file that is fine.
       - name: The workflow files are valid GitHub Actions
         run: |
-          nix shell nixpkgs#actionlint -c \
+          nix shell --inputs-from . nixpkgs#actionlint -c \
             actionlint -ignore 'SC[0-9]+:(info|style):'
 
   # Every preset in data/devenv-presets.nix, scaffolded with the real
@@ -513,7 +519,22 @@ jobs:
           # the build IS the assertion.
           nix build --keep-going --no-link --print-build-logs "${targets[@]}"
 
+      # Not on pull requests, and this is the file's own doctrine finally
+      # applied: the schedule comment at the top says a scheduled run is what
+      # notices "the live issue list the roadmap check reads".
+      #
+      # It reads state no diff contains. Closing #159 -- correct, and with all
+      # five children done -- turned every open pull request red at once, none
+      # of which had touched the README. The author of an unrelated change
+      # cannot fix that and should not be blocked by it.
+      #
+      # Still gated where it can act: every push to main, so a merge that
+      # staled the roadmap is caught immediately, and weekly, so an issue
+      # closed in the web UI is caught within seven days. What is given up is
+      # catching it on the PR that closes the epic -- which is not where it
+      # gets noticed anyway, because closing happens after the merge.
       - name: The README's roadmap still matches the open epics
+        if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -866,9 +887,21 @@ jobs:
                 want = builtins.filter (v: (v ? attr) && !(v.ours or false))
                          (builtins.attrValues a);
             in builtins.concatStringsSep " " (map (v: v.attr) want)')
+          # --inputs-from ., so `nixpkgs#` means THIS repository's pinned
+          # nixpkgs and not the runner's flake registry.
+          #
+          # The registry resolves to a channel that moves daily, so this step
+          # was answering a different question from the one it asks: whether
+          # an app evaluates against some nixpkgs nobody here uses. Two costs,
+          # and the second is the worse one. A package going broken upstream
+          # reddened every open pull request, for a reason present in none of
+          # their diffs. And a package broken in OUR pin -- the one users
+          # actually rebuild against -- would pass here as long as the channel
+          # had already fixed it.
           bad=""
           for a in $attrs; do
-            nix eval --impure --raw "nixpkgs#$a.name" >/dev/null 2>&1 || bad="$bad $a"
+            nix eval --inputs-from . --impure --raw "nixpkgs#$a.name" \
+              >/dev/null 2>&1 || bad="$bad $a"
           done
           if [ -n "$bad" ]; then
             echo "::error::these mapped packages do not evaluate:$bad"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -338,7 +338,11 @@ jobs:
           # disk-free step, or a Hyprland closure that wants its own concurrency
           # group. Naming them here is a claim that is CHECKED below in both
           # directions, so the list cannot rot into fiction.
-          claimed="install free-space installer-refusal
+          # wifi-hwsim is a nixosTest and needs /dev/kvm. The generated step
+          # runs in THIS job, which has no KVM setup -- the udev rule lives in
+          # `box` -- so leaving it generated put a VM test in a job that cannot
+          # boot one. The integration that added the check is what surfaced it.
+          claimed="wifi-hwsim install free-space installer-refusal
             install-encrypted install-iso install-iso-net iso-budget microvm-boot
             box-boot box-template coexist dashboard-clock installer-ui
             installer-wizard integration microvm-template options plugin
@@ -1228,6 +1232,14 @@ jobs:
           grep -Eq 'vmx|svm' /proc/cpuinfo || { echo "::error::no vmx/svm in /proc/cpuinfo"; exit 1; }
           test -w /dev/kvm || { echo "::error::/dev/kvm is not writable"; exit 1; }
           ls -l /dev/kvm
+
+      # Here rather than in the generated batch, and the integration is what
+      # showed why: it is a nixosTest and needs the /dev/kvm the step above
+      # sets up. The generated step runs in the `omarchy` job, which has no
+      # KVM, so a VM test landed in a job that cannot boot one -- a bespoke
+      # need, which is exactly what the claimed list is for.
+      - name: A VM with a radio can associate to a network
+        run: nix build .#checks.x86_64-linux.wifi-hwsim --print-build-logs
 
       - name: Create a box offline, and pin what enter does without a network
         # checks.box-boot: the pinned image is preloaded from the store

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,6 +166,12 @@ jobs:
       - name: The doctor reads a GPU correctly
         run: nix build .#checks.x86_64-linux.doctor-graphics --print-build-logs
 
+      # Three network failures told apart, and a blocked radio from a missing
+      # one. checks.install-iso runs -nic none against a machine with no radio,
+      # which is the one shape where every branch of both is unreachable.
+      - name: The installer can tell three network failures apart
+        run: nix build .#checks.x86_64-linux.installer-network --print-build-logs
+
       # The doctor's wireless rules. The install VM has a virtio NIC and no
       # radio, so not one of the three no-wlan0 cases can occur there -- the
       # same gap that let the no-VAAPI-driver branch ship unreachable (#352).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,6 +185,13 @@ jobs:
       - name: Wi-Fi joined during the install is carried over
         run: nix build .#checks.x86_64-linux.installer-network-profiles --print-build-logs
 
+      # That a failed install says what KIND of failure it was, not only that
+      # something failed. checks.install-iso asserts installs that SUCCEED, so
+      # a passing install renders no failure screen at all and can never reach
+      # any of this.
+      - name: The failure screen names the failure
+        run: nix build .#checks.x86_64-linux.installer-failure-hints --print-build-logs
+
       # And that the configuration iso-wifi asserts actually carries an
       # association, against a real radio: mac80211_hwsim gives the VM two
       # wiphys, hostapd serves one, NetworkManager and wpa_supplicant drive the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,16 @@ jobs:
       - name: The ISO can associate to a network
         run: nix build .#checks.x86_64-linux.iso-wifi --print-build-logs
 
+      # And that the configuration iso-wifi asserts actually carries an
+      # association, against a real radio: mac80211_hwsim gives the VM two
+      # wiphys, hostapd serves one, NetworkManager and wpa_supplicant drive the
+      # other, and the handshake is asserted from both ends. Nothing else in
+      # this repo has ever had a wireless card -- install-iso boots -nic none
+      # and every other install test uses a virtio NIC -- which is why five
+      # wireless bugs reached testers before any check could see one.
+      - name: A VM with a radio can associate to a network
+        run: nix build .#checks.x86_64-linux.wifi-hwsim --print-build-logs
+
       # The doctor's wireless rules. The install VM has a virtio NIC and no
       # radio, so not one of the three no-wlan0 cases can occur there -- the
       # same gap that let the no-VAAPI-driver branch ship unreachable (#352).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,110 +113,16 @@ jobs:
       - name: deadnix
         run: nix run nixpkgs#deadnix -- --fail .
 
-      # Cheap, and it belongs with the other things that are checked before
-      # anything is built: it reads files rather than making them. `nix run
-      # .#review` watches every hand-pinned package; this watches that it can
-      # still see them, which is how that script rots.
-      - name: The nightly review can still read every pin
-        run: nix build .#checks.x86_64-linux.review-pins --print-build-logs
 
-      # The lock the installer writes, checked for the fields nix would have
-      # written itself. installer/mkFlake.nix assembles that node by hand, and a
-      # hand-assembled node can be missing a field without failing: the flake
-      # evaluates and whatever reads it takes a fallback. `lastModified` went
-      # missing exactly that way, which changed the omarchy derivation on the
-      # installed machine, which made an offline install build what it meant to
-      # copy -- surfacing 25 minutes later as a missing ESP.
-      - name: The installer's generated lock has the fields nix would write
-        run: nix build .#checks.x86_64-linux.installer-lock --print-build-logs
 
-      # Whether the live store can hold what the install must fetch. A live
-      # ISO's store is a RAM-backed overlay at half the machine's memory, and
-      # when it fills the install dies several levels under an error naming
-      # none of it -- reaching one user as a machine with no bootloader.
-      # checks.install cannot see this: it installs onto a machine whose store
-      # fits, which is the only shape that does not fail. So the decision is
-      # unit-tested here instead, in seconds.
-      - name: The installer refuses a build the live store cannot hold
-        run: nix build .#checks.x86_64-linux.installer-store-space --print-build-logs
 
-      # Every attribute nixos-generate-config can emit, against what the ISO
-      # bakes. #382: an Intel NPU made the tool write
-      # hardware.cpu.intel.npu.enable, which added a package no reference
-      # closure carried, which the offline image then tried to BUILD -- into
-      # the stdenv source bootstrap, after partitioning the disk. qemu exposes
-      # no NPU, so every install check in this file passed while that shipped.
-      #
-      # Pure evaluation, seconds of wall clock, and it goes red on the nixpkgs
-      # bump that introduces the next such attribute rather than on the user
-      # who owns the hardware.
-      - name: Every generate-config attribute is one the image can satisfy
-        run: nix build .#checks.x86_64-linux.generate-config-surface --print-build-logs
 
-      # The initrd pin install.sh writes must stay conditional on the kernel
-      # its module lists came from. An unguarded pin makes `omarchy update`
-      # fail outright on any machine whose kernel has moved -- nixos-rebuild
-      # cannot build the initrd, so it produces no system at all. Seconds of
-      # wall clock; it greps the built installer.
-      - name: The initrd pin names the kernel it was captured from
-        run: nix build .#checks.x86_64-linux.initrd-pin-guard --print-build-logs
 
-      # The doctor's GPU rules, against fixture machines. checks.install's VM
-      # has no PCI display controller, so nothing else can reach these branches.
-      - name: The doctor reads a GPU correctly
-        run: nix build .#checks.x86_64-linux.doctor-graphics --print-build-logs
 
-      # The doctor's wireless rules. The install VM has a virtio NIC and no
-      # radio, so not one of the three no-wlan0 cases can occur there -- the
-      # same gap that let the no-VAAPI-driver branch ship unreachable (#352).
-      - name: The doctor tells the three no-wlan0 cases apart
-        run: nix build .#checks.x86_64-linux.doctor-wireless --print-build-logs
 
-      # That an installed machine carries firmware without depending on a virt
-      # probe, and can still refuse it. Every guest reports a virt type, so
-      # every install check takes the branch where this is false and the branch
-      # real users are on is the one nothing covers.
-      - name: Installed systems carry firmware, and can still refuse it
-        run: nix build .#checks.x86_64-linux.firmware-guard --print-build-logs
-      # Which nixos-hardware modules the installer picks, against four fixture
-      # machines. The install VM is one machine and these rules are about being
-      # on many -- and it is the one shape that reaches none of the interesting
-      # branches: virtio GPU, no battery, and a squashfs loop that a naive
-      # rotational test reads as an SSD.
-      - name: The installer picks the right hardware modules
-        run: nix build .#checks.x86_64-linux.hardware-modules --print-build-logs
 
-      # And that the offline image can satisfy them. common-gpu-intel pulls
-      # intel-media-driver, intel-compute-runtime and vpl-gpu-rt, and an
-      # offline Intel laptop selects it without asking -- #382's failure mode,
-      # made reachable again and wider.
-      - name: The offline image carries those modules' packages
-        run: nix build .#checks.x86_64-linux.offline-hardware-packages --print-build-logs
 
-      # The `nix run #try` front door, on the machines it will actually meet:
-      # no KVM, no kvm group, 1 GB of RAM, a tmpfs working directory, a
-      # declined binary cache, a disk left by a ctrl-C'd install. Each must
-      # refuse in a sentence naming the number and the way out, and a
-      # preflight nobody has seen fail is a preflight nobody knows works --
-      # so every path is driven here with a stubbed environment, in seconds.
-      # The happy path (a bootable UEFI window) needs KVM and a display no
-      # sandbox has; what CAN be asserted cheaply is asserted on every PR.
-      - name: The try front door refuses in sentences, not stack traces
-        run: nix build .#checks.x86_64-linux.try-preflight --print-build-logs
 
-      # --from-repo, the install mode that clones the user's OWN configuration
-      # repository and installs the host it finds there. Both of its branches
-      # -- host already in the repo, host added to it -- had zero coverage
-      # until now, and it is the only mode that writes to something the user
-      # owns as well as to a disk.
-      #
-      # Wired here rather than left for a follow-up. #323 makes this file's
-      # coverage guard actually work; a check in the flake that no workflow
-      # runs fails that guard on main and on every PR after it, which is the
-      # empty-`box:` deadlock from another direction. An unrun check is worse
-      # than no check -- it occupies the slot.
-      - name: --from-repo installs the host the repository names
-        run: nix build .#checks.x86_64-linux.installer-from-repo --print-build-logs
 
       # Where a crash report goes. The prose said Nixarchy and every `gh`
       # command said Basecamp, so an agent read the rule, concluded correctly,
@@ -248,52 +154,13 @@ jobs:
           nix shell nixpkgs#actionlint -c \
             actionlint -ignore 'SC[0-9]+:(info|style):'
 
-      - name: Crash reports route to the repository the rule names
-        run: nix build .#checks.x86_64-linux.crash-report-repo --print-build-logs
 
-      # The bus room is public, permanent and undeletable, so the redaction
-      # hook's dangerous failure is passing something it claimed to catch --
-      # and its other dangerous failure is blocking ordinary messages until
-      # agents route around it. Both directions are asserted, which is why
-      # this runs here rather than being trusted.
-      - name: The bus redaction hook blocks what it claims, and only that
-        run: nix build .#checks.x86_64-linux.bus-redact --print-build-logs
 
-      # The vendored MCP server is a copy of a file in a repo CI cannot see,
-      # so drift cannot be diffed away -- instead the copy is started over
-      # real stdio and held to the tool contract SKILL.md documents. The
-      # failure this defends against is a re-vendored copy that is subtly
-      # behind and still runs. Seconds of wall clock, so it runs per-PR.
-      - name: The vendored bus server still honours its documented contract
-        run: nix build .#checks.x86_64-linux.bus-mcp --print-build-logs
 
-      # Same shape, same reason: its dangerous failure is reporting nothing.
-      - name: The Omarchy package delta still sees a change
-        run: nix build .#checks.x86_64-linux.package-delta --print-build-logs
 
-      # The rest of the bump PR body. The config delta scans the seeded tree
-      # for the executables it names -- the class of bug #202 was -- and the
-      # patched-files intersection derives what this port has its hands on by
-      # grepping four statements the repo makes about itself. Both fail by
-      # falling quiet, so both are fed a known answer here.
-      - name: The seeded-config delta still sees a change
-        run: nix build .#checks.x86_64-linux.config-delta --print-build-logs
 
-      - name: The patched-file intersection still finds what this port patches
-        run: nix build .#checks.x86_64-linux.patched-files --print-build-logs
 
-      # And the release notes those deltas go into, which have four scans to
-      # rot rather than one -- the Omarchy pin, the pinned versions, the
-      # mkDefault lines, and the option set -- and where reporting nothing
-      # reaches every person deciding whether to upgrade.
-      - name: The release notes still see what changed
-        run: nix build .#checks.x86_64-linux.release-notes --print-build-logs
 
-      # Prose, checked the way the app and subcommand counts already are: an
-      # option path in the README or the manual is a claim about the option
-      # set, and #214 shipped one that had been false for a release.
-      - name: The documentation only quotes options that exist
-        run: nix build .#checks.x86_64-linux.doc-options --print-build-logs
 
   # Every preset in data/devenv-presets.nix, scaffolded with the real
   # `nixarchy dev init` and handed to a real devenv to evaluate.
@@ -465,7 +332,46 @@ jobs:
           # entry is an `inherit` of the package, so building the package IS
           # building the check. The old awk-based extraction could never see it
           # at all, which is why it was not listed here before.)
+          # WHO claims each check, rather than "is it named anywhere".
+          #
+          # This list is the opt-OUT. Everything not on it is built by the next
+          # step, which derives its targets from the flake -- so adding a check
+          # now runs it, with no YAML to write and nothing to forget. That
+          # inversion is the point: `checks.<name> is defined but no workflow
+          # runs it` fired four times in one day, every time because a check was
+          # added and a step was not, and the gate can only ever report that
+          # after the fact.
+          #
+          # These are the checks another job runs for a reason the generated
+          # step cannot satisfy -- a bigger runner, KVM, a 90-minute budget, a
+          # disk-free step, or a Hyprland closure that wants its own concurrency
+          # group. Naming them here is a claim that is CHECKED below in both
+          # directions, so the list cannot rot into fiction.
+          claimed="install free-space installer-refusal
+            install-encrypted install-iso install-iso-net iso-budget microvm-boot
+            box-boot box-template coexist dashboard-clock installer-ui
+            installer-wizard integration microvm-template options plugin
+            reference-toplevel session try-nixarchy vm-toplevel"
+
+          # Two are covered by a path the grep below cannot see, and are listed
+          # here rather than left to look accidental:
+          #   omarchy                        built as `nix build .#omarchy`
+          #   reference-unencrypted-toplevel pulled in by checks.install
+          #   omarchy-runtime                built as `nix build .#omarchy-runtime`
+          # (omarchy-runtime is the same derivation either way -- the checks
+          # entry is an `inherit` of the package, so building the package IS
+          # building the check.)
           exempt="omarchy omarchy-runtime reference-unencrypted-toplevel"
+
+          # Collapsed to single spaces before anything tests membership.
+          # `case " $claimed " in *" $c "*)` wants a space on BOTH sides, and
+          # the list above is written across lines for readability -- so the
+          # last name on every line was followed by a newline and matched
+          # nothing. Four checks (installer-refusal, microvm-boot, installer-ui,
+          # plugin) were silently added to the generated set while another job
+          # already built them, and only the count not adding up showed it:
+          # 24 generated + 22 claimed against 45 checks.
+          claimed=$(printf '%s' "$claimed" | tr -s ' \n' ' ')
 
           # And the same hole one level up, which is #164. "Some workflow names
           # it" was never the whole question: a check named only by nightly.yml
@@ -474,26 +380,15 @@ jobs:
           # sat in exactly this position for most of this repo's life, and #123
           # shipped straight through it, green.
           #
-          # These two stay there deliberately, and the cost is the reason:
-          #   install-iso  builds a 5.6 GB image and installs it -- ~3h
+          # These stay there deliberately, and the cost is the reason:
+          #   install-iso  builds a 6 GB image and installs it -- ~3h
           #   iso-budget   measures that same image, so pays the same build
-          # Per-push, an hour of wall clock each makes the queue the bottleneck.
-          # Written down here rather than arrived at by omission, which is the
-          # argument the guard above already rests on.
-          #   install-iso-net  the same image build plus a closure fetch; it is
-          #                    install-iso's sibling and belongs in the same
-          #                    bucket. Measured 483s warm, so promoting it to
-          #                    per-PR is affordable if the appetite is there --
-          #                    see the note above about this list's cost
-          #                    argument being stale.
+          #   install-iso-net  the same image build plus a closure fetch
           #   install-encrypted  an install-class VM with the same 85-minute
-          #                    driver budget as checks.install. install-check.yml
-          #                    already runs two of those concurrently against its
-          #                    90-minute job on the one big runner, and that pair
-          #                    grazed the timeout under load on 2026-09-03; a
-          #                    third has no budget to fit in. nightly.yml's job
-          #                    prints its timings -- promote per-PR with those in
-          #                    hand, since encryption is the default answer.
+          #                    driver budget as checks.install; install-check.yml
+          #                    already runs two of those against a 90-minute job
+          #                    and that pair grazed the timeout on 2026-09-03
+          #   microvm-boot     a nested VM on the -tcg runner
           nightly_only="install-iso iso-budget microvm-boot install-iso-net install-encrypted"
 
           # Ask Nix, do not parse the file.
@@ -502,9 +397,7 @@ jobs:
           # EIGHT spaces of indentation. #299 added a `let ... in` around the
           # checks block, every entry moved to TEN, and the grep silently
           # matched nothing from that commit onward: the guard printed its
-          # success line having extracted zero names. checks.installer-refusal
-          # and checks.install-iso-net both merged unwired while it stood dead,
-          # which is #133 twice over with the tripwire built for it switched off.
+          # success line having extracted zero names.
           #
           # A guard that reads the source's LAYOUT rather than its VALUE fails
           # this way. `nix eval` cannot go stale when someone adds a binding.
@@ -512,14 +405,7 @@ jobs:
             ".#checks.x86_64-linux" \
             --apply 'c: builtins.concatStringsSep "\n" (builtins.attrNames c)')
 
-          # A floor, because the interesting failure of this guard is not a
-          # wrong answer but an EMPTY one. It has now passed-while-checking-
-          # nothing twice: once when the awk indentation went stale, and it
-          # would do so again if `nix eval` ever returned an empty set for a
-          # reason nobody predicted. AGENTS.md 1 says prove your check fails;
-          # that was never applied to the guard itself.
-          #
-          # 20 is well under the current 33 and well over zero -- it catches
+          # 20 is well under the current 45 and well over zero -- it catches
           # "extracted nothing" without needing maintenance every time a check
           # is added or removed.
           count=$(printf '%s\n' "$names" | grep -c . || true)
@@ -529,35 +415,95 @@ jobs:
             exit 1
           fi
 
-          missing=""
+          # Every CLAIM, in both directions. A claimed check that no longer
+          # exists is a stale list; a claimed check no workflow names is a job
+          # that was deleted and a check that now runs nowhere -- and unlike
+          # before, that one would be silent, because the generated step below
+          # skips exactly what this list names.
+          bad=""
           ungated=""
-          for c in $names; do
-            case " $exempt " in *" $c "*) continue ;; esac
+          for c in $claimed $exempt; do
+            printf '%s\n' "$names" | grep -qx "$c" ||
+              { bad="$bad $c:not-a-check"; continue; }
+          done
+          for c in $claimed; do
+            # Already reported as not being a check at all; a second error
+            # saying no workflow names it is true and adds nothing.
+            case " $bad " in *" $c:"*) continue ;; esac
 
             # Not \b, which counts `-` as a boundary: `install` would match a
-            # line naming `install-iso`, and a nightly-only check could borrow
-            # the pull-request coverage of a longer-named sibling.
+            # line naming `install-iso`.
             named=$(grep -rlE "checks\.x86_64-linux\.$c([^a-z0-9-]|\$)" .github/workflows/ || true)
-            if [ -z "$named" ]; then missing="$missing $c"; continue; fi
-
+            if [ -z "$named" ]; then bad="$bad $c:claimed-but-unrun"; continue; fi
             case " $nightly_only " in *" $c "*) continue ;; esac
             # Top-level `on:` key only. `pull_request` also appears in
-            # install-check.yml as `github.event_name == 'pull_request'`, and a
-            # loose grep would read that expression as a trigger.
+            # install-check.yml as `github.event_name == 'pull_request'`.
             echo "$named" | xargs grep -lE '^  pull_request:' >/dev/null 2>&1 ||
               ungated="$ungated $c"
           done
 
-          if [ -n "$missing$ungated" ]; then
-            for c in $missing; do
-              echo "::error::checks.$c is defined but no workflow runs it"
+          if [ -n "$bad$ungated" ]; then
+            for c in $bad; do
+              case $c in
+                *:not-a-check)
+                  echo "::error::${c%%:*} is in the claimed list and is not a check in the flake" ;;
+                *:claimed-but-unrun)
+                  echo "::error::${c%%:*} is claimed by the list and named by no workflow --" \
+                       "the generated step skips it, so it now runs nowhere" ;;
+              esac
             done
             for c in $ungated; do
-              echo "::error::checks.$c is run by no workflow that triggers on a pull request"
+              echo "::error::checks.$c is claimed but run by no workflow that triggers on a pull request"
             done
             exit 1
           fi
-          echo "every check in the flake is built by a workflow that runs on pull requests"
+
+          # What the next step builds: everything nobody claimed. Written to a
+          # file rather than recomputed there, so the lists above are the single
+          # place either step reads.
+          : > /tmp/generated-checks
+          for c in $names; do
+            case " $claimed $exempt " in *" $c "*) continue ;; esac
+            echo ".#checks.x86_64-linux.$c" >> /tmp/generated-checks
+          done
+          gen=$(grep -c . /tmp/generated-checks || true)
+          if [ "${gen:-0}" -lt 5 ]; then
+            echo "::error::only $gen checks would be built by the generated step;" \
+                 "the claimed list has swallowed the flake" >&2
+            exit 1
+          fi
+          echo "$gen checks are generated, $(printf '%s' "$claimed" | wc -w) are claimed elsewhere"
+
+      - name: Build every check no other job claims
+        run: |
+          # The 20 steps this replaces were byte-identical except for the name:
+          # `nix build .#checks.x86_64-linux.<x> --print-build-logs`, no setup,
+          # no runner of their own. Maintaining that list by hand is what made
+          # "checks.<name> is defined but no workflow runs it" the most repeated
+          # CI failure in the repo -- four times in one day.
+          #
+          # One `nix build`, not a job matrix. A 20-job matrix pays 20 runner
+          # spin-ups, 20 nix installs and 20 cachix setups to parallelise work
+          # nix already parallelises internally, and turns four required status
+          # contexts into twenty-four. --keep-going reports every failure in one
+          # run rather than stopping at the first, which is what the matrix would
+          # have been bought for.
+          #
+          # The list comes from the previous step, which owns the claimed/exempt
+          # lists and has already verified them.
+          mapfile -t targets < /tmp/generated-checks
+          # mapfile returns 0 whatever the redirect did; an empty array here
+          # would make this `nix build` with no installables, which builds
+          # .#default and passes having checked nothing. The step before has a
+          # floor of its own, and this is the second half of the same guard --
+          # cheap, and the failure it prevents is a green run over no checks.
+          if [ "${#targets[@]}" -eq 0 ]; then
+            echo "::error::no generated targets; refusing to build .#default and call it a pass" >&2
+            exit 1
+          fi
+          printf 'building %s checks:\n' "${#targets[@]}"
+          printf '  %s\n' "${targets[@]}"
+          nix build --keep-going --print-build-logs "${targets[@]}"
 
       - name: The README's roadmap still matches the open epics
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         # five-minute window, pushed fine. That reads as a ceiling on cachix's
         # side rather than anything in the change, and a red check that means
         # "the cache was busy" teaches everyone to re-run without reading --
-        # the habit AGENTS.md 9 exists to prevent.
+        # the habit AGENTS.md 10 exists to prevent.
         #
         # `continue-on-error` on the step, not `skipPush`, because pushing
         # from pull requests is what fills the cache before main needs it. A
@@ -1212,7 +1212,7 @@ jobs:
         # writable and the shell's IPC is reachable.
         run: nix build .#checks.x86_64-linux.plugin --print-build-logs
 
-  # PROPOSED CI-GATE CHANGE (AGENTS.md 3 and 10): this job is new gate wiring,
+  # PROPOSED CI-GATE CHANGE (AGENTS.md 4 and 11): this job is new gate wiring,
   # merged by a human, not an agent.
   #
   # Creates and enters a real box inside a NixOS test VM -- see

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,6 +172,13 @@ jobs:
       - name: The installer can tell three network failures apart
         run: nix build .#checks.x86_64-linux.installer-network --print-build-logs
 
+      # That the ISO can associate at all. No VM in this repo has a radio --
+      # install-iso boots -nic none and every other install test uses a virtio
+      # NIC -- so there is nowhere in the suite this can be caught by running
+      # something. Only by asking the configuration what it says.
+      - name: The ISO can associate to a network
+        run: nix build .#checks.x86_64-linux.iso-wifi --print-build-logs
+
       # The doctor's wireless rules. The install VM has a virtio NIC and no
       # radio, so not one of the three no-wlan0 cases can occur there -- the
       # same gap that let the no-VAAPI-driver branch ship unreachable (#352).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,12 @@ jobs:
       - name: The ISO can associate to a network
         run: nix build .#checks.x86_64-linux.iso-wifi --print-build-logs
 
+      # That the Wi-Fi someone joins during the install is carried onto the
+      # machine, and that the file holding their PSK never lands in the git
+      # repository nixarchy-config-repo pushes to GitHub.
+      - name: Wi-Fi joined during the install is carried over
+        run: nix build .#checks.x86_64-linux.installer-network-profiles --print-build-logs
+
       # And that the configuration iso-wifi asserts actually carries an
       # association, against a real radio: mac80211_hwsim gives the VM two
       # wiphys, hostapd serves one, NetworkManager and wpa_supplicant drive the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,32 @@ on:
     - cron: "0 6 * * 1"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # On a PR branch, a newer push supersedes the older one and cancelling is
-  # right. On main it is data loss: every push here is a DIFFERENT merged
-  # commit, and cancelling discards the only verdict that commit will ever
-  # get -- nothing re-tests it. Five consecutive merges this morning left
-  # main with no `box` result at all, each run killed by the next merge.
-  # Same argument the `system` job already makes below, one scope up.
+  # Per COMMIT on main, per branch everywhere else.
+  #
+  # `cancel-in-progress: false` was not enough, and the reason is a separate
+  # GitHub rule the flag does not touch: only one run per group may be
+  # PENDING, and "any previously pending job or workflow in the concurrency
+  # group will be canceled" when a newer one queues. So with one run building
+  # and merges arriving behind it, run 2 is cancelled by run 3, run 3 by run
+  # 4, and only the first and last of a burst ever report.
+  #
+  # That is the data loss the note below describes, still happening after the
+  # fix written for it: five consecutive merges left main with no `box` result
+  # at all. A shared group cannot express "keep every one of these" -- so on
+  # main the SHA joins the group and each merged commit gets a group of its
+  # own, which nothing can supersede.
+  #
+  # On a PR branch the old behaviour is right and is kept: a newer push really
+  # does supersede the older one, and cancelling saves a runner.
+  #
+  # The cost, stated: a burst of merges to main now runs concurrently rather
+  # than serially, so the self-hosted queue can grow. That is the trade being
+  # made deliberately -- a verdict nobody gets is worth less than a runner
+  # minute, and every push to main is a different merged commit that nothing
+  # will ever re-test.
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}-${{
+      github.ref == 'refs/heads/main' && github.sha || 'shared' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
@@ -124,11 +143,6 @@ jobs:
 
 
 
-      # Where a crash report goes. The prose said Nixarchy and every `gh`
-      # command said Basecamp, so an agent read the rule, concluded correctly,
-      # and then copied a command that filed into somebody else's tracker --
-      # people who cannot act on a NixOS store or rebuild problem. Cheap enough
-      # to sit here: a runCommand over the already-built package, no VM.
       # The workflow files themselves, against GitHub's own schema.
       #
       # Added because build.yml shipped BROKEN and nothing caught it: a bad
@@ -153,14 +167,6 @@ jobs:
         run: |
           nix shell nixpkgs#actionlint -c \
             actionlint -ignore 'SC[0-9]+:(info|style):'
-
-
-
-
-
-
-
-
 
   # Every preset in data/devenv-presets.nix, scaffolded with the real
   # `nixarchy dev init` and handed to a real devenv to evaluate.
@@ -1001,8 +1007,17 @@ jobs:
     # cancel-in-progress it is killed by any push landing within that window
     # -- which meant the most valuable check in this workflow routinely never
     # completed. Queue it behind the previous one instead of discarding it.
+    #
+    # Per commit on main, for the same reason the workflow-level group above
+    # is: cancel-in-progress: false stops a RUNNING job being killed and does
+    # nothing about a PENDING one, which GitHub cancels as soon as a newer run
+    # queues into the group. Under a burst of merges this job -- the most
+    # expensive and most valuable in the workflow -- reported for the first
+    # and last commit and nothing between.
     concurrency:
-      group: ${{ github.workflow }}-system-${{ github.ref }}
+      group: >-
+        ${{ github.workflow }}-system-${{ github.ref }}-${{
+          github.ref == 'refs/heads/main' && github.sha || 'shared' }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -67,44 +67,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Honour this flake's own nixConfig instead of warning and
-          # discarding it. Without this every `nix build` here prints
-          #
-          #   warning: ignoring untrusted flake configuration setting
-          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
-          #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
-          #
-          # Scoped to the flake being invoked, which is this repository's
-          # own. It does not extend trust to inputs.
-          # accept-flake-config alone is not enough, and the reason cost a
-          # day: the runner is not in the daemon's `trusted-users`, so every
-          # substituter and key the flake declares is DISCARDED with
-          #
-          #   warning: ignoring the client-specified setting
-          #   'trusted-public-keys', because it is a restricted setting and
-          #   you are not a trusted user
-          #
-          # and the job then BUILDS what it should have downloaded. On
-          # 2026-09-07 the `omarchy` and `box` jobs each compiled Hyprland to
-          # 55% and hit timeout-minutes, while `system` survived only because
-          # it had a hand-written `sudo tee -a /etc/nix/nix.conf` step nobody
-          # had copied to the others.
-          #
-          # extra-conf is written into the SYSTEM nix.conf as root, so what is
-          # set here is trusted and actually applies. The store path nixarchy
-          # uses is byte-identical to the one hyprwm publish -- verified, not
-          # assumed -- so with this the compositor is a download.
-          extra-conf: |
-            accept-flake-config = true
-            extra-substituters = https://nixarchy.cachix.org https://hyprland.cachix.org
-            extra-trusted-public-keys = nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM= hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE=
+      - uses: ./.github/actions/setup-nix
 
       - name: What the apps are on today
         id: before

--- a/.github/workflows/install-check.yml
+++ b/.github/workflows/install-check.yml
@@ -203,11 +203,18 @@ jobs:
       # other step in the job totalled four. Two independent derivations, run
       # serially, on a machine with forty cores.
       #
-      # The envelope fits with room: each is memorySize 6144, cores 4,
-      # diskSize 32768, so two at once asks 12 GB and 8 cores of a 40-core,
-      # 94 GB box. Each also carries its own globalTimeout of 85 minutes, so
-      # the driver still loses the race against this job's 90 and fails with a
-      # log instead of being recorded as cancelled.
+      # THREE now, and --max-jobs matches. installer-refusal was added as a
+      # third derivation and the cap stayed at 2, so it queued behind one of
+      # the installs and its wall clock ADDED to theirs instead of overlapping
+      # -- in a 90-minute job that the pair alone already grazed under load on
+      # 2026-09-03. It is a VM too (memorySize 2048, cores 2), not a
+      # runCommand, so the wait is minutes rather than seconds.
+      #
+      # The envelope still fits with room: 6144 + 6144 + 2048 is 14.3 GB and
+      # ten cores of a 40-core, 94 GB box. Each install also carries its own
+      # globalTimeout of 85 minutes, so the driver still loses the race against
+      # this job's 90 and fails with a log instead of being recorded as
+      # cancelled.
       #
       # What this gives up, stated because it was deliberate: free-space used
       # to run second, so that an installer broken in a way that has nothing to
@@ -225,7 +232,7 @@ jobs:
       - name: Install onto a blank disk, and into free space beside a neighbour
         if: needs.gate.outputs.relevant == 'true'
         run: |
-          nix build --print-build-logs --max-jobs 2 \
+          nix build --print-build-logs --max-jobs 3 \
             .#checks.x86_64-linux.install \
             .#checks.x86_64-linux.free-space \
             .#checks.x86_64-linux.installer-refusal

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -386,7 +386,14 @@ jobs:
   report:
     name: report a failure
     runs-on: ubuntu-latest
-    needs: [install, install-iso, microvm, cache, canary]
+    # install-encrypted was missing here, and the omission is the same class
+    # of bug as the cancelled() note below: a watchdog that cannot see one of
+    # its subjects. `if: failure()` observes only the jobs in `needs`, so on
+    # 2026-09-08 install-encrypted failed, this job ran, saw five green
+    # dependencies, and reported SUCCESS. The encrypted install is the DEFAULT
+    # answer to the installer's own question, and it was the one failure that
+    # filed no issue.
+    needs: [install, install-encrypted, install-iso, microvm, cache, canary]
     # cancelled() too. On 2026-09-02 install-iso hit its 180-minute timeout,
     # which GitHub records as cancelled rather than failed, and this job --
     # the one whose whole purpose is that a 03:00 failure does not cost a day
@@ -423,6 +430,16 @@ jobs:
             # themselves are green, though; a night where both broke is an
             # install problem first.
             title="nightly: tomorrow's flake update breaks a user's eval"
+          elif [ "${{ needs.microvm.result }}" != "success" ] &&
+            [ "${{ needs.install.result }}" = "success" ] &&
+            [ "${{ needs.install-encrypted.result }}" = "success" ] &&
+            [ "${{ needs.install-iso.result }}" = "success" ]; then
+            # microvm was in `needs` and in no branch of this ladder, so a
+            # MicroVM boot failure was titled "the install checks are failing"
+            # -- the #236 shape the comment above warns about, committed two
+            # jobs later. It also collides with the dedupe search, appending a
+            # sandbox failure to the install issue.
+            title="nightly: a sandbox will not boot"
           else
             title="nightly: the install checks are failing"
           fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -206,44 +206,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Honour this flake's own nixConfig instead of warning and
-          # discarding it. Without this every `nix build` here prints
-          #
-          #   warning: ignoring untrusted flake configuration setting
-          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
-          #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
-          #
-          # Scoped to the flake being invoked, which is this repository's
-          # own. It does not extend trust to inputs.
-          # accept-flake-config alone is not enough, and the reason cost a
-          # day: the runner is not in the daemon's `trusted-users`, so every
-          # substituter and key the flake declares is DISCARDED with
-          #
-          #   warning: ignoring the client-specified setting
-          #   'trusted-public-keys', because it is a restricted setting and
-          #   you are not a trusted user
-          #
-          # and the job then BUILDS what it should have downloaded. On
-          # 2026-09-07 the `omarchy` and `box` jobs each compiled Hyprland to
-          # 55% and hit timeout-minutes, while `system` survived only because
-          # it had a hand-written `sudo tee -a /etc/nix/nix.conf` step nobody
-          # had copied to the others.
-          #
-          # extra-conf is written into the SYSTEM nix.conf as root, so what is
-          # set here is trusted and actually applies. The store path nixarchy
-          # uses is byte-identical to the one hyprwm publish -- verified, not
-          # assumed -- so with this the compositor is a download.
-          extra-conf: |
-            accept-flake-config = true
-            extra-substituters = https://nixarchy.cachix.org https://hyprland.cachix.org
-            extra-trusted-public-keys = nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM= hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE=
+      - uses: ./.github/actions/setup-nix
 
       - name: The cache holds what main last built
         run: |
@@ -328,44 +291,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Honour this flake's own nixConfig instead of warning and
-          # discarding it. Without this every `nix build` here prints
-          #
-          #   warning: ignoring untrusted flake configuration setting
-          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
-          #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
-          #
-          # Scoped to the flake being invoked, which is this repository's
-          # own. It does not extend trust to inputs.
-          # accept-flake-config alone is not enough, and the reason cost a
-          # day: the runner is not in the daemon's `trusted-users`, so every
-          # substituter and key the flake declares is DISCARDED with
-          #
-          #   warning: ignoring the client-specified setting
-          #   'trusted-public-keys', because it is a restricted setting and
-          #   you are not a trusted user
-          #
-          # and the job then BUILDS what it should have downloaded. On
-          # 2026-09-07 the `omarchy` and `box` jobs each compiled Hyprland to
-          # 55% and hit timeout-minutes, while `system` survived only because
-          # it had a hand-written `sudo tee -a /etc/nix/nix.conf` step nobody
-          # had copied to the others.
-          #
-          # extra-conf is written into the SYSTEM nix.conf as root, so what is
-          # set here is trusted and actually applies. The store path nixarchy
-          # uses is byte-identical to the one hyprwm publish -- verified, not
-          # assumed -- so with this the compositor is a download.
-          extra-conf: |
-            accept-flake-config = true
-            extra-substituters = https://nixarchy.cachix.org https://hyprland.cachix.org
-            extra-trusted-public-keys = nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM= hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE=
+      - uses: ./.github/actions/setup-nix
 
       - name: Resolve every input the way a user would tomorrow
         run: nix flake update

--- a/.github/workflows/omarchy.yml
+++ b/.github/workflows/omarchy.yml
@@ -397,7 +397,7 @@ jobs:
           labels: dependencies
           delete-branch: true
 
-      # PROPOSED CI-GATE CHANGE (AGENTS.md 10): --admin becomes --auto, so
+      # PROPOSED CI-GATE CHANGE (AGENTS.md 11): --admin becomes --auto, so
       # the required checks gate this PR like every other.
       #
       # The comment that stood here said "Reaching this step already means

--- a/.github/workflows/omarchy.yml
+++ b/.github/workflows/omarchy.yml
@@ -33,44 +33,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Honour this flake's own nixConfig instead of warning and
-          # discarding it. Without this every `nix build` here prints
-          #
-          #   warning: ignoring untrusted flake configuration setting
-          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
-          #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
-          #
-          # Scoped to the flake being invoked, which is this repository's
-          # own. It does not extend trust to inputs.
-          # accept-flake-config alone is not enough, and the reason cost a
-          # day: the runner is not in the daemon's `trusted-users`, so every
-          # substituter and key the flake declares is DISCARDED with
-          #
-          #   warning: ignoring the client-specified setting
-          #   'trusted-public-keys', because it is a restricted setting and
-          #   you are not a trusted user
-          #
-          # and the job then BUILDS what it should have downloaded. On
-          # 2026-09-07 the `omarchy` and `box` jobs each compiled Hyprland to
-          # 55% and hit timeout-minutes, while `system` survived only because
-          # it had a hand-written `sudo tee -a /etc/nix/nix.conf` step nobody
-          # had copied to the others.
-          #
-          # extra-conf is written into the SYSTEM nix.conf as root, so what is
-          # set here is trusted and actually applies. The store path nixarchy
-          # uses is byte-identical to the one hyprwm publish -- verified, not
-          # assumed -- so with this the compositor is a download.
-          extra-conf: |
-            accept-flake-config = true
-            extra-substituters = https://nixarchy.cachix.org https://hyprland.cachix.org
-            extra-trusted-public-keys = nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM= hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE=
+      - uses: ./.github/actions/setup-nix
       - uses: cachix/cachix-action@v17
         # A cache upload failing must not fail a build that succeeded (#235).
         continue-on-error: true
@@ -325,18 +288,6 @@ jobs:
       # pure black while every other check here passed, because a wallpaper
       # wider than GL_MAX_TEXTURE_SIZE draws nothing at all and Qt still
       # reports the image Ready.
-      - name: Add hyprland binary cache
-        if: steps.rel.outputs.changed == 'true'
-        # Nixarchy pins Hyprland ahead of nixpkgs, so without this the runner
-        # compiles a compositor from source. build.yml has had this since it
-        # started building the same closure; this job never did, which is the
-        # other half of why it kept running out of its budget.
-        run: |
-          sudo tee -a /etc/nix/nix.conf >/dev/null <<'EOF'
-          extra-substituters = https://hyprland.cachix.org
-          extra-trusted-public-keys = hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE=
-          EOF
-          sudo systemctl restart nix-daemon || true
 
       - name: Boot a session and check the desktop renders
         if: steps.rel.outputs.changed == 'true'
@@ -419,6 +370,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
+          # The twin of this block in flake-update.yml has had this line since
+          # it was written and this one never did -- the same script, copied,
+          # diverging in the one respect that decides whether a failure
+          # halfway through is noticed. Without it a `gh` call that fails
+          # leaves the step running on stale state and exiting 0.
+          set -euo pipefail
+
           pr=${{ steps.pr.outputs.pull-request-number }}
 
           # Needs the repository setting "Allow auto-merge" (Settings ->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -501,11 +501,52 @@ jobs:
       # deliberately, when a human cuts a tag, not with every bot merge that
       # moves main. Plain push, not force: a release branch that moved
       # backwards would downgrade the next machine to update, so a non
-      # fast-forward here should fail loudly and be looked at.
+      # fast-forward must never happen silently.
+      #
+      # It is now DETECTED rather than discovered by the push failing, and the
+      # difference is what the job reports. The workflow_dispatch entry point
+      # at the top of this file exists to re-publish an already-existing tag
+      # after a run died -- and re-running an OLDER tag makes this push a non
+      # fast-forward, so the assets uploaded correctly and then the job went
+      # red on its last step. That is the "published but red" state everything
+      # else here is careful to avoid: it reads as a failed release when the
+      # release succeeded, and the next person re-runs it again.
+      #
+      # So: fast-forward, push. Not a fast-forward, say so loudly in the log
+      # and the summary and leave the branch alone -- which is the right
+      # outcome anyway, since moving it backwards is the thing the old comment
+      # was protecting against. Nobody has to guess whether the release
+      # shipped.
       - name: Move the release branch to this tag
         env:
           TAG: ${{ steps.version.outputs.tag }}
-        run: git push origin "refs/tags/$TAG^{}:refs/heads/release"
+        run: |
+          git fetch -q origin refs/heads/release:refs/remotes/origin/release || true
+          commit=$(git rev-parse "refs/tags/$TAG^{}")
+
+          # No release branch yet is the first release, and pushing is right.
+          if ! git rev-parse -q --verify refs/remotes/origin/release >/dev/null; then
+            git push origin "$commit:refs/heads/release"
+            exit 0
+          fi
+
+          if git merge-base --is-ancestor refs/remotes/origin/release "$commit"; then
+            git push origin "$commit:refs/heads/release"
+            echo "release branch moved to $TAG" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "::warning::$TAG is not a descendant of the release branch, so it" \
+               "was NOT moved -- moving it backwards would downgrade the next" \
+               "machine to update. The release itself published fine."
+          {
+            echo "**The release branch was not moved.**"
+            echo
+            echo "\`$TAG\` is behind \`origin/release\` "
+            echo "(\`$(git rev-parse --short refs/remotes/origin/release)\`), which is what a"
+            echo "workflow_dispatch re-run of an older tag looks like. The assets"
+            echo "published; only the pointer users update against was left alone."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # 5.6 GB of parts on the runner's root filesystem, which is the small
       # one. The workspace is cleaned at the start of the next run, but a

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -36,44 +36,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Honour this flake's own nixConfig instead of warning and
-          # discarding it. Without this every `nix build` here prints
-          #
-          #   warning: ignoring untrusted flake configuration setting
-          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
-          #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
-          #
-          # Scoped to the flake being invoked, which is this repository's
-          # own. It does not extend trust to inputs.
-          # accept-flake-config alone is not enough, and the reason cost a
-          # day: the runner is not in the daemon's `trusted-users`, so every
-          # substituter and key the flake declares is DISCARDED with
-          #
-          #   warning: ignoring the client-specified setting
-          #   'trusted-public-keys', because it is a restricted setting and
-          #   you are not a trusted user
-          #
-          # and the job then BUILDS what it should have downloaded. On
-          # 2026-09-07 the `omarchy` and `box` jobs each compiled Hyprland to
-          # 55% and hit timeout-minutes, while `system` survived only because
-          # it had a hand-written `sudo tee -a /etc/nix/nix.conf` step nobody
-          # had copied to the others.
-          #
-          # extra-conf is written into the SYSTEM nix.conf as root, so what is
-          # set here is trusted and actually applies. The store path nixarchy
-          # uses is byte-identical to the one hyprwm publish -- verified, not
-          # assumed -- so with this the compositor is a download.
-          extra-conf: |
-            accept-flake-config = true
-            extra-substituters = https://nixarchy.cachix.org https://hyprland.cachix.org
-            extra-trusted-public-keys = nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM= hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE=
+      - uses: ./.github/actions/setup-nix
 
       - name: Review, and say so
         # always(), because a review that only reports when it feels like it is

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -28,44 +28,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Honour this flake's own nixConfig instead of warning and
-          # discarding it. Without this every `nix build` here prints
-          #
-          #   warning: ignoring untrusted flake configuration setting
-          #   'extra-substituters'. Pass '--accept-flake-config' to trust it
-          #
-          # and the nixarchy and hyprland caches flake.nix declares are
-          # simply not used. The hyprland one was then re-added by hand in
-          # ONE job, writing /etc/nix/nix.conf because "without this the
-          # runner compiles a compositor from source and times out" -- a
-          # workaround for a setting the flake already carried.
-          #
-          # Scoped to the flake being invoked, which is this repository's
-          # own. It does not extend trust to inputs.
-          # accept-flake-config alone is not enough, and the reason cost a
-          # day: the runner is not in the daemon's `trusted-users`, so every
-          # substituter and key the flake declares is DISCARDED with
-          #
-          #   warning: ignoring the client-specified setting
-          #   'trusted-public-keys', because it is a restricted setting and
-          #   you are not a trusted user
-          #
-          # and the job then BUILDS what it should have downloaded. On
-          # 2026-09-07 the `omarchy` and `box` jobs each compiled Hyprland to
-          # 55% and hit timeout-minutes, while `system` survived only because
-          # it had a hand-written `sudo tee -a /etc/nix/nix.conf` step nobody
-          # had copied to the others.
-          #
-          # extra-conf is written into the SYSTEM nix.conf as root, so what is
-          # set here is trusted and actually applies. The store path nixarchy
-          # uses is byte-identical to the one hyprwm publish -- verified, not
-          # assumed -- so with this the compositor is a download.
-          extra-conf: |
-            accept-flake-config = true
-            extra-substituters = https://nixarchy.cachix.org https://hyprland.cachix.org
-            extra-trusted-public-keys = nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM= hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE=
+      - uses: ./.github/actions/setup-nix
       - uses: cachix/cachix-action@v17
         # A cache upload failing must not fail a build that succeeded (#235).
         continue-on-error: true

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -102,6 +102,25 @@ jobs:
           # repacks, and it avoids trusting a filename-to-attribute convention
           # nothing enforces.
           mapfile -t attrs < <(nix eval --json .#update.pinned | jq -r '.[] | ".#" + .')
+
+          # mapfile returns 0 whatever the process substitution did -- a failed
+          # eval, a renamed output, a jq that is not there -- and an empty
+          # array then makes the line below `nix build --impure
+          # --print-build-logs` with no installables, which builds .#default
+          # and exits GREEN. The one step that proves the rewritten packages
+          # still build would have built none of them and said nothing.
+          #
+          # Six is what .#update.pinned holds today (hey-cli, omacalc, omacut,
+          # omawrite, once, ttfx). The floor is 1 rather than 6 so removing a
+          # package from the set is an ordinary edit and not a CI break, while
+          # "the list came back empty" still stops the job.
+          if [ "${#attrs[@]}" -eq 0 ]; then
+            echo "::error::.#update.pinned produced no attributes, so this step" \
+                 "would build .#default and pass without checking the packages" \
+                 "the bump just rewrote" >&2
+            exit 1
+          fi
+
           echo "building: ${attrs[*]}"
           nix build --impure --print-build-logs "${attrs[@]}"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,45 @@ an assertion; the config side had neither. #202 lived exactly in that gap, and
 #204 is the same defect in mirror image: `satty` ships as a runtime dependency
 and no config names it.
 
-## 3. A check that nothing runs is worse than no check
+## 3. Vary the variable that matters
+
+§1 is about a check that cannot fail. This is its wider form: **a check that
+cannot vary proves nothing about the variable it holds constant** — and it will
+pass, at every priority, with the bug fully present.
+
+Five bugs in one day, every one found by a tester on real hardware, every one
+invisible to a green suite. Not one of them was a missing check.
+
+Every automated install used the username `omarchy` — the one name the image's
+baked reference closure cannot diverge from, so every per-user derivation
+matched a seeded one. Every disk was `/dev/vda`, never an NVMe with its `p1`
+partition names. Every NIC was virtio: no VM in this repository had ever had a
+radio, so NetworkManager's entire wireless path had no coverage of any kind.
+And every guest reports a virt type, so `nixos-generate-config`'s
+`if ($virt eq "none")` branch — where firmware and microcode live — had never
+once executed anywhere in CI. Installed machines shipped with no firmware and
+no microcode, and the suite was green throughout.
+
+So when a bug arrives from real hardware, the first sentence of the fix is not
+the fix. It is: **name the variable that separated that machine from every
+machine the suite boots.**
+
+Then vary *that* variable, at the cheapest layer that can reach it:
+
+- an **evaluation** check that enumerates the branch no VM can take —
+  `generate-config-surface` reads out everything the virt gate can emit,
+  precisely because no VM will ever take it;
+- a **stubbed `runCommand`** — `installer-network` fakes rfkill states no guest
+  produces;
+- a **VM handed the hardware** — `wifi-hwsim` gives one a radio via
+  `mac80211_hwsim`.
+
+If no layer can reach it, **say so**. A row in `tests/install-matrix.py` and a
+sentence in `tests/AGENTS.md` naming the hole is worth more than a check that
+closes it on paper. A documented hole gets tested by a human; an undocumented
+one gets tested by a user.
+
+## 4. A check that nothing runs is worse than no check
 
 `checks.installer-ui` was written, wired into `checks` in `flake.nix`, and
 named by **no workflow**. The PR adding it went green without the check ever
@@ -123,7 +161,7 @@ So: adding a `checks.<name>` entry means also naming
 `pull_request` — and that workflow edit is a CI-gate change, which needs a
 human (see §10). Raise it in the PR rather than wiring it yourself.
 
-## 4. Git and flake mechanics that bite
+## 5. Git and flake mechanics that bite
 
 - **A flake in a worktree sees only tracked or staged files.** A new file you
   have not `git add`ed fails evaluation with `path '…' does not exist` — not
@@ -133,13 +171,13 @@ human (see §10). Raise it in the PR rather than wiring it yourself.
 - **`installer/mkFlake.nix` requires a committed tree.** `git add` is not
   enough — it reads `self.rev`, which a dirty tree does not have, and throws:
   `flake-template: build from a committed tree; the generated flake pins
-  nixarchy by commit`. Commit (the subject can be temporary; see §7) before
+  nixarchy by commit`. Commit (the subject can be temporary; see §8) before
   building anything that pulls it in, which includes the installer checks.
 - **Work in a worktree under `/mnt/data/vmtest/`, never `/tmp`.** `/tmp` is a
   32 GB tmpfs. A VM disk image or an ISO build there is competing with the
   machine's RAM, and loses quietly.
 
-## 5. How to run the checks, and what each one costs
+## 6. How to run the checks, and what each one costs
 
 Checks are built one at a time by name — `nix flake check` is not how this
 repo works:
@@ -177,7 +215,7 @@ to your branch cancels and restarts your own run (that is deliberate — a PR
 only needs an answer about its current head), but the queue is shared:
 batching your pushes is a courtesy to everyone else's merge latency.
 
-## 6. Code rules the repo has already written down
+## 7. Code rules the repo has already written down
 
 Do not restate these in new comments; read them where they live, because the
 files carry the full reasoning and the failure history.
@@ -215,7 +253,7 @@ files carry the full reasoning and the failure history.
   command your script calls and does not declare is a runtime failure that no
   build catches.
 
-## 7. Commits and pull requests
+## 8. Commits and pull requests
 
 - The final commit subject is a full sentence describing the change — read
   `git log --oneline -10` for the register. No `conventional-commits`
@@ -228,7 +266,7 @@ files carry the full reasoning and the failure history.
 - Fill in the PR template, including the section that asks for your check's
   failing output. That section is §1 in form-field shape.
 
-## 8. Territory, and the failure no single PR can see
+## 9. Territory, and the failure no single PR can see
 
 When several agents work this repo at once, each PR should name the files it
 touches, and stay inside them. But the sharper lesson is this: two PRs, each
@@ -256,7 +294,7 @@ The room is public and world-readable. Post no credentials, no tokens, no
 internal hostnames, no paths that reveal a private tree — a gotcha generalises
 perfectly well without any of them.
 
-## 9. When a check fails for reasons unrelated to your change
+## 10. When a check fails for reasons unrelated to your change
 
 First establish that it *is* unrelated: is `main` red too? One standing trap —
 opening an issue with the `epic` label without adding a row to README's
@@ -273,7 +311,7 @@ editing README from a PR about something else.
 
 Do not retry-until-green. A flaky pass is a bug report you deleted.
 
-## 10. What not to do without asking a human
+## 11. What not to do without asking a human
 
 - **Destructive git**: `push --force` to any shared branch, deleting branches
   you did not create, rewriting published history, `git reset --hard` on work

--- a/flake.nix
+++ b/flake.nix
@@ -1098,6 +1098,12 @@
           # The installer's interactive screens, at every width worth caring
           # about. Nothing else draws them: every other harness passes
           # --answers, which is exactly how #133 shipped.
+          # Why: tests/iso-wifi.nix
+          iso-wifi = import ./tests/iso-wifi.nix {
+            inherit inputs;
+            pkgs = pkgsFor.${system};
+          };
+
           # Why: tests/installer-network.nix
           installer-network = import ./tests/installer-network.nix {
             pkgs = pkgsFor.${system};

--- a/flake.nix
+++ b/flake.nix
@@ -1098,6 +1098,12 @@
           # The installer's interactive screens, at every width worth caring
           # about. Nothing else draws them: every other harness passes
           # --answers, which is exactly how #133 shipped.
+          # Why: tests/wifi-hwsim.nix
+          wifi-hwsim = import ./tests/wifi-hwsim.nix {
+            inherit inputs;
+            pkgs = pkgsFor.${system};
+          };
+
           # Why: tests/iso-wifi.nix
           iso-wifi = import ./tests/iso-wifi.nix {
             inherit inputs;

--- a/flake.nix
+++ b/flake.nix
@@ -1100,7 +1100,6 @@
           # --answers, which is exactly how #133 shipped.
           # Why: tests/wifi-hwsim.nix
           wifi-hwsim = import ./tests/wifi-hwsim.nix {
-            inherit inputs;
             pkgs = pkgsFor.${system};
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1110,6 +1110,12 @@
             pkgs = pkgsFor.${system};
           };
 
+          # Why: tests/installer-network-profiles.nix
+          installer-network-profiles = import ./tests/installer-network-profiles.nix {
+            pkgs = pkgsFor.${system};
+            installScript = ./installer/install.sh;
+          };
+
           # Why: tests/installer-network.nix
           installer-network = import ./tests/installer-network.nix {
             pkgs = pkgsFor.${system};

--- a/flake.nix
+++ b/flake.nix
@@ -1098,6 +1098,12 @@
           # The installer's interactive screens, at every width worth caring
           # about. Nothing else draws them: every other harness passes
           # --answers, which is exactly how #133 shipped.
+          # Why: tests/installer-network.nix
+          installer-network = import ./tests/installer-network.nix {
+            pkgs = pkgsFor.${system};
+            installScript = ./installer/install.sh;
+          };
+
           installer-store-space = import ./tests/installer-store-space.nix {
             pkgs = pkgsFor.${system};
             installScript = ./installer/install.sh;

--- a/flake.nix
+++ b/flake.nix
@@ -1104,6 +1104,12 @@
             dashboardScript = ./installer/lib/dashboard.sh;
           };
 
+          # Why: tests/installer-offline-rescue.nix
+          installer-offline-rescue = import ./tests/installer-offline-rescue.nix {
+            pkgs = pkgsFor.${system};
+            installScript = ./installer/install.sh;
+          };
+
           # The doctor's GPU rules, against fixture machines. checks.install's
           # VM runs llvmpipe and has no PCI display controller, so this is the
           # only place these branches are ever exercised -- and one of them was

--- a/flake.nix
+++ b/flake.nix
@@ -1110,6 +1110,13 @@
             pkgs = pkgsFor.${system};
           };
 
+          # Why: tests/installer-failure-hints.nix
+          installer-failure-hints = import ./tests/installer-failure-hints.nix {
+            pkgs = pkgsFor.${system};
+            dashboardScript = ./installer/lib/dashboard.sh;
+            installScript = ./installer/install.sh;
+          };
+
           # Why: tests/installer-network-profiles.nix
           installer-network-profiles = import ./tests/installer-network-profiles.nix {
             pkgs = pkgsFor.${system};

--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -249,11 +249,35 @@ in
     pkgs.git
   ];
 
-  # installation-cd-minimal brings wpa_supplicant; the installed machine uses
-  # NetworkManager, and so does anyone reaching for nmtui when the wireless
-  # does not come up on its own. The two conflict, so one has to go, and it
-  # should be the one the finished system does not use.
-  networking.wireless.enable = lib.mkForce false;
+  # NetworkManager, for the same reason the installed machine uses it and for
+  # anyone reaching for nmtui when the wireless does not come up on its own.
+  #
+  # `networking.wireless.enable` is deliberately NOT forced off here, and the
+  # line that used to do it made every Wi-Fi install impossible:
+  #
+  #   device (wlp0s20f3): Couldn't initialize supplicant interface:
+  #     Failed to D-Bus activate wpa_supplicant service
+  #
+  # repeating every thirteen seconds, forever, on a card whose driver was bound
+  # and whose radio rfkill reported unblocked.
+  #
+  # NetworkManager does not avoid wpa_supplicant -- it DRIVES it. Its own
+  # module says so and sets it up (networkmanager.nix:694-698):
+  #
+  #   # Enable wpa_supplicant but fully control it over DBus
+  #   wireless.enable = true;
+  #   wireless.autoDetectInterfaces = false;
+  #   wireless.dbusControlled = true;
+  #
+  # A mkForce here overrode that and left NM with a backend it was told to use
+  # and had no way to start. The conflict the old comment described -- a
+  # STANDALONE supplicant grabbing interfaces behind NM's back -- is exactly
+  # what those other two settings prevent, so the answer was already in the
+  # module and forcing the switch off threw it away.
+  #
+  # The premise was also stale: nothing in nixpkgs' installation media enables
+  # networking.wireless any more. installation-device.nix's only mention is the
+  # login banner telling you to run nmtui.
   networking.networkmanager.enable = true;
 
   # Straight into the installer, with no boot menu -- upstream shows none and

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -509,6 +509,17 @@ ask_network() {
     if [ -n "$answers_file" ] || network_ready; then
       return 0
     fi
+    # And only where there is a radio to use. cfg80211 creates a phy80211 link
+    # for every driver that registers a wiphy, so its absence means this
+    # machine has no wireless interface -- a desktop on ethernet, or the VM
+    # every wizard check runs in.
+    #
+    # Without this the screen appeared on machines that cannot act on it, and
+    # checks.installer-wizard sat on it for 180 seconds waiting for a keyboard
+    # screen that was one un-answerable prompt away. An optional step is still
+    # a step: offering one to somebody who has no way to take it is the same
+    # cost as requiring it.
+    ls -d /sys/class/net/*/phy80211 >/dev/null 2>&1 || return 0
     offer_optional_wifi
     return 0
   fi

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -384,14 +384,66 @@ connect_wifi() {
   # Asked for every network, including open ones, where an empty answer is
   # correct and is passed as no password at all. One prompt that handles both
   # beats detecting the security column and being wrong about WEP.
-  ui_left "\e[90mLeave blank if the network is open.\e[0m"
-  pw=$(gum input --padding "$(ui_gum_pad)" --password --prompt "Password> ")
+  # Three attempts at the password, and the reason is the failure it replaces.
+  #
+  # `|| return 1` sent every failure back to the outer menu with nothing but
+  # nmcli's own stderr, so a mistyped password, a network that has gone out of
+  # range, and a NetworkManager that is not running all looked identical and
+  # all cost a full round trip through "No network yet" to try again. The one
+  # that is nearly always the answer -- the password -- is the one that should
+  # be one keystroke away.
+  #
+  # nmcli's exit statuses are documented (nmcli(1) EXIT STATUS) and specific
+  # enough to act on:
+  #
+  #   3   timeout
+  #   4   connection activation failed
+  #   8   NetworkManager is not running
+  #   10  connection, device or access point does not exist
+  local attempt rc
+  for attempt in 1 2 3; do
+    ui_left "\e[90mLeave blank if the network is open.\e[0m"
+    pw=$(gum input --padding "$(ui_gum_pad)" --password --prompt "Password> ")
 
-  if [ -z "$pw" ]; then
-    nmcli device wifi connect "$ssid" || return 1
-  else
-    nmcli device wifi connect "$ssid" password "$pw" || return 1
-  fi
+    rc=0
+    if [ -z "$pw" ]; then
+      nmcli device wifi connect "$ssid" || rc=$?
+    else
+      nmcli device wifi connect "$ssid" password "$pw" || rc=$?
+    fi
+    [ "$rc" -eq 0 ] && return 0
+
+    case $rc in
+      4)
+        # "Usually", not "the password is wrong": activation also fails on a
+        # network that hands out no address, and telling someone their correct
+        # password is wrong is worse than being vague.
+        ui_left "\e[31mCould not connect -- usually that is the password.\e[0m"
+        [ "$attempt" -lt 3 ] && continue
+        ui_left "\e[90mThree tries is enough; back to the network list.\e[0m"
+        ;;
+      10)
+        ui_left "\e[31m$ssid is not there any more.\e[0m"
+        ui_left "\e[90mIt was in the scan a moment ago, so it has gone out of range or\e[0m"
+        ui_left "\e[90mstopped advertising. Pick another, or move closer and rescan.\e[0m"
+        ;;
+      3)
+        ui_left "\e[31mThe connection timed out.\e[0m"
+        ui_left "\e[90mThe network answered and then stopped. A weak signal does this.\e[0m"
+        ;;
+      8)
+        # Not the user's problem and not fixable from this screen.
+        ui_left "\e[31mNetworkManager is not running on this image.\e[0m"
+        ui_left "\e[90mThat is a bug in nixarchy, not something you can work around\e[0m"
+        ui_left "\e[90mhere -- please report it. A cable will still install.\e[0m"
+        ;;
+      *)
+        ui_left "\e[31mnmcli failed with status $rc.\e[0m"
+        ;;
+    esac
+    sleep 3
+    return 1
+  done
 }
 
 # Wi-Fi on an image that does not need it, for the machine that will.

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -63,6 +63,16 @@ TRUSTED_KEYS="nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM=
 # not.
 #
 # installer/cd.nix writes the marker.
+#
+# Kept, not discarded. The offline image clears these so the store answers
+# first, and that stays true for the build it is expected to do -- but an image
+# that turns out to be missing a path has, until now, had nowhere to go: the
+# install dies on a machine with a perfectly good network, because the only
+# copy of the answer was on a cache the installer had just told itself to
+# forget. rescue_build below spends them, once, loudly.
+RESCUE_SUBSTITUTERS="$SUBSTITUTERS"
+RESCUE_TRUSTED_KEYS="$TRUSTED_KEYS"
+
 if [ -f /etc/nixarchy-iso ]; then
   SUBSTITUTERS=""
   TRUSTED_KEYS=""
@@ -1856,6 +1866,105 @@ check_store_space() {
 # it to say "network image" without an /etc to write a marker into.
 on_net_image() { [ -f /etc/nixarchy-iso-net ]; }
 
+# The OFFLINE image specifically -- the one that carries the closure and has
+# cleared its substituters. Not `! on_net_image`: checks.install runs with no
+# marker of either kind and a seeded store, so a negation would call that an
+# offline image and change what a passing check is testing.
+on_offline_image() { [ -f /etc/nixarchy-iso ] && [ ! -f /etc/nixarchy-iso-net ]; }
+
+# Where the rescue records what the image could not supply, for
+# `omarchy bug-report` and for a person reading the installed machine later.
+RESCUE_REPORT=/var/log/nixarchy-image-incomplete.log
+
+# The offline image was missing something. Say so, at length, and fetch it.
+#
+# The offline image clears its substituters on purpose (see the comment where
+# that happens): the store answers first, no per-path connection timeouts, and
+# -- the load-bearing half -- "the image's completeness is tested by everyone
+# who boots it", because a missing path cannot be quietly downloaded by whoever
+# happens to have a network and left for the one person who does not.
+#
+# That argument is right and this does not discard it. What it does is stop the
+# failure being TOTAL. Today an image missing one path produces neither an
+# installed machine nor a diagnosis: the build works backwards to the source
+# bootstrap, dies fetching a perl tarball, and the screen names texinfo. That
+# happened on real hardware -- the microcode was on no image, every real
+# machine asks for it, and no VM ever does.
+#
+# So: the fast path is unchanged and still proves completeness. Only when it
+# has already FAILED, and only on the offline image, and only with a network,
+# is the cache spent -- and then the paths that were missing are named on the
+# screen and written to $RESCUE_REPORT, which is a stronger signal than the
+# silent download the original comment was guarding against. The bug becomes a
+# list somebody can paste into an issue instead of a machine that will not
+# install.
+rescue_build() {
+  local flakeref=$1 plan fetch
+
+  on_offline_image || return 1
+
+  echo >&2
+  echo "nixarchy-install: the build failed, and this is the offline image." >&2
+  echo "  Checking whether a network can supply what the image could not." >&2
+
+  if ! network_ready; then
+    echo "  No network, so there is nothing to fall back to. The image is" >&2
+    echo "  missing something it should carry -- please report this with" >&2
+    echo "  /var/log/nixarchy-install.log." >&2
+    return 1
+  fi
+
+  # WHAT was missing, before fetching it. --dry-run with the caches restored
+  # lists exactly the paths this image should have carried and did not, which
+  # is the report; without it the rescue would be the silent download the
+  # offline design exists to prevent.
+  plan=$(nix "${NIX_FLAGS[@]}" build --dry-run "${SUBSTITUTE_FLAGS[@]}" \
+    --extra-substituters "$RESCUE_SUBSTITUTERS" \
+    --extra-trusted-public-keys "$RESCUE_TRUSTED_KEYS" \
+    "$flakeref" 2>&1) || true
+
+  # Paths only. `nix build --dry-run` prints its headings on stderr and the
+  # store paths indented beneath them, so the indent is the selector.
+  fetch=$(printf '%s\n' "$plan" | sed -n 's|^ *\(/nix/store/[^ ]*\)$|\1|p' | sort -u)
+
+  {
+    echo "nixarchy image incomplete"
+    echo "image:  $(cat /etc/nixarchy-iso 2>/dev/null || echo unknown)"
+    echo "date:   $(date -Is)"
+    echo "flake:  $flakeref"
+    echo
+    echo "These paths were not on the medium and were downloaded instead:"
+    printf '%s\n' "${fetch:-  (nix named none -- see the plan below)}"
+    echo
+    printf '%s\n' "$plan"
+  } > "$RESCUE_REPORT" 2>/dev/null || true
+
+  echo >&2
+  echo "  ============================================================" >&2
+  echo "  THIS IMAGE IS INCOMPLETE. That is a bug in nixarchy, not in" >&2
+  echo "  your machine, and the install is continuing over the network" >&2
+  echo "  so you get a working system anyway." >&2
+  echo >&2
+  echo "  Missing from the medium:" >&2
+  printf '%s\n' "${fetch:-  (none named; the plan is in the log)}" |
+    head -20 | sed 's|^|    |' >&2
+  if [ "$(printf '%s\n' "$fetch" | grep -c .)" -gt 20 ]; then
+    echo "    ... and more, all of them in $RESCUE_REPORT" >&2
+  fi
+  echo >&2
+  echo "  Please report this with $RESCUE_REPORT --" >&2
+  echo "  it is copied onto the installed system, and omarchy bug-report" >&2
+  echo "  collects it. An offline image that needs the network is exactly" >&2
+  echo "  the thing we cannot find without you telling us." >&2
+  echo "  ============================================================" >&2
+  echo >&2
+
+  nix "${NIX_FLAGS[@]}" build --no-link --print-out-paths "${SUBSTITUTE_FLAGS[@]}" \
+    --extra-substituters "$RESCUE_SUBSTITUTERS" \
+    --extra-trusted-public-keys "$RESCUE_TRUSTED_KEYS" \
+    "$flakeref"
+}
+
 # Prove the build could start BEFORE the disk is wiped (#300).
 #
 # main() chains format_disk five phases ahead of the build, and that order is
@@ -2035,6 +2144,15 @@ run_install() {
   #   error: could not find a flake.nix file
   #
   # naming nothing that has anything to do with what actually went wrong.
+  # One retry, over the network, on the offline image only -- see rescue_build.
+  # Placed here rather than inside the assignment above so the fast path keeps
+  # its exact shape: no substituters, no timeouts, and a store that answers
+  # first. This runs only once that has already failed.
+  if [ -z "$system" ]; then
+    system=$(rescue_build \
+      "/mnt/etc/nixos#nixosConfigurations.$hostname.config.system.build.toplevel") || true
+  fi
+
   if [ -z "$system" ]; then
     echo "nixarchy-install: the system did not build; nothing was installed." >&2
     echo "The build output is above, in /var/log/nixarchy-install.log." >&2
@@ -2403,6 +2521,17 @@ main() {
     ( umask 077 && cat "$log" >/mnt/var/log/nixarchy-install.log ) 2>/dev/null \
       && chown 0:0 /mnt/var/log/nixarchy-install.log 2>/dev/null \
       && target_log=/var/log/nixarchy-install.log
+
+    # And the incompleteness report, if the offline image had to fall back to
+    # the network. It goes onto the INSTALLED machine deliberately: the live
+    # medium is gone after the reboot, and this is the one artefact that says
+    # the image was missing something. Same umask as the log above, for the
+    # same reason -- it quotes a build plan and nothing should assume a build
+    # plan is free of anything sensitive.
+    if [ -f "$RESCUE_REPORT" ]; then
+      ( umask 077 && cat "$RESCUE_REPORT" >/mnt"$RESCUE_REPORT" ) 2>/dev/null \
+        && chown 0:0 /mnt"$RESCUE_REPORT" 2>/dev/null || true
+    fi
   fi
 
   if [ "$rc" -ne 0 ]; then

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -255,6 +255,38 @@ network_ready() {
   curl -sfI --max-time 8 https://cache.nixos.org/nix-cache-info >/dev/null 2>&1
 }
 
+# WHICH half of "no network" it is, in one word on stdout.
+#
+# network_ready is the right test -- the install needs that cache and nothing
+# less proves it -- but it collapses three situations into one screen saying
+# "No network yet", and they want three different actions:
+#
+#   nolink  no carrier and no address; plug something in or join a network
+#   nodns   associated, but nothing resolves -- a captive portal does this,
+#           and no amount of retrying fixes it from here
+#   nocache resolves and routes, but cache.nixos.org will not answer; a proxy,
+#           a filtered network, or the cache genuinely being down
+#
+# A tester sat on "No network yet" with working Wi-Fi and nothing to act on.
+# The screen said the same thing for a cable that was not plugged in.
+network_fault() {
+  # Any non-loopback interface with a global address. `ip` is on the medium
+  # (iproute2 is in the base system) and this asks the kernel rather than
+  # NetworkManager, which reports "connected" for an association that has not
+  # got as far as an address.
+  ip -o -4 addr show scope global 2>/dev/null | grep -qv ' lo ' ||
+    ip -o -6 addr show scope global 2>/dev/null | grep -q . ||
+    { echo nolink; return; }
+
+  # Resolution, against the host the install actually needs rather than a
+  # well-known one: a captive portal that answers for example.com and not for
+  # cache.nixos.org is still a portal, and DNS that works for one name and not
+  # the other is the same problem to the person in front of it.
+  getent hosts cache.nixos.org >/dev/null 2>&1 || { echo nodns; return; }
+
+  echo nocache
+}
+
 # The way out of any question, said out loud.
 #
 # Every prompt in the flow is a `var=$(... gum ...)` assignment, and the flow
@@ -273,9 +305,49 @@ ui_abort() {
   exit 1
 }
 
+# Is the radio blocked, and by what? Echoes hard, soft or none.
+#
+# `nmcli radio wifi on` clears NetworkManager's own idea of the radio and
+# nothing else, so a machine rfkill'd at the kernel scans, finds nothing, and
+# is told the driver may be missing. On a ThinkPad that is a Fn+F8 away, and
+# the message sends the reader after a driver that is present and bound.
+#
+# rfkill is on the medium: util-linux is in the ISO's package set, verified
+# rather than assumed.
+wifi_block() {
+  local out
+  out=$(rfkill list wifi 2>/dev/null) || { echo none; return; }
+  case $out in
+    *"Hard blocked: yes"*) echo hard ;;
+    *"Soft blocked: yes"*) echo soft ;;
+    *) echo none ;;
+  esac
+}
+
 connect_wifi() {
   ui_screen "Let's get you on Wi-Fi..."
   nmcli radio wifi on >/dev/null 2>&1 || true
+
+  # A soft block is ours to clear, and clearing it is the whole fix on a
+  # machine that has been suspended with the radio off or booted after a
+  # different OS turned it down.
+  if [ "$(wifi_block)" = soft ]; then
+    rfkill unblock wifi >/dev/null 2>&1 || true
+    # The radio needs a moment to come up before a scan means anything.
+    sleep 1
+  fi
+
+  # A hard block is not, and saying so is the point. No software clears a
+  # physical switch or a BIOS setting, so a scan here would find nothing and
+  # the "No networks found" text below would blame the image.
+  if [ "$(wifi_block)" = hard ]; then
+    ui_left "\e[31mThe wireless radio is blocked by hardware.\e[0m"
+    ui_left "\e[90mA physical switch or a BIOS setting is holding it off -- on many\e[0m"
+    ui_left "\e[90mThinkPads that is Fn+F8, and in BIOS setup it is \"Wireless LAN\".\e[0m"
+    ui_left "\e[90mNothing here can override it. A cable works in the meantime.\e[0m"
+    sleep 5
+    return 1
+  fi
 
   # --rescan yes because the cached list is empty on a radio that came up
   # seconds ago, which is every boot of a live image. Deduplicated on SSID:
@@ -288,7 +360,18 @@ connect_wifi() {
 
   if [ -z "$list" ]; then
     ui_left "\e[31mNo networks found.\e[0m"
-    ui_left "\e[90mA USB adapter may need a moment, or the driver may not be on this image.\e[0m"
+    # Only where it can be true. This line used to be unconditional, and on a
+    # machine whose driver was bound and whose radio was merely blocked it sent
+    # the reader after a missing driver that was not missing. cfg80211 creates
+    # a phy80211 link for every driver that registers, so its absence is the
+    # honest test for "no wireless device at all".
+    if ! ls -d /sys/class/net/*/phy80211 >/dev/null 2>&1; then
+      ui_left "\e[90mThis machine has no wireless interface: no driver claimed the card,\e[0m"
+      ui_left "\e[90mor there is no card. A USB adapter may need a moment.\e[0m"
+    else
+      ui_left "\e[90mThe adapter is working but saw nothing. Move closer, or check the\e[0m"
+      ui_left "\e[90mnetwork is on 2.4/5 GHz this card supports.\e[0m"
+    fi
     sleep 3
     return 1
   fi
@@ -339,7 +422,29 @@ ask_network() {
   while true; do
     ui_screen "Let's get you online..."
     ui_left "This image downloads the desktop as it installs, so it needs a network."
-    ui_left "\e[90mA wired connection is picked up on its own -- plug it in and try again.\e[0m"
+
+    # WHICH failure, not just that there is one. The same screen used to greet
+    # a cable that was not plugged in and a laptop associated to a captive
+    # portal, and only one of those is fixed by trying again -- a tester sat on
+    # it with working Wi-Fi and nothing to act on.
+    case $(network_fault) in
+      nolink)
+        ui_left "\e[90mNothing is connected yet. A wired connection is picked up on its\e[0m"
+        ui_left "\e[90mown -- plug it in and choose Try again.\e[0m"
+        ;;
+      nodns)
+        ui_left "\e[33mConnected, but names are not resolving.\e[0m"
+        ui_left "\e[90mThat is what a captive portal looks like: a hotel or guest network\e[0m"
+        ui_left "\e[90mwanting a login page first. Sign in from another device on the same\e[0m"
+        ui_left "\e[90mnetwork, then Try again -- or use the offline image, which needs no\e[0m"
+        ui_left "\e[90mnetwork at all.\e[0m"
+        ;;
+      nocache)
+        ui_left "\e[33mConnected and resolving, but cache.nixos.org will not answer.\e[0m"
+        ui_left "\e[90mA proxy or a filtered network does this. The offline image installs\e[0m"
+        ui_left "\e[90mwithout reaching any cache.\e[0m"
+        ;;
+    esac
     echo
 
     local choice

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -394,6 +394,33 @@ connect_wifi() {
   fi
 }
 
+# Wi-Fi on an image that does not need it, for the machine that will.
+#
+# Split from ask_network because the two are different questions wearing the
+# same screen: the net image cannot proceed without a network, and this one can
+# and simply produces a better machine with one. Conflating them is how the
+# offline image ended up with no way to configure Wi-Fi at all.
+offer_optional_wifi() {
+  ui_screen "Wi-Fi, if you want it..."
+  ui_left "This image installs without a network, so this is optional."
+  ui_left "\e[90mA network you join here is carried onto the installed machine, so it\e[0m"
+  ui_left "\e[90mis already online at the first boot rather than asking again.\e[0m"
+  echo
+
+  local choice
+  choice=$(printf '%s\n' "Skip" "Connect to Wi-Fi" |
+    gum choose --height "$(ui_widget_height)" --padding "$(ui_gum_pad)" \
+      --header "Set up Wi-Fi now?") || choice=""
+
+  # Skip on anything that is not an explicit yes, INCLUDING an interrupt. The
+  # net image's screen calls ui_abort there because it cannot go on; this one
+  # can, and treating Escape as "get out of my way" is what the person means.
+  case $choice in
+    "Connect to Wi-Fi") connect_wifi || true ;;
+    *) return 0 ;;
+  esac
+}
+
 ask_network() {
   # Only the network image asks. Keyed on that image's own marker rather than
   # on the absence of the offline one, and the difference is not cosmetic:
@@ -403,6 +430,24 @@ ask_network() {
   # this screen is for is the one image that genuinely cannot proceed without
   # one, and that image says so itself.
   if [ ! -f /etc/nixarchy-iso-net ]; then
+    # The OFFLINE image, which needs nothing from a network to install -- and
+    # produces a machine that does. Every profile the user joins here is
+    # carried onto the target by carry_network_profiles, so this screen is the
+    # difference between a first boot that is already online and one where
+    # they type their Wi-Fi password again at a desktop that cannot reach
+    # anything to look up how.
+    #
+    # Offered, never demanded, and that asymmetry is the whole design. The
+    # image installs perfectly without it, so a prompt that BLOCKED would be
+    # inventing a requirement -- which is what the old early return was
+    # rightly avoiding. Skipping is one keypress and the default.
+    #
+    # Not under --answers: unattended means nobody is there to pick a network,
+    # and the check that installs offline in a sandbox must not grow a screen.
+    if [ -n "$answers_file" ] || network_ready; then
+      return 0
+    fi
+    offer_optional_wifi
     return 0
   fi
 
@@ -2187,6 +2232,42 @@ run_install() {
 # behaviour every machine had before this existed. What stops the absence
 # going unnoticed is checks.install, which asserts both subvolumes exist and
 # are read-only after a real install.
+# The Wi-Fi the user just joined, carried onto the machine they are building.
+#
+# Nothing did this, and the cost was a report that read as a firmware bug and
+# was two bugs: "Wi-Fi worked while installing and was gone after the reboot".
+# Firmware was half of it. The other half is that NetworkManager writes the
+# profile -- SSID, PSK, everything -- to /etc/NetworkManager/system-connections
+# on the LIVE medium, which is a tmpfs that ceases to exist at reboot. Someone
+# who typed their password into the installer typed it into a RAM disk.
+#
+# Deliberately NOT into /etc/nixos. That directory is a git repository
+# nixarchy-config-repo exists to push to GitHub, and a .nmconnection file holds
+# the pre-shared key in the clear -- the same argument
+# installer/template/host/configuration.nix makes for keeping the crypt hash
+# out of it. /etc/NetworkManager is where NM looks anyway, and 0600 root:root
+# is what it refuses to read the file without.
+#
+# Best effort by design: a machine installed over ethernet has no profiles to
+# carry, and an install must not fail because a copy of a convenience did.
+carry_network_profiles() {
+  local src=/etc/NetworkManager/system-connections
+  local dst=/mnt/etc/NetworkManager/system-connections
+  local n
+
+  [ -d "$src" ] || return 0
+  # `find`, not a glob: an unmatched glob under `set -u` expands to itself and
+  # the copy below would try to read a file called '*.nmconnection'.
+  n=$(find "$src" -maxdepth 1 -name '*.nmconnection' 2>/dev/null | grep -c . || true)
+  [ "${n:-0}" -gt 0 ] || return 0
+
+  install -d -m 0700 -o 0 -g 0 "$dst" 2>/dev/null || return 0
+  find "$src" -maxdepth 1 -name '*.nmconnection' -exec \
+    install -m 0600 -o 0 -g 0 {} "$dst/" \; 2>/dev/null || true
+
+  echo "nixarchy-install: carried $n network profile(s) onto the new system."
+}
+
 take_factory_snapshot() {
   local device top rc=0
 
@@ -2451,6 +2532,7 @@ main() {
       write_password_hash &&
       run_install &&
       chown_flake_dir &&
+      carry_network_profiles &&
       take_factory_snapshot
   } >>"$log" 2>&1 || rc=$?
   ui_dashboard_stop

--- a/installer/lib/dashboard.sh
+++ b/installer/lib/dashboard.sh
@@ -229,6 +229,38 @@ ui_finished() {
 # When it goes wrong, the log is the only thing worth showing, and it is the
 # thing the dashboard has been hiding. Put the tail of it on screen rather than
 # leaving a person with a cleared terminal and a failure they cannot describe.
+# What KIND of failure this is, in one line, or nothing.
+#
+# Its own function so a check can call THIS rather than a copy of it. The first
+# test of this logic re-implemented it in the test script, and passed happily
+# with the real classifier broken -- AGENTS.md 1, by the person who had just
+# written it down.
+#
+# Matched on the whole log, not the tail: the bootstrap announces itself
+# hundreds of lines before it dies, and by the last twenty-five it is
+# downloading a perl tarball with nothing on screen connecting that to the
+# machine in front of you.
+#
+# Order matters. A bootstrap log almost always contains "unable to download"
+# too -- nix says it about the source it then tries to build -- so the download
+# arm comes first and means only what it says: a plain fetch failure. The
+# bootstrap arm is the one that must not be reported as "no network", because
+# the network is not the problem, the missing path is.
+ui_failure_hint() {
+  local log=$1
+  if grep -q "unable to download" "$log" 2>/dev/null; then
+    printf '%s' "This install needed something over the network and could not reach it."
+  elif grep -qE "texinfo|savannah|CPAN|hex0-seed" "$log" 2>/dev/null; then
+    # The stdenv bootstrap: a derivation was not on the medium and not
+    # substitutable, so nix set about building it from source -- with no
+    # compiler here that walks back to a seed. The tail names texinfo or perl,
+    # several layers below anything the reader did.
+    printf '%s' "Something your hardware needs is missing from this image, so the install tried to compile it. That is a bug in nixarchy -- please report it. The net image, or a network cable, will finish this install today."
+  elif grep -qE "No space left on device|out of disk" "$log" 2>/dev/null; then
+    printf '%s' "The live medium ran out of space. A machine with more RAM, or the net image, will get further."
+  fi
+}
+
 ui_failed() {
   local log=$1 rc=$2 target_log=${3:-}
   ui_init
@@ -237,6 +269,25 @@ ui_failed() {
   ui_logo
   ui_centre "\e[1;31mnixarchy installation stopped\e[0m" 28
   echo
+  # One line saying what this failure IS, above the tail rather than instead
+  # of it.
+  #
+  # The tail is the right thing to show and the wrong thing to read: three
+  # signatures account for most real failures here, each of them a wall of
+  # store paths whose meaning is nowhere in the text. Every one cost a tester
+  # most of a day.
+  #
+  # Matched on the whole log, not the tail: the bootstrap in particular
+  # announces itself hundreds of lines before it dies, and by the last
+  # twenty-five it is downloading a perl tarball with nothing on screen to
+  # connect that to the machine in front of you.
+  local hint
+  hint=$(ui_failure_hint "$log")
+  if [ -n "$hint" ]; then
+    ui_left "\e[33m$hint\e[0m"
+    echo
+  fi
+
   ui_left "\e[90mexit $rc -- the last of $log:\e[0m"
   echo
   tail -25 "$log" 2>/dev/null | sed "s/^/$(printf '%*s' "${UI_PAD:-0}" '')/"

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -60,8 +60,45 @@ So, when changing what the ISO carries or how the installer writes a machine:
 MATRIX_OFFLINE_ISO=result/iso/nixarchy-*.iso python3 tests/install-matrix.py off-free manual
 ```
 
-and **type a username that is not `omarchy`**. The scripted cells cannot see
-this class of bug, and adding more of them will not help.
+and **type a username that is not `omarchy`**.
+
+**Partly closed since.** `checks.install-iso` now installs as `lovelace`, so
+one automated cell finally varies this — offline, nightly, already paying for a
+full image build, so a per-user rebuild costs wall clock nobody waits on.
+`checks.install` keeps `omarchy` deliberately: it is PR-gated and its seeded
+store is the thing under test there.
+
+What is still uncovered, and worth typing by hand: a name with a **hyphen or a
+digit**, which also stresses systemd unit naming (`home-manager-<user>.service`)
+and home-manager's own paths. `install-iso` varies one variable on purpose —
+a compound change makes a failure unattributable.
+
+## The other one nothing here can prove: a disk that is not virtio
+
+Every check installs to `/dev/vda`. Real machines are NVMe, where partitions are
+`nvme0n1p1` rather than `vda1` — a different naming rule in every path that
+builds a partition name.
+
+This is not an omission that can be fixed by writing a check, and the reason is
+worth knowing before you try: **qemu-vm.nix cannot make one.** `driveCmdline`
+hardcodes `-device virtio-blk-pci` or `scsi-hd`, and `virtualisation.qemu.diskInterface`
+is an enum of exactly `virtio | scsi | ide`. `emptyDiskImages` entries take a
+`driveConfig`, but it reaches `driveExtraOpts`/`deviceExtraOpts` on those
+devices — not a different device. Attaching an NVMe controller means bypassing
+the framework with raw `qemu.options` and creating the image yourself, inside a
+90-minute test.
+
+So it lives in the harness instead, which drives real qemu directly:
+
+```
+MATRIX_NVME=1 MATRIX_OFFLINE_ISO=result/iso/nixarchy-*.iso \
+  python3 tests/install-matrix.py off-whole-plain
+```
+
+Run it when changing anything that builds a partition name, mounts by path, or
+touches `installer/disk-config.nix`. Both an online and an offline whole-disk
+install through it passed on 2026-09-08, which is what "no check covers this"
+is allowed to mean here: measured by a person, written down, and repeatable.
 
 ## The cheap ones, which is where new checks usually belong
 
@@ -90,6 +127,17 @@ Two branches only these can reach, as illustration:
 - Assert the outcome, not the mechanism. `stat -c %U` asks the wrong machine
   when the test driver's passwd is not the target's; compare numeric ids
   against the target's own `/etc/passwd`.
+- **The harness is a module too, and it outranks you.** `qemu-vm.nix` is merged
+  into every nixosTest node and does not only add virtio devices — it CHANGES
+  config at priority 10, above any plain assignment.
+  `networking.wireless.enable = mkVMOverride false` (`qemu-vm.nix:1504`)
+  silently re-created the exact production misconfiguration a test existed to
+  prove fixed, with the identical journal line — and that line was read as "the
+  fix does not work" for most of a day. It was the test that did not work.
+  Before concluding a node reproduces a production failure, evaluate the
+  **node's merged config**, not the module you wrote and not the production
+  system it copies from. And treat an identical error message as a hypothesis
+  about the cause, never as an identification of it.
 - A forbid-pattern matches prose too. Forbidding a bare package name failed
   against correctly-gated code because the surrounding comment mentioned it —
   match the call, not the string.

--- a/tests/install-iso.nix
+++ b/tests/install-iso.nix
@@ -93,11 +93,32 @@ let
         # installer catches it ("not a crypt(3) hash"), which is the only
         # reason this was a one-line fix rather than a mystery about why the
         # greeter rejects the password.
+        # NOT `omarchy`, and that is the whole point of this line.
+        #
+        # Every automated install in this repository used `omarchy` -- the one
+        # username the image's baked reference closure cannot diverge from, so
+        # every per-user derivation matched a seeded one and nothing ever
+        # tested what happens when they do not. Five bugs in one day were
+        # variables held constant like this; see AGENTS.md.
+        #
+        # This is the check that can afford to vary it: offline, nightly, and
+        # already paying for a full image build, so a per-user rebuild here
+        # costs wall clock nobody is waiting on. checks.install keeps `omarchy`
+        # deliberately -- it is PR-gated and its seeded store is the thing
+        # under test there.
+        #
+        # `password_hash` is unaffected: the hash below is of the PASSWORD
+        # "omarchy", which has nothing to do with the account name.
+        #
+        # One variable, not two: a name with a hyphen or a digit would also
+        # stress systemd unit naming (home-manager-<user>.service) and
+        # home-manager's paths, and a failure could not be attributed. That is
+        # the next cell, not this one.
         cat > answers <<'EOF'
         device=/dev/vda
         encrypt=no
         hostname=isotest
-        username=omarchy
+        username=lovelace
         password_hash=${passwordHash}
         timezone=UTC
         keymap=us

--- a/tests/installer-failure-hints.nix
+++ b/tests/installer-failure-hints.nix
@@ -1,0 +1,130 @@
+{
+  pkgs,
+  dashboardScript,
+  installScript,
+}:
+# The failure screen names what the failure IS, and connect_wifi says which
+# failure it hit.
+#
+# Both exist because a correct diagnostic that nobody can read is not a
+# diagnostic. ui_failed showed twenty-five lines of store paths -- the right
+# thing to show, and the wrong thing to read: three signatures account for most
+# real failures here and each cost a tester most of a day.
+#
+#   "unable to download"   the install needed the network and had none
+#   texinfo / savannah     the stdenv bootstrap, meaning something was not on
+#                          the medium and nix set about compiling it from a
+#                          seed. The tail names texinfo or a perl tarball,
+#                          which is several layers below anything the reader
+#                          did, and reads as "nixarchy is broken" rather than
+#                          "this image is missing one file".
+#   No space left          the live medium's RAM-backed store filled
+#
+# And connect_wifi returned 1 for everything, so a mistyped password, a network
+# gone out of range, and a NetworkManager that is not running were the same
+# screen -- each costing a full round trip through the menu to retry the one
+# thing that is nearly always the answer.
+#
+# runCommand, not a VM: both are shell over strings. checks.install-iso cannot
+# reach either -- it asserts installs that SUCCEED, and a passing install
+# renders no failure screen at all.
+pkgs.runCommand "nixarchy-installer-failure-hints" { nativeBuildInputs = [ pkgs.gnugrep ]; } ''
+  # The REAL classifier, extracted and called. Not a copy: the first version of
+  # this file re-implemented the if/elif chain inside the test script and
+  # passed with the product's own classifier broken -- exactly the failure
+  # AGENTS.md 1 is about, and the reason ui_failure_hint is a function at all.
+  sed -n '/^ui_failure_hint()/,/^}/p' ${dashboardScript} > f.sh
+  test -s f.sh || { echo "ui_failure_hint is gone from dashboard.sh" >&2; exit 1; }
+
+  cat > t.sh <<'EOF'
+  . ./f.sh
+
+  # The classes, by the sentence each produces. Matching a distinctive phrase
+  # rather than the whole string: the wording is meant to be edited, the
+  # CLASSIFICATION is not.
+  hint_for() {
+    case $(ui_failure_hint "$1") in
+      *"could not reach it"*)      printf network ;;
+      *"tried to compile it"*)     printf bootstrap ;;
+      *"ran out of space"*)        printf space ;;
+      "")                          ;;
+      *)                           printf unknown-class ;;
+    esac
+  }
+
+  fails=0
+  t() { # t <want> <name> <log-content>
+    printf '%s\n' "$3" > lg
+    got=$(hint_for lg)
+    if [ "$got" = "$1" ]; then echo "  ok      $2"; else
+      echo "  FAILED  $2: wanted '$1', got '$got'"; fails=$((fails + 1)); fi
+  }
+
+  t network "an unreachable substituter is named" \
+    "error: unable to download 'https://cache.nixos.org/x.narinfo': Couldn't resolve host"
+
+  # The one that matters most: the reader sees texinfo and has no way to know
+  # it means "this image is missing a file your machine needs".
+  t bootstrap "the stdenv bootstrap is named" \
+    "building '/nix/store/aaa-texinfo-7.3.tar.xz.drv'..."
+  t bootstrap "and by its other signatures too" \
+    "trying https://download.savannah.gnu.org/releases/x.tar.gz"
+
+  t space "a full store is named" \
+    "error: writing to file: No space left on device"
+
+  # A failure nobody has classified must produce NO hint. A wrong hint is
+  # worse than none: it sends the reader somewhere confidently.
+  t "" "an unrecognised failure gets no hint" \
+    "error: builder for '/nix/store/zzz-thing.drv' failed with exit code 1"
+
+  # Ordering. A bootstrap log almost always contains a download line too --
+  # nix says "unable to download" for the source it then tries to build. If
+  # the download arm won, every bootstrap would be reported as "no network",
+  # which is the wrong action: the network is not the problem, the missing
+  # path is.
+  t network "a plain download failure stays a download failure" \
+    "error: unable to download 'https://cache.nixos.org/x'"
+
+  [ "$fails" = 0 ] || { echo "$fails case(s) failed"; exit 1; }
+  EOF
+  ${pkgs.bash}/bin/bash t.sh
+
+  # connect_wifi's exit-code mapping, asserted on the source: the branches are
+  # inside a gum prompt loop, so reaching them needs an interactive terminal
+  # and a radio. What must not regress is that the codes are distinguished at
+  # all -- `|| return 1` for everything is what this replaced.
+  sed -n '/^connect_wifi()/,/^}/p' ${installScript} > c.sh
+  fails=0
+  for code in 4 10 3 8; do
+    if grep -qE "^\s+$code\)" c.sh; then
+      echo "  ok      nmcli exit $code has its own message"
+    else
+      echo "  FAILED  nmcli exit $code is no longer distinguished"; fails=1
+    fi
+  done
+  # And that a wrong password does not cost a trip through the outer menu.
+  grep -q 'for attempt in' c.sh ||
+    { echo "  FAILED  the password is no longer re-offered in place"; fails=1; }
+  echo "  ok      a wrong password is re-offered in place"
+  # Never assert the password is wrong: exit 4 is also a network that hands
+  # out no address, and telling someone their correct password is wrong is
+  # worse than being vague.
+  #
+  # Matched on what is PRINTED, with comments stripped first. A first draft
+  # grepped the whole function and failed against correct code, because the
+  # comment above the branch says '"Usually", not "the password is wrong"' --
+  # tests/AGENTS.md already records that a forbid-pattern matches prose too,
+  # and this walked into it anyway. Deleting that comment to make the check
+  # pass would have removed the explanation and kept the behaviour.
+  grep -v '^\s*#' c.sh | grep 'ui_left' > printed.sh || true
+  if grep -qiE 'password is (wrong|incorrect)' printed.sh; then
+    echo "  FAILED  it claims the password is wrong, which exit 4 does not prove"; fails=1
+  else
+    echo "  ok      and it says 'usually', because exit 4 does not prove it"
+  fi
+  [ "$fails" = 0 ] || exit 1
+
+  echo "the installer says what went wrong, not only that something did"
+  touch $out
+''

--- a/tests/installer-network-profiles.nix
+++ b/tests/installer-network-profiles.nix
@@ -1,0 +1,107 @@
+{ pkgs, installScript }:
+# carry_network_profiles, against a fixture live medium.
+#
+# Why it exists: nothing carried them, and the cost was a report that read as
+# one bug and was two. "Wi-Fi worked while installing and was gone after the
+# reboot" was half missing firmware -- and half this: NetworkManager writes the
+# profile, PSK included, to /etc/NetworkManager/system-connections on the LIVE
+# medium, which is a tmpfs that ceases to exist at reboot. Someone who typed
+# their Wi-Fi password into the installer typed it into a RAM disk.
+#
+# Three of the four properties below are about NOT doing damage. A copy of a
+# convenience must never fail an install that has otherwise succeeded, and the
+# file it copies holds a pre-shared key in the clear -- so where it lands, and
+# with what mode, is the security half of this and not a detail.
+#
+# A runCommand and not a VM: the function is shell over a directory, and
+# checks.install has no wireless profile to carry because its guest has no
+# radio -- the one shape where this function does nothing at all.
+pkgs.runCommand "nixarchy-installer-network-profiles" { } ''
+  sed -n '/^carry_network_profiles()/,/^}/p' ${installScript} > f.sh
+  test -s f.sh || { echo "carry_network_profiles is gone from install.sh" >&2; exit 1; }
+
+  cat > t.sh <<'EOF'
+  . ./f.sh
+
+  fails=0
+  ok()  { echo "  ok      $1"; }
+  bad() { echo "  FAILED  $1"; fails=$((fails + 1)); }
+
+  # The real paths are absolute, so the function is driven with its own
+  # variables pointed at fixtures -- the same shape it has in production, with
+  # the two roots moved.
+  setup() {
+    rm -rf live target
+    mkdir -p target/etc
+    if [ "$1" = with-profiles ]; then
+      mkdir -p live/etc/NetworkManager/system-connections
+      printf '[wifi]\nssid=home\n[wifi-security]\npsk=hunter2\n' \
+        > live/etc/NetworkManager/system-connections/home.nmconnection
+      printf '[wifi]\nssid=cafe\n' \
+        > live/etc/NetworkManager/system-connections/cafe.nmconnection
+    elif [ "$1" = empty-dir ]; then
+      mkdir -p live/etc/NetworkManager/system-connections
+    fi
+  }
+
+  run() {
+    # Same function, rooted at the fixtures.
+    ( src=$PWD/live/etc/NetworkManager/system-connections
+      dst=$PWD/target/etc/NetworkManager/system-connections
+      [ -d "$src" ] || exit 0
+      n=$(find "$src" -maxdepth 1 -name '*.nmconnection' 2>/dev/null | grep -c . || true)
+      [ "''${n:-0}" -gt 0 ] || exit 0
+      install -d -m 0700 "$dst" 2>/dev/null || exit 0
+      find "$src" -maxdepth 1 -name '*.nmconnection' -exec \
+        install -m 0600 {} "$dst/" \; 2>/dev/null || true
+      echo "carried $n" )
+  }
+
+  # Both profiles arrive.
+  setup with-profiles
+  run > out
+  if [ "$(find target -name '*.nmconnection' | wc -l)" = 2 ]; then
+    ok "profiles are carried onto the target"
+  else
+    bad "profiles are carried onto the target"
+  fi
+
+  # 0600, because the file holds the PSK in the clear and NetworkManager
+  # refuses to read it otherwise -- the mode is both the security property and
+  # a functional requirement.
+  m=$(stat -c '%a' target/etc/NetworkManager/system-connections/home.nmconnection)
+  if [ "$m" = 600 ]; then ok "and are mode 0600"; else bad "and are mode 0600 (got $m)"; fi
+  d=$(stat -c '%a' target/etc/NetworkManager/system-connections)
+  if [ "$d" = 700 ]; then ok "in a 0700 directory"; else bad "in a 0700 directory (got $d)"; fi
+
+  # An ethernet install has none, and must not fail.
+  setup empty-dir
+  if run >/dev/null 2>&1; then ok "an empty profile directory is not an error"
+  else bad "an empty profile directory is not an error"; fi
+
+  # Neither must a medium that never started NetworkManager.
+  setup none
+  if run >/dev/null 2>&1; then ok "a missing profile directory is not an error"
+  else bad "a missing profile directory is not an error"; fi
+
+  [ "$fails" = 0 ] || { echo "$fails case(s) failed"; exit 1; }
+  EOF
+
+  ${pkgs.bash}/bin/bash t.sh
+
+  # And the property no fixture can show, asserted on the source: these files
+  # must never reach /etc/nixos. That directory is a git repository
+  # nixarchy-config-repo pushes to GitHub, and a .nmconnection holds the PSK in
+  # the clear -- the same argument the template makes for the crypt hash. A
+  # future edit that "tidies" the destination into the flake would publish
+  # every tester's Wi-Fi password.
+  if grep -A25 '^carry_network_profiles()' ${installScript} | grep -q '/etc/nixos'; then
+    echo "carry_network_profiles now touches /etc/nixos, which is pushed to" >&2
+    echo "GitHub -- a .nmconnection holds the PSK in the clear" >&2
+    exit 1
+  fi
+  echo "  ok      and never into /etc/nixos, which gets pushed"
+
+  echo "the Wi-Fi you joined during the install survives the reboot"
+  touch $out
+''

--- a/tests/installer-network-profiles.nix
+++ b/tests/installer-network-profiles.nix
@@ -16,92 +16,102 @@
 # A runCommand and not a VM: the function is shell over a directory, and
 # checks.install has no wireless profile to carry because its guest has no
 # radio -- the one shape where this function does nothing at all.
-pkgs.runCommand "nixarchy-installer-network-profiles" { } ''
-  sed -n '/^carry_network_profiles()/,/^}/p' ${installScript} > f.sh
-  test -s f.sh || { echo "carry_network_profiles is gone from install.sh" >&2; exit 1; }
+pkgs.runCommand "nixarchy-installer-network-profiles"
+  {
+    # Declared rather than inherited from stdenv's PATH, for the reason
+    # checks.installer-network's header gives: an implicit tool dependency is
+    # fine until it is not, and invisible when it breaks.
+    nativeBuildInputs = [
+      pkgs.gnugrep
+      pkgs.gnused
+    ];
+  }
+  ''
+    sed -n '/^carry_network_profiles()/,/^}/p' ${installScript} > f.sh
+    test -s f.sh || { echo "carry_network_profiles is gone from install.sh" >&2; exit 1; }
 
-  cat > t.sh <<'EOF'
-  . ./f.sh
+    cat > t.sh <<'EOF'
+    . ./f.sh
 
-  fails=0
-  ok()  { echo "  ok      $1"; }
-  bad() { echo "  FAILED  $1"; fails=$((fails + 1)); }
+    fails=0
+    ok()  { echo "  ok      $1"; }
+    bad() { echo "  FAILED  $1"; fails=$((fails + 1)); }
 
-  # The real paths are absolute, so the function is driven with its own
-  # variables pointed at fixtures -- the same shape it has in production, with
-  # the two roots moved.
-  setup() {
-    rm -rf live target
-    mkdir -p target/etc
-    if [ "$1" = with-profiles ]; then
-      mkdir -p live/etc/NetworkManager/system-connections
-      printf '[wifi]\nssid=home\n[wifi-security]\npsk=hunter2\n' \
-        > live/etc/NetworkManager/system-connections/home.nmconnection
-      printf '[wifi]\nssid=cafe\n' \
-        > live/etc/NetworkManager/system-connections/cafe.nmconnection
-    elif [ "$1" = empty-dir ]; then
-      mkdir -p live/etc/NetworkManager/system-connections
+    # The real paths are absolute, so the function is driven with its own
+    # variables pointed at fixtures -- the same shape it has in production, with
+    # the two roots moved.
+    setup() {
+      rm -rf live target
+      mkdir -p target/etc
+      if [ "$1" = with-profiles ]; then
+        mkdir -p live/etc/NetworkManager/system-connections
+        printf '[wifi]\nssid=home\n[wifi-security]\npsk=hunter2\n' \
+          > live/etc/NetworkManager/system-connections/home.nmconnection
+        printf '[wifi]\nssid=cafe\n' \
+          > live/etc/NetworkManager/system-connections/cafe.nmconnection
+      elif [ "$1" = empty-dir ]; then
+        mkdir -p live/etc/NetworkManager/system-connections
+      fi
+    }
+
+    run() {
+      # Same function, rooted at the fixtures.
+      ( src=$PWD/live/etc/NetworkManager/system-connections
+        dst=$PWD/target/etc/NetworkManager/system-connections
+        [ -d "$src" ] || exit 0
+        n=$(find "$src" -maxdepth 1 -name '*.nmconnection' 2>/dev/null | grep -c . || true)
+        [ "''${n:-0}" -gt 0 ] || exit 0
+        install -d -m 0700 "$dst" 2>/dev/null || exit 0
+        find "$src" -maxdepth 1 -name '*.nmconnection' -exec \
+          install -m 0600 {} "$dst/" \; 2>/dev/null || true
+        echo "carried $n" )
+    }
+
+    # Both profiles arrive.
+    setup with-profiles
+    run > out
+    if [ "$(find target -name '*.nmconnection' | wc -l)" = 2 ]; then
+      ok "profiles are carried onto the target"
+    else
+      bad "profiles are carried onto the target"
     fi
-  }
 
-  run() {
-    # Same function, rooted at the fixtures.
-    ( src=$PWD/live/etc/NetworkManager/system-connections
-      dst=$PWD/target/etc/NetworkManager/system-connections
-      [ -d "$src" ] || exit 0
-      n=$(find "$src" -maxdepth 1 -name '*.nmconnection' 2>/dev/null | grep -c . || true)
-      [ "''${n:-0}" -gt 0 ] || exit 0
-      install -d -m 0700 "$dst" 2>/dev/null || exit 0
-      find "$src" -maxdepth 1 -name '*.nmconnection' -exec \
-        install -m 0600 {} "$dst/" \; 2>/dev/null || true
-      echo "carried $n" )
-  }
+    # 0600, because the file holds the PSK in the clear and NetworkManager
+    # refuses to read it otherwise -- the mode is both the security property and
+    # a functional requirement.
+    m=$(stat -c '%a' target/etc/NetworkManager/system-connections/home.nmconnection)
+    if [ "$m" = 600 ]; then ok "and are mode 0600"; else bad "and are mode 0600 (got $m)"; fi
+    d=$(stat -c '%a' target/etc/NetworkManager/system-connections)
+    if [ "$d" = 700 ]; then ok "in a 0700 directory"; else bad "in a 0700 directory (got $d)"; fi
 
-  # Both profiles arrive.
-  setup with-profiles
-  run > out
-  if [ "$(find target -name '*.nmconnection' | wc -l)" = 2 ]; then
-    ok "profiles are carried onto the target"
-  else
-    bad "profiles are carried onto the target"
-  fi
+    # An ethernet install has none, and must not fail.
+    setup empty-dir
+    if run >/dev/null 2>&1; then ok "an empty profile directory is not an error"
+    else bad "an empty profile directory is not an error"; fi
 
-  # 0600, because the file holds the PSK in the clear and NetworkManager
-  # refuses to read it otherwise -- the mode is both the security property and
-  # a functional requirement.
-  m=$(stat -c '%a' target/etc/NetworkManager/system-connections/home.nmconnection)
-  if [ "$m" = 600 ]; then ok "and are mode 0600"; else bad "and are mode 0600 (got $m)"; fi
-  d=$(stat -c '%a' target/etc/NetworkManager/system-connections)
-  if [ "$d" = 700 ]; then ok "in a 0700 directory"; else bad "in a 0700 directory (got $d)"; fi
+    # Neither must a medium that never started NetworkManager.
+    setup none
+    if run >/dev/null 2>&1; then ok "a missing profile directory is not an error"
+    else bad "a missing profile directory is not an error"; fi
 
-  # An ethernet install has none, and must not fail.
-  setup empty-dir
-  if run >/dev/null 2>&1; then ok "an empty profile directory is not an error"
-  else bad "an empty profile directory is not an error"; fi
+    [ "$fails" = 0 ] || { echo "$fails case(s) failed"; exit 1; }
+    EOF
 
-  # Neither must a medium that never started NetworkManager.
-  setup none
-  if run >/dev/null 2>&1; then ok "a missing profile directory is not an error"
-  else bad "a missing profile directory is not an error"; fi
+    ${pkgs.bash}/bin/bash t.sh
 
-  [ "$fails" = 0 ] || { echo "$fails case(s) failed"; exit 1; }
-  EOF
+    # And the property no fixture can show, asserted on the source: these files
+    # must never reach /etc/nixos. That directory is a git repository
+    # nixarchy-config-repo pushes to GitHub, and a .nmconnection holds the PSK in
+    # the clear -- the same argument the template makes for the crypt hash. A
+    # future edit that "tidies" the destination into the flake would publish
+    # every tester's Wi-Fi password.
+    if grep -A25 '^carry_network_profiles()' ${installScript} | grep -q '/etc/nixos'; then
+      echo "carry_network_profiles now touches /etc/nixos, which is pushed to" >&2
+      echo "GitHub -- a .nmconnection holds the PSK in the clear" >&2
+      exit 1
+    fi
+    echo "  ok      and never into /etc/nixos, which gets pushed"
 
-  ${pkgs.bash}/bin/bash t.sh
-
-  # And the property no fixture can show, asserted on the source: these files
-  # must never reach /etc/nixos. That directory is a git repository
-  # nixarchy-config-repo pushes to GitHub, and a .nmconnection holds the PSK in
-  # the clear -- the same argument the template makes for the crypt hash. A
-  # future edit that "tidies" the destination into the flake would publish
-  # every tester's Wi-Fi password.
-  if grep -A25 '^carry_network_profiles()' ${installScript} | grep -q '/etc/nixos'; then
-    echo "carry_network_profiles now touches /etc/nixos, which is pushed to" >&2
-    echo "GitHub -- a .nmconnection holds the PSK in the clear" >&2
-    exit 1
-  fi
-  echo "  ok      and never into /etc/nixos, which gets pushed"
-
-  echo "the Wi-Fi you joined during the install survives the reboot"
-  touch $out
-''
+    echo "the Wi-Fi you joined during the install survives the reboot"
+    touch $out
+  ''

--- a/tests/installer-network.nix
+++ b/tests/installer-network.nix
@@ -1,0 +1,102 @@
+{ pkgs, installScript }:
+# network_fault and wifi_block, driven against a stubbed kernel.
+#
+# What they defend, and both cost a tester an evening:
+#
+#   "No network yet" was one screen for three situations. A cable that is not
+#   plugged in, a laptop associated to a captive portal, and a network that
+#   filters the binary cache all want different actions, and only the first is
+#   fixed by choosing Try again. Someone sat on that screen with working Wi-Fi
+#   and nothing to act on.
+#
+#   connect_wifi never touched rfkill. `nmcli radio wifi on` clears
+#   NetworkManager's idea of the radio and not the kernel's, so a blocked card
+#   scanned, found nothing, and the installer said "the driver may not be on
+#   this image" -- about an Intel AX201 whose driver was bound the whole time.
+#   On a ThinkPad the actual answer is Fn+F8.
+#
+# A runCommand and not a VM: these read `ip`, `getent`, `curl` and `rfkill`, and
+# checks.install-iso runs with -nic none against a machine with no radio at
+# all -- the one shape where every branch below is unreachable.
+pkgs.runCommand "nixarchy-installer-network" { } ''
+  for fn in network_ready network_fault wifi_block; do
+    sed -n "/^$fn()/,/^}/p" ${installScript} >> f.sh
+    echo >> f.sh
+  done
+  grep -q '^network_fault()' f.sh ||
+    { echo "network_fault is not in install.sh any more" >&2; exit 1; }
+  grep -q '^wifi_block()' f.sh ||
+    { echo "wifi_block is not in install.sh any more" >&2; exit 1; }
+
+  cat > t.sh <<'EOF'
+  . ./f.sh
+
+  # The kernel, stubbed. Each variable is one of the three things the function
+  # asks about, so a case is a triple rather than a mock script.
+  ip()     { [ "$HAVE_ADDR" = 1 ] && echo "2: enp0s31f6    inet 192.168.1.4/24 scope global"; }
+  getent() { [ "$HAVE_DNS" = 1 ]; }
+
+  fails=0
+  t() { # t <want> <name> <addr> <dns>
+    HAVE_ADDR=$3 HAVE_DNS=$4
+    got=$(network_fault)
+    if [ "$got" = "$1" ]; then echo "  ok      $2"; else
+      echo "  FAILED  $2: wanted $1, got $got"; fails=$((fails + 1)); fi
+  }
+
+  # No address at all: the cable is out, or the radio never associated.
+  t nolink  "no address is nolink"            0 0
+  # Associated with an address and nothing resolves. THE captive portal shape,
+  # and the one that used to read as "try again" forever.
+  t nodns   "address but no DNS is nodns"     1 0
+  # Everything resolves and the cache still will not answer: a proxy, a filter,
+  # or the cache being down. Distinct because the action is different -- no
+  # amount of waiting on this network fixes it.
+  t nocache "resolving but no cache is nocache" 1 1
+
+  # ---- the radio ---------------------------------------------------------
+  rfkill() {
+    case "$STATE" in
+      hard) printf '0: phy0: Wireless LAN\n\tSoft blocked: yes\n\tHard blocked: yes\n' ;;
+      soft) printf '0: phy0: Wireless LAN\n\tSoft blocked: yes\n\tHard blocked: no\n' ;;
+      none) printf '0: phy0: Wireless LAN\n\tSoft blocked: no\n\tHard blocked: no\n' ;;
+      gone) return 1 ;;
+    esac
+  }
+  b() { # b <want> <name> <state>
+    STATE=$3
+    got=$(wifi_block)
+    if [ "$got" = "$1" ]; then echo "  ok      $2"; else
+      echo "  FAILED  $2: wanted $1, got $got"; fails=$((fails + 1)); fi
+  }
+
+  b none "an unblocked radio is none"        none
+  # Ours to clear, and clearing it is the whole fix.
+  b soft "a soft block is soft"              soft
+  # Hard wins over soft: rfkill reports BOTH yes for a hardware switch, and
+  # reading the soft line first would call it soft, try to unblock it, fail
+  # silently, and fall through to "no networks found" -- which is the bug this
+  # whole file exists for, one layer down.
+  b hard "hard beats soft when both are set" hard
+  # No rfkill at all must not read as blocked: that would refuse to scan on a
+  # machine whose radio is fine.
+  b none "a missing rfkill is not a block"   gone
+
+  [ "$fails" = 0 ] || { echo "$fails case(s) failed"; exit 1; }
+  EOF
+
+  ${pkgs.bash}/bin/bash t.sh
+
+  # And the sentence that misled the tester: it may only be said when there is
+  # genuinely no wireless interface. Asserted on the source, because the branch
+  # lives inside connect_wifi's scan path and reaching it needs a whole nmcli.
+  grep -q 'phy80211' ${installScript} || {
+    echo "connect_wifi no longer tests for a wireless interface before" >&2
+    echo "blaming the image for a missing driver" >&2
+    exit 1
+  }
+  echo "  ok      the missing-driver line is gated on there being no interface"
+
+  echo "the installer can tell three network failures apart, and a blocked radio from a missing one"
+  touch $out
+''

--- a/tests/installer-network.nix
+++ b/tests/installer-network.nix
@@ -18,111 +18,145 @@
 # A runCommand and not a VM: these read `ip`, `getent`, `curl` and `rfkill`, and
 # checks.install-iso runs with -nic none against a machine with no radio at
 # all -- the one shape where every branch below is unreachable.
-pkgs.runCommand "nixarchy-installer-network" { } ''
-  for fn in network_ready network_fault wifi_block; do
-    sed -n "/^$fn()/,/^}/p" ${installScript} >> f.sh
-    echo >> f.sh
-  done
-  grep -q '^network_fault()' f.sh ||
-    { echo "network_fault is not in install.sh any more" >&2; exit 1; }
-  grep -q '^wifi_block()' f.sh ||
-    { echo "wifi_block is not in install.sh any more" >&2; exit 1; }
-
-  cat > t.sh <<'EOF'
-  . ./f.sh
-
-  # The kernel, stubbed. Each variable is one of the three things the function
-  # asks about, so a case is a triple rather than a mock script.
-  ip()     { [ "$HAVE_ADDR" = 1 ] && echo "2: enp0s31f6    inet 192.168.1.4/24 scope global"; }
-  getent() { [ "$HAVE_DNS" = 1 ]; }
-
-  fails=0
-  t() { # t <want> <name> <addr> <dns>
-    HAVE_ADDR=$3 HAVE_DNS=$4
-    got=$(network_fault)
-    if [ "$got" = "$1" ]; then echo "  ok      $2"; else
-      echo "  FAILED  $2: wanted $1, got $got"; fails=$((fails + 1)); fi
+pkgs.runCommand "nixarchy-installer-network"
+  {
+    # Declared, not inherited. This builder greps and seds the installer, and
+    # the only reason it worked without saying so is that stdenv happens to put
+    # both on PATH -- an implicit dependency that is fine until it is not, and
+    # invisible when it breaks. checks.installer-failure-hints already declares
+    # gnugrep for the same reason.
+    nativeBuildInputs = [
+      pkgs.gnugrep
+      pkgs.gnused
+    ];
   }
+  ''
+    for fn in network_ready network_fault wifi_block; do
+      sed -n "/^$fn()/,/^}/p" ${installScript} >> f.sh
+      echo >> f.sh
+    done
+    grep -q '^network_fault()' f.sh ||
+      { echo "network_fault is not in install.sh any more" >&2; exit 1; }
+    grep -q '^wifi_block()' f.sh ||
+      { echo "wifi_block is not in install.sh any more" >&2; exit 1; }
 
-  # No address at all: the cable is out, or the radio never associated.
-  t nolink  "no address is nolink"            0 0
-  # Associated with an address and nothing resolves. THE captive portal shape,
-  # and the one that used to read as "try again" forever.
-  t nodns   "address but no DNS is nodns"     1 0
-  # Everything resolves and the cache still will not answer: a proxy, a filter,
-  # or the cache being down. Distinct because the action is different -- no
-  # amount of waiting on this network fixes it.
-  t nocache "resolving but no cache is nocache" 1 1
+    cat > t.sh <<'EOF'
+    . ./f.sh
 
-  # ---- the radio ---------------------------------------------------------
-  rfkill() {
-    case "$STATE" in
-      hard) printf '0: phy0: Wireless LAN\n\tSoft blocked: yes\n\tHard blocked: yes\n' ;;
-      soft) printf '0: phy0: Wireless LAN\n\tSoft blocked: yes\n\tHard blocked: no\n' ;;
-      none) printf '0: phy0: Wireless LAN\n\tSoft blocked: no\n\tHard blocked: no\n' ;;
-      gone) return 1 ;;
-    esac
-  }
-  b() { # b <want> <name> <state>
-    STATE=$3
-    got=$(wifi_block)
-    if [ "$got" = "$1" ]; then echo "  ok      $2"; else
-      echo "  FAILED  $2: wanted $1, got $got"; fails=$((fails + 1)); fi
-  }
+    # The kernel, stubbed. Each variable is one of the three things the function
+    # asks about, so a case is a triple rather than a mock script.
+    ip()     { [ "$HAVE_ADDR" = 1 ] && echo "2: enp0s31f6    inet 192.168.1.4/24 scope global"; }
+    getent() { [ "$HAVE_DNS" = 1 ]; }
 
-  b none "an unblocked radio is none"        none
-  # Ours to clear, and clearing it is the whole fix.
-  b soft "a soft block is soft"              soft
-  # Hard wins over soft: rfkill reports BOTH yes for a hardware switch, and
-  # reading the soft line first would call it soft, try to unblock it, fail
-  # silently, and fall through to "no networks found" -- which is the bug this
-  # whole file exists for, one layer down.
-  b hard "hard beats soft when both are set" hard
-  # No rfkill at all must not read as blocked: that would refuse to scan on a
-  # machine whose radio is fine.
-  b none "a missing rfkill is not a block"   gone
+    fails=0
+    t() { # t <want> <name> <addr> <dns>
+      HAVE_ADDR=$3 HAVE_DNS=$4
+      got=$(network_fault)
+      if [ "$got" = "$1" ]; then echo "  ok      $2"; else
+        echo "  FAILED  $2: wanted $1, got $got"; fails=$((fails + 1)); fi
+    }
 
-  [ "$fails" = 0 ] || { echo "$fails case(s) failed"; exit 1; }
-  EOF
+    # No address at all: the cable is out, or the radio never associated.
+    t nolink  "no address is nolink"            0 0
+    # Associated with an address and nothing resolves. THE captive portal shape,
+    # and the one that used to read as "try again" forever.
+    t nodns   "address but no DNS is nodns"     1 0
+    # Everything resolves and the cache still will not answer: a proxy, a filter,
+    # or the cache being down. Distinct because the action is different -- no
+    # amount of waiting on this network fixes it.
+    t nocache "resolving but no cache is nocache" 1 1
 
-  ${pkgs.bash}/bin/bash t.sh
+    # ---- the radio ---------------------------------------------------------
+    rfkill() {
+      case "$STATE" in
+        hard) printf '0: phy0: Wireless LAN\n\tSoft blocked: yes\n\tHard blocked: yes\n' ;;
+        soft) printf '0: phy0: Wireless LAN\n\tSoft blocked: yes\n\tHard blocked: no\n' ;;
+        none) printf '0: phy0: Wireless LAN\n\tSoft blocked: no\n\tHard blocked: no\n' ;;
+        gone) return 1 ;;
+      esac
+    }
+    b() { # b <want> <name> <state>
+      STATE=$3
+      got=$(wifi_block)
+      if [ "$got" = "$1" ]; then echo "  ok      $2"; else
+        echo "  FAILED  $2: wanted $1, got $got"; fails=$((fails + 1)); fi
+    }
 
-  # The offline image offers Wi-Fi and never demands it. Asserted on the source
-  # because the branch is a gum screen: what matters is that it cannot block an
-  # install needing no network, and cannot fire unattended.
-  #
-  # The old early return left the offline image with no way to configure Wi-Fi
-  # at all -- correct for the install, wrong for the machine it produces, whose
-  # first boot then has neither a network nor the credentials for one.
-  grep -q 'offer_optional_wifi' ${installScript} || {
-    echo "the offline image can no longer offer Wi-Fi at all" >&2; exit 1; }
-  sed -n '/^ask_network()/,/^}/p' ${installScript} | grep -q 'answers_file' || {
-    echo "the offline Wi-Fi screen is no longer skipped under --answers;" >&2
-    echo "an unattended install would hang on a prompt nobody answers" >&2
-    exit 1; }
-  echo "  ok      the offline image offers Wi-Fi, and skips it unattended"
+    b none "an unblocked radio is none"        none
+    # Ours to clear, and clearing it is the whole fix.
+    b soft "a soft block is soft"              soft
+    # Hard wins over soft: rfkill reports BOTH yes for a hardware switch, and
+    # reading the soft line first would call it soft, try to unblock it, fail
+    # silently, and fall through to "no networks found" -- which is the bug this
+    # whole file exists for, one layer down.
+    b hard "hard beats soft when both are set" hard
+    # No rfkill at all must not read as blocked: that would refuse to scan on a
+    # machine whose radio is fine.
+    b none "a missing rfkill is not a block"   gone
 
-  # And only where there is a radio. Without this the screen appeared on every
-  # machine with no wireless card -- a desktop on ethernet, and the VM every
-  # wizard check runs in, where checks.installer-wizard sat on it for 180
-  # seconds waiting for the keyboard screen behind it. An optional step is
-  # still a step.
-  sed -n '/^ask_network()/,/^}/p' ${installScript} | grep -q 'phy80211' || {
-    echo "the offline Wi-Fi screen is no longer gated on a wireless interface;" >&2
-    echo "it will be offered to machines that have no radio to use it" >&2
-    exit 1; }
-  echo "  ok      and only where there is a radio to use"
+    [ "$fails" = 0 ] || { echo "$fails case(s) failed"; exit 1; }
+    EOF
 
-  # And the sentence that misled the tester: it may only be said when there is
-  # genuinely no wireless interface. Asserted on the source, because the branch
-  # lives inside connect_wifi's scan path and reaching it needs a whole nmcli.
-  grep -q 'phy80211' ${installScript} || {
-    echo "connect_wifi no longer tests for a wireless interface before" >&2
-    echo "blaming the image for a missing driver" >&2
-    exit 1
-  }
-  echo "  ok      the missing-driver line is gated on there being no interface"
+    ${pkgs.bash}/bin/bash t.sh
 
-  echo "the installer can tell three network failures apart, and a blocked radio from a missing one"
-  touch $out
-''
+    # The offline image offers Wi-Fi and never demands it. Asserted on the source
+    # because the branch is a gum screen: what matters is that it cannot block an
+    # install needing no network, and cannot fire unattended.
+    #
+    # The old early return left the offline image with no way to configure Wi-Fi
+    # at all -- correct for the install, wrong for the machine it produces, whose
+    # first boot then has neither a network nor the credentials for one.
+    grep -q 'offer_optional_wifi' ${installScript} || {
+      echo "the offline image can no longer offer Wi-Fi at all" >&2; exit 1; }
+    # Extracted once and kept, so a failure can SHOW what it read.
+    #
+    # As a bare pipeline this reported "the screen is no longer skipped under
+    # --answers" for any reason sed produced nothing -- a renamed function, a
+    # changed brace, a missing tool -- and the message named a cause it had not
+    # established. That cost an afternoon on a failure that reproduced in CI and
+    # not locally, on a byte-identical derivation, with nothing to look at but a
+    # sentence asserting the wrong thing.
+    sed -n '/^ask_network()/,/^}/p' ${installScript} > ask_network.txt || true
+    if ! [ -s ask_network.txt ]; then
+      echo "could not extract ask_network() from the installer at all." >&2
+      echo "sed found no /^ask_network()/ .. /^}/ range, so every assertion" >&2
+      echo "below would fail for a reason that has nothing to do with Wi-Fi." >&2
+      echo "First 40 lines of what was searched:" >&2
+      head -40 ${installScript} >&2
+      exit 1
+    fi
+    if ! grep -q 'answers_file' ask_network.txt; then
+      echo "the offline Wi-Fi screen is no longer skipped under --answers;" >&2
+      echo "an unattended install would hang on a prompt nobody answers." >&2
+      echo "ask_network() as extracted:" >&2
+      sed 's/^/  | /' ask_network.txt >&2
+      exit 1
+    fi
+    echo "  ok      the offline image offers Wi-Fi, and skips it unattended"
+
+    # And only where there is a radio. Without this the screen appeared on every
+    # machine with no wireless card -- a desktop on ethernet, and the VM every
+    # wizard check runs in, where checks.installer-wizard sat on it for 180
+    # seconds waiting for the keyboard screen behind it. An optional step is
+    # still a step.
+    if ! grep -q 'phy80211' ask_network.txt; then
+      echo "the offline Wi-Fi screen is no longer gated on a wireless interface;" >&2
+      echo "it will be offered to machines that have no radio to use it." >&2
+      sed 's/^/  | /' ask_network.txt >&2
+      exit 1
+    fi
+    echo "  ok      and only where there is a radio to use"
+
+    # And the sentence that misled the tester: it may only be said when there is
+    # genuinely no wireless interface. Asserted on the source, because the branch
+    # lives inside connect_wifi's scan path and reaching it needs a whole nmcli.
+    grep -q 'phy80211' ${installScript} || {
+      echo "connect_wifi no longer tests for a wireless interface before" >&2
+      echo "blaming the image for a missing driver" >&2
+      exit 1
+    }
+    echo "  ok      the missing-driver line is gated on there being no interface"
+
+    echo "the installer can tell three network failures apart, and a blocked radio from a missing one"
+    touch $out
+  ''

--- a/tests/installer-network.nix
+++ b/tests/installer-network.nix
@@ -102,6 +102,17 @@ pkgs.runCommand "nixarchy-installer-network" { } ''
     exit 1; }
   echo "  ok      the offline image offers Wi-Fi, and skips it unattended"
 
+  # And only where there is a radio. Without this the screen appeared on every
+  # machine with no wireless card -- a desktop on ethernet, and the VM every
+  # wizard check runs in, where checks.installer-wizard sat on it for 180
+  # seconds waiting for the keyboard screen behind it. An optional step is
+  # still a step.
+  sed -n '/^ask_network()/,/^}/p' ${installScript} | grep -q 'phy80211' || {
+    echo "the offline Wi-Fi screen is no longer gated on a wireless interface;" >&2
+    echo "it will be offered to machines that have no radio to use it" >&2
+    exit 1; }
+  echo "  ok      and only where there is a radio to use"
+
   # And the sentence that misled the tester: it may only be said when there is
   # genuinely no wireless interface. Asserted on the source, because the branch
   # lives inside connect_wifi's scan path and reaching it needs a whole nmcli.

--- a/tests/installer-network.nix
+++ b/tests/installer-network.nix
@@ -87,6 +87,21 @@ pkgs.runCommand "nixarchy-installer-network" { } ''
 
   ${pkgs.bash}/bin/bash t.sh
 
+  # The offline image offers Wi-Fi and never demands it. Asserted on the source
+  # because the branch is a gum screen: what matters is that it cannot block an
+  # install needing no network, and cannot fire unattended.
+  #
+  # The old early return left the offline image with no way to configure Wi-Fi
+  # at all -- correct for the install, wrong for the machine it produces, whose
+  # first boot then has neither a network nor the credentials for one.
+  grep -q 'offer_optional_wifi' ${installScript} || {
+    echo "the offline image can no longer offer Wi-Fi at all" >&2; exit 1; }
+  sed -n '/^ask_network()/,/^}/p' ${installScript} | grep -q 'answers_file' || {
+    echo "the offline Wi-Fi screen is no longer skipped under --answers;" >&2
+    echo "an unattended install would hang on a prompt nobody answers" >&2
+    exit 1; }
+  echo "  ok      the offline image offers Wi-Fi, and skips it unattended"
+
   # And the sentence that misled the tester: it may only be said when there is
   # genuinely no wireless interface. Asserted on the source, because the branch
   # lives inside connect_wifi's scan path and reaching it needs a whole nmcli.

--- a/tests/installer-offline-rescue.nix
+++ b/tests/installer-offline-rescue.nix
@@ -1,0 +1,168 @@
+{ pkgs, installScript }:
+# rescue_build, driven against fixture markers and a nix that fails or does not.
+#
+# What it defends:
+#
+#   The offline image clears its substituters on purpose, so the store answers
+#   first and -- the load-bearing half -- a path missing from the medium cannot
+#   be quietly downloaded by whoever happens to have a network and left for the
+#   one person who does not.
+#
+#   That argument holds and this does not undo it. What it stops is the failure
+#   being TOTAL. An image missing one path produced neither an installed
+#   machine nor a diagnosis: the build worked backwards to the source bootstrap
+#   and the screen named texinfo. That happened on real hardware, twice, and
+#   the missing thing was the CPU microcode -- which every real machine asks
+#   for and no VM ever does.
+#
+# The four properties below are the whole contract, and three of them are ways
+# the rescue could be WORSE than the failure it replaces:
+#
+#   * it must not fire on the net image, which has substituters already and
+#     whose failure means something else entirely
+#   * it must not fire on a plain test node -- checks.install runs with no
+#     marker of either kind and a seeded store, and a rescue there would change
+#     what a passing install check proves
+#   * it must not fire with no network, where there is nothing to fall back to
+#     and the honest answer is the failure
+#   * when it does fire it must SAY SO, name what was missing, and leave the
+#     report behind -- a silent rescue is the exact thing the offline design
+#     was protecting against, and would be a regression dressed as a fix
+#
+# A runCommand and not a VM: the function is shell and its inputs are a marker
+# file, a curl and a nix. checks.install-iso cannot reach it at all -- it runs
+# with -nic none against an image that is complete, which is the one shape that
+# never rescues.
+pkgs.runCommand "nixarchy-installer-offline-rescue" { } ''
+  # The functions on their own. Extracted rather than sourced: install.sh runs
+  # a wizard when sourced.
+  for fn in rescue_build on_offline_image on_net_image network_ready; do
+    sed -n "/^$fn()/,/^}/p" ${installScript} >> f.sh
+    echo >> f.sh
+  done
+  grep -q '^rescue_build()' f.sh ||
+    { echo "rescue_build is not in install.sh any more" >&2; exit 1; }
+
+  cat > t.sh <<'EOF'
+  . ./f.sh
+
+  NIX_FLAGS=(--extra-experimental-features "nix-command flakes")
+  SUBSTITUTE_FLAGS=(--option always-allow-substitutes true)
+  RESCUE_SUBSTITUTERS="https://example.invalid"
+  RESCUE_TRUSTED_KEYS="k-1:AAAA="
+  RESCUE_REPORT=$PWD/report.log
+
+  # The two inputs the function reads about the world, stubbed. `nix` prints a
+  # plan on --dry-run and a store path otherwise, which is the shape the real
+  # one has; `curl` decides whether there is a network.
+  nix() {
+    case "$*" in
+      *--dry-run*)
+        echo "these 2 paths will be fetched (1.00 MiB download):"
+        echo "  /nix/store/aaaa-microcode-intel-20260812"
+        echo "  /nix/store/bbbb-amd-ucode-20260810"
+        ;;
+      *) echo "/nix/store/cccc-nixos-system-rescued" ;;
+    esac
+  }
+  curl() { return "''${CURL_RC:-0}"; }
+  date() { echo "2026-09-08T00:00:00+00:00"; }
+
+  fails=0
+  ok()   { echo "  ok      $1"; }
+  bad()  { echo "  FAILED  $1"; fails=$((fails + 1)); }
+
+  run() { # run <marker-dir>
+    rm -f report.log
+    ISO_MARKER_DIR=$1
+    out=$(rescue_build ".#toplevel" 2>&1); rc=$?
+    printf '%s' "$out" > last.out
+    return $rc
+  }
+
+  # /etc is not writable here, so the markers are faked by overriding the
+  # tests the function makes. Same two conditions, addressable.
+  on_offline_image() { [ "$OFFLINE" = 1 ]; }
+
+  # ---- it fires, and loudly ----------------------------------------------
+  OFFLINE=1 CURL_RC=0
+  if out=$(rescue_build ".#toplevel" 2>&1) && [ -n "$out" ]; then
+    ok "an incomplete offline image is rescued"
+  else
+    bad "an incomplete offline image is rescued"
+  fi
+
+  # The rescue is only defensible if it is impossible to miss. A silent one
+  # would restore the very thing the offline image's cleared substituters
+  # exist to prevent.
+  case "$out" in
+    *"THIS IMAGE IS INCOMPLETE"*) ok "it says the image is incomplete" ;;
+    *) bad "it says the image is incomplete" ;;
+  esac
+  case "$out" in
+    *microcode-intel*) ok "it names what was missing" ;;
+    *) bad "it names what was missing" ;;
+  esac
+  case "$out" in
+    *"report this"*) ok "it asks for a report" ;;
+    *) bad "it asks for a report" ;;
+  esac
+  if grep -q "microcode-intel" report.log 2>/dev/null; then
+    ok "and writes the report to disk"
+  else
+    bad "and writes the report to disk"
+  fi
+  # The path it hands back is what gets installed, so an empty or chatty
+  # return is a machine installed from nothing.
+  if [ "$(printf '%s' "$out" | tail -1)" = "/nix/store/cccc-nixos-system-rescued" ]; then
+    ok "the built path is the last thing on stdout"
+  else
+    bad "the built path is the last thing on stdout"
+  fi
+
+  # ---- and refuses everywhere it should ----------------------------------
+  OFFLINE=1 CURL_RC=1
+  if rescue_build ".#toplevel" >/dev/null 2>&1; then
+    bad "no network means no rescue"
+  else
+    ok "no network means no rescue"
+  fi
+
+  # The net image already has substituters; its failure is a different bug and
+  # a rescue there would report an incomplete image that is complete.
+  OFFLINE=0 CURL_RC=0
+  if rescue_build ".#toplevel" >/dev/null 2>&1; then
+    bad "the net image is never rescued"
+  else
+    ok "the net image is never rescued"
+  fi
+
+  [ "$fails" = 0 ] || { echo "$fails case(s) failed"; exit 1; }
+  EOF
+
+  ${pkgs.bash}/bin/bash t.sh
+
+  # The real predicate, separately: the stub above replaces on_offline_image to
+  # make the branches reachable, so the shipped one is checked here against the
+  # two markers it actually reads. A predicate that answered `true` on a test
+  # node would rescue inside checks.install and change what it proves.
+  cat > m.sh <<'EOF'
+  . ./f.sh
+  fails=0
+  probe() { # probe <want> <name> <iso> <iso-net>
+    ISO=$3 ISONET=$4
+    on_offline_image() { [ "$ISO" = 1 ] && [ "$ISONET" != 1 ]; }
+    if on_offline_image; then got=yes; else got=no; fi
+    if [ "$got" = "$1" ]; then echo "  ok      $2"; else
+      echo "  FAILED  $2: wanted $1, got $got"; fails=$((fails + 1)); fi
+  }
+  probe yes "the offline image is offline"      1 0
+  probe no  "the net image is not"              1 1
+  probe no  "a test node with no markers is not" 0 0
+  [ "$fails" = 0 ] || exit 1
+  EOF
+  ${pkgs.bash}/bin/bash m.sh
+
+  echo "the rescue fires only where it should, and never quietly"
+  touch $out
+''

--- a/tests/iso-wifi.nix
+++ b/tests/iso-wifi.nix
@@ -1,0 +1,75 @@
+{ inputs, pkgs, ... }:
+# The ISO can actually associate to a Wi-Fi network.
+#
+# What this defends, and it cost a tester two evenings:
+#
+#   installer/cd.nix used to force networking.wireless.enable = false, on the
+#   reasoning that installation-cd-minimal's wpa_supplicant conflicts with
+#   NetworkManager and one of them has to go.
+#
+#   NetworkManager does not avoid wpa_supplicant. It DRIVES it, and its own
+#   module says so (networkmanager.nix:694-698):
+#
+#     # Enable wpa_supplicant but fully control it over DBus
+#     wireless.enable = true;
+#     wireless.autoDetectInterfaces = false;
+#     wireless.dbusControlled = true;
+#
+#   The mkForce overrode that, so NM was left with a backend it was configured
+#   to use and no way to start it. On a ThinkPad T15 with a bound iwlwifi and
+#   an unblocked radio:
+#
+#     device (wlp0s20f3): Couldn't initialize supplicant interface:
+#       Failed to D-Bus activate wpa_supplicant service
+#
+#   every thirteen seconds, forever. The net image cannot install without a
+#   network, so for anyone without a cable that image simply did not work.
+#
+# Evaluation, not a VM, and that is the point: no VM in this repo has a radio,
+# so checks.install-iso boots with -nic none and every install test uses a
+# virtio NIC. There is nowhere in the suite this could have been caught by
+# running something -- only by asking the configuration what it says.
+let
+  c = inputs.self.nixosConfigurations.iso.config;
+  b = v: if v then "true" else "false";
+in
+pkgs.runCommand "nixarchy-iso-wifi" { } ''
+  fail=0
+  check() { # check <name> <actual> <wanted>
+    if [ "$2" = "$3" ]; then echo "  ok      $1"
+    else echo "  FAILED  $1: got $2, wanted $3"; fail=1; fi
+  }
+
+  # The one that was false. NM needs a supplicant it can activate over D-Bus,
+  # and the whole failure was that there was not one.
+  check "the ISO has a wpa_supplicant to drive" \
+    ${b c.networking.wireless.enable} true
+
+  # And that it is NM driving it rather than a standalone supplicant, which is
+  # the conflict the old comment was right to worry about -- these two are how
+  # NetworkManager prevents it, and they are the reason forcing enable=false
+  # was never necessary.
+  check "and drives it over D-Bus" \
+    ${b c.networking.wireless.dbusControlled} true
+  check "without grabbing interfaces itself" \
+    ${b c.networking.wireless.autoDetectInterfaces} false
+
+  # NM itself, since everything above is meaningless without it.
+  check "NetworkManager is on" \
+    ${b c.networking.networkmanager.enable} true
+
+  # The backend NM was configured for. iwd would be a legitimate other answer
+  # and would need wireless.enable false -- so this asserts the PAIR is
+  # consistent rather than either half alone.
+  check "the configured backend is wpa_supplicant" \
+    "${c.networking.networkmanager.wifi.backend}" wpa_supplicant
+
+  # And the firmware, because a supplicant with no blob is the same dead end
+  # one layer down: the ISO's own iwlwifi/rtl_nic blobs come from here.
+  check "the ISO carries redistributable firmware" \
+    ${b c.hardware.enableRedistributableFirmware} true
+
+  [ "$fail" = 0 ] || exit 1
+  echo "the ISO can associate to a network"
+  touch $out
+''

--- a/tests/wifi-hwsim.nix
+++ b/tests/wifi-hwsim.nix
@@ -1,0 +1,175 @@
+{ inputs, pkgs }:
+# The ISO's wireless configuration, against a radio.
+#
+# The hole this fills, said plainly: no VM in this repo has ever had a
+# wireless card. checks.install-iso boots -nic none, and every other install
+# test uses a virtio NIC. So the whole Wi-Fi path -- NetworkManager, its
+# supplicant, association -- had NO coverage of any kind, and that is exactly
+# where the bug lived.
+#
+# installer/cd.nix forced networking.wireless.enable = false, believing the
+# installation media's wpa_supplicant conflicted with NetworkManager. It does
+# not: NetworkManager DRIVES wpa_supplicant, and its own module says so and
+# sets it up (networkmanager.nix:694-698). The mkForce overrode that, so NM
+# was configured for a backend it could not start, and on a ThinkPad T15 with
+# a bound iwlwifi and an unblocked radio it retried every thirteen seconds,
+# forever:
+#
+#   device (wlp0s20f3): Couldn't initialize supplicant interface:
+#     Failed to D-Bus activate wpa_supplicant service
+#
+# The net image cannot install without a network, so for anyone without a
+# cable it did not work at all.
+#
+# tests/iso-wifi.nix asserts the ISO's settings are the right ones. This
+# asserts the settings actually WORK -- a configuration check cannot tell you
+# that wpa_supplicant starts, that NM finds it, or that an interface
+# associates, and all three failed here at once.
+#
+# mac80211_hwsim is the kernel's virtual radio (CONFIG_MAC80211_HWSIM=m in
+# nixpkgs' kernel, verified). It creates two real wiphys the real cfg80211
+# stack drives, so wpa_supplicant and hostapd are the genuine articles talking
+# over a simulated medium. This is how the kernel and NetworkManager projects
+# test wireless.
+pkgs.testers.runNixOSTest {
+  name = "nixarchy-wifi-hwsim";
+
+  nodes.machine =
+    { lib, ... }:
+    {
+      # Two radios from one module load: wlan0 for the client, wlan1 for the
+      # access point. They see each other over hwsim's simulated medium.
+      boot.kernelModules = [ "mac80211_hwsim" ];
+
+      # EXACTLY what installer/cd.nix says, and nothing more. Not a copy of
+      # the ISO -- a copy of the one line whose absence was the bug.
+      networking = {
+        networkmanager.enable = true;
+
+        # qemu-vm.nix:1504 does `networking.wireless.enable = mkVMOverride false`,
+        # so EVERY NixOS VM test force-disables wireless. Without this override
+        # the node reproduces the exact production symptom
+        #
+        #   device (wlan0): Couldn't initialize supplicant interface:
+        #     Failed to D-Bus activate wpa_supplicant service
+        #
+        # for a completely different reason, and that is not hypothetical: the
+        # first version of this file did, and the identical message was read as
+        # evidence that the production fix did not work. It was the test that did
+        # not work. nixpkgs' own nixos/tests/wpa_supplicant.nix carries the same
+        # line with the same explanation.
+        #
+        # mkOverride 0 rather than mkForce: mkVMOverride is priority 10, and
+        # mkForce is 50 -- it loses.
+        wireless.enable = lib.mkOverride 0 true;
+
+        # NM manages wlan0. wlan1 belongs to hostapd, and without this NM takes
+        # it too and fights the AP for the interface.
+        networkmanager.unmanaged = [ "interface-name:wlan1" ];
+      };
+
+      # The regulatory database, or the radio comes up restricted and the
+      # channel below may not be allowed.
+      hardware.wirelessRegulatoryDatabase = true;
+
+      services.hostapd = {
+        enable = true;
+        radios.wlan1 = {
+          band = "2g";
+          channel = 1;
+          networks.wlan1 = {
+            ssid = "nixarchy-test";
+            authentication.saePasswords = [ { password = "supersecret"; } ];
+            authentication.wpaPassword = "supersecret";
+          };
+        };
+      };
+
+      environment.systemPackages = [
+        pkgs.iw
+        # wpa_cli, to ask the supplicant directly rather than through NM.
+        pkgs.wpa_supplicant
+      ];
+      # Small, and the default is not: this test only needs to associate.
+      virtualisation.memorySize = 2048;
+    };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    # The radios exist at all. If hwsim did not load there is nothing to test
+    # and every assertion below would fail for the wrong reason.
+    machine.succeed("iw dev | grep -q wlan0")
+    machine.succeed("iw dev | grep -q wlan1")
+
+    machine.wait_for_unit("NetworkManager.service")
+
+    # wpa_supplicant is D-BUS ACTIVATED, not started at boot: dbusControlled
+    # means NetworkManager brings it up when it first has a wireless device to
+    # manage. A first draft of this waited for the unit straight after
+    # multi-user.target and failed with "inactive and there are no pending
+    # jobs" -- testing the right unit at the wrong moment, on a machine where
+    # nothing had asked for it yet.
+    #
+    # Waiting for NM to see the device and THEN for the unit is not a
+    # workaround; it is the exact sequence that broke. The tester's NM saw
+    # wlp0s20f3, asked for the supplicant, and got nothing.
+    machine.wait_until_succeeds("nmcli -t -f DEVICE,TYPE device | grep -q '^wlan0:wifi'", timeout=60)
+    print(machine.execute("systemctl status wpa_supplicant.service")[1])
+    print(machine.execute("journalctl -u wpa_supplicant --no-pager")[1])
+    print(machine.execute("ls -l /run/current-system/sw/share/dbus-1/system-services/ 2>&1 | head -30")[1])
+    print(machine.execute("cat /etc/dbus-1/system.d/wpa_supplicant.conf 2>&1 | head -5")[1])
+    machine.wait_until_succeeds("systemctl is-active wpa_supplicant.service", timeout=30)
+
+    # And that the activation never failed on the way. The tester's journal
+    # filled with this line every thirteen seconds; its absence is the fix,
+    # and the negative is worth asserting because everything else can look
+    # healthy while it repeats.
+    machine.fail("journalctl -u NetworkManager | grep -q 'Failed to D-Bus activate wpa_supplicant'")
+
+    machine.wait_for_unit("hostapd.service")
+
+    # Association, over the simulated medium, with the real supplicant. The
+    # end of the path the ISO needs and could not walk.
+    machine.wait_until_succeeds("nmcli device wifi list --rescan yes | grep -q nixarchy-test", timeout=60)
+
+    # link-local, not DHCP. `nmcli device wifi connect` waits for a full IP
+    # configuration and there is no DHCP server behind this AP, so the first
+    # version of this associated perfectly -- hostapd logged
+    # AP-STA-CONNECTED and EAPOL-4WAY-HS-COMPLETED -- and then failed with
+    # exit 4 forty-six seconds later when addressing timed out, disconnecting
+    # on the way out. That would have read as "wireless is broken" while the
+    # wireless was the half that worked.
+    #
+    # Adding a DHCP server would test dnsmasq. What is under test is whether
+    # the ISO's supplicant configuration can carry an association, so the IP
+    # layer is taken out of the question rather than simulated.
+    machine.succeed(
+        "nmcli connection add type wifi ifname wlan0 con-name test "
+        "ssid nixarchy-test "
+        "wifi-sec.key-mgmt wpa-psk wifi-sec.psk supersecret "
+        "ipv4.method link-local ipv6.method ignore"
+    )
+    machine.succeed("nmcli connection up test")
+
+    # Asserted from BOTH ends of the link, and not with wpa_cli: dbusControlled
+    # runs the supplicant with -u and no control socket, so wpa_cli only ever
+    # answers "Failed to connect to non-global ctrl_ifname" -- it is the wrong
+    # instrument for the configuration under test, which is the point of the
+    # configuration.
+    #
+    # NetworkManager's own view of the device.
+    machine.wait_until_succeeds(
+        "nmcli -t -f DEVICE,STATE device | grep -q '^wlan0:connected'", timeout=60)
+
+    # And the access point's, which is independent of everything on the client
+    # side: hostapd only logs this after the four-way handshake completes, so
+    # it cannot be satisfied by a client that merely thinks it is connected.
+    machine.succeed("journalctl -u hostapd | grep -q AP-STA-CONNECTED")
+    machine.succeed("journalctl -u hostapd | grep -q EAPOL-4WAY-HS-COMPLETED")
+
+    print(machine.succeed("nmcli device status"))
+
+    print(machine.succeed("nmcli device status"))
+  '';
+}

--- a/tests/wifi-hwsim.nix
+++ b/tests/wifi-hwsim.nix
@@ -1,4 +1,4 @@
-{ inputs, pkgs }:
+{ pkgs }:
 # The ISO's wireless configuration, against a radio.
 #
 # The hole this fills, said plainly: no VM in this repo has ever had a


### PR DESCRIPTION
**Stacked on #412** — it shares `build.yml`, so this branch is based on it and
should merge after. All eight findings from a code review of the workflows, each
verified against the file before being believed.

## The two that changed correctness, not just flakiness

**`nixpkgs#` meant the runner's flake registry, not this repository's pin.**
*"Verify every mapped app still evaluates"* resolved against a channel that moves
daily, so it answered a different question from the one it asks. A package
broken in **our** pin — the one users rebuild against — would have passed as long
as the channel had already fixed it. And a package going broken upstream
reddened every open PR, for a reason in none of their diffs. Now
`--inputs-from .`; verified the registry is unpinned here, our lock is
`dc5d91f84032`, and the eval returns `vscode-1.136.1`.

**A concurrency guard that did not guard.** `cancel-in-progress: false` stops a
*running* job being killed and does nothing about a *pending* one, which GitHub
cancels as soon as a newer run queues. Under a burst of merges only the first
and last commit ever reported — the exact data loss the existing comment
described, still happening after the fix written for it. Main now gets a
per-commit group; the `system` job had the same gap.

## The duplication

The nix-installer block was copied into **eleven** places, byte-identical *by
luck*. `.github/actions/setup-nix` replaces all of them — **418 lines deleted,
11 added**.

It deliberately excludes the cachix step: that depends on
`continue-on-error: true` (#235), and whether a composite action's `uses:` step
honours it is not a thing to discover from a broken pipeline.

Two `sudo tee` blocks were already redundant once the action landed — verified
*per job* that the action is present before deleting. `omarchy.yml`'s carried
its own history: *"build.yml has had this since it started building the same
closure; this job never did."*

And drift that had already happened: `omarchy.yml`'s auto-merge block is
`flake-update.yml`'s minus `set -euo pipefail` — the same script, diverging in
the one respect that decides whether a mid-step failure is noticed.

## The rest

| | |
| --- | --- |
| roadmap gate | ran on PRs and reads the live issue tracker; closing #159 reddened every open PR. Now pushes-to-main and the weekly schedule — **this file's own doctrine**, written at the top and never implemented |
| `--max-jobs 2`, 3 derivations | `installer-refusal` is a VM too (2048 MB), so it queued behind an install in a 90-minute job that already grazed its cap. Now 3; envelope is 14.3 GB / 10 cores of 94 GB / 40 cores |
| release goes red after publishing | the `workflow_dispatch` recovery path re-publishes an older tag, making the branch push a non-fast-forward *after* the assets uploaded. Now detected and warned; the branch is still never moved backwards |
| `--impure` in `app-versions.sh` | its justification named an env var its only caller never sets, and `.version` never needed it — measured, `vscode 1.136.1` with both vars unset. Cost was the eval cache for 106 evaluations. The *other* `--impure` is genuinely required and kept |
| orphaned comment | removed; the step it described is generated now |

`actionlint` per file is unchanged from `main` — `build.yml` 4, `omarchy.yml` 1,
every other workflow 0 — checked by stashing and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5