### PR TITLE
The two files the installer invents are written to the log

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1623,6 +1623,32 @@ generate_hardware_config() {
 
   reuse_baked_initrd "$hostdir/hardware-configuration.nix"
   write_hardware_modules "$hostdir/nixarchy-hardware.nix"
+
+  # Both files, into the log, before anything uses them.
+  #
+  # These two are the ONLY inputs to the installed system that this machine
+  # invents -- everything else comes from the template or the answers. So when
+  # an offline install has to build something the image should have carried,
+  # the difference is here, and there was no way to see it: the files live on
+  # the target disk, the failure happens minutes later, and what the log kept
+  # was the consequence -- a list of 681 derivations walking down to the
+  # source bootstrap, which names the toolchain and never names the cause.
+  #
+  # That is exactly how #382 was found the hard way (an Intel NPU attribute
+  # pulling a cmake package no closure carried) and how the 2026-09-07
+  # regression stayed unexplained: the evidence was written to the disk and
+  # thrown away.
+  #
+  # `>&2` so it lands in /var/log/nixarchy-install.log with everything else,
+  # which is the file the failure screen already asks people to attach. Two
+  # small files, no secrets: a module list and a set of imports.
+  {
+    echo "--- generated hardware-configuration.nix ---"
+    cat "$hostdir/hardware-configuration.nix"
+    echo "--- generated nixarchy-hardware.nix ---"
+    cat "$hostdir/nixarchy-hardware.nix"
+    echo "--- end generated hardware files ---"
+  } >&2
 }
 
 # The nixos-hardware modules this machine wants, as a file the host imports.


### PR DESCRIPTION
hardware-configuration.nix and nixarchy-hardware.nix are the only inputs to
the installed system that the machine itself decides -- everything else comes
from the template or the answers. So when an offline install has to build
something the image should have carried, the difference is in one of those two
files, and there was no way to see it: they live on the target disk, the
failure happens minutes later, and what the log kept was the consequence.

That consequence is 681 derivations walking down to the stage0 source
bootstrap. It names bash-2.05b, binutils, hex0 and the rest of the toolchain,
which is what building ANYTHING from source looks like on an image with no
compiler -- and it never names the cause. I read that list three times today
and drew two wrong conclusions from it before noticing the deps in it are
cmake's closure, not a different package set.

This is how #382 was found the hard way too, and its comment in flake.nix says
so: an Intel NPU attribute put intel-npu-driver into systemPackages, no baked
closure carried it, and building a cmake package with no compiler is the
source bootstrap "which is where two users' installs died, after the disk was
partitioned".

Both files go to the log, before anything reads them, at the moment they are
written. >&2 so they land in /var/log/nixarchy-install.log -- the file the
failure screen already asks people to attach. Two small files and no secrets:
a module list and a set of imports.

This fixes no bug. It is the evidence needed to find one, and the current
offline-install failure (#404) is blocked on exactly this.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5

## Verified

- `bash -n` and `nix build .#install`
- shellcheck: unchanged from main (one pre-existing SC2148, the file is a
  writeShellApplication body and has no shebang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5