### PR TITLE
Aether builds here, and the cache carries it so nobody else builds it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -942,6 +942,14 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build every app the flake ships itself
+        env:
+          # grok-bot is unfree, and a bare `nix build` refuses to evaluate it.
+          # The same pair the menu-mapping job above uses, for the same
+          # reasons: unfree is allowed because the app selection offers unfree
+          # apps, and broken is NOT, because a package nixpkgs marks broken
+          # aborts the user's whole rebuild rather than just its own install.
+          NIXPKGS_ALLOW_UNFREE: "1"
+          NIXPKGS_ALLOW_BROKEN: "0"
         run: |
           mapfile -t attrs < <(nix eval --raw --impure --expr '
             let
@@ -955,7 +963,9 @@ jobs:
           echo "apps to build: ${#attrs[@]}"
           test "${#attrs[@]}" -ge 8
 
-          nix build --keep-going --no-link --print-build-logs \
+          # --impure because NIXPKGS_ALLOW_UNFREE is an environment variable,
+          # and a pure evaluation cannot see it.
+          nix build --impure --keep-going --no-link --print-build-logs \
             "${attrs[@]/#/.#}"
 
   system:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -913,6 +913,51 @@ jobs:
           nix-instantiate --parse result-sys/etc/nixarchy/apps-template.nix >/dev/null
           echo "app template parses"
 
+  # The opt-in applications, built so nobody else has to.
+  #
+  # Every other job here builds a system or a check, and an app nobody enables
+  # by default is in neither -- so programs.nixarchy.apps.aether meant a Go
+  # toolchain, an npm tree and a webkit link on the user's own laptop, every
+  # time. Nothing was wrong; nothing had ever pushed them.
+  #
+  # The list is read from data/apps.nix rather than written here, because a
+  # hand-copied list of nine names is a list that silently stops covering the
+  # tenth. `ours = true` is the same flag the Install menu uses to decide an
+  # app comes from this flake instead of nixpkgs, which is exactly the set that
+  # has no cache anywhere else.
+  #
+  # The nixpkgs-derived ones in that set (retroarch, zen-browser) cost close to
+  # nothing: they substitute from cache.nixos.org rather than build.
+  apps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-nix
+      - uses: cachix/cachix-action@v17
+        # A cache upload failing must not fail a build that succeeded (#235).
+        continue-on-error: true
+        with:
+          name: nixarchy
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build every app the flake ships itself
+        run: |
+          mapfile -t attrs < <(nix eval --raw --impure --expr '
+            let
+              cat = import ./data/apps.nix;
+              ours = builtins.filter (n: (cat.${n}.ours or false)) (builtins.attrNames cat);
+            in builtins.concatStringsSep "\n" (map (n: cat.${n}.attr or n) ours)
+          ')
+
+          # A floor, because `nix build` over an empty list exits 0 and would
+          # turn "the catalogue stopped parsing" into a green job.
+          echo "apps to build: ${#attrs[@]}"
+          test "${#attrs[@]}" -ge 8
+
+          nix build --keep-going --no-link --print-build-logs \
+            "${attrs[@]/#/.#}"
+
   system:
     runs-on: ubuntu-latest
     # 45, not 30. The job's own work is ~20 minutes (see below), so 30 looked

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | **`nixarchy` command** | this port's own commands, and a way through to Omarchy's 431 |
 | **Remove menu** | deselects apps, never touches your own config |
 | **Update menu** | `nh os switch --update <flake>` |
-| 60 apps in the selection | 46 from nixpkgs, 4 as NixOS modules, 8 built here, 2 with no equivalent |
+| 61 apps in the selection | 46 from nixpkgs, 4 as NixOS modules, 9 built here, 2 with no equivalent |
 | Learn menu | NixOS wiki, `search.nixos.org` packages and options |
 | Shell functions | bash and zsh source the chain; fish derives it from the same files |
 | RetroArch | 13 libretro cores, resolved from the store rather than `/usr/lib` |
@@ -1482,7 +1482,7 @@ done
 
 Almost nothing here waits on a maintainer.
 
-**50 of the 60 apps never touch this repo.** Brave, VSCode, Signal and the rest
+**50 of the 61 apps never touch this repo.** Brave, VSCode, Signal and the rest
 are installed as `pkgs.<name>` from **your** nixpkgs, and the five
 module-backed ones (Steam, 1Password, Tailscale, Firefox, Xbox controllers)
 come from there too — the module is NixOS', not this repo's. Your own
@@ -1541,7 +1541,7 @@ Most of it is not our job, and should not be:
 
 | where the app comes from | who updates it |
 |---|---|
-| nixpkgs (50 of 60 apps) | **nobody** — your own `nix flake update` |
+| nixpkgs (50 of 61 apps) | **nobody** — your own `nix flake update` |
 | pinned in this repo (2) | a nightly bot, opening a PR |
 | `zen` | upstream's own flake |
 | `retroarch` | nixpkgs, via this flake's own pin — it is a rebuild with cores |

--- a/data/apps.nix
+++ b/data/apps.nix
@@ -444,6 +444,20 @@
     attr = "omacut";
     ours = true;
   };
+  aether = {
+    # The fourth of the four in the note on omawrite, and the only one that is
+    # not a script or a small Qt program: a Wails app, a Go backend and a Svelte
+    # frontend in one binary rendered through webkitgtk. Same reasoning, same
+    # opt-in form -- programs.nixarchy.apps.aether.
+    #
+    # Utility rather than a theming category, because there is no theming
+    # category: it sits beside Omacalc and Omacut, which is where someone
+    # looking for the Omarchy applications will look.
+    label = "Aether";
+    category = "Utility";
+    attr = "aether";
+    ours = true;
+  };
   hey-cli = {
     # No menuId: Omarchy v4.0.1 ships no HEY row at all -- hey.com/agents asks
     # for "Omarchy 4.1 or later", which is unreleased, and v4.0.1's AI group is

--- a/flake.nix
+++ b/flake.nix
@@ -285,12 +285,16 @@
           # Why: docs/internals/flake.md#not-built-here-upstreams-own-flake-re-exported-int
           zen-browser = zen-browser.packages.${final.stdenv.hostPlatform.system}.default;
 
-          # Two of the four applications Omarchy writes itself. nixpkgs has
-          # none of them, which is why modules/nixos.nix cannot reproduce
-          # upstream's preinstall set; these two close half that gap.
+          # The four applications Omarchy writes itself. nixpkgs has none of
+          # them, which is why modules/nixos.nix cannot reproduce upstream's
+          # preinstall set; these close that gap.
           omawrite = final.callPackage ./pkgs/apps/omawrite.nix { };
           omacalc = final.callPackage ./pkgs/apps/omacalc.nix { };
           omacut = final.callPackage ./pkgs/apps/omacut.nix { };
+
+          # The fourth, and the only one that is not a small script or a Qt
+          # program: a Wails app, so a Go module set AND an npm tree to pin.
+          aether = final.callPackage ./pkgs/apps/aether.nix { };
 
           # Not one of Omarchy's preinstalls -- a terminal-effects toy from the
           # same authors, packaged because it was asked for.
@@ -670,6 +674,7 @@
             omawrite
             omacalc
             omacut
+            aether
             ttfx
             ;
 

--- a/pkgs/apps/aether-lockfile.patch
+++ b/pkgs/apps/aether-lockfile.patch
@@ -1,0 +1,197 @@
+--- a/frontend/package-lock.json
++++ b/frontend/package-lock.json
+@@ -17,13 +17,39 @@
+         "vite": "^8.0.10"
+       }
+     },
++    "node_modules/@emnapi/core": {
++      "version": "1.11.3",
++      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
++      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "peer": true,
++      "dependencies": {
++        "@emnapi/wasi-threads": "1.2.3",
++        "tslib": "^2.4.0"
++      }
++    },
++    "node_modules/@emnapi/runtime": {
++      "version": "1.11.3",
++      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
++      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "peer": true,
++      "dependencies": {
++        "tslib": "^2.4.0"
++      }
++    },
+     "node_modules/@emnapi/wasi-threads": {
+-      "version": "1.2.1",
+-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
++      "version": "1.2.3",
++      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
++      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+       "dev": true,
+       "license": "MIT",
+       "optional": true,
++      "peer": true,
+       "dependencies": {
+         "tslib": "^2.4.0"
+       }
+@@ -330,6 +356,40 @@
+         "node": "^20.19.0 || >=22.12.0"
+       }
+     },
++    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
++      "version": "1.10.0",
++      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
++      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "dependencies": {
++        "@emnapi/wasi-threads": "1.2.1",
++        "tslib": "^2.4.0"
++      }
++    },
++    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
++      "version": "1.10.0",
++      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
++      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "dependencies": {
++        "tslib": "^2.4.0"
++      }
++    },
++    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
++      "version": "1.2.1",
++      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
++      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "dependencies": {
++        "tslib": "^2.4.0"
++      }
++    },
+     "node_modules/@rolldown/binding-win32-arm64-msvc": {
+       "version": "1.0.0-rc.17",
+       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+@@ -624,6 +684,70 @@
+         "node": ">=14.0.0"
+       }
+     },
++    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
++      "version": "1.8.1",
++      "dev": true,
++      "inBundle": true,
++      "license": "MIT",
++      "optional": true,
++      "dependencies": {
++        "@emnapi/wasi-threads": "1.1.0",
++        "tslib": "^2.4.0"
++      }
++    },
++    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
++      "version": "1.8.1",
++      "dev": true,
++      "inBundle": true,
++      "license": "MIT",
++      "optional": true,
++      "dependencies": {
++        "tslib": "^2.4.0"
++      }
++    },
++    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
++      "version": "1.1.0",
++      "dev": true,
++      "inBundle": true,
++      "license": "MIT",
++      "optional": true,
++      "dependencies": {
++        "tslib": "^2.4.0"
++      }
++    },
++    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
++      "version": "1.1.1",
++      "dev": true,
++      "inBundle": true,
++      "license": "MIT",
++      "optional": true,
++      "dependencies": {
++        "@emnapi/core": "^1.7.1",
++        "@emnapi/runtime": "^1.7.1",
++        "@tybys/wasm-util": "^0.10.1"
++      },
++      "funding": {
++        "type": "github",
++        "url": "https://github.com/sponsors/Brooooooklyn"
++      }
++    },
++    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
++      "version": "0.10.1",
++      "dev": true,
++      "inBundle": true,
++      "license": "MIT",
++      "optional": true,
++      "dependencies": {
++        "tslib": "^2.4.0"
++      }
++    },
++    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
++      "version": "2.8.1",
++      "dev": true,
++      "inBundle": true,
++      "license": "0BSD",
++      "optional": true
++    },
+     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+       "version": "4.2.4",
+       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
+@@ -704,7 +828,6 @@
+       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+       "dev": true,
+       "license": "MIT",
+-      "peer": true,
+       "bin": {
+         "acorn": "bin/acorn"
+       },
+@@ -1215,7 +1338,6 @@
+       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+       "dev": true,
+       "license": "MIT",
+-      "peer": true,
+       "engines": {
+         "node": ">=12"
+       },
+@@ -1329,7 +1451,6 @@
+       "integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
+       "dev": true,
+       "license": "MIT",
+-      "peer": true,
+       "dependencies": {
+         "@jridgewell/remapping": "^2.3.4",
+         "@jridgewell/sourcemap-codec": "^1.5.0",
+@@ -1428,7 +1549,6 @@
+       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+       "dev": true,
+       "license": "Apache-2.0",
+-      "peer": true,
+       "bin": {
+         "tsc": "bin/tsc",
+         "tsserver": "bin/tsserver"
+@@ -1443,7 +1563,6 @@
+       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+       "dev": true,
+       "license": "MIT",
+-      "peer": true,
+       "dependencies": {
+         "lightningcss": "^1.32.0",
+         "picomatch": "^4.0.4",

--- a/pkgs/apps/aether.nix
+++ b/pkgs/apps/aether.nix
@@ -1,0 +1,236 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  buildNpmPackage,
+  applyPatches,
+  fetchFromGitHub,
+  nodejs,
+  wails,
+  pkg-config,
+  webkitgtk_4_1,
+  gtk3,
+  wrapGAppsHook3,
+  makeDesktopItem,
+  copyDesktopItems,
+  nix-update,
+  writeShellApplication,
+}:
+let
+  pname = "aether";
+  version = "4.29.8";
+
+  src = fetchFromGitHub {
+    owner = "omacom";
+    repo = "aether";
+    tag = "v${version}";
+    hash = "sha256-gB6vRNoo309eAWhAhDFDiIzHjSBalKpOjafnx8wzZP0=";
+  };
+
+  # The Svelte frontend, built on its own and handed to the Go build finished.
+  #
+  # Not `npmDeps` on the buildGoModule below, which is the obvious shape and
+  # does not work: nativeBuildInputs reach the go-modules derivation too, so
+  # npmConfigHook runs where there is no package-lock.json and the vendor
+  # fetch dies with "ERROR: no dependencies were specified" -- a message about
+  # npm, printed by a derivation that is fetching Go modules.
+  #
+  # Two derivations also means the npm tree is fetched once and cached, rather
+  # than re-fetched whenever a Go dependency moves.
+  # The frontend source with its lock file corrected.
+  #
+  # Upstream's package-lock.json is out of sync with its package.json, and
+  # `npm ci` -- which buildNpmPackage uses, correctly, because it is the only
+  # npm mode that installs exactly what is locked -- refuses outright:
+  #
+  #   npm error `npm ci` can only install packages when your package.json and
+  #   package-lock.json ... are in sync.
+  #   npm error Missing: @emnapi/core@ from lock file
+  #   npm error Missing: @emnapi/runtime@ from lock file
+  #
+  # Those are optional native transitive dependencies npm omitted when the lock
+  # was generated on another platform. Regenerating needs a network, which a
+  # sandboxed build has not got, so the corrected lock is carried as a patch --
+  # produced with `npm install --package-lock-only` against the tagged source,
+  # 146 lines adding what npm was missing.
+  #
+  # Patched HERE rather than inside buildNpmPackage, and that is the point:
+  # fetchNpmDeps reads the lock from `src`, so a patch applied within the
+  # package fetches against the old lock and builds against the new one --
+  # which surfaces as a hash mismatch that looks like a stale npmDepsHash and
+  # is not.
+  #
+  # It comes off the moment upstream's lock is in sync: the build fails loudly
+  # if the patch stops applying, which is the notification.
+  frontendSrc = applyPatches {
+    # applyPatches cannot derive a name from a string src.
+    name = "${pname}-frontend-source";
+    src = "${src}/frontend";
+    patches = [ ./aether-lockfile.patch ];
+    # -p2: the patch was made against frontend/package-lock.json from the
+    # repository root, and this source IS frontend/.
+    patchFlags = [ "-p2" ];
+  };
+
+  frontend = buildNpmPackage {
+    pname = "${pname}-frontend";
+    inherit version;
+    src = frontendSrc;
+
+    npmDepsHash = "sha256-Ry8BEmGVVL+RjkLFZTdsC9/M37DtjGw3m5zDtAcPj7s=";
+
+    # `npm run build` writes dist/, which is what wails embeds.
+    installPhase = ''
+      runHook preInstall
+      cp -r dist $out
+      runHook postInstall
+    '';
+  };
+in
+buildGoModule {
+  inherit pname version src;
+
+  # Sibling of pkgs/apps/omawrite.nix, omacalc.nix and omacut.nix: the fourth
+  # of the applications Omarchy writes itself, none of which nixpkgs carries.
+  # Available through programs.nixarchy.apps.aether rather than added to the
+  # preinstalls, because a Wails binary is not something to give every machine
+  # whether or not anyone asked for it.
+  #
+  # Unlike its three siblings this is not a shell script or a small Qt program:
+  # a Go backend and a Svelte frontend compiled into one binary and rendered
+  # through webkitgtk, so there are two dependency graphs to pin.
+
+  vendorHash = "sha256-0cNNFCI/hFYM/BmuHEDDunKf7byj8JCb0lRElsWWaT0=";
+
+  nativeBuildInputs = [
+    nodejs
+    wails
+    pkg-config
+    copyDesktopItems
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    webkitgtk_4_1
+    gtk3
+  ];
+
+  # -m skips the `go mod tidy` wails runs first. Tidy resolves the imports of
+  # every package including test-only ones, which vendor/ deliberately does not
+  # contain, so it fails on golang.org/x/image/font -- imported by a _test.go
+  # file that is never built here. The module graph is already pinned by
+  # vendorHash; re-tidying it in a sandbox could only fail or change the pin.
+  #
+  # -skipbindings because the binding generator cannot run in a sandbox: it
+  # invokes `go list` from a scratch directory of its own, outside the source
+  # tree, so the vendor/ that buildGoModule provides is not visible and every
+  # import fails with "module lookup disabled by GOPROXY=off" -- a network
+  # error, from the one step that needs a network.
+  #
+  # Nothing is lost: upstream commits the generated bindings at
+  # frontend/wailsjs/{go,runtime}, and they are generated from the Go source of
+  # this same tag, so regenerating them here could only reproduce them. The
+  # frontend derivation above has already compiled against them.
+  #
+  # -s skips wails' own `npm install && npm run build`, which cannot run here:
+  # the sandbox has no network and npm would want one. The finished dist/ from
+  # the derivation above is dropped in its place first.
+  #
+  # -tags webkit2_41 matches what upstream's Makefile computes:
+  #
+  #   WEBKIT_TAGS := $(shell pkg-config --exists webkit2gtk-4.0 || echo "-tags webkit2_41")
+  #
+  # nixpkgs carries webkitgtk_4_1 and not the 4.0 series, so the tag is always
+  # required here. Hardcoded rather than computed, because a silently-absent
+  # tag builds against an API that is not present and fails deep inside cgo.
+  buildPhase = ''
+    # Upstream does not commit frontend/dist, and main.go embeds it with
+    # `//go:embed all:frontend/dist`. The finished dist from the derivation
+    # above goes in before wails is asked to skip building it.
+    #
+    # Inline rather than in preBuild, because buildPhase is replaced here and
+    # preBuild is a hook OF the phase being replaced -- it would never run, and
+    # the build would still succeed: wails creates an empty frontend/dist when
+    # one is missing, so the binary links, installs, and opens a blank window.
+    # That is exactly the failure installCheckPhase below exists to catch.
+    rm -rf frontend/dist
+    cp -r ${frontend} frontend/dist
+    chmod -R u+w frontend/dist
+
+    wails build -s -m -skipbindings -tags webkit2_41 -o ${pname}
+    runHook postBuild
+  '';
+
+  # buildGoModule's checkPhase calls getGoDirs, a shell function its buildPhase
+  # defines -- and buildPhase is replaced above, so the function does not exist
+  # and the phase prints "getGoDirs: command not found" and passes. A check that
+  # cannot fail is worse than no check, so it is turned off and said out loud:
+  # the tests import golang.org/x/image/font, which vendor/ does not carry
+  # because it is a test-only dependency, so they could not run here regardless.
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 build/bin/${pname} $out/bin/${pname}
+
+    # The desktop item below names icon = "aether", which resolves to nothing
+    # unless a file of that name is in the icon theme -- the entry would show
+    # a generic placeholder in the launcher. Upstream's Makefile installs
+    # assets/aether-icon-512.png; so does this.
+    install -Dm644 assets/aether-icon-512.png \
+      $out/share/icons/hicolor/512x512/apps/${pname}.png
+    runHook postInstall
+  '';
+
+  # The one failure this package can have that still exits 0.
+  #
+  # go:embed writes the embedded file's path into the binary, so a build that
+  # embedded the real dist contains "frontend/dist/index.html" and one that
+  # embedded wails' empty placeholder does not. The first build here passed
+  # every phase, produced a 20M ELF linked against webkit, and had nothing
+  # inside it -- an app that starts and shows a white rectangle.
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    # -r over bin/, not the binary by name: wrapGAppsHook3 has already run by
+    # installCheck time, so $out/bin/${pname} is a wrapper script and the ELF is
+    # the hidden .${pname}-wrapped beside it.
+    grep -qra "frontend/dist/index.html" $out/bin || {
+      echo "ERROR: the frontend was not embedded; the window would be blank"
+      exit 1
+    }
+    runHook postInstallCheck
+  '';
+
+  # Upstream's Makefile writes one into ~/.local/share/applications at install
+  # time. A package cannot do that, so it is built here -- the same thing
+  # pkgs/apps/omacalc.nix does, for the same reason.
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      icon = pname;
+      desktopName = "Aether";
+      comment = "Native Omarchy theming";
+      categories = [
+        "Utility"
+        "Settings"
+      ];
+    })
+  ];
+
+  passthru.updateScript = writeShellApplication {
+    name = "update-aether";
+    runtimeInputs = [ nix-update ];
+    text = "nix-update aether";
+  };
+
+  meta = {
+    description = "Native Omarchy theming made easy";
+    homepage = "https://github.com/omacom/aether";
+    license = lib.licenses.mit;
+    mainProgram = pname;
+    platforms = lib.platforms.linux;
+    broken = !stdenv.hostPlatform.isLinux;
+  };
+}


### PR DESCRIPTION

The fourth of the applications Omarchy writes itself, and the only one that
is not a script or a small Qt program: a Go backend and a Svelte frontend
compiled into one binary and rendered through webkitgtk, so there are two
dependency graphs to pin. Available as programs.nixarchy.apps.aether.

## Three things wails does that a sandbox cannot

Binding generation runs `go list` from a scratch directory outside the source
tree, so vendor/ is invisible and every import fails with "module lookup
disabled by GOPROXY=off" -- a network error from the one step that needs a
network. Upstream commits the generated bindings for this same tag, so
-skipbindings loses nothing.

`go mod tidy` runs before the compile and resolves test-only imports, which
vendor/ deliberately does not carry. -m skips it; vendorHash already pins the
graph, and re-tidying could only fail or move the pin.

And `npm ci` refuses upstream's own lock file, which is out of sync with its
package.json -- two optional native transitive deps npm omitted when the lock
was generated elsewhere. The corrected lock is carried as a patch, applied to
the source BEFORE buildNpmPackage rather than inside it: fetchNpmDeps reads
the lock from src, so a patch applied within the package fetches against the
old lock and builds against the new one, and that surfaces as a hash mismatch
that looks like a stale npmDepsHash and is not.

## The build that succeeded and shipped nothing

The first working version produced a 20M ELF, linked against webkit, passing
every phase -- with an empty frontend. The dist copy sat in preBuild, which
never runs, because buildGoModule's buildPhase is replaced here and preBuild
is a hook of the phase being replaced. wails creates an empty frontend/dist
when one is missing, so the binary linked, installed, and would have opened a
white rectangle.

Nothing in the build could have caught it, so installCheckPhase does: go:embed
writes the embedded path into the binary, and "frontend/dist/index.html" is
present iff the real dist went in. Proven red on that exact defect before it
was fixed, not on a synthetic one.

Two smaller versions of the same thing: checkPhase called getGoDirs, a shell
function the replaced buildPhase defines, so it printed "command not found"
and passed -- turned off and said out loud instead. And the desktop item named
an icon nothing installed.

## Pushing it

No job built the opt-in apps. Every other job builds a system or a check, and
an app nobody enables by default is in neither -- so enabling one meant a Go
toolchain and a webkit link on the user's own laptop, every time.

The new job reads its list from data/apps.nix rather than hardcoding nine
names, because `ours = true` already means "comes from this flake, so no cache
anywhere else has it", and a hand-copied list silently stops covering the
tenth. It has a floor, because `nix build` over an empty list exits 0.

## Verified

- `nix build .#aether` -- 20M ELF, webkit linked, frontend embedded
- `programs.nixarchy.apps.aether.enable = true` on `reference` resolves to
  that exact store path
- `installCheckPhase` proven red on the un-embedded build and green on the
  fixed one
- the new job's list evaluates to 9 attrs, all of which are flake packages
- `nix fmt -- --ci`, `statix`, `actionlint`, `checks.options`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
