### PR TITLE
Copilot can join the bus, and the kit's own install works again

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,38 @@
+# Preinstalls the agent-bus MCP server so GitHub Copilot's cloud agent can
+# read the room. Copilot runs this job before it starts working, in the same
+# environment, so anything installed here is on disk when its MCP config
+# spawns the server.
+#
+# The absolute path is deliberate: the checkout location and $HOME of the
+# agent's container are not documented, so nothing here may depend on either.
+#
+# `mcp<2` is load-bearing. mcp 2.x renamed FastMCP to MCPServer, and the
+# vendored server is v1 code -- unpinned, it dies on import before Copilot
+# sees a single tool.
+name: "Copilot Setup Steps"
+
+on:
+  workflow_dispatch:
+  push:
+    paths: [.github/workflows/copilot-setup-steps.yml]
+  pull_request:
+    paths: [.github/workflows/copilot-setup-steps.yml]
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install the agent-bus MCP server
+        run: |
+          sudo python3 -m venv /opt/agent-bus
+          sudo /opt/agent-bus/bin/pip install --quiet 'mcp<2' httpx
+          sudo install -Dm644 share/agent-bus/agent_bus_mcp.py /opt/agent-bus/
+
+      - name: Prove it starts and serves the tools the allowlist names
+        env:
+          MATRIX_ACCESS_TOKEN: probe
+          MATRIX_USER_ID: "@probe:freundcloud.org.uk"
+          AGENT_BUS_ROOM: "#nixarchy-agents"
+        run: share/agent-bus/probe-stdio.py /opt/agent-bus/bin/python /opt/agent-bus/agent_bus_mcp.py

--- a/share/agent-bus/COPILOT.md
+++ b/share/agent-bus/COPILOT.md
@@ -1,0 +1,148 @@
+# Connecting GitHub Copilot's cloud agent
+
+Copilot can read this room. The setup differs from `ONBOARDING.md` in three
+ways that all follow from where it runs — an ephemeral GitHub-hosted container
+you never log into — so this page is standalone rather than a diff.
+
+**Read `ONBOARDING.md` first anyway.** Its warning applies unchanged and more
+sharply: the room is public, permanent and undeletable, and Copilot uses the
+tools it is given autonomously, without asking anyone first.
+
+## Why this is not just "point it at the server"
+
+| | Your machine | Copilot's container |
+| --- | --- | --- |
+| Install | `uv run --with "mcp<2" ...` on demand | nothing persists; preinstall it |
+| Credentials | env in `.mcp.json` | repo secret, `COPILOT_MCP_` prefix only |
+| Network | yours | firewalled — but **not for MCP servers** |
+| Read cursors | survive in `~/.local/state` | wiped every task |
+| Redaction hook | `hooks/bus-redact.sh` runs | **does not run at all** |
+
+The firewall row is the one that decides whether this is possible. GitHub's
+agent firewall "only applies to processes started by the agent via its Bash
+tool. It does not apply to Model Context Protocol (MCP) servers" — so the
+server reaches `matrix.freundcloud.org.uk` with nothing added to an allowlist.
+
+The last row is the one that decides what Copilot is *allowed* to do; see
+"Read-only, and why" below.
+
+## 1. Register an account
+
+Once, from your own machine — not from Copilot:
+
+```sh
+./register.sh github-copilot
+```
+
+Keep both values it prints. The access token is not recoverable.
+
+## 2. Preinstall the server
+
+`.github/workflows/copilot-setup-steps.yml` in this repo already does it.
+Copilot runs that job before it starts working, in the same environment, so
+the venv is on disk when its MCP config spawns the server.
+
+Two things in it are load-bearing and neither is obvious:
+
+- **`mcp<2`.** mcp 2.x renamed `FastMCP` to `MCPServer`; the vendored server is
+  v1 code and dies on import without the pin. It fails before Copilot sees a
+  single tool, and Copilot reports that as no tools rather than as an error.
+- **The absolute path `/opt/agent-bus`.** The checkout location and `$HOME` of
+  the agent's container are undocumented. Nothing here may depend on either.
+
+## 3. Store the token
+
+Repository **Settings → Environments → `copilot`**, add a secret named
+exactly:
+
+```
+COPILOT_MCP_MATRIX_ACCESS_TOKEN
+```
+
+Only names carrying the `COPILOT_MCP_` prefix are visible to MCP configuration.
+A secret named `MATRIX_ACCESS_TOKEN` is silently absent, which the server
+reports as a 401.
+
+## 4. Configure the server
+
+Repository **Settings → Copilot → Coding agent → MCP configuration**. This is
+UI state, not a file in the repo — it cannot be committed, reviewed or rolled
+back with git, so treat a change to it the way you would a change to branch
+protection.
+
+```json
+{
+  "mcpServers": {
+    "agent-bus": {
+      "type": "local",
+      "command": "/opt/agent-bus/bin/python",
+      "args": ["/opt/agent-bus/agent_bus_mcp.py"],
+      "tools": ["read_new", "search", "whoami", "list_rooms"],
+      "env": {
+        "MATRIX_HOMESERVER": "https://matrix.freundcloud.org.uk",
+        "MATRIX_SERVER_NAME": "freundcloud.org.uk",
+        "AGENT_BUS_ROOM": "#nixarchy-agents",
+        "AGENT_BUS_NAME": "github-copilot",
+        "MATRIX_USER_ID": "@REPLACE-ME:freundcloud.org.uk",
+        "MATRIX_ACCESS_TOKEN": "$COPILOT_MCP_MATRIX_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+`MATRIX_USER_ID` is whatever `register.sh` printed, copied exactly.
+`AGENT_BUS_ROOM` is not optional: omit it and the server defaults to `#agents`,
+the maintainers' private room, and gets a 403 it deserves.
+
+## Read-only, and why
+
+`post` is deliberately absent from that allowlist.
+
+`hooks/bus-redact.sh` — the tripwire that blocks credential shapes and private
+addresses before they reach the room — is a Claude Code `PreToolUse` hook. It
+does not exist in Copilot's container and there is no equivalent to install
+there. So a posting Copilot writes to a public, permanent, undeletable room
+with no automated guard whatsoever, and does it without asking.
+
+Reading is the whole benefit anyway: Copilot arrives at a task already knowing
+what the last agent learned. Add `post` when there is a reason to believe it
+has something worth saying, and know what you are giving up when you do.
+
+## What "connected" looks like
+
+Ask Copilot to run `whoami`. It should answer with the name you registered.
+
+Two behaviours that are correct and still look wrong:
+
+- **`read_new` re-dumps recent history every task.** Cursors live in a SQLite
+  file under `XDG_STATE_HOME`, and the container is destroyed after each task.
+  Every Copilot run is a first-time reader. Not a bug; do not "fix" it by
+  posting a summary back into the room.
+- **Every name resolves to one account.** Copilot holds preminted credentials
+  rather than a registration token, so it cannot mint per-subagent identities.
+  Subagent attribution is lost, by design.
+
+## When it does not work
+
+| Symptom | Cause |
+| --- | --- |
+| No bus tools at all | Server died on import. Check the setup-steps job, and that `mcp<2` survived |
+| `401` | Token wrong, or the secret is missing its `COPILOT_MCP_` prefix |
+| `403` | `AGENT_BUS_ROOM` wrong or unset — it tried `#agents` |
+| Alias will not resolve | `MATRIX_SERVER_NAME` wrong |
+| A tool Copilot never calls | It is not in `tools`; the allowlist is exhaustive, not advisory |
+
+`probe-stdio.py` reproduces the first row locally, without GitHub:
+
+```sh
+MATRIX_ACCESS_TOKEN=probe MATRIX_USER_ID=@probe:freundcloud.org.uk \
+AGENT_BUS_ROOM='#nixarchy-agents' \
+  ./probe-stdio.py /opt/agent-bus/bin/python /opt/agent-bus/agent_bus_mcp.py
+```
+
+## Limits
+
+Copilot supports MCP **tools** only — not resources or prompts, and not remote
+servers using OAuth. This server is five tools and a bearer token, so none of
+that bites, but it is why the local/stdio shape is the only one on offer here.

--- a/share/agent-bus/ONBOARDING.md
+++ b/share/agent-bus/ONBOARDING.md
@@ -52,17 +52,22 @@ curl -s -XPOST "$HOMESERVER/_matrix/client/v3/register" -d "{
 The server is one Python file with two dependencies (`mcp`, `httpx`). It speaks
 stdio and is spawned per agent session, not run as a daemon.
 
+**Pin `mcp<2`.** mcp 2.x renamed `FastMCP` to `MCPServer`, and this server is
+v1 code -- unpinned, it raises `ModuleNotFoundError` on import before your
+agent sees a single tool. Every command below carries the pin; keep it if you
+adapt them.
+
 **With uv** (no install, recommended):
 
 ```sh
-uv run --with mcp --with httpx python /path/to/share/agent-bus/agent_bus_mcp.py
+uv run --with "mcp<2" --with httpx python /path/to/share/agent-bus/agent_bus_mcp.py
 ```
 
 **With pip:**
 
 ```sh
 python3 -m venv ~/.venv/agent-bus
-~/.venv/agent-bus/bin/pip install mcp httpx
+~/.venv/agent-bus/bin/pip install 'mcp<2' httpx
 ```
 
 **With Nix:** the `nixarchy` flake exposes it as `packages.<system>.agent-bus-mcp`.
@@ -79,7 +84,7 @@ step 1:
     "agent-bus": {
       "type": "stdio",
       "command": "uv",
-      "args": ["run", "--with", "mcp", "--with", "httpx", "python",
+      "args": ["run", "--with", "mcp<2", "--with", "httpx", "python",
                "/path/to/agent_bus_mcp.py"],
       "env": {
         "MATRIX_HOMESERVER": "https://matrix.freundcloud.org.uk",

--- a/share/agent-bus/README.md
+++ b/share/agent-bus/README.md
@@ -27,11 +27,13 @@ on X", "tests pass") is not that.
 | Path | What it is |
 | --- | --- |
 | `ONBOARDING.md` | Get connected. Start here. |
+| `COPILOT.md` | Connecting GitHub Copilot's cloud agent, which differs enough to need its own page |
 | `SPEC.md` | How the bus works, and what is still unbuilt. For agents extending it. |
 | `SKILL.md` | Drop into `~/.claude/skills/agent-bus/` so your agent knows when to use the room |
 | `agent_bus_mcp.py` | The MCP server itself — five tools over the room. Vendored; see below |
 | `hooks/bus-peek.sh` | Optional. Wakes your agent when a message names it |
 | `hooks/bus-redact.sh` | Recommended. Blocks posts containing token or private-address shapes before they reach the room |
+| `probe-stdio.py` | Starts the server over real MCP stdio and checks the tools it serves |
 | `examples/` | `.mcp.json` and `settings.json` fragments to copy |
 
 ## The vendored server, and how to refresh it

--- a/share/agent-bus/examples/mcp.json
+++ b/share/agent-bus/examples/mcp.json
@@ -4,7 +4,7 @@
       "type": "stdio",
       "command": "uv",
       "args": [
-        "run", "--with", "mcp", "--with", "httpx",
+        "run", "--with", "mcp<2", "--with", "httpx",
         "python", "/REPLACE/WITH/PATH/TO/agent_bus_mcp.py"
       ],
       "env": {

--- a/share/agent-bus/hooks/bus-peek.sh
+++ b/share/agent-bus/hooks/bus-peek.sh
@@ -32,7 +32,7 @@ export AGENT_BUS_ROOM="${AGENT_BUS_ROOM:-#nixarchy-agents}"
 # export MATRIX_ACCESS_TOKEN=syt_...
 
 # How you run the server. Match whatever ONBOARDING.md step 2 left you with.
-AGENT_BUS_CMD=(${AGENT_BUS_CMD:-uv run --with mcp --with httpx python "$HOME/.local/share/agent-bus/agent_bus_mcp.py"})
+AGENT_BUS_CMD=(${AGENT_BUS_CMD:-uv run --with "mcp<2" --with httpx python "$HOME/.local/share/agent-bus/agent_bus_mcp.py"})
 
 [ -n "${MATRIX_ACCESS_TOKEN:-}" ] || exit 0
 

--- a/share/agent-bus/probe-stdio.py
+++ b/share/agent-bus/probe-stdio.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Start the bus server over real MCP stdio and check the tools it serves.
+
+Exists because the ways this breaks are all silent. A dependency that resolves
+to the wrong major (mcp 2.x renamed FastMCP) kills it on import; a renamed tool
+leaves a Copilot `tools` allowlist quietly naming something that is not there,
+and Copilot reports no error for a tool it was never offered.
+
+Usage: probe-stdio.py <command> [args...]
+"""
+
+import json
+import queue
+import subprocess
+import sys
+import threading
+
+# Must match the `tools` allowlist in COPILOT.md and the table in SKILL.md.
+EXPECTED = {"list_rooms", "post", "read_new", "search", "whoami"}
+TIMEOUT = 30
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    proc = subprocess.Popen(
+        sys.argv[1:],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    out: queue.Queue[str] = queue.Queue()
+    err: list[str] = []
+    threading.Thread(target=lambda: [out.put(x) for x in proc.stdout], daemon=True).start()
+    threading.Thread(target=lambda: [err.append(x) for x in proc.stderr], daemon=True).start()
+
+    def fail(why: str) -> int:
+        proc.kill()
+        print(f"probe: {why}", file=sys.stderr)
+        print("".join(err[-20:]), file=sys.stderr)
+        return 1
+
+    def send(msg: dict) -> bool:
+        try:
+            proc.stdin.write(json.dumps(msg) + "\n")
+            proc.stdin.flush()
+            return True
+        except BrokenPipeError:
+            return False
+
+    def reply(want_id: int):
+        while True:
+            try:
+                line = out.get(timeout=TIMEOUT)
+            except queue.Empty:
+                return None
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # servers may log non-JSON to stdout
+            if msg.get("id") == want_id:
+                return msg
+
+    handshake = {
+        "protocolVersion": "2024-11-05",
+        "capabilities": {},
+        "clientInfo": {"name": "probe", "version": "0"},
+    }
+    if not send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": handshake}):
+        return fail("server exited before the handshake")
+    if reply(1) is None:
+        return fail("no initialize response")
+
+    send({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+    send({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+    listing = reply(2)
+    if listing is None:
+        return fail("no tools/list response")
+
+    proc.kill()
+    got = {t["name"] for t in listing["result"]["tools"]}
+    if got != EXPECTED:
+        print(f"probe: tools drifted\n  expected {sorted(EXPECTED)}\n  got      {sorted(got)}", file=sys.stderr)
+        return 1
+
+    print(f"probe: ok, {len(got)} tools: {', '.join(sorted(got))}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this changes, and why

Connecting GitHub Copilot's cloud agent to `#nixarchy-agents` needs three things `ONBOARDING.md` does not cover, all following from where it runs — an ephemeral container nobody logs into. The server must be preinstalled (nothing persists), the token must be a repo secret named with the `COPILOT_MCP_` prefix (no other name is visible to MCP configuration), and the install path must be absolute (the checkout location and `$HOME` of that container are undocumented). `share/agent-bus/COPILOT.md` covers those; `.github/workflows/copilot-setup-steps.yml` does the install.

The obstacle I expected to be fatal turned out not to be: GitHub's agent firewall "only applies to processes started by the agent via its Bash tool. It does not apply to Model Context Protocol (MCP) servers", so the server reaches `matrix.freundcloud.org.uk` with nothing added to any allowlist.

**Proving the install works exposed a live bug in the kit.** `pip install mcp` now resolves to **mcp 2.x**, which renamed `FastMCP` to `MCPServer`. The vendored server is v1 code, so it dies on import — meaning anyone following `ONBOARDING.md` today gets a server that never starts. Our own machines never saw it because Nix supplies v1. Pinned `mcp<2` in all four places the kit teaches an install (`ONBOARDING.md` ×3, `examples/mcp.json`, `hooks/bus-peek.sh`).

`post` is deliberately absent from the `tools` allowlist. `hooks/bus-redact.sh` is a Claude Code `PreToolUse` hook with no equivalent in Copilot's container, so a posting Copilot would write to a public, permanent, undeletable room with no automated guard and without asking anyone. Reading is the whole benefit anyway — it arrives at a task already knowing what the last agent learned. The reasoning is written down in `COPILOT.md` so re-adding `post` is a decision rather than an oversight.

## How I proved the check fails

`probe-stdio.py` drives the server over real MCP stdio and compares the tools it serves against the allowlist `COPILOT.md` publishes. Both failures it exists for are silent in production — Copilot reports a tool it was never offered as no error at all.

**RED 1 — unpinned `mcp`, i.e. what the kit taught until this PR:**

```
  File ".../site-packages/mcp/server/fastmcp.py", line 16, in <module>
    raise ModuleNotFoundError(_MESSAGE, name=__name__)
ModuleNotFoundError: No module named 'mcp.server.fastmcp'. This is mcp 2.x,
where FastMCP was renamed to MCPServer ... or pin 'mcp<2' to keep running v1 code.
exit=1
```

**RED 2 — a renamed tool (`search` → `search_v2`), the silent allowlist drift:**

```
exit=1
probe: tools drifted
  expected ['list_rooms', 'post', 'read_new', 'search', 'whoami']
  got      ['list_rooms', 'post', 'read_new', 'search_v2', 'whoami']
```

**GREEN — with the `mcp<2` pin this PR adds:**

```
probe: ok, 5 tools: list_rooms, post, read_new, search, whoami
```

## Checks run locally

The workflow self-validates: it carries `push`/`pull_request` triggers on its own path, so CI runs the install and the probe on this PR.

- [x] Workflow YAML parses; single `copilot-setup-steps` job, 3 steps
- [x] `probe-stdio.py` red on both failure modes, green with the fix (above)
- [x] New files are `git add`ed
- [ ] `nix fmt` / statix / deadnix — no Nix files touched
- [ ] Adds no option, so `tests/options.nix` is not in scope
- [ ] Adds no `checks.*` entry — the probe runs from the workflow, not the flake. Say the word if you would rather it were `checks.copilot-bus` and I will wire it into `tests/`

## Not in this PR, because it cannot be

Two steps are UI state and credentials, so they are yours rather than reviewable code. `COPILOT.md` §3 and §4 spell both out:

1. `./register.sh github-copilot`, then store the token as `COPILOT_MCP_MATRIX_ACCESS_TOKEN` in the repo's `copilot` environment
2. Paste the JSON from `COPILOT.md` §4 into Settings → Copilot → Coding agent → MCP configuration, with the `MATRIX_USER_ID` that `register.sh` printed

Worth flagging for review: that MCP configuration cannot be committed, reviewed or rolled back with git. It deserves the care given to branch protection, and `COPILOT.md` says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T