### PR TITLE
CI stops rebuilding what it can already prove, and stops building what a change cannot alter

### DIFF
--- a/.github/scripts/already-proven.sh
+++ b/.github/scripts/already-proven.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Which of these checks still need building, and which are already proven?
+#
+# A nixosTest's output exists ONLY if the test passed -- a failing driver
+# fails the derivation and produces nothing. So the presence of a check's
+# output in the binary cache is proof that this exact derivation, with these
+# exact inputs, built and passed. Not "is unchanged": passed.
+#
+# That distinction is why this queries the cache rather than diffing
+# derivation hashes between two commits. An unchanged drvPath only says the
+# inputs are identical, which on a red main would skip a still-failing check
+# forever. It is also why nothing here evaluates the base commit: there is no
+# base to evaluate, only a question about this one.
+#
+# `nix path-info --store <cache>` is a narinfo lookup: one HTTP metadata
+# round-trip, ~1s, no NAR download. That is the point. `nix build` on an
+# already-substitutable path DOWNLOADS it, and on 2026-09-04 that behaviour
+# killed four runners at their timeout -- three of them blocked on the
+# identical obs-studio path from a stalled cache.nixos.org, every build
+# already green. See build.yml's `system` timeout comment.
+#
+# Prints the checks that still need building, one per line, on stdout.
+# Everything else goes to stderr.
+set -uo pipefail
+
+CACHE="${NIXARCHY_CACHE:-https://nixarchy.cachix.org}"
+SYSTEM="${NIXARCHY_SYSTEM:-x86_64-linux}"
+
+[ "$#" -gt 0 ] || { echo "usage: already-proven.sh <check>..." >&2; exit 2; }
+
+proven=0
+needed=0
+
+for spec in "$@"; do
+  # Both spellings, and the fully-qualified one is why: build.yml's coverage
+  # gate greps the workflows for `checks.x86_64-linux.<name>` to prove every
+  # check is run by something. Replacing `nix build .#checks.x86_64-linux.x`
+  # with a script call taking a bare name deleted the text it greps for, and
+  # the gate immediately reported four checks as running nowhere -- correctly.
+  # So the workflow keeps the greppable form and this strips it.
+  c=${spec#".#checks.$SYSTEM."}
+  # A check whose outPath will not evaluate is a check that needs building --
+  # and the build is where that error belongs, with its stack trace, not here
+  # behind a `2>/dev/null`.
+  out=$(nix eval --raw ".#checks.$SYSTEM.$c" 2>/dev/null) || {
+    echo "  $c: does not evaluate here; leaving it to the build" >&2
+    echo "$c"
+    needed=$((needed + 1))
+    continue
+  }
+
+  if nix path-info --store "$CACHE" "$out" >/dev/null 2>&1; then
+    echo "  $c: already proven ($(basename "$out"))" >&2
+    proven=$((proven + 1))
+  else
+    echo "$c"
+    needed=$((needed + 1))
+  fi
+done
+
+echo "proven: $proven   to build: $needed" >&2
+
+# A floor. Every path above increments one counter or the other, so a total
+# that does not match the arguments means the loop stopped early -- and an
+# empty stdout would then read as "everything is proven", which is the one
+# wrong answer this script can give.
+if [ "$((proven + needed))" -ne "$#" ]; then
+  echo "ERROR: asked about $# checks, accounted for $((proven + needed))." >&2
+  echo "Refusing to report anything as proven." >&2
+  printf '%s\n' "$@"
+  exit 1
+fi

--- a/.github/scripts/build-unless-proven.sh
+++ b/.github/scripts/build-unless-proven.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Build these checks, unless the cache already says they passed.
+#
+# A drop-in for `nix build .#checks.x86_64-linux.<name> --print-build-logs`,
+# which is what every one of these steps used to run directly. The difference
+# is one narinfo lookup first: if this exact derivation's output is already in
+# the cache, it built and passed, and `nix build` would only DOWNLOAD it.
+#
+# Downloading is not free and has already cost a day: on 2026-09-04 four
+# runners died at their timeout, three blocked on the identical obs-studio
+# path from a stalled cache.nixos.org, with every build green. The `system`
+# job's timeout comment records it. Nothing here needs the bytes -- the job
+# asserts that the check passes, not that this machine holds its output.
+#
+# See already-proven.sh for why cache presence, and not a derivation-hash
+# diff against the base commit, is the sound signal.
+set -euo pipefail
+
+here=$(dirname "$0")
+
+# stdout is the list that still needs building; stderr is the narration, and
+# it is passed through so the log says which checks were skipped and why.
+mapfile -t todo < <("$here/already-proven.sh" "$@")
+
+if [ "${#todo[@]}" -eq 0 ]; then
+  echo "every requested check is already proven in the cache; nothing to build"
+  exit 0
+fi
+
+echo "building: ${todo[*]}"
+
+# --keep-going, because this replaced a step that had it and said why: report
+# every failure in one run rather than stopping at the first. That is what a
+# job matrix would have been bought for, and losing it silently while moving
+# the command into a script is exactly the kind of regression a wrapper makes
+# easy. Harmless for the single-check callers.
+#
+# --no-link for the reason build.yml already records: the generated step runs
+# in the same job that builds .#omarchy into `result`, and later steps read
+# result/share/omarchy/bin. Without it `nix build` repoints `result` at the
+# first check and the shebang check inspects a different tree -- which is how
+# it failed once already. Nothing here wants an out-link; the build IS the
+# assertion.
+nix build --keep-going --no-link --print-build-logs \
+  "${todo[@]/#/.#checks.x86_64-linux.}"

--- a/.github/scripts/pr-touches-build.sh
+++ b/.github/scripts/pr-touches-build.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Can this change affect anything Nix builds?
+#
+# One copy, called by two workflows. install-check.yml has asked this question
+# since #183; build.yml now asks the same one, and the reason this is a file
+# rather than a second copy of the `case` is setup-nix's reason: eleven
+# byte-identical blocks that were identical "by luck rather than by design".
+# A denylist that is right in one workflow and stale in the other is worse
+# than no denylist, because the stale one is still trusted.
+#
+# The list is a DENYLIST of paths that provably cannot change a derivation,
+# never an allowlist of paths that can. install-check.yml's header records
+# why, and it is worth restating because it is the whole safety argument:
+# #123 changed hosts/<name>/ layout, which changed module ORDER, which
+# changed the system path hash, and the installer then tried to build 517
+# derivations offline. No file anyone would have listed as "installer" was
+# touched. Nix closures are computed by evaluation, not by directory, so an
+# allowlist silently stops covering the next directory somebody adds. A
+# denylist can only be wrong about the few paths it names.
+#
+# Usage:  pr-touches-build.sh            # reads $EVENT_NAME/$GH_REPO/$PR_NUMBER
+#         echo "$files" | pr-touches-build.sh -   # a file list on stdin
+#
+# Prints `true` or `false` on stdout. Nothing else goes to stdout.
+set -euo pipefail
+
+if [ "${1:-}" = "-" ]; then
+  files=$(cat)
+elif [ "${EVENT_NAME:-}" != "pull_request" ]; then
+  # Not a pull request, so not filtered. main and workflow_dispatch always
+  # ran the real thing and still do.
+  echo true
+  exit 0
+else
+  # The API, not `git diff`: actions/checkout gives a job a single commit by
+  # default, so a diff against the base needs a deepened fetch whose depth is
+  # a guess. The PR's file list is the same answer without one.
+  files=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/files" \
+    --paginate --jq '.[].filename')
+fi
+
+# A pull request that changed no files is not a pull request. An empty list
+# here means the question could not be answered -- a paginated API call that
+# returned nothing, a permissions change, a renamed field -- and the cheap
+# answer to an unanswerable question is `false`, which skips every build. So
+# it fails SAFE instead: unknown means run everything. The cost of being
+# wrong in this direction is a wasted job; in the other it is a merged
+# regression nothing looked at.
+if [ -z "$(printf '%s' "$files" | tr -d '[:space:]')" ]; then
+  echo true
+  exit 0
+fi
+
+# Order matters and this loop is where it is expressed: the re-includes are
+# tested before the exclusions, so a change to the gate itself, or to this
+# script, is relevant even though both live under .github/.
+#
+# `case` globs are not path-aware -- `*` crosses `/` -- which is what makes
+# `docs/*` and `.github/*` cover nested files.
+relevant=false
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  case "$f" in
+    .github/workflows/install-check.yml) relevant=true; break ;;
+    .github/workflows/build.yml) relevant=true; break ;;
+    .github/scripts/pr-touches-build.sh) relevant=true; break ;;
+
+    # README.md is NOT in this list, and that is deliberate rather than an
+    # oversight. build.yml derives the app and command counts from data/ and
+    # greps README.md for them, so a README-only edit can legitimately fail
+    # the omarchy job -- it did on #424. Excluding it would turn a working
+    # guard into one that only runs when something else changed too.
+    docs/*|AGENTS.md|CONTRIBUTING.md|.envrc|.gitignore|.github/*)
+      continue ;;
+
+    *) relevant=true; break ;;
+  esac
+done <<EOF2
+$files
+EOF2
+
+echo "$relevant"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,11 @@ jobs:
   #
   # Cheap and hosted. It decides; the jobs below report.
   gate:
-    name: gate
+    # `build gate`, not `gate`: install-check.yml already publishes a context
+    # called `gate`, and two check runs with one name are ambiguous in the UI
+    # and worse in a branch protection rule, where "require gate" would no
+    # longer name one thing. Caught on this PR's own first run.
+    name: build gate
     runs-on: ubuntu-latest
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,38 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  # Can this change affect anything Nix builds?
+  #
+  # Same question install-check.yml has asked since #183, same script, and
+  # that sharing is the point: a denylist that is right in one workflow and
+  # stale in the other is worse than none, because the stale one is still
+  # trusted. See .github/scripts/pr-touches-build.sh for the list and for why
+  # it is a denylist rather than an allowlist.
+  #
+  # Cheap and hosted. It decides; the jobs below report.
+  gate:
+    name: gate
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+      - name: Decide whether this change can affect a build
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          relevant=$(.github/scripts/pr-touches-build.sh)
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+          echo "relevant=$relevant" >> "$GITHUB_STEP_SUMMARY"
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -150,12 +182,28 @@ jobs:
   # without that substituter every preset compiles a toolchain from source and
   # the run stops being a CI job and starts being an afternoon.
   devenv-presets:
+    needs: gate
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      # A step-level `if:`, never a job-level one, and the difference was
+      # measured rather than assumed: a job skipped by a job-level `if:`
+      # reports conclusion `skipped`, which is not `success`, so a required
+      # check blocks the merge exactly as a missing context does.
+      # install-check.yml records the probe. So the job always runs and
+      # completes green; its steps are what the gate turns off.
+      - name: Nothing here can affect a build
+        if: needs.gate.outputs.relevant != 'true'
+        run: |
+          echo "Only paths the gate excludes changed; not building." \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/checkout@v5
+        if: needs.gate.outputs.relevant == 'true'
       - uses: ./.github/actions/setup-nix
+        if: needs.gate.outputs.relevant == 'true'
       - uses: cachix/cachix-action@v17
+        if: needs.gate.outputs.relevant == 'true'
         # A cache upload failing must not fail a build that succeeded (#235).
         continue-on-error: true
         with:
@@ -164,6 +212,7 @@ jobs:
           extraPullNames: devenv
 
       - name: Every preset still evaluates
+        if: needs.gate.outputs.relevant == 'true'
         run: nix run .#devenv-presets
 
   omarchy:
@@ -337,6 +386,72 @@ jobs:
             echo "$named" | xargs grep -lE '^  pull_request:' >/dev/null 2>&1 ||
               ungated="$ungated $c"
           done
+
+          # ---- and that a conditional job is conditional on the GATE ----
+          #
+          # The three assertions above read `on:` triggers and grep for check
+          # names. None of them looks at `if:`. So the moment a job that runs
+          # claimed checks became conditional -- which is exactly what this
+          # commit does to system, box, devenv-presets and apps -- the gate
+          # kept reporting full coverage for checks that no longer run on
+          # every pull request. A coverage gate that cannot see a skip is a
+          # rubber stamp, and it would have been one silently.
+          #
+          # Rather than parse YAML in shell to work out which job owns which
+          # check, this asserts the property that actually matters and is
+          # cheap to state: EVERY condition in these two workflows must be one
+          # of a known set. The set is the shared gate, its negation, and the
+          # two deliberate exceptions. A new condition -- `github.actor ==`,
+          # a label check, a hand-written path filter -- fails here and has to
+          # be added on purpose, in a diff someone reviews, next to this
+          # reasoning.
+          #
+          # That is the safety property for the whole skip scheme: every skip
+          # in this repository is decided by one script
+          # (.github/scripts/pr-touches-build.sh), so there is one denylist to
+          # audit rather than a condition per job.
+          allowed_ifs="needs.gate.outputs.relevant == 'true'
+          needs.gate.outputs.relevant != 'true'
+          always() && needs.gate.outputs.relevant == 'true'
+          github.event_name != 'pull_request'"
+
+          rogue=""
+          # Process substitution, NOT a heredoc. The first version of this
+          # used <<'CONDS' with a $(grep ...) inside it -- quoted, so the
+          # command substitution never ran and the loop compared the literal
+          # text of its own grep against the allowlist. It "failed" on every
+          # run, describing its own source as a rogue condition. A pipe would
+          # be just as wrong in the other direction: the loop would run in a
+          # subshell and `rogue` would be empty afterwards, so it would pass
+          # no matter what it read.
+          while IFS= read -r cond; do
+            [ -n "$cond" ] || continue
+            printf '%s\n' "$allowed_ifs" | sed 's/^ *//' | grep -qxF "$cond" ||
+              rogue="$rogue|$cond"
+          done < <(grep -h "^[[:space:]]*if:" .github/workflows/build.yml \
+                     .github/workflows/install-check.yml \
+                   | sed 's/^[[:space:]]*if: //')
+
+          # A floor. If the grep stops matching -- the key is renamed, the
+          # files move -- this loop runs zero times and passes having checked
+          # nothing, which is the failure it exists to prevent.
+          conds_seen=$(grep -hc "^[[:space:]]*if:" .github/workflows/build.yml \
+            .github/workflows/install-check.yml | paste -sd+ | bc)
+          echo "conditions checked: $conds_seen"
+          if [ "$conds_seen" -lt 5 ]; then
+            echo "::error::found $conds_seen conditions in the workflows; expected at least 5." \
+                 "The skip scheme is gated by if: expressions, so failing to see them" \
+                 "means this assertion is checking nothing."
+            exit 1
+          fi
+
+          if [ -n "$rogue" ]; then
+            echo "::error::a workflow condition is not the shared gate:" \
+                 "$(printf '%s' "$rogue" | tr '|' ' ')"
+            echo "::error::every skip must be decided by .github/scripts/pr-touches-build.sh," \
+                 "so there is one denylist to audit rather than one per job."
+            exit 1
+          fi
 
           if [ -n "$bad$ungated" ]; then
             for c in $bad; do
@@ -929,12 +1044,28 @@ jobs:
   # The nixpkgs-derived ones in that set (retroarch, zen-browser) cost close to
   # nothing: they substitute from cache.nixos.org rather than build.
   apps:
+    needs: gate
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      # A step-level `if:`, never a job-level one, and the difference was
+      # measured rather than assumed: a job skipped by a job-level `if:`
+      # reports conclusion `skipped`, which is not `success`, so a required
+      # check blocks the merge exactly as a missing context does.
+      # install-check.yml records the probe. So the job always runs and
+      # completes green; its steps are what the gate turns off.
+      - name: Nothing here can affect a build
+        if: needs.gate.outputs.relevant != 'true'
+        run: |
+          echo "Only paths the gate excludes changed; not building." \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/checkout@v5
+        if: needs.gate.outputs.relevant == 'true'
       - uses: ./.github/actions/setup-nix
+        if: needs.gate.outputs.relevant == 'true'
       - uses: cachix/cachix-action@v17
+        if: needs.gate.outputs.relevant == 'true'
         # A cache upload failing must not fail a build that succeeded (#235).
         continue-on-error: true
         with:
@@ -942,6 +1073,7 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build every app the flake ships itself
+        if: needs.gate.outputs.relevant == 'true'
         env:
           # grok-bot is unfree, and a bare `nix build` refuses to evaluate it.
           # The same pair the menu-mapping job above uses, for the same
@@ -969,6 +1101,7 @@ jobs:
             "${attrs[@]/#/.#}"
 
   system:
+    needs: gate
     runs-on: ubuntu-latest
     # 45, not 30. The job's own work is ~20 minutes (see below), so 30 looked
     # like ample headroom until 2026-09-04, when a cache.nixos.org stall of
@@ -997,9 +1130,24 @@ jobs:
           github.ref == 'refs/heads/main' && github.sha || 'shared' }}
       cancel-in-progress: false
     steps:
+      # A step-level `if:`, never a job-level one, and the difference was
+      # measured rather than assumed: a job skipped by a job-level `if:`
+      # reports conclusion `skipped`, which is not `success`, so a required
+      # check blocks the merge exactly as a missing context does.
+      # install-check.yml records the probe. So the job always runs and
+      # completes green; its steps are what the gate turns off.
+      - name: Nothing here can affect a build
+        if: needs.gate.outputs.relevant != 'true'
+        run: |
+          echo "Only paths the gate excludes changed; not building." \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/checkout@v5
+        if: needs.gate.outputs.relevant == 'true'
       - uses: ./.github/actions/setup-nix
+        if: needs.gate.outputs.relevant == 'true'
       - uses: cachix/cachix-action@v17
+        if: needs.gate.outputs.relevant == 'true'
         # A cache upload failing must not fail a build that succeeded (#235).
         continue-on-error: true
         with:
@@ -1007,6 +1155,7 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Free disk space
+        if: needs.gate.outputs.relevant == 'true'
         # Hyprland plus a full desktop closure does not fit in the default
         # runner alongside the preinstalled toolchains.
         run: |
@@ -1016,15 +1165,18 @@ jobs:
 
 
       - name: Build the VM system closure
+        if: needs.gate.outputs.relevant == 'true'
         run: nix build .#checks.x86_64-linux.vm-toplevel --print-build-logs
 
       - name: Build the installed-machine closure
+        if: needs.gate.outputs.relevant == 'true'
         # The reference host: what the installer produces, with a real
         # bootloader and disko filesystems. Built here so the install path
         # cannot rot unnoticed between releases.
         run: nix build .#checks.x86_64-linux.reference-toplevel --print-build-logs
 
       - name: Read a MicroVM runner without booting it
+        if: needs.gate.outputs.relevant == 'true'
         # checks.microvm-template: what hypervisor, whether the store is
         # shared or imaged, whether the network needs root -- read off the
         # built package and qemu command line, plus nixarchy-vm's launch and
@@ -1034,6 +1186,7 @@ jobs:
         run: nix build .#checks.x86_64-linux.microvm-template --print-build-logs
 
       - name: Read a box template without pulling it online
+        if: needs.gate.outputs.relevant == 'true'
         # checks.box-template: the catalogue INI names a real, pinned image
         # (pulled as a fixed-output derivation, network allowed because the
         # hash -- not the sandbox -- makes it reproducible), and nixarchy
@@ -1041,6 +1194,7 @@ jobs:
         run: nix build .#checks.x86_64-linux.box-template --print-build-logs
 
       - name: Drive a session and the app-selection loop
+        if: needs.gate.outputs.relevant == 'true'
         # Boots a machine, picks two apps through nixarchy-app-enable, checks
         # the file still parses, and checks nixarchy-apply copies the
         # selection into the flake. Nothing else here proves that the Install
@@ -1051,11 +1205,13 @@ jobs:
       # check here was blind to -- and then nothing ran them, which is how the
       # gap they exist to close stayed open a second time.
       - name: Check every option both ways
+        if: needs.gate.outputs.relevant == 'true'
         # Cheap: evaluated, not booted. Each option here does its work by
         # putting a package in a list, so evaluation is where the answer is.
         run: nix build .#checks.x86_64-linux.options --print-build-logs
 
       - name: Build onto a config that already exists
+        if: needs.gate.outputs.relevant == 'true'
         # An overridden package, its own Hyprland, greetd already greeting.
         # Built rather than evaluated: a desktop file colliding with a real
         # package, two nixpkgs instances, and runtime dependencies in two
@@ -1063,12 +1219,14 @@ jobs:
         run: nix build .#checks.x86_64-linux.integration --print-build-logs
 
       - name: Boot the Omarchy session beside another Hyprland
+        if: needs.gate.outputs.relevant == 'true'
         # A foreign hyprland.lua in place, the session started from its own
         # .desktop, and the desktop asserted to render -- the arrangement the
         # README tells people with an existing Hyprland to use.
         run: nix build .#checks.x86_64-linux.coexist --print-build-logs
 
       - name: The installer's screens draw at every width
+        if: needs.gate.outputs.relevant == 'true'
         # checks.installer-ui was added with #133 and then run by nothing: it
         # went into `checks` and into no workflow, so the PR that introduced it
         # went green without it ever executing. A check nobody runs is worse
@@ -1076,6 +1234,7 @@ jobs:
         run: nix build .#checks.x86_64-linux.installer-ui --print-build-logs
 
       - name: The no-nix front door refuses in sentences
+        if: needs.gate.outputs.relevant == 'true'
         # installer/try-nixarchy.sh is for somebody on Ubuntu or Fedora with
         # no nix, so almost all of it is refusals -- and a refusal nobody has
         # watched fire is a refusal nobody knows works. Counterpart to
@@ -1083,6 +1242,7 @@ jobs:
         run: nix build .#checks.x86_64-linux.try-nixarchy --print-build-logs
 
       - name: The install dashboard survives a rewound clock
+        if: needs.gate.outputs.relevant == 'true'
         # The VM install checks cannot catch this: their clocks are stable, so
         # every duration they compute is positive. On a real machine the RTC is
         # wrong, the installer asks for a timezone, NTP corrects it mid-install
@@ -1091,6 +1251,7 @@ jobs:
         run: nix build .#checks.x86_64-linux.dashboard-clock --print-build-logs
 
       - name: Answer the installer's questions
+        if: needs.gate.outputs.relevant == 'true'
         # The interactive path, which every other harness skips by passing
         # --answers: the greeter, the six questions, the two validators and the
         # summary, typed at over a serial line. --dry-run, so it costs about
@@ -1099,6 +1260,7 @@ jobs:
         run: nix build .#checks.x86_64-linux.installer-wizard --print-build-logs
 
       - name: Add third-party plugins from real repos
+        if: needs.gate.outputs.relevant == 'true'
         # `omarchy plugin add <url> --enable` for two published plugins, then
         # disable and remove. The plugin system is the one deliberately
         # imperative corner of Omarchy -- it clones into ~/.config at runtime
@@ -1114,12 +1276,28 @@ jobs:
   # job's 30-minute budget is already mostly spent, and this needs /dev/kvm
   # arranged first, which no step there does.
   box:
+    needs: gate
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      # A step-level `if:`, never a job-level one, and the difference was
+      # measured rather than assumed: a job skipped by a job-level `if:`
+      # reports conclusion `skipped`, which is not `success`, so a required
+      # check blocks the merge exactly as a missing context does.
+      # install-check.yml records the probe. So the job always runs and
+      # completes green; its steps are what the gate turns off.
+      - name: Nothing here can affect a build
+        if: needs.gate.outputs.relevant != 'true'
+        run: |
+          echo "Only paths the gate excludes changed; not building." \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/checkout@v5
+        if: needs.gate.outputs.relevant == 'true'
       - uses: ./.github/actions/setup-nix
+        if: needs.gate.outputs.relevant == 'true'
       - uses: cachix/cachix-action@v17
+        if: needs.gate.outputs.relevant == 'true'
         # A cache upload failing must not fail a build that succeeded (#235).
         continue-on-error: true
         with:
@@ -1127,6 +1305,7 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: /dev/kvm is real and writable, or fail here
+        if: needs.gate.outputs.relevant == 'true'
         # ubuntu-latest runners have /dev/kvm, but root:kvm 0660 and the nix
         # build users are not in `kvm`; the udev rule is GitHub's own
         # documented fix. Loud rather than falling back: without a usable
@@ -1148,9 +1327,11 @@ jobs:
       # KVM, so a VM test landed in a job that cannot boot one -- a bespoke
       # need, which is exactly what the claimed list is for.
       - name: A VM with a radio can associate to a network
+        if: needs.gate.outputs.relevant == 'true'
         run: nix build .#checks.x86_64-linux.wifi-hwsim --print-build-logs
 
       - name: Create a box offline, and pin what enter does without a network
+        if: needs.gate.outputs.relevant == 'true'
         # checks.box-boot: the pinned image is preloaded from the store
         # (dockerTools.pullImage is fixed-output), `nixarchy box create` runs
         # end to end as a rootless user, the recorded distrobox-init mount is

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -521,7 +521,18 @@ jobs:
           # shebangs were patched" inspects a completely different tree --
           # which is exactly how it failed. Nothing here wants an out-link;
           # the build IS the assertion.
-          nix build --keep-going --no-link --print-build-logs "${targets[@]}"
+          # Anything the cache can already vouch for is dropped first. This
+          # step is the one that still runs on a docs-only pull request --
+          # `omarchy` stays unconditional because it greps README.md for the
+          # app and command counts -- so it is where the remaining minutes of
+          # such a run are spent, on 26 checks a documentation edit cannot
+          # change. A miss degrades safely: it builds.
+          #
+          # The targets go through as they are: the script accepts the
+          # fully-qualified attr as well as a bare name, and every caller uses
+          # the qualified form so the coverage gate above can still grep the
+          # workflows for `checks.x86_64-linux.<name>`.
+          .github/scripts/build-unless-proven.sh "${targets[@]}"
 
       # Not on pull requests, and this is the file's own doctrine finally
       # applied: the schedule comment at the top says a scheduled run is what
@@ -1166,14 +1177,14 @@ jobs:
 
       - name: Build the VM system closure
         if: needs.gate.outputs.relevant == 'true'
-        run: nix build .#checks.x86_64-linux.vm-toplevel --print-build-logs
+        run: .github/scripts/build-unless-proven.sh .#checks.x86_64-linux.vm-toplevel
 
       - name: Build the installed-machine closure
         if: needs.gate.outputs.relevant == 'true'
         # The reference host: what the installer produces, with a real
         # bootloader and disko filesystems. Built here so the install path
         # cannot rot unnoticed between releases.
-        run: nix build .#checks.x86_64-linux.reference-toplevel --print-build-logs
+        run: .github/scripts/build-unless-proven.sh .#checks.x86_64-linux.reference-toplevel
 
       - name: Read a MicroVM runner without booting it
         if: needs.gate.outputs.relevant == 'true'
@@ -1183,7 +1194,7 @@ jobs:
         # locking behaviour against a stub `nix`. Also how the templates
         # reach nixarchy.cachix.org: cachix-action above pushes what this
         # job builds.
-        run: nix build .#checks.x86_64-linux.microvm-template --print-build-logs
+        run: .github/scripts/build-unless-proven.sh .#checks.x86_64-linux.microvm-template
 
       - name: Read a box template without pulling it online
         if: needs.gate.outputs.relevant == 'true'
@@ -1191,7 +1202,7 @@ jobs:
         # (pulled as a fixed-output derivation, network allowed because the
         # hash -- not the sandbox -- makes it reproducible), and nixarchy
         # box never resolves distrobox through a /nix/store path.
-        run: nix build .#checks.x86_64-linux.box-template --print-build-logs
+        run: .github/scripts/build-unless-proven.sh .#checks.x86_64-linux.box-template
 
       - name: Drive a session and the app-selection loop
         if: needs.gate.outputs.relevant == 'true'
@@ -1199,7 +1210,7 @@ jobs:
         # the file still parses, and checks nixarchy-apply copies the
         # selection into the flake. Nothing else here proves that the Install
         # menu actually installs anything.
-        run: nix build .#checks.x86_64-linux.session --print-build-logs
+        run: .github/scripts/build-unless-proven.sh .#checks.x86_64-linux.session
 
       # Both of these were written after three bugs shipped that every other
       # check here was blind to -- and then nothing ran them, which is how the
@@ -1208,7 +1219,7 @@ jobs:
         if: needs.gate.outputs.relevant == 'true'
         # Cheap: evaluated, not booted. Each option here does its work by
         # putting a package in a list, so evaluation is where the answer is.
-        run: nix build .#checks.x86_64-linux.options --print-build-logs
+        run: .github/scripts/build-unless-proven.sh .#checks.x86_64-linux.options
 
       - name: Build onto a config that already exists
         if: needs.gate.outputs.relevant == 'true'
@@ -1216,14 +1227,14 @@ jobs:
         # Built rather than evaluated: a desktop file colliding with a real
         # package, two nixpkgs instances, and runtime dependencies in two
         # profiles at once are none of them evaluation errors.
-        run: nix build .#checks.x86_64-linux.integration --print-build-logs
+        run: .github/scripts/build-unless-proven.sh .#checks.x86_64-linux.integration
 
       - name: Boot the Omarchy session beside another Hyprland
         if: needs.gate.outputs.relevant == 'true'
         # A foreign hyprland.lua in place, the session started from its own
         # .desktop, and the desktop asserted to render -- the arrangement the
         # README tells people with an existing Hyprland to use.
-        run: nix build .#checks.x86_64-linux.coexist --print-build-logs
+        run: .github/scripts/build-unless-proven.sh .#checks.x86_64-linux.coexist
 
       - name: The installer's screens draw at every width
         if: needs.gate.outputs.relevant == 'true'
@@ -1231,7 +1242,7 @@ jobs:
         # went into `checks` and into no workflow, so the PR that introduced it
         # went green without it ever executing. A check nobody runs is worse
         # than no check, because it reads like coverage.
-        run: nix build .#checks.x86_64-linux.installer-ui --print-build-logs
+        run: .github/scripts/build-unless-proven.sh .#checks.x86_64-linux.installer-ui
 
       - name: The no-nix front door refuses in sentences
         if: needs.gate.outputs.relevant == 'true'
@@ -1239,7 +1250,7 @@ jobs:
         # no nix, so almost all of it is refusals -- and a refusal nobody has
         # watched fire is a refusal nobody knows works. Counterpart to
         # try-preflight, which does this for the `nix run …#try` door.
-        run: nix build .#checks.x86_64-linux.try-nixarchy --print-build-logs
+        run: .github/scripts/build-unless-proven.sh .#checks.x86_64-linux.try-nixarchy
 
       - name: The install dashboard survives a rewound clock
         if: needs.gate.outputs.relevant == 'true'
@@ -1248,7 +1259,7 @@ jobs:
         # wrong, the installer asks for a timezone, NTP corrects it mid-install
         # and `now - UI_DASH_START` goes negative -- which fed sed a negative
         # line number and drew its usage text over the installer.
-        run: nix build .#checks.x86_64-linux.dashboard-clock --print-build-logs
+        run: .github/scripts/build-unless-proven.sh .#checks.x86_64-linux.dashboard-clock
 
       - name: Answer the installer's questions
         if: needs.gate.outputs.relevant == 'true'
@@ -1257,7 +1268,7 @@ jobs:
         # summary, typed at over a serial line. --dry-run, so it costs about
         # half a minute of test script rather than the install checks.install
         # already covers.
-        run: nix build .#checks.x86_64-linux.installer-wizard --print-build-logs
+        run: .github/scripts/build-unless-proven.sh .#checks.x86_64-linux.installer-wizard
 
       - name: Add third-party plugins from real repos
         if: needs.gate.outputs.relevant == 'true'
@@ -1266,7 +1277,7 @@ jobs:
         # imperative corner of Omarchy -- it clones into ~/.config at runtime
         # -- so what this proves is that the seed leaves that directory
         # writable and the shell's IPC is reachable.
-        run: nix build .#checks.x86_64-linux.plugin --print-build-logs
+        run: .github/scripts/build-unless-proven.sh .#checks.x86_64-linux.plugin
 
   # PROPOSED CI-GATE CHANGE (AGENTS.md 4 and 11): this job is new gate wiring,
   # merged by a human, not an agent.
@@ -1328,7 +1339,7 @@ jobs:
       # need, which is exactly what the claimed list is for.
       - name: A VM with a radio can associate to a network
         if: needs.gate.outputs.relevant == 'true'
-        run: nix build .#checks.x86_64-linux.wifi-hwsim --print-build-logs
+        run: .github/scripts/build-unless-proven.sh .#checks.x86_64-linux.wifi-hwsim
 
       - name: Create a box offline, and pin what enter does without a network
         if: needs.gate.outputs.relevant == 'true'
@@ -1339,4 +1350,4 @@ jobs:
         # `distrobox enter` fails loudly at the entrypoint -- the measured
         # answer to the epic's open first-start question, asserted as
         # observed. See tests/box-boot.nix.
-        run: nix build .#checks.x86_64-linux.box-boot --print-build-logs
+        run: .github/scripts/build-unless-proven.sh .#checks.x86_64-linux.box-boot

--- a/.github/workflows/install-check.yml
+++ b/.github/workflows/install-check.yml
@@ -94,6 +94,15 @@ jobs:
       relevant: ${{ steps.filter.outputs.relevant }}
       runner: ${{ steps.filter.outputs.runner }}
     steps:
+      # This job used to need no checkout at all -- it asked the API for the
+      # file list and decided from that. It needs one now only because the
+      # denylist is a script in the repo rather than inline YAML. Sparse and
+      # depth 1: the one file, not the history.
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
       - name: Decide whether this change can affect an install
         id: filter
         env:
@@ -104,45 +113,24 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Anything that is not a pull request is not filtered. main and
-          # workflow_dispatch always ran the real thing and still do.
-          if [ "$EVENT_NAME" != "pull_request" ]; then
-            relevant=true
-          else
-            # The API, not `git diff`: actions/checkout gives this job a single
-            # commit by default, so a diff against the base needs a deepened
-            # fetch whose depth is a guess. The PR's file list is the same
-            # answer without one, and without a checkout at all.
-            files=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/files" \
-              --paginate --jq '.[].filename')
-
-            # Order matters and this loop is where it is expressed: the
-            # re-include is tested before the exclusions, so a change to this
-            # very file is relevant even though it lives under .github/.
-            # `case` globs are not path-aware -- `*` crosses `/` -- which is
-            # what makes `docs/*` and `.github/*` cover nested files.
-            relevant=false
-            while IFS= read -r f; do
-              [ -n "$f" ] || continue
-              case "$f" in
-                .github/workflows/install-check.yml) relevant=true; break ;;
-                # Provably cannot change what an install produces.
-                docs/*|README.md|AGENTS.md|CONTRIBUTING.md|.envrc|.gitignore|.github/*)
-                  continue ;;
-                *) relevant=true; break ;;
-              esac
-            done <<EOF
-          $files
-          EOF
-          fi
+          # The denylist moved to .github/scripts/pr-touches-build.sh, because
+          # build.yml now asks the same question and two copies of a filter is
+          # how one of them goes stale while both are still trusted. The
+          # reasoning that was here is there, next to the list.
+          relevant=$(.github/scripts/pr-touches-build.sh)
 
           echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
 
           # And which machine `install` should ask for. A run with nothing to
-          # do must not queue for the one self-hosted box -- seven concurrent
-          # PRs queue there for about three hours, and a docs PR waiting in
-          # that line for a check it is not going to run is the old bug wearing
-          # a different hat.
+          # do must not take a slot in the self-hosted pool -- four runners
+          # now (p510-nixarchy, p510-nixarchy-2, p620-nixarchy,
+          # p620-nixarchy-2), all carrying the same labels, so a job lands on
+          # whichever is free. This comment said "the one self-hosted box" and
+          # sized the queue for one; the fleet has since quadrupled and the
+          # number was left behind. The argument survives the correction, it
+          # is just four times less dire: a docs PR occupying a KVM runner for
+          # a check it is not going to run still delays every PR that needs
+          # one.
           if [ "$relevant" = true ]; then
             echo 'runner=["self-hosted","nixos","kvm","big"]' >> "$GITHUB_OUTPUT"
           else
@@ -236,6 +224,41 @@ jobs:
             .#checks.x86_64-linux.install \
             .#checks.x86_64-linux.free-space \
             .#checks.x86_64-linux.installer-refusal
+
+      # The proof that this passed, made durable and queryable.
+      #
+      # These outputs are `vm-test-run-*` store paths: 4 KB of logs each, not
+      # images. Until now they existed only in this runner's local store,
+      # which means (a) a garbage collection erases the evidence that a given
+      # derivation ever passed, and (b) nothing anywhere else can ask. A
+      # hosted job cannot cheaply find out whether this exact check has
+      # already been proven, so it cannot decide to skip it.
+      #
+      # With them in the cache, `nix path-info --store https://nixarchy...`
+      # answers that in one HTTP metadata round-trip, no download. That is a
+      # stronger signal than comparing derivation hashes between two commits:
+      # an unchanged hash only says "the inputs are identical", which on a red
+      # main would skip a still-failing check forever. A cached OUTPUT says
+      # the thing actually built and passed.
+      #
+      # cachix push rather than the action, because the action wraps the whole
+      # job in a post-step and this job's other work must not be tied to it.
+      # continue-on-error for #235's reason: a cache upload failing must not
+      # fail a build that succeeded.
+      - name: Push the proof, so nobody has to prove it twice
+        if: needs.gate.outputs.relevant == 'true'
+        continue-on-error: true
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: |
+          [ -n "$CACHIX_AUTH_TOKEN" ] || { echo "no cachix token; skipping"; exit 0; }
+          for c in install free-space installer-refusal; do
+            out=$(nix eval --raw ".#checks.x86_64-linux.$c" 2>/dev/null) || continue
+            [ -e "$out" ] || continue
+            echo "pushing $c ($(du -sh "$out" | cut -f1))"
+            nix run --inputs-from . nixpkgs#cachix -- \
+              push nixarchy "$out" || echo "push of $c failed; not fatal"
+          done
 
       - name: Report what it cost
         if: always() && needs.gate.outputs.relevant == 'true'


### PR DESCRIPTION

Measured first, because the obvious target was the wrong one. The jobs run in
parallel, so a pull request costs the LONGEST of them, not the sum:

  install          19-24m      system      17m
  omarchy           7m         box          5m
  apps              2m         devenv       1m
  lint / gate      <1m

So skipping lint saves nothing, and the entire prize is `install` and
`system`. `install` was already gated -- install-check.yml has done this since
#183. `system`, `box`, `devenv-presets` and `apps` were not, which is why a
README-only pull request still spent seventeen minutes building a NixOS system
closure that documentation cannot change.

## One denylist, in one file

.github/scripts/pr-touches-build.sh, called by both workflows. The list itself
is unchanged; what changes is that there is one copy. Two copies of a filter
is how one of them goes stale while both are still trusted -- the reason
.github/actions/setup-nix exists.

It stays a DENYLIST. install-check.yml's header has the argument and it is
worth repeating: #123 changed hosts/<name>/ layout, which changed module
ORDER, which changed the system path hash, and the installer then tried to
build 517 derivations offline -- with no file anyone would have listed as
"installer" touched. Nix closures are computed by evaluation, not by
directory, so an allowlist silently stops covering the next directory somebody
adds. A denylist can only be wrong about the few paths it names.

Two entries earn their place by being counter-intuitive:

README.md is NOT excluded. build.yml derives the app and command counts from
data/ and greps README.md for them; that guard fired on #424 this morning.
Excluding README would leave it running only when something else changed too.

An EMPTY file list now returns true. It used to fall through to false, which
skips every build -- so a paginated API call that returned nothing, or a
renamed field, would have been read as "nothing to do". Unknown now means run
everything: the cost of being wrong that way is a wasted job, and the other
way it is a merged regression nothing looked at.

## The proof, made durable and queryable

The install checks produce `vm-test-run-*` store paths -- 4 KB of logs each --
and they lived only in the self-hosted runner's local store. A garbage
collection erased the evidence that a derivation had ever passed, and nothing
elsewhere could ask. install-check.yml now pushes those three paths to cachix,
which makes `nix path-info --store https://nixarchy.cachix.org <out>` a
one-round-trip answer to "has this exact check already passed?".

That is deliberately a stronger signal than comparing derivation hashes
between commits. An unchanged hash only says the inputs are identical, which
on a red main would skip a still-failing check forever. A cached output says
the thing built and passed.

## The gate could not see a skip, and would have rubber-stamped this

The coverage gate greps workflow YAML for check names and reads `on:`
triggers. It never looked at `if:`. So the moment `system` became conditional
it would have kept reporting full coverage for checks that no longer run on
every pull request -- silently, which is the only way that matters.

Rather than parse YAML in shell to learn which job owns which check, it now
asserts the property that actually matters: every condition in these two
workflows must be one of a known set -- the shared gate, its negation, and two
deliberate exceptions. A new condition fails the gate and has to be added on
purpose, in a diff someone reviews. One denylist to audit rather than one per
job.

Proven red twice: a hand-written `github.actor` condition (rogue), and the
grep failing to match (the floor -- "0 conditions checked" is a broken
assertion, not a passing one).

## Two mistakes worth recording

The first version of that assertion used a QUOTED heredoc with a $(grep ...)
inside it, so the substitution never ran and the loop compared the literal
text of its own grep against the allowlist. It reported its own source code as
a rogue condition and would have failed every pull request. A pipe would have
been wrong in the other direction -- the loop runs in a subshell and `rogue`
is empty afterwards, so it passes no matter what it reads. Process
substitution is the form that is right in both directions.

And install-check.yml's gate ran with no checkout at all, by design. Calling a
script from the repository gave it a dependency it did not satisfy; it now
takes a sparse checkout of .github/scripts.

## A number that had quietly quadrupled

install-check.yml said a docs run "must not queue for the one self-hosted box
-- seven concurrent PRs queue there for about three hours". There are four
runners now (p510-nixarchy, p510-nixarchy-2, p620-nixarchy, p620-nixarchy-2),
all carrying the same labels, so a job lands on whichever is free. The
argument survives; it is four times less dire, and the comment now says so.

Effect: a docs-only pull request goes from ~24 minutes to ~7, and `omarchy`
remains unconditional so the README count guards still run.

## Verified

- the denylist dry-run: docs-only -> false, a module -> true, README-only ->
  true, empty -> true
- the new condition assertion proven red twice (rogue condition; the floor)
  and green, by extracting the step's own `run:` block and executing it
- the FULL coverage gate run verbatim: "conditions checked: 41", "26 checks
  are generated, 23 are claimed elsewhere", RC=0
- `actionlint` (with the repo's own `-ignore`) on both workflows

# Second commit: The second half of the same idea, and the half that helps a change which is
NOT docs-only: every `nix build .#checks.x86_64-linux.<x>` in build.yml now
asks the cache first.

A nixosTest's output exists only if the test passed -- a failing driver fails
the derivation and produces nothing. So the presence of a check's output in
the binary cache is proof that this exact derivation, with these exact inputs,
built and PASSED. `nix path-info --store https://nixarchy.cachix.org <path>`
answers that in one narinfo round-trip: measured at 1.3s, no NAR download.

Downloading is not free and has already cost a day. On 2026-09-04 four runners
died at their timeout, three of them blocked on the identical obs-studio path
from a stalled cache.nixos.org, with every build already green -- the incident
the `system` job's 45-minute cap was raised for. Nothing in these jobs wants
the bytes; they assert that a check passes, not that the runner holds its
output.

Applied to all 15 named checks in `system` and `box`, and to the generated
step in `omarchy` -- the last of those being where it matters most, because
`omarchy` stays unconditional (it greps README.md for the app and command
counts), so it is where a docs-only pull request still spends its time: 26
checks a documentation edit cannot change.

## Why there is no base-commit derivation diff here

The plan named a fourth step: record {attr: drvPath} on pushes to main and
compare a pull request against it. Not built, and this is the argument rather
than an omission.

Cache presence is a strictly stronger signal than an unchanged derivation
hash. "Unchanged" says the inputs are identical; on a red main that skips a
still-failing check forever, and it says nothing about whether the check ever
passed. "In the cache" says it built. The drv-diff also does not avoid an
evaluation -- the outPath has to be evaluated either way to know what to ask
about -- so what it would save is the BASE evaluation, and nothing here
evaluates the base at all. It would be machinery for a saving already banked.

If a future case wants it -- telling a user which checks changed, rather than
deciding what to run -- it can be added then, against a stated need.

## Measured, and the failure modes proven

  narinfo query mechanism    verified against cache.nixos.org: RC=0 on a
                             cached path, HTTP 200 on the .narinfo
  a cache with nothing       every check reported as needing a build, none
                             skipped, and the build actually runs
  a name that is not a check reported and handed to the build, where the
                             error belongs with its stack trace

Also observed while testing, and not addressed here: `aether` and
`omarchy-runtime` are in the cache (narinfo 200) but `.#omarchy` is a 404.
The apps job from #424 is demonstrably working; why the most central artefact
in the repo is absent is a separate question, and the gate degrades safely
either way -- a miss builds.

## Two regressions this nearly shipped

`--keep-going` was dropped when the command moved into a script. The step it
replaced had it deliberately -- report every failure in one run rather than
stopping at the first, which is what a job matrix would have been bought for.
Restored, and the reason is now next to the flag.

And the coverage gate caught the other one, which is the best thing in this
commit. It greps the workflows for `checks.x86_64-linux.<name>` to prove every
check is run by something. Replacing `nix build .#checks.x86_64-linux.x` with
a script call taking a bare name deleted the text it greps for, and the gate
immediately reported four checks as running nowhere. It was right. So the
workflow keeps the greppable form and the script strips the prefix -- which
also removed a sed from the generated step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
