### PR TITLE
nixpkgs: 6 app version(s) move

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,11 +548,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1788752844,
-        "narHash": "sha256-VaWGJ6+cIYN2erfSecbRV+4ljI185Ty2wUrXyvQbgOw=",
+        "lastModified": 1788881743,
+        "narHash": "sha256-2V9GZGvPfrNzxFozhI9dcqV+c3QdA8YZrvAAzqEB+dI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dc5d91f840324650bac8c379428c7037a416959a",
+        "rev": "d6524aaca2ff07876657ae2b323f24be4874944b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Nightly bump of the `nixpkgs` input. Only that input: the others
are left where they are, because at least one of them is pinned on
purpose.

| app | was | now |
|---|---|---|
| `claude-code` | 2.1.260 | 2.1.263 |
| `clojure` | 1.12.5.1664 | 1.12.6.1673 |
| `deno` | 2.9.5 | 2.9.6 |
| `obsidian` | 1.13.4 | 1.13.7 |
| `scala` | 3.3.8 | 3.9.0 |
| `symfony-cli` | 5.19.0 | 5.20.0 |

Verified before this PR was opened:

- `.#checks.x86_64-linux.vm-toplevel` evaluates
- `.#checks.x86_64-linux.reference-toplevel` evaluates

That is an evaluation check, not a build. **The gate is the CI on
this pull request**, which runs because the PR was opened with
`BUMP_TOKEN`; it merges when the required contexts report green and
not before.

What CI does not cover: an app that builds and then misbehaves at
runtime. If a package here is one you rely on, launch it before
this lands, or roll back afterwards with `nixos-rebuild --rollback`.