### PR TITLE
The install log was thrown away, and it held the only answer

### DIFF
--- a/tests/install-encrypted.nix
+++ b/tests/install-encrypted.nix
@@ -497,12 +497,31 @@ pkgs.testers.runNixOSTest {
         "grep -q test-instrumentation"
         " /mnt/etc/nixos/hosts/installed/configuration.nix")
     installer.succeed("git -C /mnt/etc/nixos add -A")
+    # The whole log to a file, the tail to the console.
+    #
+    # `| tail -20` alone threw away the only evidence that matters when the
+    # secret append below fails: systemd-boot's bootloader installer prints
+    # "failed to create initrd secrets!" or "warning: failed to update initrd
+    # secrets ..." in the middle of the install, thousands of lines above the
+    # end. So the assertion could say the hash was missing and nothing could
+    # say why -- which is how this was diagnosed twice from the same 50 lines.
     print(installer.succeed(
         "nixos-install --root /mnt --flake /mnt/etc/nixos#installed"
         " --no-root-password"
         " --option extra-experimental-features 'nix-command flakes'"
-        " --option always-allow-substitutes true 2>&1 | tail -20",
+        " --option always-allow-substitutes true"
+        " >/tmp/nixos-install.log 2>&1; rc=$?;"
+        " tail -20 /tmp/nixos-install.log; exit $rc",
         timeout=1800))
+
+    # And surfaced immediately, because a non-critical append failure lets the
+    # install SUCCEED with a pristine initrd -- the exact case where the next
+    # assertion fails and the reason is 3000 lines back.
+    secret_trouble = installer.succeed(
+        "grep -n -i 'initrd secrets' /tmp/nixos-install.log || true").strip()
+    if secret_trouble:
+        print("BOOTLOADER SAID, about initrd secrets:")
+        print(secret_trouble)
 
     # ---- the recovery credential is in the initrd on the ESP -----------
     #


### PR DESCRIPTION

The nightly's install-encrypted now fails on

  the recovery hash is NOT in /mnt/boot/EFI/nixos/<hash>-initrd.efi:
  the secret append failed and the emergency shell on this machine is locked

and nothing in the output says why, because the line above it ran

  nixos-install ... 2>&1 | tail -20

The bootloader's own explanation is not in the last twenty lines. systemd-boot
prints "failed to create initrd secrets!" or "warning: failed to update initrd
secrets ..." in the MIDDLE of the install, thousands of lines earlier -- and
the non-critical branch of that code copies a pristine initrd and lets the
install SUCCEED, which is exactly the shape of this failure: an install that
finished cleanly and an initrd with no secret in it.

So the assertion could report the hash missing while the reason had already
been discarded, and the same fifty lines got diagnosed twice.

The whole log now goes to a file, the tail still goes to the console, and the
log is grepped for "initrd secrets" immediately after the install, printing
whatever the bootloader said before the assertion that depends on it runs.

This changes no product code and fixes no bug. It is the evidence needed to
find out whether the append genuinely failed or the assertion is too strict --
a question that cannot be answered from the output as it stands.

Not to be confused with a fix: install-encrypted is expected to keep failing
until the cause it now prints is understood. Related: #404.

## Verified

- `nix eval .#checks.x86_64-linux.install-encrypted.drvPath` resolves, so the
  Python-inside-Nix edit is sound without waiting for a VM run
- (worth recording: this check cannot be evaluated from a dirty tree at all --
  the generated flake pins nixarchy by commit, so there is no rev to pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
