### PR TITLE
aether's updateScript was missing --flake, and the nightly said so

### DIFF
--- a/pkgs/apps/aether.nix
+++ b/pkgs/apps/aether.nix
@@ -222,7 +222,23 @@ buildGoModule {
   passthru.updateScript = writeShellApplication {
     name = "update-aether";
     runtimeInputs = [ nix-update ];
-    text = "nix-update aether";
+    # --flake, and the guard, both of which its siblings have and this one was
+    # written without.
+    #
+    # Without --flake, nix-update assumes a classic nixpkgs tree and imports
+    # default.nix from the repository root. There is none here, so the nightly
+    # update run died with "path '.../nixarchy/default.nix' does not exist" --
+    # and the failure named default.nix, not aether, which is why it took
+    # reading the invocation to see that this attribute alone was evaluated
+    # with `isFlake false` while every sibling had `isFlake true`.
+    #
+    # The `-f flake.nix` line is the same guard omacalc, omacut, omawrite and
+    # ttfx carry: run from anywhere else, nix-update's own error is about a
+    # missing file rather than about where it was started.
+    text = ''
+      [ -f flake.nix ] || { echo "aether: run from the repo root" >&2; exit 1; }
+      nix-update --flake aether
+    '';
   };
 
   meta = {


### PR DESCRIPTION
The nightly update run died with

  error: path '/home/runner/work/nixarchy/nixarchy/default.nix' does not exist

for aether alone. The invocation is the tell: every sibling was evaluated with
`--arg isFlake true --argstr flakeImportPath ...` and aether with `isFlake
false`, because its updateScript said

  nix-update aether

where omacalc, omacut, omawrite and ttfx all say

  [ -f flake.nix ] || { echo "...: run from the repo root" >&2; exit 1; }
  nix-update --flake omacalc

Without --flake, nix-update assumes a classic nixpkgs tree and imports
default.nix from the repository root. There is none here. The error named
default.nix rather than aether, which is why this needed reading the command
line rather than the message.

Mine, from #424. The guard is copied too: run from anywhere else and
nix-update's own error is about a missing file rather than about where it was
started.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5

## Verified

- `nix build .#aether`
- `nix fmt -- --ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5