### PR TITLE
doctor-wireless names the string it wanted and not what it got

### DIFF
--- a/tests/doctor-wireless.nix
+++ b/tests/doctor-wireless.nix
@@ -60,7 +60,19 @@ pkgs.runCommand "nixarchy-doctor-wireless" { nativeBuildInputs = [ pkgs.gnugrep 
   fails=0
   want() {
     if printf '%s' "$2" | grep -q "$3"; then echo "  ok      $1"
-    else echo "  FAILED  $1: no /$3/ in the output"; fails=$((fails + 1)); fi
+    else
+      echo "  FAILED  $1: no /$3/ in the output"
+      # And WHAT it printed instead.
+      #
+      # Without this the failure names the string it wanted and nothing else,
+      # so a case that fails in CI and passes locally -- which this file did
+      # on 2026-09-09, same derivation hash, opposite results -- leaves
+      # nothing to reason from. The Wireless section is a dozen lines; print
+      # it, indented, and the next occurrence is an answer rather than a
+      # rerun.
+      printf '%s\n' "$2" | sed -n '/Wireless/,/^$/p' | sed 's/^/          | /'
+      fails=$((fails + 1))
+    fi
   }
   wantnot() {
     if printf '%s' "$2" | grep -q "$3"; then


### PR DESCRIPTION
checks.doctor-wireless failed on #441, the nightly nixpkgs bump, with

  FAILED  and its driver with it: no /Intel, driver iwlwifi/ in the output

and passed everywhere else. The interesting part is that it is the SAME
derivation: nbhfndbimzpwfcqz5qrlbi6xy99b2p5n built in CI and here, verified
with --rebuild so it was a real run and not a cache hit, with opposite
results. So this is non-determinism, not a nixpkgs regression -- the bump only
gave a flaky check a fresh derivation to fail on.

Why it could not be diagnosed: the line it wants needs two values,

  "${wifi_make:+$wifi_make, }driver ${wifi_bound:-in-kernel}"

and the preceding case, "a working card is named", PASSED -- so the net
fixture was read and the PCI one was not. Which of vendor or driver went
missing decides where to look, and the test could not say, because it greps
for the whole string and reports only the string it wanted.

want() now prints the Wireless section when a case fails, indented under it.
The next occurrence shows whether the doctor printed "driver in-kernel" (no
vendor read) or something else entirely.

This fixes no bug. It is a strictly better failure message, and it is honest
that the cause is still unknown: I could not reproduce the failure locally,
so I cannot prove this captures the right thing -- only that the current
message captures nothing.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5

## Verified

- `checks.doctor-wireless` still passes with the change
- `nix fmt -- --ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5