### PR TITLE
The machine's name stops being an input to its system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1390,6 +1390,13 @@
             pkgs = pkgsFor.${system};
           };
 
+          # Two machines differing only by name must build the same parts, or
+          # an offline install has to build the difference. See #404.
+          machine-name-free = import ./tests/machine-name-free.nix {
+            inherit inputs;
+            pkgs = pkgsFor.${system};
+          };
+
           # And the same idea aimed at the menu: every action string checked
           # against the subcommands the CLI it invokes actually has. See
           # tests/menu-verbs.nix and the `nixarchy-vm new` row that shipped.

--- a/installer/host.nix
+++ b/installer/host.nix
@@ -153,7 +153,64 @@
     # configuration.nix; the VM sets a plaintext one as its own definition.
   };
 
-  networking.hostName = hostname;
+  # The machine's name, kept OUT of the derivation on purpose.
+  #
+  # Stage 1 of making an offline install build nothing. `networking.hostName`
+  # reaches further than it looks: nixos/modules/system/boot/systemd/initrd.nix
+  # line 597 writes it into the INITRD unconditionally
+  # (`"/etc/hostname".text = config.networking.hostName`), so two machines
+  # whose only difference is their name have two different initrds. A
+  # different initrd is a build, and on an image with no network a build is
+  # the stage0 source bootstrap -- which is the whole of #404.
+  #
+  # Empty is a supported value, not a trick: the option's type is
+  # `strMatching "^$|..."` and its own documentation says "Leave it empty if
+  # you want to obtain it from a DHCP server". /etc/hostname is then not
+  # written at all (network-interfaces.nix:1812 gates it on `!= ""`), which is
+  # what leaves the closure identical across machines.
+  #
+  # The name is not lost -- nixarchy-set-hostname below applies it on first
+  # boot, from a file the installer writes. What changes is WHEN: a fact about
+  # the running machine rather than an input to its derivation.
+  #
+  # system.name is pinned for the same reason and is NOT cosmetic: the
+  # toplevel derivation is named "nixos-system-''${system.name}-''${label}"
+  # (top-level.nix:60) and system.name defaults to the hostname, so leaving it
+  # would put the machine's name in the store path of every system it ever
+  # builds.
+  networking.hostName = "";
+  system.name = "nixarchy";
+
+  # The name, applied once, from what the installer collected.
+  #
+  # A file rather than a Nix value, because the point of the exercise is that
+  # this string never enters an evaluation. /etc/nixarchy/hostname is written
+  # by the installer and read here; a machine without one keeps the default,
+  # which is what an unattended or re-imaged machine should do.
+  #
+  # `ConditionPathExists` rather than a flag file: the unit is idempotent, and
+  # hostnamectl on every boot costs nothing and survives someone deleting the
+  # marker. Ordered before network-online so anything that cares about the
+  # name sees it set.
+  systemd.services.nixarchy-set-hostname = {
+    description = "Apply the hostname chosen at install time";
+    wantedBy = [ "multi-user.target" ];
+    before = [ "network-pre.target" ];
+    unitConfig.ConditionPathExists = "/etc/nixarchy/hostname";
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      name=$(tr -d '[:space:]' < /etc/nixarchy/hostname)
+      [ -n "$name" ] || exit 0
+      current=$(cat /proc/sys/kernel/hostname)
+      [ "$current" = "$name" ] && exit 0
+      echo "nixarchy: setting hostname to $name"
+      ${pkgs.systemd}/bin/hostnamectl set-hostname "$name" \
+        || echo "$name" > /proc/sys/kernel/hostname
+    '';
+  };
 
   # Snapshots, for the half of the machine generations do not cover.
   #

--- a/installer/host.nix
+++ b/installer/host.nix
@@ -10,6 +10,17 @@
 # already sets all three at mkDefault, and a second definition here would be
 # dead config that reads like a decision.
 {
+  # Still accepted, deliberately unused, and that is the point of stage 1.
+  #
+  # Every caller passes it -- the generated host, flake.nix's reference
+  # machines, tests/machine-name-free.nix -- and the interface is strict (no
+  # `...`), so dropping it would break all three for no gain. What changed is
+  # that nothing HERE may consume it: the moment this file uses the machine's
+  # name, the name is back in the derivation, and two machines that differ
+  # only by name have two different systems again. See the note on
+  # networking.hostName below.
+  #
+  # deadnix: skip
   hostname,
   username,
 }:

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1885,6 +1885,22 @@ PIN
 #
 # Root-owned and 0600. It is not a password, but a crypt hash is worth exactly
 # as much as the time somebody is willing to spend on it offline.
+# The machine's name, as a file rather than as a Nix value.
+#
+# installer/host.nix sets networking.hostName = "" on purpose -- the name in
+# an evaluation puts it in the initrd and in the toplevel's store path, so two
+# machines differing only by name have two different systems, and a system the
+# image does not carry has to be BUILT, which offline is the source bootstrap.
+# See the note there.
+#
+# So the name lands here, and nixarchy-set-hostname applies it on first boot.
+# Written before nixos-install so the very first boot already has it.
+write_hostname() {
+  mkdir -p /mnt/etc/nixarchy
+  printf '%s\n' "$hostname" >/mnt/etc/nixarchy/hostname
+  chmod 0644 /mnt/etc/nixarchy/hostname
+}
+
 write_password_hash() {
   ( umask 077
     mkdir -p /mnt/var/lib/nixarchy
@@ -2737,6 +2753,7 @@ main() {
       generate_hardware_config &&
       install_flake_dir &&
       write_password_hash &&
+      write_hostname &&
       run_install &&
       chown_flake_dir &&
       carry_network_profiles &&

--- a/tests/machine-name-free.nix
+++ b/tests/machine-name-free.nix
@@ -1,0 +1,95 @@
+{ inputs, pkgs }:
+# Two machines whose only difference is their name build the same system parts.
+#
+# This is the property the offline image lives or dies by, and until #404 it
+# was not true. `networking.hostName` reaches further than it looks:
+# nixos/modules/system/boot/systemd/initrd.nix:597 writes it into the INITRD
+# unconditionally, and top-level.nix:60 names the toplevel derivation
+# "nixos-system-${system.name}-${label}" with system.name defaulting to the
+# hostname. So a machine called `isotest` and a machine called `nixarchy`
+# had different initrds and different system store paths -- and a system the
+# image does not carry has to be BUILT, which with no network is the stage0
+# source bootstrap: 677 derivations, measured, dying on a Debian patch.
+#
+# The fix is to keep the name out of the evaluation and apply it at first
+# boot (installer/host.nix). This asserts it stayed out.
+#
+# It VARIES the thing it is about, which is the whole point: two real
+# configurations differing in exactly one input. A check that pinned the
+# hostname and asserted the pin would pass with the bug fully present --
+# AGENTS.md section 3, on the file that section was written for.
+let
+  inherit (pkgs) lib;
+  system = pkgs.stdenv.hostPlatform.system;
+
+  machine =
+    name:
+    inputs.nixpkgs.lib.nixosSystem {
+      inherit system;
+      specialArgs = { inherit inputs; };
+      modules = [
+        inputs.self.nixosModules.nixarchy
+        inputs.home-manager.nixosModules.home-manager
+        inputs.disko.nixosModules.disko
+        (import ../installer/host.nix {
+          hostname = name;
+          username = "someone";
+        })
+        (import ../installer/disk-config.nix {
+          device = "/dev/vda";
+          encrypt = false;
+        })
+        { nixpkgs.hostPlatform = system; }
+      ];
+    };
+
+  a = machine "alpha";
+  b = machine "omega-two";
+
+  # The three that decide whether an offline install has to build anything.
+  parts = {
+    initrd = c: c.config.system.build.initialRamdisk.drvPath;
+    toplevel = c: c.config.system.build.toplevel.drvPath;
+    etc = c: c.config.system.build.etc.drvPath;
+  };
+
+  compare = lib.mapAttrsToList (n: f: {
+    name = n;
+    same = f a == f b;
+    left = f a;
+    right = f b;
+  }) parts;
+
+  differing = builtins.filter (c: !c.same) compare;
+in
+pkgs.runCommand "nixarchy-machine-name-free"
+  {
+    report = lib.concatMapStringsSep "\n" (
+      c: "  ${c.name}: ${if c.same then "same" else "DIFFERS"}"
+    ) compare;
+    bad = lib.concatMapStringsSep "\n" (c: "  ${c.name}\n    ${c.left}\n    ${c.right}") differing;
+    checked = toString (builtins.length compare);
+  }
+  ''
+    echo "two machines, named alpha and omega-two:"
+    printf '%s\n' "$report"
+
+    # A floor. An empty comparison list would make the test below pass having
+    # compared nothing, which is the one wrong answer it can give.
+    test "$checked" -ge 3
+
+    if [ -n "$bad" ]; then
+      echo >&2
+      echo "these parts still carry the machine's name:" >&2
+      printf '%s\n' "$bad" >&2
+      echo >&2
+      echo "A part that differs per machine has to be BUILT by the installer." >&2
+      echo "On the offline image there is nothing to build it FROM, so nix walks" >&2
+      echo "back to the source bootstrap and the install dies. See #404, and the" >&2
+      echo "note on networking.hostName in installer/host.nix." >&2
+      exit 1
+    fi
+
+    echo "the machine's name is not an input to any of them"
+    touch $out
+  ''

--- a/tests/machine-name-free.nix
+++ b/tests/machine-name-free.nix
@@ -47,10 +47,22 @@ let
   b = machine "omega-two";
 
   # The three that decide whether an offline install has to build anything.
+  # unsafeDiscardStringContext, and it is the difference between a check that
+  # answers in seconds and one that builds two entire NixOS systems.
+  #
+  # A drvPath is a string WITH CONTEXT: using it inside another derivation
+  # tells nix "realise this first". So comparing two drvPaths the obvious way
+  # made this check depend on both machines being BUILT -- a multi-gigabyte
+  # download and the better part of an hour, to answer a question that is pure
+  # evaluation. The paths are wanted here as text, not as things to build.
+  #
+  # Safe precisely because nothing here consumes them: they are compared and
+  # printed. If this file ever needs to build one, the context must come back.
+  drv = p: builtins.unsafeDiscardStringContext p;
   parts = {
-    initrd = c: c.config.system.build.initialRamdisk.drvPath;
-    toplevel = c: c.config.system.build.toplevel.drvPath;
-    etc = c: c.config.system.build.etc.drvPath;
+    initrd = c: drv c.config.system.build.initialRamdisk.drvPath;
+    toplevel = c: drv c.config.system.build.toplevel.drvPath;
+    etc = c: drv c.config.system.build.etc.drvPath;
   };
 
   compare = lib.mapAttrsToList (n: f: {


### PR DESCRIPTION
Two machines differing only by their hostname built two different systems,
and a system the offline image does not carry has to be BUILT -- which with
no network is the stage0 source bootstrap. That is #404, measured: 677
derivations, dying on a Debian patch for libssh2.

networking.hostName reaches further than it looks. initrd.nix:597 writes it
into the INITRD unconditionally, and top-level.nix:60 names the toplevel
"nixos-system-${system.name}-${label}" with system.name defaulting to it. So
the name was in the initrd AND in the store path of every system the machine
would ever build.

It is now empty at evaluation -- a supported value, not a trick: the option's
type is `strMatching "^$|..."` and its own documentation says "Leave it empty
if you want to obtain it from a DHCP server", and /etc/hostname is then not
written at all (network-interfaces.nix:1812). system.name is pinned for the
same reason.

The name is not lost. The installer writes it to /etc/nixarchy/hostname and
nixarchy-set-hostname applies it on first boot. What changed is WHEN: a fact
about the running machine rather than an input to its derivation.

Measured, with the test's own answers (isotest / lovelace / unencrypted):
initrd, etc AND toplevel are now byte-identical to the baked reference. Only
the initrd was expected; the other two came free.

## checks.machine-name-free

Builds two machines called alpha and omega-two and asserts their initrd, etc
and toplevel derivations match. It VARIES the thing it is about -- two real
configurations differing in exactly one input -- because a check that pinned
the hostname and asserted the pin would pass with the bug fully present.

Proven red: reverting the change fails it, naming all three parts.

One thing worth stealing from this file: the comparison uses
unsafeDiscardStringContext. A drvPath is a string WITH CONTEXT, so comparing
two of them the obvious way made the check depend on both machines being
BUILT -- a multi-gigabyte download and the better part of an hour to answer a
question that is pure evaluation. Discarding the context takes it to 47
seconds. The first "proven red" run I did was actually a build timing out,
which is what that mistake looks like from the outside.

Stage 1 of three. Stage 2 is the username; stage 3 switches the installer to
`nixos-install --system`, which skips evaluation and building entirely, once
the toplevel is identical.

Related: #404.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5

## Verified

- `checks.machine-name-free` green; **proven red** by reverting the change
  (all three parts reported DIFFERS)
- `nix build .#install`
- `nix fmt -- --ci`, statix, deadnix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5