### PR TITLE
The cache probe could only ever pass on the commit that pushed

### DIFF
--- a/.github/workflows/install-check.yml
+++ b/.github/workflows/install-check.yml
@@ -258,6 +258,40 @@ jobs:
             echo "pushing $c ($(du -sh "$out" | cut -f1))"
             nix run --inputs-from . nixpkgs#cachix -- \
               push nixarchy "$out" || echo "push of $c failed; not fatal"
+
+            # And ask the cache whether it took it -- here, on this commit,
+            # seconds later.
+            #
+            # The first version of this verification lived in the nightly, as
+            # a probe that evaluated main and checked those paths were
+            # present. It could not work: these checks embed the flake source,
+            # so ANY commit gives them new store paths, and the probe was
+            # comparing what main evaluates now against what was pushed a
+            # commit ago. It reported the cache broken on the first nightly
+            # after a merge, and the cache was fine.
+            #
+            # Here there is no cross-commit problem to get wrong. The path was
+            # just built and just pushed; if the cache does not have it a
+            # moment later, the push genuinely did not work -- which is the
+            # only thing worth knowing, and the thing cachix will not tell us
+            # because it exits 0 on a rejected token.
+            #
+            # Not fatal, for the same reason the push is not: a cache upload
+            # must not fail a build that succeeded (#235). It is loud instead,
+            # and the summary carries it.
+            hash=$(basename "$out" | cut -d- -f1)
+            code=$(curl -s -o /dev/null -w '%{http_code}' \
+              "https://nixarchy.cachix.org/$hash.narinfo")
+            if [ "$code" = 200 ]; then
+              echo "  $c: in the cache"
+            else
+              echo "::warning::$c was pushed but the cache does not have it (HTTP $code)"
+              echo "cachix exits 0 on a rejected token, so this is the only" >&2
+              echo "signal that the push did not work. Check CACHIX_AUTH_TOKEN." >&2
+              {
+                echo "- \`$c\` pushed but not in the cache (HTTP $code)"
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
           done
 
       - name: Report what it cost

--- a/.github/workflows/install-check.yml
+++ b/.github/workflows/install-check.yml
@@ -181,9 +181,27 @@ jobs:
       - uses: actions/checkout@v5
         if: needs.gate.outputs.relevant == 'true'
 
-      # No installer action, no cachix. The runner is a NixOS machine with a
-      # warm store, which is most of why this is ten minutes rather than an
-      # hour.
+      # No installer action, and cachix to PULL from only. The runner is a
+      # NixOS machine with a warm store, which is most of why this is ten
+      # minutes rather than an hour -- when the work happens to land on the
+      # machine that did it last time.
+      #
+      # It often does not. There are FOUR self-hosted runners (p510-nixarchy,
+      # p510-nixarchy-2, p620-nixarchy, p620-nixarchy-2), they carry identical
+      # labels so a job takes whichever is free, and they do not share a
+      # store. "Warm store" is therefore a one-in-four proposition, and this
+      # comment used to say "the one self-hosted box" from when it was true.
+      #
+      # What that cost, measured: #434 changes networking.hostName, which
+      # gives every system closure a new path. Its hosted `system` job had
+      # already built and PUSHED those closures to cachix -- and this job
+      # could not pull them, so it rebuilt three reference systems and two
+      # full installs from scratch, three times, timing out at the 90-minute
+      # cap on three different machines.
+      #
+      # Pull only, deliberately. This job pushes its three proofs by hand
+      # below; it has no business uploading the rest, and a push here would
+      # race the hosted jobs that own those paths.
       #
       # Both installs in ONE nix invocation, so nix runs them at the same time
       # rather than one after the other. Measured on run 33798891329, which is
@@ -220,7 +238,14 @@ jobs:
       - name: Install onto a blank disk, and into free space beside a neighbour
         if: needs.gate.outputs.relevant == 'true'
         run: |
+          # --extra-substituters rather than the cachix action: the action
+          # installs a post-job push step, and this job must not push what it
+          # did not build. The key is public; pulling needs no token, which is
+          # also why this works on a runner whose secrets we would rather not
+          # widen.
           nix build --print-build-logs --max-jobs 3 \
+            --extra-substituters https://nixarchy.cachix.org \
+            --extra-trusted-public-keys nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM= \
             .#checks.x86_64-linux.install \
             .#checks.x86_64-linux.free-space \
             .#checks.x86_64-linux.installer-refusal

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -264,50 +264,6 @@ jobs:
             exit 1
           fi
 
-      - name: The cache holds the proof that the installs passed
-        # The third probe, and it guards a push that CANNOT report its own
-        # failure. install-check.yml pushes the three vm-test-run outputs so
-        # that "has this exact check already passed?" is answerable from a
-        # hosted runner -- which is what lets build.yml skip a check the cache
-        # can already vouch for instead of downloading it.
-        #
-        # That push is `continue-on-error` (a cache upload must not fail a
-        # build that succeeded, #235) AND cachix exits 0 on a rejected token,
-        # which is the failure mode the omarchy probe above exists for. So a
-        # push that silently stops landing shows up as nothing at all: the
-        # gate quietly never hits, every check is rebuilt exactly as before,
-        # and CI just gets slower with no red anywhere. Probe it, or the
-        # optimisation decays invisibly.
-        #
-        # These are ~4 KB of logs each, not images.
-        run: |
-          fail=0
-          for c in install free-space installer-refusal; do
-            # An eval that fails leaves $path empty, and an empty hash makes
-            # the query below return 404 -- which would report "missing from
-            # the cache" for a check that could not be evaluated at all. Two
-            # very different problems, one message. Say which.
-            if ! path=$(nix eval --raw ".#checks.x86_64-linux.$c.outPath"); then
-              echo "::error::checks.$c does not evaluate; this probe cannot"
-              echo "say anything about the cache until that is fixed."
-              exit 1
-            fi
-            hash=$(basename "$path" | cut -d- -f1)
-            code=$(curl -s -o /dev/null -w '%{http_code}' \
-              "https://nixarchy.cachix.org/$hash.narinfo")
-            echo "$c: $path -> HTTP $code"
-            [ "$code" = 200 ] || fail=1
-          done
-          if [ "$fail" -ne 0 ]; then
-            echo "::error::an install proof is missing from nixarchy.cachix.org."
-            echo "install-check.yml's push step is what puts them there, and it"
-            echo "cannot fail loudly by design. Nothing is broken for users --"
-            echo "the effect is that build.yml rebuilds checks it could have"
-            echo "skipped. Check install-check.yml's last run on main, then the"
-            echo "CACHIX_AUTH_TOKEN, in that order."
-            exit 1
-          fi
-
   # Tomorrow's user. build.yml's weekly cron re-runs the checks against the
   # COMMITTED lock, so on the flake inputs it proves nothing a merged PR did
   # not already prove -- the break that reaches people arrives through their


### PR DESCRIPTION
Last night's nightly reported two of three install proofs missing from
nixarchy.cachix.org and failed the cache job. The cache was fine: checked by
hand this morning, all three of main's current paths are present.

The probe compared what main evaluates NOW against paths pushed when the
install last ran -- at an earlier commit. These checks embed the flake source,
so any commit gives them new store paths. It therefore reported the cache
broken on the first nightly after any merge, which is most nightlies.

I wrote it yesterday, and I wrote it wrong in a way this repository already
had a name for: it asked a question whose answer could not be true.

## What made it look plausible

Of the three, installer-refusal matched across the two commits and the other
two did not, so the first reading was "the rev-dependent ones move, that one
does not -- probe only that one". That was also wrong. On a branch changing a
single workflow file, installer-refusal's path moves too: it embeds the source
like the others. The apparent stability was a coincidence of which commits
were being compared, not a property.

## Where the verification belongs

In the push step, on the same commit, seconds after pushing -- where there is
no cross-commit problem to get wrong. The path was just built and just pushed;
if the cache does not have it a moment later, the push genuinely failed, which
is the only thing worth knowing and the thing cachix will not say, because it
exits 0 on a rejected token.

Not fatal, matching the push it verifies: a cache upload must not fail a build
that succeeded (#235). It warns, and the step summary carries it.

Exercised both ways against the real cache: a present path reports "in the
cache", an absent one warns. The nightly keeps its two probes that DO work --
main's omarchy and the MicroVM template runners, neither of which has this
problem because they are checked on the commit that built them.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5

## Verified

- both branches of the new verification exercised against the real cache
- `actionlint`
- the nightly's other two cache probes are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5