### PR TITLE
Every nixarchy desktop ships with the guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | **Remote desktop** | `programs.nixarchy.services.hypr-rdp` serves the running Hyprland session to any RDP client, from an encrypted password, with the firewall closed — [the page](docs/manual/remote-desktop.md). Off by default |
 | **Sandboxes** | `nixarchy vm run` boots a disposable NixOS MicroVM sharing the host's `/nix/store`, no root and no rebuild — [the page](docs/manual/sandboxes.md). Off by default |
 | Branded boot splash | the wordmark animates in with [ttfx](https://github.com/omacom/ttfx), over a progress bar that is on for every boot |
+| **The guide** | [nixi](https://github.com/olafkfreund/nixi-nixarchy) — a hands-on tour, an offline manual search and a tutor grounded in your machine, offered in the bar — [the page](docs/manual/getting-started.md#the-guide). **On by default**; `services.nixi.enable = false` removes it entirely |
 | **Agent skills** | `nixarchy`, `nixos` and `diagnose-crash` — rewritten for NixOS, not Omarchy's Arch originals |
 | **LocalSend** | the firewall opens 53317 as upstream's `firewall.sh` does — Share ▸ Receive is reachable, not merely listening |
 | Disk Usage, screensaver | `dua` and `ttfx` are runtime dependencies, so the launcher row and `SUPER + Esc` do something |

--- a/docs/manual/getting-started.md
+++ b/docs/manual/getting-started.md
@@ -182,6 +182,34 @@ shows what selecting it *writes*. `tailscale.enable = true;` is a line you could
 have typed yourself, and the menu is only saving you the trip to
 search.nixos.org.
 
+## The guide
+
+Every nixarchy desktop ships with **[nixi](https://github.com/olafkfreund/nixi-nixarchy)**:
+a live hands-on tour, a manual search that works with the network off, and a
+tutor that answers about *your* machine rather than about Linux in general. It
+is what a first hour on an unfamiliar desktop should have.
+
+It is **on by default**, which for a bar widget means one specific thing:
+nixarchy installs it into `~/.config/omarchy/plugins/`, so the snowflake is
+*offered* under **Setup ▸ Plugins**. Installing a plugin is not enabling one —
+that choice lives in `shell.json` and is yours, exactly as it is for any plugin
+you add yourself. Turn it on once and it stays on.
+
+The server it talks to listens on `127.0.0.1:8642` and nothing else. The one
+part that touches the network is a weekly refresh of its copy of the nixarchy
+and Omarchy manuals, from those two repositories.
+
+If you would rather not have it, one line in your Home Manager configuration
+takes all of it away — the widget, the server, the timer and the package:
+
+```nix
+services.nixi.enable = false;
+```
+
+That is nixi's own option, not a nixarchy alias, so everything else it
+documents (`services.nixi.watcher.enable`, `services.nixi.port`, and the rest)
+works the same way here.
+
 ## Or: add it to NixOS you already run
 
 If the machine already runs NixOS, you do not want the ISO. The rest of this

--- a/flake.lock
+++ b/flake.lock
@@ -489,6 +489,27 @@
         "type": "github"
       }
     },
+    "nixi": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788522028,
+        "narHash": "sha256-GPa6Rm/xZIOdCc4sTHM2t8NYgEGtitoTC2K+pBM7IUQ=",
+        "owner": "olafkfreund",
+        "repo": "nixi-nixarchy",
+        "rev": "a141b1689fb69f9f7462ba5cbbe1945abfa0901a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "olafkfreund",
+        "repo": "nixi-nixarchy",
+        "rev": "a141b1689fb69f9f7462ba5cbbe1945abfa0901a",
+        "type": "github"
+      }
+    },
     "nixos-hardware": {
       "inputs": {
         "nixpkgs": [
@@ -588,6 +609,7 @@
         "hyprland": "hyprland",
         "microvm": "microvm",
         "nix-flatpak": "nix-flatpak",
+        "nixi": "nixi",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_2",
         "omarchy": "omarchy",

--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,30 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # The guide that should come with nixarchy: a live hands-on tour, an
+    # offline-first manual search, and an AI tutor grounded in the machine it
+    # runs on. An input rather than a vendored copy, even though both
+    # repositories have the same maintainer: nixi has its own release cadence,
+    # its own two checks and its own Home Manager module, and copying the tree
+    # in would mean maintaining that module twice and re-deriving the package
+    # on every bump. zen-browser and hypr-rdp are already here on that argument.
+    #
+    # `follows` is right here and wrong for hyprland above. Nixi is stdlib
+    # Python plus one QML file: `dontBuild = true`, and the derivation only
+    # places files and pins two interpreters. So overriding its nixpkgs
+    # rebuilds nothing and forfeits no binary cache -- it publishes none -- and
+    # what following buys is one node in every user's lock instead of two, and
+    # one python3 in the closure rather than a second.
+    #
+    # Pinned to a COMMIT because nixi publishes no tags at all. Checked, not
+    # assumed: `git ls-remote --tags` comes back empty and main is the release
+    # channel, which is the same situation sops-nix above is in. Bump it
+    # deliberately; never track a branch.
+    nixi = {
+      url = "github:olafkfreund/nixi-nixarchy/a141b1689fb69f9f7462ba5cbbe1945abfa0901a";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # Why: docs/internals/flake.md#221-222
     microvm = {
       url = "github:microvm-nix/microvm.nix/fdfc1821a0eb76e44a13d206b72e6ca6961fbb7c";
@@ -520,6 +544,26 @@
           # modules/apps.nix's callPackage, so checks.microvm-template can
           # build and read the exact command `nixarchy vm` execs -- same
           # reasoning as `verify` and `doctor` just below.
+          # Re-exported so `nix build .#nixi` works from this flake and CI has
+          # something to name, built against OUR nixpkgs through the `follows`
+          # on the input.
+          #
+          # Deliberately NOT in the overlay, which is where hypr-rdp and
+          # zen-browser went. The overlay exists to let a module say
+          # `pkgs.<name>` and never mention an input, and nothing here needs
+          # that: nixi's own Home Manager module already defaults
+          # `services.nixi.package` to its flake's package, and because that
+          # flake follows this nixpkgs it is the same derivation this line
+          # names. An overlay attribute would be a second way to spell one
+          # package and a second thing to keep in step.
+          #
+          # Not in data/apps.nix either. That catalogue is for things that are
+          # a package: install it and it is there. Nixi is a package plus a user
+          # unit plus config files plus a bar plugin, and installing the package
+          # alone gives a server nothing starts. It reaches users through
+          # modules/home.nix instead.
+          nixi = inputs.nixi.packages.${system}.nixi;
+
           nixarchy-vm = pkgsFor.${system}.callPackage ./pkgs/microvm.nix { inherit self; };
 
           # Exposed at top level for the same reason as nixarchy-vm just
@@ -1088,6 +1132,20 @@
 
           # Drives a real session and reports what it logged. See tests/session.nix
           # for why neither a serial console nor the smoke-test VM can do this.
+
+          # Nixi's own package build, which runs its installCheckPhase --
+          # py_compile on every program, `bash -n` on the launcher, and the
+          # assertions that its assets are present.
+          #
+          # Here rather than left to nixi's CI because modules/home.nix now
+          # names it: AGENTS.md's rule is that anything this repo ships which
+          # names something else needs something saying that something exists.
+          # The input is pinned to a commit, so this only runs when the pin
+          # moves -- and a pin that moves to a broken nixi would otherwise be
+          # discovered by whoever rebuilt first with services.nixi.enable on.
+          # Cheap: nothing compiles, the derivation places files.
+          nixi = self.packages.${system}.nixi;
+
           session = import ./tests/session.nix {
             inherit inputs;
             pkgs = pkgsFor.${system};

--- a/modules/home.nix
+++ b/modules/home.nix
@@ -188,6 +188,30 @@ let
   ) cfg.plugins;
 in
 {
+  # Nixi: the guide that should come with nixarchy -- a live hands-on tour,
+  # an offline-first manual search, and an AI tutor grounded in this machine.
+  #
+  # Imported unconditionally, and TURNED ON for every nixarchy desktop below.
+  # Upstream's whole config is `lib.mkIf cfg.enable`, so `false` really does
+  # leave nothing behind -- no unit, no timer, no plugin folder, no package,
+  # and therefore nothing listening on 8642. That is the half tests/options.nix
+  # spends most of its nixi cases on, because with a default of `true` it is
+  # the half nobody exercises on purpose.
+  #
+  # No option of nixarchy's own wrapping it, which is data/services.nix's
+  # "plain" rule applied one directory over: `services.nixi.enable = false`
+  # is one line, it is the line nixi's own documentation shows, and a
+  # `programs.nixarchy.services.nixi` alias would be a second name for one
+  # switch plus RFC 42's staleness problem. What a default-on bundle owes the
+  # user is not a second option but a findable answer, so the README feature
+  # table and docs/manual/getting-started.md both say it is on and both show
+  # the line that turns it off.
+  #
+  # It is also why no row was added to data/services.nix. That catalogue
+  # generates ~/.config/nixarchy/services.nix, which is a NixOS file; nixi is
+  # a home-manager module and there is no NixOS option for a row to write.
+  imports = [ inputs.nixi.homeModules.default ];
+
   options.programs.nixarchy = {
     enable = lib.mkEnableOption "the Omarchy user session";
 
@@ -285,6 +309,56 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # THE ONE LINE. The guide ships on, and this is where that is decided:
+    # `false` here takes it off every nixarchy desktop, and mkDefault means a
+    # user's own `services.nixi.enable = false` outranks us without needing
+    # mkForce -- which is the whole reason a default-on bundle is allowed to
+    # be a default at all.
+    #
+    # On rather than off is a change to machines that already exist: a desktop
+    # that rebuilds after this gains a guide it did not ask for. That is the
+    # maintainer's call, taken deliberately -- a guide nobody has to discover
+    # is the difference between a beginner's desktop and a desktop for people
+    # who already know. What it owes in return is that the answer be findable
+    # without reading this file, so the README feature table and
+    # docs/manual/getting-started.md both name it and both show the one line
+    # above.
+    services.nixi.enable = lib.mkDefault true;
+
+    # And the two defaults nixarchy deliberately does NOT change.
+    #
+    # `barWidget.enable` is true upstream, and stays true here -- which with
+    # the default above means every desktop gets the snowflake. It reads like
+    # "nixarchy silently puts a button on your bar", and on Arch it would be
+    # -- but not on this desktop. All it does is drop a plugin folder into
+    # ~/.config/omarchy/plugins/, and an installed plugin is not an enabled
+    # one: enablement lives in shell.json, which the running shell owns and
+    # nothing here writes. That is the same guarantee programs.nixarchy.plugins
+    # above makes, and tests/plugin.nix asserts it against a real session --
+    # a declaratively installed plugin comes up listed and NOT enabled, to be
+    # turned on once from Setup > Plugins. So the honest description of the
+    # default is "the guide is installed and offered", not "a button appeared".
+    # Re-defaulting it to false would not save anyone a button; it would hide
+    # the widget from the plugin picker and leave a server on 8642 with no way
+    # to reach it.
+    #
+    # `menuEntry.enable` is false upstream and stays false, and #220 does not
+    # change that. Nixi declines the Omarchy menu extension because owning it
+    # means owning the whole file -- and #220 is nixarchy getting OUT of that
+    # file for exactly the same reason, so that upstream's merge and
+    # third-party plugins can have it (shell/plugins/README.md tells plugins to
+    # write it). Handing it straight to a different Nix-managed writer would
+    # spend the freedom the moment it arrived. Today it is worse than
+    # unnecessary: nixarchy's own activation still relinks that path, so
+    # turning nixi's menu entry on before #220 lands does nothing at all, in
+    # silence. Nixi does not need the row either way -- the bar widget is its
+    # front door.
+    #
+    # The default above sharpens this rather than softening it: nixi is now on
+    # everywhere, so a future nixi that starts managing menu rows would be
+    # managing them on every nixarchy machine. Whoever bumps the pin should
+    # re-read this comment, and tests/options.nix fails if that default moves.
+
     # Why: modules/AGENTS.md#omarchys-desktop-is-its-hyprland-config
     warnings =
       let

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -57,6 +57,55 @@ let
       ];
     }).config;
 
+  # The home side, which nothing here had needed before. Every case above this
+  # point is a NixOS option, and modules/home.nix is a separate module tree
+  # that the NixOS one does not evaluate -- so nixi, whose module is a Home
+  # Manager module, is answerable only here.
+  #
+  # A standalone home-manager configuration rather than one nested in a NixOS
+  # machine, because it is the cheaper of the two and it is also the harsher:
+  # `osConfig` is null, which is the shape a nixarchy home module has to keep
+  # working in anyway.
+  homeWith =
+    settings:
+    (inputs.home-manager.lib.homeManagerConfiguration {
+      inherit pkgs;
+      modules = [
+        inputs.self.homeManagerModules.nixarchy
+        {
+          home = {
+            username = "someone";
+            homeDirectory = "/home/someone";
+            stateVersion = "25.05";
+          };
+          programs.nixarchy.enable = true;
+        }
+        settings
+      ];
+    }).config;
+
+  # nixi's bar plugin, by the id in its own manifest.json. Named once: the
+  # "on" and "off" halves have to ask about the same path or the pair proves
+  # nothing.
+  nixiPluginFile = "omarchy/plugins/io.github.olafkfreund.nixi/manifest.json";
+
+  # The machine that said no. A plain definition, so it beats the mkDefault in
+  # modules/home.nix without mkForce -- which is itself part of what is being
+  # asserted: an ordinary user writing an ordinary `false` must win.
+  nixiOff = homeWith { services.nixi.enable = false; };
+
+  # Everything the guide leaves in a home. The unit that binds the port, the
+  # weekly manual timer, the read-only assets, the bar plugin, and the package
+  # itself -- five different mechanisms, so a gate that came loose on any one
+  # of them shows up rather than hiding behind the other four.
+  nixiTracesIn = cfg: [
+    (cfg.systemd.user.services ? nixi)
+    (cfg.systemd.user.timers ? nixi-manual)
+    (cfg.xdg.configFile ? "nixi/ui.html")
+    (cfg.xdg.configFile ? ${nixiPluginFile})
+    (builtins.any (p: (p.pname or "") == "nixi") cfg.home.packages)
+  ];
+
   sessionNames =
     cfg: map (p: p.passthru.providedSessions or [ ]) cfg.services.displayManager.sessionPackages;
 
@@ -64,6 +113,67 @@ let
 
   # Each case is (what it should look like on, what it should look like off).
   cases = {
+    # ---- nixi, on for everyone, and provably gone when told ----
+    #
+    # These are the reverse of every other case in this file, and the header's
+    # argument still picks the same half. Elsewhere the default is on and the
+    # untested half is "off"; here the default is on TOO -- modules/home.nix
+    # sets `services.nixi.enable = lib.mkDefault true` -- so `off` is a state
+    # a user has to ask for by hand, and therefore the state nothing else
+    # exercises. It is also the state that has to be complete: a machine that
+    # says no to the guide must have no unit, no timer, no plugin folder, no
+    # assets and no package, and hence nothing listening on 8642.
+    #
+    # `homeWith { }` is the default machine and `nixiOff` is the refusal, so
+    # every pair below reads "the default has it / saying no removes it".
+    nixiUnit = {
+      on = (homeWith { }).systemd.user.services ? nixi;
+      off = nixiOff.systemd.user.services ? nixi;
+    };
+
+    # Everything the guide leaves in a home, in one case, because "off" has to
+    # be all of them and a per-trace case would let one survivor hide behind
+    # four passes. The port is not probed directly: it exists only as
+    # NIXI_PORT in the unit's Environment and as the server the unit starts,
+    # so no unit is no listener.
+    nixiTraces = {
+      on = builtins.all (t: t) (nixiTracesIn (homeWith { }));
+      off = builtins.any (t: t) (nixiTracesIn nixiOff);
+    };
+
+    # The bar plugin on its own, which nixarchy deliberately leaves at nixi's
+    # own default of on -- so on a default machine the snowflake is offered in
+    # Setup > Plugins. Separate from the traces above so that a nixarchy that
+    # re-defaults barWidget fails HERE, with the name of the decision on it,
+    # rather than inside a five-way conjunction.
+    nixiBarWidget = {
+      on = (homeWith { }).xdg.configFile ? ${nixiPluginFile};
+      off = nixiOff.xdg.configFile ? ${nixiPluginFile};
+    };
+
+    # And the menu extension, which nixarchy deliberately leaves at nixi's
+    # own default of OFF. Inverted on purpose: "on" is the default machine
+    # with that file untouched, "off" is what it takes to make Nix own
+    # ~/.config/omarchy/extensions/omarchy-menu.jsonc -- the file #210 and
+    # #220 are about handing back to the user and to third-party plugins.
+    #
+    # This is the most load-bearing case of the four now that the guide ships
+    # enabled: a nixi that started managing menu rows would be managing them
+    # on every nixarchy machine, and it would arrive through a pin bump with
+    # nothing else to notice it.
+    nixiLeavesMenuAlone = {
+      on = !((homeWith { }).xdg.configFile ? "omarchy/extensions/omarchy-menu.jsonc");
+      off =
+        !(
+          (homeWith {
+            services.nixi = {
+              enable = true;
+              menuEntry.enable = true;
+            };
+          }).xdg.configFile ? "omarchy/extensions/omarchy-menu.jsonc"
+        );
+    };
+
     session = {
       on = hasOmarchySession (configWith {
         session = true;

--- a/tests/plugin.nix
+++ b/tests/plugin.nix
@@ -116,6 +116,25 @@ pkgs.testers.runNixOSTest {
         programs.nixarchy.enable = true;
         home.stateVersion = "25.05";
 
+        # Nixi off, and this is the one machine in the repo where that is
+        # right. Nixi ships enabled on every nixarchy desktop and it IS a bar
+        # widget, so it installs a plugin folder -- which makes "no plugins
+        # installed" unreachable, and the negative half of this file's guard
+        # is exactly that state: after `plugin remove` takes the test's own
+        # plugins away, the Remove Plugin row must hide itself again.
+        #
+        # Turning it off here is not hiding the interaction, it is naming the
+        # precondition. This file tests the plugin SYSTEM, and an empty
+        # plugin directory is a state it has to be able to reach; a machine
+        # that always has one plugin cannot tell "the row hides when empty"
+        # from "the row never hides".
+        #
+        # It found this itself: the assertion below failed the moment nixi
+        # was defaulted on, which is the guard working rather than a
+        # regression. tests/options.nix covers the other direction -- that
+        # nixi installed leaves the row visible.
+        services.nixi.enable = false;
+
         # The declarative half. Same plugin the imperative flow adds below,
         # so the two paths can be compared directly -- except this one is
         # never cloned, never touched by `plugin add`, and is a read-only


### PR DESCRIPTION

Nixi is the guide that should come with this desktop: a live hands-on tour, a
manual search that works with the network off, and a tutor grounded in the
machine it is running on. It arrives as a flake input rather than a vendored
copy -- it has its own release cadence, its own checks and its own Home
Manager module, and copying the tree in would mean maintaining that module
twice. zen-browser and hypr-rdp are already here on that argument.

The input follows nixpkgs, which is the opposite of the call flake.nix makes
for hyprland and the same one it makes for disko and hypr-rdp. Nixi is stdlib
Python plus one QML file -- `dontBuild = true`, and the derivation only places
files and pins two interpreters -- so overriding its nixpkgs rebuilds nothing
and forfeits no binary cache, because it publishes none. What following buys
is one node in a user's lock instead of two. Pinned to a commit because nixi
publishes no tags at all.

## Which of the three faces it has, and why all of them

Nixi is a package, a Home Manager module, AND an omarchy bar-widget plugin
(manifest.json declares `kinds: ["bar-widget"]` with a BarWidget.qml entry
point). Shipping only the package would put binaries on PATH and no snowflake
in the bar; shipping only the plugin would give a widget calling binaries that
are not there. Importing the module is what wires both, so that is what this
does -- `imports = [ inputs.nixi.homeModules.default ]` with
`services.nixi.enable = lib.mkDefault true`.

No nixarchy option wraps it. That is data/services.nix's "plain" rule applied
one directory over: `services.nixi.enable = false` is one line, it is the line
nixi's own documentation shows, and an alias would be a second name for one
switch. What a default-on bundle owes the user is not a second option but a
findable answer, so the README feature table and the manual both say it is on
and both show the line that turns it off.

Not in data/apps.nix either: that catalogue is for things that are a package
-- install it and it is there. Nixi is a package plus a user unit plus config
files plus a bar plugin.

## What "on by default" does and does not mean

`barWidget.enable` stays true, so every desktop gets the snowflake -- but an
installed plugin is not an enabled one. All it does is drop a folder into
~/.config/omarchy/plugins; enablement lives in shell.json, which the running
shell owns and nothing here writes. tests/plugin.nix already asserts that
against a real session. So the honest description is "the guide is installed
and offered", not "a button appeared".

## Rebased rather than replayed

This work was written on 2026-09-03 and never pushed. Five days of main moved
under it, and a straight cherry-pick conflicted in four files -- mostly
because main reformatted the blocks it touches, not because anything
disagreed. Replaying it textually risked a merge that looked right, so each
conflicted file was taken from main and the nixi additions re-applied
deliberately, with the pin bumped from 335bc79 to a141b16 (nixi 0.9.7).

One thing the original needed and this does not: a hand-written build.yml step
naming checks.nixi. The coverage inversion that landed since picks a new check
up on its own -- the gate reports 29 generated where it reported 26, with no
workflow edit, which is the second time that mechanism has paid for itself.

## Verified

- `nix build .#nixi` -> the same store path as building the upstream flake
  directly, so `follows` forked nothing
- `checks.nixi` passes (nixi's own installCheckPhase: py_compile per program,
  `bash -n` on the launcher, asset assertions)
- `checks.options` passes with four nixi cases, each proven BOTH ways --
  nixiBarWidget, nixiLeavesMenuAlone, nixiTraces, nixiUnit all `on=1 off=`
- the coverage gate discovers checks.nixi by itself: 29 generated, 23 claimed
- the README count guard still agrees: total=61 ours=9
- `nix fmt --ci`, statix, deadnix, actionlint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
