### PR TITLE
A probe for a push that cannot fail, and a reason that stopped being true

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1127,11 +1127,25 @@ jobs:
     # This cap exists to fail a hung job in half an hour rather than six
     # (411c6a4); 45 still does that, while surviving a substituter blip.
     timeout-minutes: 45
-    # Its own concurrency group, and NOT cancel-in-progress. This job builds
-    # Hyprland from source and takes ~20 minutes, so under the workflow-level
-    # cancel-in-progress it is killed by any push landing within that window
-    # -- which meant the most valuable check in this workflow routinely never
-    # completed. Queue it behind the previous one instead of discarding it.
+    # Its own concurrency group, and NOT cancel-in-progress. This job takes
+    # ~19 minutes, so under the workflow-level cancel-in-progress it is killed
+    # by any push landing within that window -- which meant the most valuable
+    # check in this workflow routinely never completed. Queue it behind the
+    # previous one instead of discarding it.
+    #
+    # The reason used to read "builds Hyprland from source". It has not for a
+    # while: the Hyprland this ships is in hyprland.cachix.org and in ours,
+    # and setup-nix pulls both, so it substitutes. Measured on run
+    # 34248007661, the time is VM test runs and closure downloads --
+    #
+    #   270s  checks.session          199s  vm-toplevel
+    #   142s  checks.options          137s  plugin
+    #   106s  coexist                  71s  installer-wizard
+    #
+    # -- which changes nothing about the conclusion (still ~20 minutes, still
+    # worth queueing rather than discarding) and everything about where to
+    # look when it gets slower. A stale reason sends the next person to
+    # profile a compile that is not happening.
     #
     # Per commit on main, for the same reason the workflow-level group above
     # is: cancel-in-progress: false stops a RUNNING job being killed and does

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -264,6 +264,50 @@ jobs:
             exit 1
           fi
 
+      - name: The cache holds the proof that the installs passed
+        # The third probe, and it guards a push that CANNOT report its own
+        # failure. install-check.yml pushes the three vm-test-run outputs so
+        # that "has this exact check already passed?" is answerable from a
+        # hosted runner -- which is what lets build.yml skip a check the cache
+        # can already vouch for instead of downloading it.
+        #
+        # That push is `continue-on-error` (a cache upload must not fail a
+        # build that succeeded, #235) AND cachix exits 0 on a rejected token,
+        # which is the failure mode the omarchy probe above exists for. So a
+        # push that silently stops landing shows up as nothing at all: the
+        # gate quietly never hits, every check is rebuilt exactly as before,
+        # and CI just gets slower with no red anywhere. Probe it, or the
+        # optimisation decays invisibly.
+        #
+        # These are ~4 KB of logs each, not images.
+        run: |
+          fail=0
+          for c in install free-space installer-refusal; do
+            # An eval that fails leaves $path empty, and an empty hash makes
+            # the query below return 404 -- which would report "missing from
+            # the cache" for a check that could not be evaluated at all. Two
+            # very different problems, one message. Say which.
+            if ! path=$(nix eval --raw ".#checks.x86_64-linux.$c.outPath"); then
+              echo "::error::checks.$c does not evaluate; this probe cannot"
+              echo "say anything about the cache until that is fixed."
+              exit 1
+            fi
+            hash=$(basename "$path" | cut -d- -f1)
+            code=$(curl -s -o /dev/null -w '%{http_code}' \
+              "https://nixarchy.cachix.org/$hash.narinfo")
+            echo "$c: $path -> HTTP $code"
+            [ "$code" = 200 ] || fail=1
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::an install proof is missing from nixarchy.cachix.org."
+            echo "install-check.yml's push step is what puts them there, and it"
+            echo "cannot fail loudly by design. Nothing is broken for users --"
+            echo "the effect is that build.yml rebuilds checks it could have"
+            echo "skipped. Check install-check.yml's last run on main, then the"
+            echo "CACHIX_AUTH_TOKEN, in that order."
+            exit 1
+          fi
+
   # Tomorrow's user. build.yml's weekly cron re-runs the checks against the
   # COMMITTED lock, so on the flake inputs it proves nothing a merged PR did
   # not already prove -- the break that reaches people arrives through their


### PR DESCRIPTION
Two small things that came out of asking "is everything actually pushed to our cachix?"

The answer was mostly yes, and the interesting part was what the question
turned up on the way.

## A probe for a push that cannot fail

install-check.yml (from #427) pushes three vm-test-run outputs so that "has
this exact check already passed?" is answerable from a hosted runner -- which
is what lets build.yml skip a check the cache can already vouch for instead of
downloading it.

Two things conspire to make that push silent if it ever stops working: it is
`continue-on-error`, because a cache upload must not fail a build that
succeeded (#235), and cachix exits 0 on a rejected token -- the exact failure
mode the `omarchy` probe already sitting in this job exists for.

So a push that quietly stops landing shows up as nothing at all. The gate
never hits, every check is rebuilt exactly as before, and CI just gets slower
with no red anywhere. An optimisation that decays invisibly is worse than no
optimisation, because the next person reads the code and believes it.

Third probe in the same job, same shape as the two above it. It also tells an
eval failure apart from a cache miss, because an empty path makes the query
return 404 and "checks.install does not evaluate" would otherwise be reported
as "the cache is missing it" -- two very different problems, one message.

## A reason that stopped being true

The `system` job's concurrency comment justified itself with "this job builds
Hyprland from source and takes ~20 minutes". It does not. The Hyprland this
ships is in hyprland.cachix.org AND in ours, and setup-nix pulls both, so it
substitutes.

The conclusion is unchanged -- still about twenty minutes, still worth queueing
rather than discarding -- but the reason now says where the time actually
goes, measured from run 34248007661:

    270s  checks.session          199s  vm-toplevel
    142s  checks.options          137s  plugin
    106s  coexist                  71s  installer-wizard

VM runs and closure downloads, not compilation. A stale reason is worse than
none here: it sends the next person to profile a compile that is not
happening. I nearly reasoned from it myself.

## What was deliberately NOT done

Pushing the nightly's own check results. They have no consumer: the
nightly-only checks never run on a pull request, and the next nightly
evaluates a different revision, so nothing would ever hit those paths. The ISO
images that job also builds are gigabytes, and pushing them to a size-limited
cache risks evicting the paths that are currently earning their keep -- which
would make CI slower, not faster.

## Verified

- the probe's own `run:` block extracted and executed: it evaluates the three
  real store paths and reports 404, which is the correct answer today because
  the push that fills them is only just merged
- `actionlint` with the repo's own `-ignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
