### PR TITLE
Two rows that could never have worked, and the checks that would have said so

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1321,6 +1321,14 @@
             pkgs = pkgsFor.${system};
           };
 
+          # And the same idea aimed at the menu: every action string checked
+          # against the subcommands the CLI it invokes actually has. See
+          # tests/menu-verbs.nix and the `nixarchy-vm new` row that shipped.
+          menu-verbs = import ./tests/menu-verbs.nix {
+            inherit inputs;
+            pkgs = pkgsFor.${system};
+          };
+
           # The other half of that: every option path the README and the manual
           # quote, checked against the option set they claim to describe. See
           # tests/doc-options.nix and #214.

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -501,7 +501,13 @@ let
         "trigger.vm.new" = {
           icon = "󰕍";
           label = "New sandbox";
-          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-vm new";
+          # `create`, not `new`. The menu KEY is trigger.vm.new and the action
+          # was written to match the key instead of the CLI, so every click
+          # printed "nixarchy-vm: unknown subcommand 'new'" and closed. The
+          # sibling rows only work because run/stop/rm happen to be spelled the
+          # same on both sides; checks.menu-verbs now asserts that rather than
+          # leaving it to coincidence.
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-vm create";
           description = "Name one, pick a template, and open it";
         };
         "trigger.vm.open" = {

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -506,6 +506,33 @@ in
     # flags a repeated top-level key, and it is right that they read better
     # together.
     programs = {
+      # Omarchy's screen recording, which could not work as shipped.
+      #
+      # gpu-screen-recorder is in the omarchy wrapper's runtime PATH, and that
+      # installs the PACKAGE. Recording needs more than the package:
+      # gsr-kms-server opens the DRM device and needs cap_sys_admin, which on
+      # NixOS comes only from this module's setcap wrapper. Without it the
+      # capture backend exits before it starts --
+      #
+      #   kms server died or never started, exit code: 127
+      #
+      # -- and there is no fallback, because gpu-screen-recorder then tries
+      # pkexec, which wants a setuid helper that NixOS' polkit does not ship.
+      # A tester hit exactly this.
+      #
+      # Enabling the module is enough, and it is worth writing down why the
+      # package in our wrapper picks the privileged binary up rather than the
+      # unprivileged one beside it: gpu-screen-recorder's own wrapper does
+      # `--prefix PATH : ${wrapperDir}` and `--suffix PATH : $out/bin`, and
+      # wrapperDir already defaults to /run/wrappers/bin. Wrapper first, store
+      # second. The module's `.override { inherit wrapperDir; }` only matters
+      # on a non-default security.wrapperDir, which is why plain
+      # `pkgs.gpu-screen-recorder` in runtimeDeps is not a second bug.
+      #
+      # ui.enable stays off: that is GPU Screen Recorder's own overlay, and
+      # Omarchy drives recording from its own keybindings.
+      gpu-screen-recorder.enable = lib.mkDefault true;
+
       # Why: modules/AGENTS.md#etc-nixos-belongs-to-the-installed-user-installer-
       git = {
         enable = lib.mkDefault true;

--- a/tests/menu-verbs.nix
+++ b/tests/menu-verbs.nix
@@ -1,0 +1,105 @@
+{ inputs, pkgs }:
+# Every menu row's action, against the subcommands the CLI it invokes has.
+#
+# The case: "trigger.vm.new" ran `nixarchy-vm new`. There is no `new` -- the
+# verb is `create` -- so the row printed
+#
+#   nixarchy-vm: unknown subcommand 'new'
+#
+# and closed the terminal. It shipped, and a tester found it, because the
+# action had been written to match the menu KEY (trigger.vm.new) rather than
+# the CLI. Its siblings work only by coincidence: run, stop and rm happen to
+# be spelled the same on both sides.
+#
+# Nothing here could have caught it. The group is gated on `nixarchy-vm
+# --check`, which is `exit 0` and says nothing about any verb; the VM tests
+# call `nixarchy-vm create` directly, spelling it correctly and never reading
+# the menu; and a menu action is a string in a Nix attrset, which evaluation
+# does not validate. Sibling of tests/doc-options.nix: text that names a real
+# thing is a claim, and a claim gets checked.
+#
+# Read from the GENERATED menu rather than from modules/apps.nix, because that
+# is the file the desktop executes, it is where the box template rows exist at
+# all (they are produced by a mapAttrs' and have no source line of their own),
+# and a bug in the generator is as capable of breaking a row as a typo is.
+let
+  inherit (pkgs) lib;
+  system = pkgs.stdenv.hostPlatform.system;
+
+  # reference, plus boxes -- the box group is gated on services.boxes.enable
+  # and would otherwise contribute no rows, quietly halving what is checked.
+  eval = inputs.self.nixosConfigurations.reference.extendModules {
+    modules = [ { programs.nixarchy.services.boxes.enable = true; } ];
+  };
+
+  menu = eval.config.environment.etc."nixarchy/omarchy-menu.jsonc".source;
+
+  vmcli = inputs.self.packages.${system}.nixarchy-vm;
+  boxcli = inputs.self.packages.${system}.nixarchy-box;
+in
+pkgs.runCommand "nixarchy-menu-verbs"
+  {
+    nativeBuildInputs = [
+      pkgs.gnugrep
+      pkgs.gnused
+    ];
+  }
+  ''
+    set -euo pipefail
+
+    # The verbs each CLI accepts, read out of the shipped script's own case
+    # block -- the built artifact, not the repo source, so a build that mangles
+    # the dispatch is caught too.
+    verbs_of() {
+      sed -n '/case "''${1:-}" in/,/^ *esac/p' "$1" \
+        | grep -oE '^[[:space:]]*[-a-z|"]+\)' \
+        | tr -d ' )"' \
+        | tr '|' '\n' \
+        | grep -vE '^\*?$' \
+        | sort -u
+    }
+
+    verbs_of ${vmcli}/bin/nixarchy-vm   > vm-verbs
+    verbs_of ${boxcli}/bin/nixarchy-box > box-verbs
+
+    echo "nixarchy-vm accepts:  $(tr '\n' ' ' < vm-verbs)"
+    echo "nixarchy-box accepts: $(tr '\n' ' ' < box-verbs)"
+
+    # A floor. An empty verb list makes every row below pass, turning "the
+    # dispatch stopped parsing" into a green check -- the exact shape of failure
+    # this file exists to reject.
+    test "$(wc -l < vm-verbs)"  -ge 5
+    test "$(wc -l < box-verbs)" -ge 5
+
+    fail=0
+    checked=0
+
+    # Both spellings, because both are in use: the vm rows call `nixarchy-vm
+    # <verb>` and the box rows go through the top-level `nixarchy box <verb>`.
+    scan() {
+      local pattern="$1" field="$2" cli="$3" list="$4"
+      while read -r verb; do
+        [ -n "$verb" ] || continue
+        checked=$((checked + 1))
+        if ! grep -qx -- "$verb" "$list"; then
+          echo "ERROR: a menu row runs '$cli $verb', which $cli does not accept" >&2
+          echo "       it accepts: $(tr '\n' ' ' < "$list")" >&2
+          fail=1
+        fi
+      done < <(grep -oE "$pattern" ${menu} | awk "{print \$$field}" | sort -u)
+    }
+
+    scan '\bnixarchy-vm +[-a-z]+'      2 nixarchy-vm  vm-verbs
+    scan '\bnixarchy +vm +[-a-z]+'     3 nixarchy-vm  vm-verbs
+    scan '\bnixarchy-box +[-a-z]+'     2 nixarchy-box box-verbs
+    scan '\bnixarchy +box +[-a-z]+'    3 nixarchy-box box-verbs
+
+    # The second floor: if the menu stopped carrying these rows, every scan
+    # above would run zero times and the check would pass having read nothing.
+    echo "menu verbs checked: $checked"
+    test "$checked" -ge 8
+
+    test "$fail" -eq 0
+    echo "every menu row names a subcommand its CLI has"
+    touch $out
+  ''

--- a/tests/menu-verbs.nix
+++ b/tests/menu-verbs.nix
@@ -23,7 +23,6 @@
 # all (they are produced by a mapAttrs' and have no source line of their own),
 # and a bug in the generator is as capable of breaking a row as a typo is.
 let
-  inherit (pkgs) lib;
   system = pkgs.stdenv.hostPlatform.system;
 
   # reference, plus boxes -- the box group is gated on services.boxes.enable

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -2042,6 +2042,43 @@ pkgs.runCommand "nixarchy-options"
 
         python3 ${./home-backup-menu.py} "$vm/etc/nixarchy/omarchy-menu.jsonc"
 
+        # ---- screen recording has the capability it cannot work without ----
+        #
+        # gpu-screen-recorder is in omarchy's runtime PATH, which installs the
+        # package; recording additionally needs gsr-kms-server to hold
+        # cap_sys_admin, and on NixOS only programs.gpu-screen-recorder.enable
+        # produces that setcap wrapper. Without it recording dies with "kms
+        # server died or never started, exit code: 127", and pkexec cannot
+        # rescue it because NixOS ships no setuid pkexec. A tester hit this.
+        #
+        # Asserted on the built system rather than on the option being set,
+        # because the option is a means: what has to be true is that a wrapper
+        # for gsr-kms-server, carrying that capability, exists in the unit that
+        # creates the wrappers. Setting the option and having the capability
+        # not arrive is a distinct failure, and the one that would actually
+        # reach a user.
+        wrapperUnit="$vm/etc/systemd/system/suid-sgid-wrappers.service"
+        test -e "$wrapperUnit" || {
+          echo "no suid-sgid-wrappers unit: security.wrappers produced nothing" >&2
+          exit 1
+        }
+        wrapperScript=$(grep -oE 'ExecStart=[^ ]+' "$wrapperUnit" | head -1 | cut -d= -f2-)
+        test -n "$wrapperScript" && test -e "$wrapperScript" || {
+          echo "could not follow the wrappers unit to its script" >&2
+          exit 1
+        }
+        grep -q 'gsr-kms-server' "$wrapperScript" || {
+          echo "gsr-kms-server has no setcap wrapper: screen recording will fail with" >&2
+          echo "  kms server died or never started, exit code: 127" >&2
+          echo "set programs.gpu-screen-recorder.enable -- the package alone is not enough" >&2
+          exit 1
+        }
+        grep -q 'cap_sys_admin' "$wrapperScript" || {
+          echo "the gsr-kms-server wrapper exists but grants no cap_sys_admin" >&2
+          exit 1
+        }
+        echo "gsr-kms-server has its cap_sys_admin wrapper, so recording can start"
+
           touch $out
       ''
     else


### PR DESCRIPTION

Both found by testers, both invisible to every check here, and neither is a
hard bug -- which is the point: nothing was looking.

## "unknown subcommand 'new'"

The New sandbox row ran `nixarchy-vm new`. The verb is `create`. The action
had been written to match the menu KEY (trigger.vm.new) rather than the CLI,
so every click printed the error and closed the terminal. Its siblings work
only by coincidence: run, stop and rm happen to be spelled the same on both
sides.

Nothing could have caught it. The group is gated on `nixarchy-vm --check`,
which is `exit 0` and says nothing about any verb; the VM tests call
`nixarchy-vm create` directly, spelling it correctly and never reading the
menu; and a menu action is a string in an attrset, which evaluation does not
validate.

checks.menu-verbs reads the GENERATED menu -- the file the desktop actually
executes, and the only place the box template rows exist at all, since a
mapAttrs' produces them and they have no source line -- and checks every verb
against the case block of the shipped CLI script. Both spellings, because both
are in use: `nixarchy-vm <verb>` and `nixarchy box <verb>`.

It has two floors. An empty verb list would make every row pass, and a menu
that stopped carrying these rows would make the check pass having read
nothing; both turn a broken check into a green one, which is the failure this
file exists to reject. Proven red on the exact reported bug and green after.

The box group was checked for the same mistake and does not have it.

## "kms server died or never started, exit code: 127"

Screen recording could not work as shipped. gpu-screen-recorder is in
omarchy's runtime PATH, and that installs the PACKAGE; recording needs
gsr-kms-server to hold cap_sys_admin, which on NixOS comes only from
programs.gpu-screen-recorder.enable and its setcap wrapper. There is no
fallback either -- gpu-screen-recorder then tries pkexec, which wants a setuid
helper NixOS' polkit does not ship. The tester's diagnosis was right in every
particular.

Worth writing down why enabling the module is sufficient, because the obvious
worry is that our wrapper shadows the privileged binary with the store one:
gpu-screen-recorder's own wrapper does `--prefix PATH : ${wrapperDir}` and
`--suffix PATH : $out/bin`, and wrapperDir already defaults to
/run/wrappers/bin. Wrapper first, store second. The module's `.override
{ inherit wrapperDir; }` only matters on a non-default security.wrapperDir,
so plain pkgs.gpu-screen-recorder in runtimeDeps is not a second bug.

Asserted on the built system rather than on the option being set: what has to
be true is that a wrapper for gsr-kms-server carrying that capability exists
in the unit that creates the wrappers. Setting the option and having the
capability not arrive is a distinct failure, and the one that would reach a
user. Proven red with the option off, which prints the tester's own error
text.

## Verified

- `checks.menu-verbs` red on `nixarchy-vm new`, green on `create`
- `checks.options` red with `gpu-screen-recorder.enable = false` (prints the
  tester's own error text), green with it on
- `nix fmt -- --ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
