### PR TITLE
Omarchy 4.0.3, and a bump that asks instead of blocking

### DIFF
--- a/.github/scripts/check-menu-mapping.py
+++ b/.github/scripts/check-menu-mapping.py
@@ -28,6 +28,7 @@ here would turn a real break into a green light.
 Usage: check-menu-mapping.py <omarchy-menu.jsonc> <catalogue.nix>...
 """
 
+import os
 import re
 import sys
 
@@ -59,14 +60,53 @@ def main(argv):
             "this check stopped being able to read it, which is worse"
         )
 
-    missing = sorted((r, a) for r, a in wanted if a not in known)
+    # Rows this port has DECIDED not to map, with the reason.
+    #
+    # data/menu-exceptions.nix, not a list in this file, because
+    # tests/options.nix asks the same question and used to carry its own copy
+    # -- so recording a decision satisfied one gate and left the other red on
+    # the same row. One file, two readers.
+    #
+    # Parsed with a regex rather than by evaluating Nix: this script is
+    # stdlib-only and runs where nix may not, and the file is a flat attrset
+    # of string values by construction. A shape it cannot read is reported,
+    # never assumed empty -- an unreadable exceptions file that silently
+    # excepted nothing would fail every row, and one that silently excepted
+    # everything would be worse.
+    exceptions = {}
+    exc_path = os.path.join(os.path.dirname(os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__)))), "data", "menu-exceptions.nix")
+    if os.path.exists(exc_path):
+        text = open(exc_path).read()
+        for rid, reason in re.findall(
+            r'"(install\.[a-z0-9.\-]+)"\s*=\s*(.+?);\s*$', text, flags=re.M | re.S
+        ):
+            exceptions[rid] = " ".join(reason.split())
+        if not exceptions:
+            sys.exit(
+                f"{exc_path} exists and yielded no entries -- this check cannot "
+                "tell a deliberate exception from an unmapped row, so it refuses "
+                "to report either"
+            )
+
+    # An exception with no reason is not a decision.
+    blank = sorted(r for r, why in exceptions.items() if not why.strip(' "'))
+    if blank:
+        for r in blank:
+            print(f"::error::{r} is in data/menu-exceptions.nix with no reason")
+        sys.exit(f"{len(blank)} exceptions carry no reason")
+
+    missing = sorted((r, a) for r, a in wanted if a not in known and r not in exceptions)
     for rid, arch in missing:
         names = " or ".join(catalogues)
         print(f"::error::{rid} installs '{arch}', which {names} does not map")
+        print(f"::error::  map it there, or record the decision in data/menu-exceptions.nix")
     if missing:
         sys.exit(f"{len(missing)} unmapped Install rows")
 
-    print(f"all {len(wanted)} Install rows are mapped")
+    excepted = sorted(r for r, _ in wanted if r in exceptions)
+    print(f"all {len(wanted)} Install rows are mapped "
+          f"({len(excepted)} by a recorded exception)")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,6 +266,49 @@ jobs:
             fi
           done
 
+          # The other two numbers in that paragraph, which were NOT checked and
+          # both went stale.
+          #
+          # Omarchy 4.0.3 moved the command count from 431 to 444 and this
+          # check caught it. It did not catch "24 of 431 scripts actually run
+          # pacman/yay" (really 32) or "Ten of those are replaced outright"
+          # (really 6), because nothing derived them -- they were prose next to
+          # a gated number, which is the most convincing place for a wrong
+          # number to sit. Found only because updating 431 meant reading the
+          # sentence around it.
+          #
+          # Both are one grep. The whole argument of that paragraph is the SIZE
+          # of the distro-coupling surface, so a stale count there is not a
+          # typo, it is the claim being wrong.
+          pac=$(grep -rlE '\b(pacman|yay)\b' result/share/omarchy/bin | wc -l)
+          claim_pac=$(grep -oE '\*\*[0-9]+ of [0-9]+ scripts\*\*' README.md |
+            grep -oE '^\*\*[0-9]+' | grep -oE '[0-9]+')
+          echo "scripts touching pacman/yay: $pac (README says ${claim_pac:-none})"
+          if [ "${claim_pac:-}" != "$pac" ]; then
+            echo "README says $claim_pac scripts run pacman/yay; there are $pac" >&2
+            exit 1
+          fi
+
+          # Of those, the ones this port replaces outright: an exact filename
+          # match against pkgs/omarchy/nix-bin, which is what "replaced" means
+          # here -- a nix-bin file whose name is an upstream bin's name.
+          ls pkgs/omarchy/nix-bin | sort > /tmp/nixbin.txt
+          grep -rlE '\b(pacman|yay)\b' result/share/omarchy/bin |
+            xargs -n1 basename | sort > /tmp/pac.txt
+          repl=$(comm -12 /tmp/pac.txt /tmp/nixbin.txt | wc -l)
+          word=$(grep -oE '^(Six|Seven|Eight|Nine|Ten|Eleven|Twelve) of those are replaced' README.md |
+            awk '{print $1}')
+          case "$word" in
+            Six) n=6 ;; Seven) n=7 ;; Eight) n=8 ;; Nine) n=9 ;;
+            Ten) n=10 ;; Eleven) n=11 ;; Twelve) n=12 ;; *) n="" ;;
+          esac
+          echo "pacman scripts replaced in nix-bin: $repl (README says ${word:-none})"
+          if [ "${n:-}" != "$repl" ]; then
+            echo "README says $word ($n) of them are replaced; it is $repl" >&2
+            echo "The number is spelled as a word in that sentence; update both." >&2
+            exit 1
+          fi
+
       # The README quotes app counts in four places. They are derivable from
       # data/apps.nix, and they silently went stale twice -- once when an app
       # was added, once when RetroArch moved to being built here -- so derive

--- a/.github/workflows/omarchy.yml
+++ b/.github/workflows/omarchy.yml
@@ -264,6 +264,24 @@ jobs:
 
       - name: Check nothing became unmapped or unwired
         if: steps.rel.outputs.changed == 'true'
+        # continue-on-error, and this is the difference between a bump that
+        # blocks and a bump that asks.
+        #
+        # A new Omarchy release adding an Install row this port has not seen
+        # is NORMAL -- it is most of what a release does. Failing the bump on
+        # it stops the whole adoption, including the security fixes, behind a
+        # question nobody has been asked yet: v4.0.2 sat unadopted for three
+        # days behind exactly this step, over a row services.nix had already
+        # mapped.
+        #
+        # So the answer is not to weaken the check but to move WHEN it blocks.
+        # Here it reports, and the step below turns what it found into a
+        # decision list in the pull request body. On that pull request
+        # build.yml runs the same script as a normal gate, where it is fatal
+        # -- so the row still cannot reach main unmapped, it just cannot stop
+        # the bump from being proposed.
+        continue-on-error: true
+        id: mapping
         run: |
           # The same script build.yml runs on every pull request, against the
           # newest Omarchy instead of the pinned one. It was an inline copy
@@ -273,7 +291,51 @@ jobs:
           # along. A security release sat unadopted for three days behind it.
           python3 .github/scripts/check-menu-mapping.py \
             result/share/omarchy/default/omarchy/omarchy-menu.jsonc \
-            data/apps.nix data/services.nix
+            data/apps.nix data/services.nix 2>&1 | tee /tmp/mapping.txt
+
+      - name: Turn what it found into a decision list
+        if: steps.rel.outputs.changed == 'true'
+        id: decisions
+        run: |
+          # The bump PR's fifth section. Every unmapped row, what it installs,
+          # and the two ways to answer it -- so adopting a release is reading a
+          # checklist rather than rediscovering the mechanism each time.
+          {
+            echo "## Install rows that need a decision"
+            echo
+          } > /tmp/decisions.md
+
+          if grep -q "does not map" /tmp/mapping.txt 2>/dev/null; then
+            {
+              echo "This release adds rows this port has not seen. Neither"
+              echo "outcome blocks the bump; both are one line:"
+              echo
+              echo "- **it is an app** -> add it to \`data/apps.nix\` with its"
+              echo "  \`menuId\` and the nixpkgs attribute"
+              echo "- **it is not** -> record why in \`data/menu-exceptions.nix\`"
+              echo
+              echo "Check the package is the right one before mapping it:"
+              echo "nixpkgs' \`openclaw\` is an AI agent AND a platformer, and"
+              echo "\`hey\` is an HTTP load generator. See the notes in"
+              echo "data/apps.nix."
+              echo
+              grep "does not map" /tmp/mapping.txt | sed 's/::error:://; s/^/- [ ] /'
+            } >> /tmp/decisions.md
+          else
+            echo "None: every Install row in this release is mapped or has a" >> /tmp/decisions.md
+            echo "recorded exception." >> /tmp/decisions.md
+          fi
+
+          cat /tmp/decisions.md >> "$GITHUB_STEP_SUMMARY"
+
+          # Into the PR body as the fifth interpolated section, the same way
+          # the release notes, package delta, config delta and patched-files
+          # sections already travel.
+          {
+            echo "decisions<<DECISIONS_EOF"
+            cat /tmp/decisions.md
+            echo "DECISIONS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       # Booting the session builds the closure on the way, so there is no
       # separate closure step: it would double an hour-long Hyprland compile
@@ -332,8 +394,12 @@ jobs:
             - every bin this port replaces is still present
             - every `substituteInPlace` anchor still matches
             - every menu row it overrides still exists
-            - all Install rows are still mapped in `data/apps.nix`
             - **a booted session renders its wallpaper**
+
+            Install rows are NOT claimed as mapped here, deliberately: a new
+            release adding one this port has not seen is normal, and the
+            section below is where that gets decided rather than a reason the
+            bump could not be opened.
 
             ${{ steps.notes.outputs.notes }}
 
@@ -342,6 +408,8 @@ jobs:
             ${{ steps.config.outputs.config }}
 
             ${{ steps.patched.outputs.patched }}
+
+            ${{ steps.decisions.outputs.decisions }}
 
             If something is wrong anyway, roll back with
             `nixos-rebuild --rollback` or the boot menu, and open an issue.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | **`nixarchy` command** | this port's own commands, and a way through to Omarchy's 444 |
 | **Remove menu** | deselects apps, never touches your own config |
 | **Update menu** | `nh os switch --update <flake>` |
-| 61 apps in the selection | 46 from nixpkgs, 4 as NixOS modules, 9 built here, 2 with no equivalent |
+| 62 apps in the selection | 47 from nixpkgs, 4 as NixOS modules, 9 built here, 2 with no equivalent |
 | Learn menu | NixOS wiki, `search.nixos.org` packages and options |
 | Shell functions | bash and zsh source the chain; fish derives it from the same files |
 | RetroArch | 13 libretro cores, resolved from the store rather than `/usr/lib` |
@@ -1491,7 +1491,7 @@ done
 
 Almost nothing here waits on a maintainer.
 
-**50 of the 61 apps never touch this repo.** Brave, VSCode, Signal and the rest
+**51 of the 62 apps never touch this repo.** Brave, VSCode, Signal and the rest
 are installed as `pkgs.<name>` from **your** nixpkgs, and the five
 module-backed ones (Steam, 1Password, Tailscale, Firefox, Xbox controllers)
 come from there too — the module is NixOS', not this repo's. Your own
@@ -1550,7 +1550,7 @@ Most of it is not our job, and should not be:
 
 | where the app comes from | who updates it |
 |---|---|
-| nixpkgs (50 of 61 apps) | **nobody** — your own `nix flake update` |
+| nixpkgs (51 of 62 apps) | **nobody** — your own `nix flake update` |
 | pinned in this repo (2) | a nightly bot, opening a PR |
 | `zen` | upstream's own flake |
 | `retroarch` | nixpkgs, via this flake's own pin — it is a rebuild with cores |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [Omarchy](https://omarchy.org) vendored for NixOS — the whole desktop, with its
 menus rewired to Nix instead of pacman.
 
-Omarchy 4.x is not a dotfiles repo, it's an application: **431 shell commands**,
+Omarchy 4.x is not a dotfiles repo, it's an application: **444 shell commands**,
 a QuickShell desktop shell, 22 themes, and Hyprland configured through the Lua
 API introduced in 0.55. Nixarchy packages that tree as a derivation and replaces
 the parts that assume Arch, rather than reimplementing it in Nix.
@@ -60,10 +60,10 @@ More in [`docs/screenshots/`](docs/screenshots).
 | | |
 |---|---|
 | Hyprland session, QuickShell bar, 22 themes | as upstream ships them |
-| `omarchy` CLI | all 431 subcommands, `omarchy commands --check` green |
+| `omarchy` CLI | all 444 subcommands, `omarchy commands --check` green |
 | **Install menu** | picks write to a Nix config, not pacman |
 | **Install ▸ Search** | one picker over 137k rows — every nixpkgs package, every NixOS option, and the app selection |
-| **`nixarchy` command** | this port's own commands, and a way through to Omarchy's 431 |
+| **`nixarchy` command** | this port's own commands, and a way through to Omarchy's 444 |
 | **Remove menu** | deselects apps, never touches your own config |
 | **Update menu** | `nh os switch --update <flake>` |
 | 61 apps in the selection | 46 from nixpkgs, 4 as NixOS modules, 9 built here, 2 with no equivalent |
@@ -102,7 +102,7 @@ nixarchy theme set catppuccin   # → omarchy theme set catppuccin, unchanged
 Anything `nixarchy` does not own it `exec`s through to `omarchy`, so both names
 work and the exit status, terminal and signals stay the command's own.
 
-**Upstream's 431 commands keep upstream's name, deliberately.** `omarchy theme
+**Upstream's 444 commands keep upstream's name, deliberately.** `omarchy theme
 set` is the same script here as on Arch — a bug in it is a bug to report there,
 and renaming it would say otherwise. It would also cost the property this repo
 is built on: tracking a release is a source bump because nixarchy replaces 19
@@ -128,10 +128,10 @@ package.path = home.."/.local/state/?.lua;"..home.."/.config/?.lua;"
 ```
 
 Point `OMARCHY_PATH` at a store path and the bins, the QML shell, the themes and
-the Lua defaults all follow. Only **24 of 431 scripts** actually run
+the Lua defaults all follow. Only **32 of 444 scripts** actually run
 `pacman`/`yay` — that's the entire distro-coupling surface.
 
-Ten of those are replaced outright, in `pkgs/omarchy/nix-bin/`: the ones the
+Six of those are replaced outright, in `pkgs/omarchy/nix-bin/`: the ones the
 menus drive. The rest manage Arch release channels, keyrings and orphan
 pruning, none of which have a Nix meaning worth reimplementing — your flake
 input *is* the release channel, and the store has no orphans. Those fail either

--- a/data/apps.nix
+++ b/data/apps.nix
@@ -408,15 +408,32 @@
     arch = "grok-bot";
   };
   t3-code = {
-    # No menuId: Omarchy v4.0.1 has no install.ai.t3-code row -- it was added
-    # upstream after the tag this flake pins. The package is still available
-    # as programs.nixarchy.apps.t3-code; the menu row returns when the omarchy
-    # input is bumped. The generator fails on a menuId upstream does not
-    # ship, which is how this was caught.
+    # The row arrived in Omarchy 4.0.3, exactly as the note that stood here
+    # predicted: "the menu row returns when the omarchy input is bumped". It
+    # did, and the bump's own gate is what noticed.
+    menuId = "install.ai.t3-code";
     label = "T3 Code";
     category = "AI";
     attr = "t3code";
     arch = "t3code-bin";
+  };
+  openclaw = {
+    # New in Omarchy 4.0.3.
+    #
+    # nixpkgs' `openclaw` is the right package and that was checked rather
+    # than assumed, because the name is shared: there is a well-known
+    # Captain Claw reimplementation by that name, and mapping it would have
+    # installed a platformer to someone asking for an AI agent. nixpkgs
+    # describes this one as "Self-hosted, open-source AI assistant/agent"
+    # with homepage openclaw.ai, which is what upstream's
+    # omarchy-install-ai-openclaw fetches with `omarchy-pkg-add openclaw`.
+    #
+    # This is the `hey` trap in the hey-cli entry below, one release later.
+    menuId = "install.ai.openclaw";
+    label = "OpenClaw";
+    category = "AI";
+    attr = "openclaw";
+    arch = "openclaw";
   };
   omawrite = {
     # No menuId: Omarchy has no install row for its own applications -- upstream

--- a/data/menu-exceptions.nix
+++ b/data/menu-exceptions.nix
@@ -1,0 +1,68 @@
+# Install rows that are deliberately NOT applications in this port.
+#
+# One file, read by both gates that ask the question -- .github/scripts/
+# check-menu-mapping.py and tests/options.nix. Before this existed the answer
+# lived only in tests/options.nix, so recording a decision satisfied one gate
+# and left the other red on the same row. A bump then looked like two
+# problems and was one.
+#
+# ## What belongs here
+#
+# A row whose action installs something this port cannot or should not offer
+# as `programs.nixarchy.apps.<name>`:
+#
+#   - an ACTION rather than an application (install.webapp, install.aur)
+#   - a package nixpkgs does not carry, where wrapping it would mean packaging
+#     it first
+#   - a row upstream documents as needing a hand
+#
+# A row does NOT belong here just because mapping it is work. The reason is
+# read by a human at review time and by whoever bumps Omarchy next; "not done
+# yet" is a TODO, not an exception.
+#
+# ## What the reason is for
+#
+# Both gates require it to be non-empty. It is the difference between "we
+# decided" and "nobody looked", and on a bump those are the only two states
+# that matter -- see docs/internals/omarchy-bumps.md.
+{
+  # Actions, not applications.
+  "install.aur" = "an Arch package manager. There is no NixOS equivalent to map.";
+  "install.package" = "installs an arbitrary named package; the row IS the mechanism.";
+  "install.preinstalls" =
+    "re-runs Omarchy's own preinstall set, which this port expresses as modules.";
+  "install.style.background" = "sets a wallpaper. Not a package.";
+  "install.style.theme" = "installs a theme. Handled by programs.nixarchy.theme.";
+  "install.tui" = "installs a TUI app by name, like install.package.";
+  "install.webapp" = "installs a web app as a chromium PWA. Nothing to package.";
+  "install.windows" = "a Windows VM helper, out of scope for this port.";
+  "install.service.chromium-account" = "adds a browser profile. Not a package.";
+
+  # Fonts go through omarchy-install-font and the Arch-name map.
+  "install.style.font.bitstream" = "font, installed by omarchy-install-font.";
+  "install.style.font.cascadia" = "font, installed by omarchy-install-font.";
+  "install.style.font.fira" = "font, installed by omarchy-install-font.";
+  "install.style.font.iosevka" = "font, installed by omarchy-install-font.";
+  "install.style.font.meslo" = "font, installed by omarchy-install-font.";
+  "install.style.font.victor" = "font, installed by omarchy-install-font.";
+
+  # Documented gaps -- the README names these as needing a hand.
+  "install.ai.ollama" = "a service, not an app: programs.nixarchy.services.local-ai.";
+  "install.gaming.battlenet" = "needs a hand; documented in the README.";
+  "install.gaming.geforce-now" = "needs a hand; documented in the README.";
+  "install.gaming.retro-launcher" = "needs a hand; documented in the README.";
+  "install.gaming.xbox-cloud" = "needs a hand; documented in the README.";
+  "install.development.docker-dbs" = "a compose stack, not a package.";
+  "install.development.elixir.phoenix" = "a framework scaffold, not a package.";
+  "install.development.php.laravel" = "a framework scaffold, not a package.";
+  "install.development.rails" = "a framework scaffold, not a package.";
+
+  # New in Omarchy 4.0.3.
+  "install.ai.hermes" =
+    "nixpkgs has no `hermes` and no `hermes-cli`; upstream fetches a binary "
+    + "with its own installer. Left unmapped rather than pointed at some other "
+    + "`hermes` -- see the openclaw note in data/apps.nix for why that matters.";
+  "install.ai.perplexity" =
+    "a web app, not a package: its action is `omarchy-install-and-launch "
+    + "Perplexity perplexity perplexity`, the same shape as install.webapp.";
+}

--- a/docs/manual/how-this-is-tested.md
+++ b/docs/manual/how-this-is-tested.md
@@ -1,0 +1,167 @@
+---
+title: How this is tested
+---
+
+# How this is tested
+
+Nixarchy is a port. Omarchy ships a new release and this repository has to
+follow it without breaking the machines already running. That is the whole
+engineering problem, and most of what is written here exists to solve it.
+
+This page is the honest version: what runs, when, what it proves, and — the
+part usually left out — what it does **not** prove.
+
+## The shape of it
+
+Nine workflows. Five run nightly on their own clock, one runs weekly, and the
+rest run on what you push.
+
+| when | what runs | what it is for |
+|---|---|---|
+| every pull request | `build`, `install check` | does this change break the desktop, or the installer |
+| 03:00 daily | `nightly` | the things that need real hardware: installs, ISOs, MicroVMs |
+| 04:00 daily | `omarchy` | has upstream released? adopt it |
+| 05:00 daily | `update` | have the pinned apps moved? |
+| 06:00 daily | `review` | write down what needs attention |
+| 07:00 daily | `flake-update` | what a *user's* `nix flake update` would get |
+| 06:00 Mondays | `build` again | the same checks against a lock nobody touched |
+| on a tag | `release` | build the image, publish it, prove it attached |
+
+The split matters. A pull request must answer quickly, so the slow and
+hardware-bound work moves to the night. What the night finds becomes an issue
+rather than a blocked merge.
+
+## Following Omarchy
+
+At 04:00 the `omarchy` workflow asks GitHub for the newest Omarchy release. If
+it is newer than the pin, it bumps the flake input and then tries to prove the
+port still holds:
+
+- **the vendored tree builds** — every one of upstream's commands is present,
+  shebangs patched, the `bin/` symlink farm intact
+- **every `substituteInPlace` anchor still matches**. This port edits upstream
+  scripts in place; an anchor upstream rewrote is a patch that silently stops
+  applying. `--replace-fail` turns that into a build failure instead
+- **every menu row it overrides still exists**
+- **a booted session renders its wallpaper** — a real desktop in qemu,
+  screenshotted, its average colour compared to the wallpaper's own. Without
+  this a green run meant little: the desktop once rendered pure black while
+  every other check passed, because an image wider than `GL_MAX_TEXTURE_SIZE`
+  draws nothing and Qt still reports it Ready
+
+It also **reads the release**: what packages it adds and drops, what upstream's
+own notes say, what changed in the config tree seeded into `~/.config`, and
+which of the files this port patches upstream touched. All of that lands in the
+pull request body, so adopting a release is reading rather than archaeology.
+
+### What happens when a release adds something new
+
+Most releases add an application, a menu row, or a coding agent. That is normal,
+and until recently it **blocked the bump** — the check that verifies every
+Install row maps to something in this port would fail, and the whole adoption
+stopped behind a question nobody had been asked yet. A security release once sat
+unadopted for three days that way.
+
+Now the bump **asks**. Unmapped rows become a checklist in the pull request:
+
+> **Install rows that need a decision**
+>
+> - [ ] `install.ai.hermes` installs `hermes-desktop`, which `data/apps.nix` or
+>       `data/services.nix` does not map
+
+Each has exactly two answers, and both are one line:
+
+- **it is an app** — add it to `data/apps.nix` with its `menuId` and its nixpkgs
+  attribute
+- **it is not** — record *why* in `data/menu-exceptions.nix`
+
+That second file is the interesting one. Both gates that ask this question read
+it, so the decision is recorded once. Before it existed the answer lived only in
+the test, and recording it satisfied one check while leaving the other red on the
+same row — one problem wearing two faces. An exception with an empty reason is
+rejected, because "we decided" and "nobody looked" must not look alike.
+
+The row still cannot reach `main` unmapped: the same script runs as an ordinary,
+fatal gate on the pull request. What changed is *when* it blocks.
+
+### The names are checked, not assumed
+
+Omarchy 4.0.3 added an agent called **openclaw**, and nixpkgs has a package by
+that name. It is also the name of a well-known Captain Claw reimplementation.
+Mapping the wrong one would have installed a platformer for someone asking for an
+AI assistant, and nothing would have complained.
+
+The same trap already had a victim: `hey` in nixpkgs is an HTTP load generator,
+not the HEY CLI, which is why this port ships `hey-cli`. Both cases are written
+down next to the entries so the next person meets the warning before the mistake.
+
+## Verifying the port itself
+
+Every check lives in the flake, so anyone can run the same thing CI runs:
+
+```sh
+nix build .#checks.x86_64-linux.<name>
+```
+
+They fall into layers:
+
+**Does it evaluate and build** — the vendored tree, the system closures, the ISO
+images, every packaged application.
+
+**Does it behave** — dozens of VM tests that boot a real machine: the desktop
+session, the installer's screens at every width, plugins from real repositories,
+a MicroVM, a container, wireless with a simulated radio.
+
+**Does it install** — the part that matters most and is hardest to fake. A VM
+partitions a blank disk, installs, boots the result *on its own bootloader*, and
+asserts a rebuild builds nothing. Encrypted installs unlock at the passphrase
+prompt. One test installs beside an existing operating system in free space and
+asserts the neighbour survived.
+
+**Does the prose still tell the truth** — the counts in the README are derived
+from the code and compared. So are the option paths quoted in this manual: a
+worked example that has rotted is worse than no example, and one sat here for
+months because prose is not built.
+
+### No check may be defined and never run
+
+There is a gate whose only job is to notice a check nobody runs. It reads every
+check in the flake, subtracts the ones a job claims by name, and builds the rest
+in one go. Add a check and it is picked up automatically; the last two new checks
+needed no workflow edit at all.
+
+It also fails in the other direction — a job claiming a check that no longer
+exists — because a list that only agrees with itself proves nothing.
+
+## What is deliberately not proven
+
+**No machine here is real.** Every install test runs in qemu with a virtual
+disk and a virtual NIC. That has cost this project real bugs: a guest reports a
+virtualisation type, so `nixos-generate-config` skips the firmware and microcode
+lines it writes on bare metal — and no VM ever exercised them. Installed
+machines shipped with no firmware at all, and Wi-Fi worked during the install
+and vanished on reboot. The tests were green throughout.
+
+The lesson is written into `AGENTS.md` as its own section: *a check that cannot
+vary proves nothing about the variable it holds constant.* Several checks now
+deliberately vary the thing they are about — two machines differing only by
+hostname, two usernames, two disk modes — because a test that pins a value
+cannot tell you anything about it.
+
+**The offline image is not currently published.** It carried the whole system
+closure and promised an install with no network; it stopped keeping that promise,
+and rather than ship an image whose only reason to exist is broken, it is
+withdrawn until the check that installs from it offline is green. The network
+image is unaffected and is what people install from.
+
+## If you want to look
+
+- `.github/workflows/` — the workflows, each with its reasoning in comments
+- `flake.nix` — every check, and why each exists
+- `tests/` — the VM tests; most files open with the bug they were written for
+- `data/menu-exceptions.nix` — the rows this port deliberately does not map
+- `AGENTS.md` — the rules the checks are written against
+
+The commit messages are part of the documentation. When something here was wrong,
+the commit that fixed it says what was wrong, how it was found, and what would
+have caught it sooner.

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -77,6 +77,7 @@ the documentation as much as the code.
 | **Making your own theme** | **differs on NixOS** — [read here](making-your-own-theme) |
 | Mac support | same as Omarchy — [read there](https://omarchy.org/manual/mac-support/) |
 | **Troubleshooting** | **differs on NixOS** — [read here](troubleshooting) |
+| **How this is tested** | **nixarchy only** — [read here](how-this-is-tested) |
 | Faq | same as Omarchy — [read there](https://omarchy.org/manual/faq/) |
 | **System snapshots** | **differs on NixOS** — [read here](system-snapshots) |
 | **Security** | **differs on NixOS** — [read here](security) |

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -4,6 +4,10 @@ title: Troubleshooting
 
 # Troubleshooting
 
+Before any of this: if you are wondering whether a problem is *yours* or
+*ours*, [how this is tested](how-this-is-tested) says what CI proves about
+each release and — more usefully — what it deliberately does not.
+
 ### Start with the doctor
 
 ```sh

--- a/flake.lock
+++ b/flake.lock
@@ -565,16 +565,16 @@
     "omarchy": {
       "flake": false,
       "locked": {
-        "lastModified": 1788130066,
-        "narHash": "sha256-DtaDI3gyvK7YVnul2vRmNHHGK86Hn64WfbAVeG4888Y=",
+        "lastModified": 1788886195,
+        "narHash": "sha256-+LF1Etj6akqmam9stdTeJJNBfoxAL+ZYyWvqo9R2P2E=",
         "owner": "basecamp",
         "repo": "omarchy",
-        "rev": "346e69e1cec6c4e8924531874af6ba010a1bc99e",
+        "rev": "0534987009061cbe2dacdde4ad564092ab698d12",
         "type": "github"
       },
       "original": {
         "owner": "basecamp",
-        "ref": "v4.0.2",
+        "ref": "v4.0.3",
         "repo": "omarchy",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
     hyprland.url = "github:hyprwm/Hyprland";
 
     omarchy = {
-      url = "github:basecamp/omarchy/v4.0.2";
+      url = "github:basecamp/omarchy/v4.0.3";
       flake = false;
     };
 
@@ -137,7 +137,7 @@
         }
       );
 
-      omarchyVersion = "4.0.2";
+      omarchyVersion = "4.0.3";
 
       # Why: docs/internals/flake.md#which-nixarchy-built-this-machine-208-for-nixarchy
       nixarchyRev = self.shortRev or self.dirtyShortRev or "unknown";

--- a/pkgs/omarchy/default.nix
+++ b/pkgs/omarchy/default.nix
@@ -751,6 +751,42 @@ stdenvNoCC.mkDerivation {
                   --replace-fail 'ExecStart=/usr/bin/pipewire' \
                   'ExecStart=/run/current-system/sw/bin/pipewire'
 
+                # omarchy-apply-lock resets PATH when it runs as root, and the
+                # value it resets to is empty on NixOS.
+                #
+                # Upstream's reasoning is sound and worth keeping: an install
+                # or upgrade may start this helper as root, and it does not
+                # want optional commands resolving out of a user-writable
+                # directory. On Arch the answer is /usr/bin and friends. Here
+                # those hold nothing, so the script would lose `tee`, `getent`
+                # and everything else it shells out to -- it writes PAM files
+                # for the lock screen, so the failure would be a lock screen
+                # that cannot authenticate, discovered at the worst moment.
+                #
+                # /run/wrappers/bin first, then the system profile: the same
+                # two directories a root login gets here, both root-owned,
+                # which is exactly the property upstream is reaching for.
+                #
+                # New in 4.0.3, and checks.session caught it -- that check
+                # scans every shipped command for /usr and is the reason this
+                # is a patch rather than a surprise on somebody's laptop.
+                substituteInPlace $out/share/omarchy/bin/omarchy-apply-lock \
+                  --replace-fail \
+                  'export PATH=/usr/share/omarchy/bin:/usr/local/bin:/usr/bin:/bin' \
+                  'export PATH=/run/wrappers/bin:/run/current-system/sw/bin'
+
+                # And its fingerprint probe, in the same file.
+                #
+                # `[[ -x /usr/bin/fprintd-list ]]` is false here whatever the
+                # machine has, so the branch that writes the fingerprint PAM
+                # stack never ran -- a laptop with a working reader got a lock
+                # screen that only takes a password, silently. Pointed at the
+                # system profile it now fires exactly when fprintd is actually
+                # installed, which is what the guard was always asking.
+                substituteInPlace $out/share/omarchy/bin/omarchy-apply-lock \
+                  --replace-fail '/usr/bin/fprintd-list' \
+                  '/run/current-system/sw/bin/fprintd-list'
+
                 # The two image-editor call sites that hardcode tensaku-edit, which
                 # is not packaged anywhere here -- see the satty-edit wrapper in the
                 # runtime dependencies above for why a wrapper and not satty itself.

--- a/pkgs/omarchy/default.nix
+++ b/pkgs/omarchy/default.nix
@@ -1039,7 +1039,23 @@ stdenvNoCC.mkDerivation {
                     # JSON -- which parses as an invalid control character, not as a shell
                     # `&&`. The jsonc is re-parsed at the end of this phase for that reason.
                     menu=$out/share/omarchy/default/omarchy/omarchy-menu.jsonc
-                    for a in claude codex copilot crush gemini grok omp opencode pi; do
+                    # 4.0.3 added four: cursor-agent, hermes, muse, openclaw. The
+                    # assertion at the end of this phase is what found them -- it
+                    # failed the build of the bump rather than letting four rows
+                    # ship that tick for an agent the machine does not have.
+                    #
+                    # All four use their id as their command, checked against
+                    # upstream's own bin/omarchy-default-agent: muse says so
+                    # outright (`bin=muse` in its package spec) and the other three
+                    # set `agent=<id>` with no separate binary. antigravity below is
+                    # still the only one that differs, and it is written out for
+                    # exactly that reason.
+                    #
+                    # Getting a command name wrong here fails SAFE: the row simply
+                    # never ticks, which reads as "that agent is not installed".
+                    # The direction that would matter -- ticking for an agent that
+                    # is absent -- is the one this loop exists to prevent.
+                    for a in claude codex copilot crush cursor-agent gemini grok hermes muse omp openclaw opencode pi; do
                       substituteInPlace $menu \
                         --replace-fail "== \\\"$a\\\" ]]" "== \\\"$a\\\" ]] && command -v $a >/dev/null"
                     done

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -441,32 +441,20 @@ let
   # Rows that are actions rather than applications, plus the gaps the README
   # names. Fonts go through omarchy-install-font and the Arch-name map; the
   # four gaming rows and three frameworks are documented as needing a hand.
-  notApps = [
-    "install.aur"
-    "install.package"
-    "install.preinstalls"
-    "install.style.background"
-    "install.style.theme"
-    "install.tui"
-    "install.webapp"
-    "install.windows"
-    "install.service.chromium-account"
-    "install.style.font.bitstream"
-    "install.style.font.cascadia"
-    "install.style.font.fira"
-    "install.style.font.iosevka"
-    "install.style.font.meslo"
-    "install.style.font.victor"
-    "install.ai.ollama"
-    "install.gaming.battlenet"
-    "install.gaming.geforce-now"
-    "install.gaming.retro-launcher"
-    "install.gaming.xbox-cloud"
-    "install.development.docker-dbs"
-    "install.development.elixir.phoenix"
-    "install.development.php.laravel"
-    "install.development.rails"
-  ];
+  # Rows that are actions rather than applications, and the gaps the README
+  # names.
+  #
+  # data/menu-exceptions.nix, not a list here, because
+  # .github/scripts/check-menu-mapping.py asks the same question and this file
+  # used to carry its own copy of the answer. Recording a decision then
+  # satisfied one gate and left the other red on the same row -- which is what
+  # the Omarchy 4.0.3 bump ran into, and it read as two problems when it was
+  # one. One file, two readers.
+  #
+  # The reason strings are not used here; this check only needs the set. They
+  # are read by a human at review time, and the mapping script refuses an
+  # exception that carries none.
+  notApps = builtins.attrNames (import ../data/menu-exceptions.nix);
 
   # The built reference machine, for the things that are facts about a system
   # rather than about an option.

--- a/tests/session.nix
+++ b/tests/session.nix
@@ -1095,7 +1095,33 @@ pkgs.testers.runNixOSTest {
                # fwupd's EFI capsule lives wherever the fwupd package puts it;
                # on NixOS that is services.fwupd's business, not a path this
                # repo should pin.
-               "omarchy-update-firmware"]
+               "omarchy-update-firmware",
+               # New in Omarchy 4.0.3. The only /usr in it is an ICON path,
+               # /usr/lib/node_modules/openclaw/.../apple-touch-icon.png,
+               # handed to omarchy-webapp-install as its icon reference.
+               #
+               # Harmless because that script tests it with `elif [[ -f
+               # $ICON_REF ]]` (omarchy-webapp-install:194) and falls through
+               # to its bundled-icon branch when the file is absent. The web
+               # app still installs; it gets the fallback icon. Pinning the
+               # path into the nixpkgs openclaw package instead would tie this
+               # port to that package's internal layout, which is a worse
+               # trade for an icon.
+               "omarchy-install-ai-openclaw",
+               # Also new in 4.0.3, and unusable here by construction: the
+               # whole script is a wrapper around /usr/share/hermes-desktop/
+               # install.sh and runtime.patch, files that come from the Arch
+               # `hermes-desktop` package. nixpkgs has no hermes and no
+               # hermes-cli, which is why install.ai.hermes is recorded in
+               # data/menu-exceptions.nix as well.
+               #
+               # It refuses cleanly rather than half-running: line 16 tests
+               # both files with -r and exits 1 with "The installed Hermes
+               # package cannot prepare in-app updates", and its first line is
+               # `omarchy-pkg-add hermes-desktop`, which reaches this port's
+               # pacman shim and says so. Patching the paths would point at
+               # files that do not exist either.
+               "omarchy-install-ai-hermes"]
     # The offender list comes back from one plain shell command and the
     # filtering happens here. A first version did the allowlisting in shell
     # too, with a grep -v -x -F against a generated list, and it matched


### PR DESCRIPTION
## The release

Four new coding agents -- cursor-agent, hermes, muse, openclaw -- 13 agent
rows where there were 9. Upstream's rows tick on $OMARCHY_DEFAULT_AGENT
alone, which on Arch means installed; here it does not, so each row gains
`&& command -v <a>`. The build assertion in pkgs/omarchy/default.nix is what
caught them, by failing the bump rather than shipping four rows that tick for
an agent the machine has not got.

Each command was checked against upstream's own bin/omarchy-default-agent
rather than assumed equal to the id -- that assumption is exactly why
antigravity is written out separately (its command is `agy`). All four use
their id; muse says so outright with `bin=muse` in its package spec. Getting
one wrong fails safe: the row never ticks, which reads as "not installed".

Four new Install rows, decided:

  t3-code      mapped. The entry has sat in data/apps.nix with "the menu row
               returns when the omarchy input is bumped" written on it. It did.
  openclaw     mapped. nixpkgs has it, and it is the RIGHT one -- checked, not
               assumed, because the name is shared with a Captain Claw
               reimplementation. nixpkgs describes this one as "Self-hosted,
               open-source AI assistant/agent" at openclaw.ai, which is what
               omarchy-install-ai-openclaw fetches.
  hermes       excepted. nixpkgs has no `hermes` and no `hermes-cli`.
  perplexity   excepted. A web app, not a package.

## The part that matters more than the release

A bump should not fail because upstream added something. It should say what
was added and let a person answer. Two things were in the way.

**The same decision had to be recorded twice, and could only ever satisfy
one gate.** tests/options.nix carried a `notApps` list;
check-menu-mapping.py had no escape hatch at all. Recording hermes and
perplexity in options.nix turned that check green and left the mapping script
red on the same two rows -- one problem wearing two faces, which is how this
bump first read.

Now there is one file. data/menu-exceptions.nix maps a row id to the reason
it is not an app, and both gates read it. Both also refuse an exception with
an empty reason, because "we decided" and "nobody looked" are the only two
states that matter on a bump and they must not look alike. Proven red three
ways: a removed exception, a blank reason, and an unreadable file.

**And the bump blocked on it.** That step is now continue-on-error, and what
it finds becomes a checklist in the pull request body -- every unmapped row,
what it installs, and the two one-line ways to answer it. The row still
cannot reach main unmapped: build.yml runs the same script as a normal gate,
where it is fatal. What changed is that a question nobody has been asked yet
can no longer stop a release from being proposed. v4.0.2 sat unadopted for
three days behind exactly that, over a row services.nix had already mapped.

The PR body also stops claiming "all Install rows are still mapped" among the
things the job has proved, because after this it deliberately has not.

Related: #404 is unaffected; this is the adoption path, not the installer.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5

## Verified

- `nix build .#omarchy` against 4.0.3
- `checks.options`, `checks.patched-files`, `checks.menu-verbs`,
  `checks.doc-options` all pass
- `check-menu-mapping.py`: "all 41 Install rows are mapped (2 by a recorded
  exception)", and proven red on a removed exception and on a blank reason
- `actionlint`, `nix fmt -- --ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5