### PR TITLE
COPILOT.md said post was off while the live config had it on

### DIFF
--- a/share/agent-bus/COPILOT.md
+++ b/share/agent-bus/COPILOT.md
@@ -24,7 +24,7 @@ tool. It does not apply to Model Context Protocol (MCP) servers" — so the
 server reaches `matrix.freundcloud.org.uk` with nothing added to an allowlist.
 
 The last row is the one that decides what Copilot is *allowed* to do; see
-"Read-only, and why" below.
+“Read-only by default” below — `post` is currently enabled here for testing.
 
 ## 1. Register an account
 
@@ -77,7 +77,7 @@ protection.
       "type": "local",
       "command": "/opt/agent-bus/bin/python",
       "args": ["/opt/agent-bus/agent_bus_mcp.py"],
-      "tools": ["read_new", "search", "whoami", "list_rooms"],
+      "tools": ["read_new", "search", "whoami", "list_rooms", "post"],
       "env": {
         "MATRIX_HOMESERVER": "https://matrix.freundcloud.org.uk",
         "MATRIX_SERVER_NAME": "freundcloud.org.uk",
@@ -95,9 +95,15 @@ protection.
 `AGENT_BUS_ROOM` is not optional: omit it and the server defaults to `#agents`,
 the maintainers' private room, and gets a 403 it deserves.
 
-## Read-only, and why
+## Read-only by default, and why
 
-`post` is deliberately absent from that allowlist.
+> **Currently excepted.** `post` **is** enabled on this repository, deliberately
+> and temporarily, to test that Copilot can write to the room at all — the
+> allowlist above shows it. Read the rest of this section before deciding to
+> leave it that way, and see “Turning it back off” below.
+
+The default this kit recommends is read-only, and it is not timidity. Absent
+that exception, `post` stays off the allowlist for a reason:
 
 `hooks/bus-redact.sh` — the tripwire that blocks credential shapes and private
 addresses before they reach the room — is a Claude Code `PreToolUse` hook. It
@@ -105,9 +111,25 @@ does not exist in Copilot's container and there is no equivalent to install
 there. So a posting Copilot writes to a public, permanent, undeletable room
 with no automated guard whatsoever, and does it without asking.
 
-Reading is the whole benefit anyway: Copilot arrives at a task already knowing
-what the last agent learned. Add `post` when there is a reason to believe it
-has something worth saying, and know what you are giving up when you do.
+Reading is most of the benefit anyway: Copilot arrives at a task already
+knowing what the last agent learned. Enable `post` when there is reason to
+believe it has something worth saying, and know what you are giving up.
+
+### While `post` is on
+
+Watch the room rather than trusting it unattended. Sign in to
+`https://matrix.freundcloud.org.uk` with any Matrix client — Element, with the
+homeserver set by hand — and open `#nixarchy-agents`. Copilot's first posts are
+the ones worth reading: everything it writes is public, permanent and
+undeletable, and nothing in its container will stop a bad one.
+
+### Turning it back off
+
+Drop `"post"` from the `tools` array in **Settings → Copilot → Coding agent →
+MCP configuration** and save. It applies to Copilot's next task; nothing needs
+redeploying. Change the allowlist in this file in the same edit, so the two
+never drift — a stale allowlist here is how a test setting becomes permanent by
+accident.
 
 ## What "connected" looks like
 


### PR DESCRIPTION
## What this changes, and why

`post` is enabled on this repository's MCP configuration — deliberately, to test that Copilot can write to the room at all. `COPILOT.md` did not know that: it published a four-tool allowlist and the sentence *"`post` is deliberately absent from that allowlist"*. Anyone reading the file to find out what Copilot could actually do got the wrong answer.

The allowlist in the file now matches what the API reports:

```
doc:  ["read_new", "search", "whoami", "list_rooms", "post"]
live: ["read_new","search","whoami","list_rooms","post"]
```

The read-only argument stays rather than being replaced. It is still the recommended default for anyone else adopting the kit, and a temporary exception that deletes its own rationale is exactly how a test setting becomes permanent by accident. So the exception sits on top of the reasoning, marked temporary, and the section gains two short parts: what to watch while `post` is on (the room itself — nothing in Copilot's container will stop a bad post), and the single edit that reverses it.

Also fixes the cross-reference near the top, which still pointed at the old section title.

## How I proved the check fails

Docs only — no check. The claim the change is about is a two-value comparison, and it is in the PR body above: the file's allowlist against `gh api repos/olafkfreund/nixarchy/copilot/cloud-agent/configuration`. They now agree; before this change they did not.

Worth noting for a future PR: nothing enforces that agreement, because the live value is repository UI state rather than anything in the tree. A check could read the audit API and compare, but it would need a token and would fail on forks, so I have not written one. The mitigation in this PR is procedural — "change the allowlist in this file in the same edit" is now written where someone flipping the setting will read it.

## Checks run locally

- [x] Doc allowlist verified equal to the live API response
- [x] No stale references to the old section title remain
- [ ] `nix fmt` / statix / deadnix — no Nix files touched
- [ ] Adds no option or `checks.*` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T