### PR TITLE
One script owns every derived number, with --check and --fix

### DIFF
--- a/.github/scripts/readme-counts.sh
+++ b/.github/scripts/readme-counts.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Every number in the README that is derived from this repository.
+#
+#   readme-counts.sh --check   compare, and fail on drift          (pull requests)
+#   readme-counts.sh --fix     rewrite the README to agree         (the Omarchy bump)
+#
+# ## Why this exists
+#
+# Adopting Omarchy 4.0.3 hit three separate count drifts in one bump -- the
+# command count (431 -> 444), and two numbers in the same paragraph that were
+# NOT checked and had been wrong for some time (24 -> 32 scripts, "Ten" -> Six
+# replaced). Each failed the build. None of them needed a human to decide
+# anything: a count has exactly one correct value, derivable from the repo.
+#
+# Asking a person to type it, and failing the release until they do, is asking
+# them to be a calculator. So on a bump these are APPLIED, and the diff is
+# what gets reviewed. Decisions -- is this new Install row an app? -- are a
+# different thing and stay a checklist (see data/menu-exceptions.nix).
+#
+# ## Why no marker comments
+#
+# The obvious design is <!--n:commands-->444<!--/n--> spans. This uses a table
+# of patterns instead: the README stays readable in raw form, and adding a
+# number is still one entry here rather than a new grep in a workflow -- which
+# is the actual complaint. Markers remain the answer if a number ever appears
+# somewhere a pattern cannot describe.
+#
+# ## The rule this file must never break
+#
+# --fix propagates a WRONG DERIVATION confidently: get a computation wrong and
+# the README is silently rewritten to agree with it. So every quantity must
+# REFUSE rather than fix when it cannot be computed, and every pattern must
+# refuse when it matches nothing. A check that cannot fail is worse than no
+# check; an auto-fixer that cannot refuse is worse than a check.
+set -uo pipefail
+
+mode=${1:-}
+case "$mode" in
+  --check | --fix) ;;
+  *)
+    echo "usage: $0 --check | --fix" >&2
+    exit 2
+    ;;
+esac
+
+root=$(cd "$(dirname "$0")/../.." && pwd)
+readme="$root/README.md"
+omarchy=${OMARCHY_TREE:-$root/result}
+
+[ -f "$readme" ] || { echo "no README at $readme" >&2; exit 1; }
+[ -d "$omarchy/share/omarchy/bin" ] || {
+  echo "no omarchy tree at $omarchy -- build it first:" >&2
+  echo "  nix build .#omarchy --out-link result" >&2
+  echo "or set OMARCHY_TREE to one." >&2
+  exit 1
+}
+
+fail=0
+changed=0
+report=""
+
+# A quantity: a name, its value, and a sed expression that finds it in the
+# README with the value as \1. Both halves refuse on their own.
+quantity() {
+  local name=$1 value=$2 find=$3 repl=$4
+  local current
+
+  if [ -z "$value" ] || [ "$value" = "0" ]; then
+    echo "::error::$name computed as '${value:-empty}' -- refusing to check or fix" >&2
+    fail=1
+    return
+  fi
+
+  current=$(sed -nE "s/$find/\1/p" "$readme" | head -1)
+  if [ -z "$current" ]; then
+    echo "::error::$name: nothing in README.md matches its pattern" >&2
+    echo "::error::  the wording moved, or the pattern is wrong. Not guessing." >&2
+    fail=1
+    return
+  fi
+
+  if [ "$current" = "$value" ]; then
+    report="$report  $name: $value\n"
+    return
+  fi
+
+  if [ "$mode" = "--check" ]; then
+    echo "::error::$name: README says $current, the repository says $value" >&2
+    fail=1
+  else
+    # $repl is already a complete sed expression. Wrapping it in another
+    # s/.../ produced `s/s/...`, which sed rejected -- and the first version
+    # of this function ignored sed's exit status, so it printed "(fixed)" and
+    # "README.md updated." while changing nothing at all. An auto-fixer that
+    # reports success on failure is worse than no auto-fixer: the next run of
+    # --check contradicts it, and the person reading the bump believes the
+    # first one.
+    #
+    # So: run it, and PROVE the file moved. Comparing before and after is the
+    # only claim worth making here, because sed exits 0 for a pattern that
+    # matched nothing.
+    local before after
+    before=$(cksum < "$readme")
+    if ! sed -i -E "$repl" "$readme"; then
+      echo "::error::$name: sed refused the replacement expression" >&2
+      fail=1
+      return
+    fi
+    after=$(cksum < "$readme")
+    if [ "$before" = "$after" ]; then
+      echo "::error::$name: the replacement changed nothing -- its pattern" >&2
+      echo "::error::  found the number but could not rewrite it." >&2
+      fail=1
+      return
+    fi
+    report="$report  $name: $current -> $value  (fixed)\n"
+    changed=1
+  fi
+}
+
+# ---- the quantities ---------------------------------------------------------
+
+commands=$("$omarchy/bin/omarchy" commands --check 2>/dev/null |
+  grep -oE '[0-9]+ commands' | grep -oE '[0-9]+' | head -1)
+
+# The app counts, using the expression build.yml already had -- verbatim, so
+# the two cannot drift apart while both exist. The field names are the
+# load-bearing part: `x ? option` for the ones that are NixOS modules and
+# `x ? unavailable` for the ones with no equivalent. Guessing them (`module`,
+# `unavailable or false`) yields zero and an unbound variable, which is how
+# this was caught here rather than in a README nobody re-read.
+eval "$(cd "$root" && nix eval --raw --impure --expr '
+  let lib = (builtins.getFlake (toString ./.)).inputs.nixpkgs.lib;
+      a = import ./data/apps.nix;
+      c = f: toString (lib.length (lib.attrNames (lib.filterAttrs f a)));
+  in "a_total=" + toString (lib.length (lib.attrNames a))
+   + " a_mod=" + c (_: x: x ? option)
+   + " a_ours=" + c (_: x: x.ours or false)
+   + " a_un=" + c (_: x: x ? unavailable)
+' 2>/dev/null)"
+a_total=${a_total:-}
+a_mod=${a_mod:-}
+a_ours=${a_ours:-}
+a_un=${a_un:-}
+if [ -n "$a_total" ] && [ -n "$a_mod" ] && [ -n "$a_ours" ] && [ -n "$a_un" ]; then
+  a_nixpkgs=$((a_total - a_mod - a_ours - a_un))
+  # "never touch this repo" is the nixpkgs ones plus the module-backed ones:
+  # both come from upstream nixpkgs, neither is built here.
+  a_untouched=$((a_nixpkgs + a_mod))
+else
+  a_nixpkgs=""
+  a_untouched=""
+fi
+
+pac=$(grep -rlE '\b(pacman|yay)\b' "$omarchy/share/omarchy/bin" 2>/dev/null | wc -l)
+# mktemp, not a fixed /tmp name: two of the four self-hosted runners share a
+# machine, so two jobs writing /tmp/rc-pac.txt at once would read each other's
+# half-written file and disagree about a number neither computed.
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+ls "$root/pkgs/omarchy/nix-bin" 2>/dev/null | sort > "$tmp/nixbin"
+grep -rlE '\b(pacman|yay)\b' "$omarchy/share/omarchy/bin" 2>/dev/null |
+  xargs -r -n1 basename | sort > "$tmp/pac"
+repl_n=$(comm -12 "$tmp/pac" "$tmp/nixbin" | wc -l)
+
+# The one number the README spells as a word.
+word_for() {
+  case "$1" in
+    5) echo Five ;; 6) echo Six ;; 7) echo Seven ;; 8) echo Eight ;;
+    9) echo Nine ;; 10) echo Ten ;; 11) echo Eleven ;; 12) echo Twelve ;;
+    *) echo "" ;;
+  esac
+}
+repl_word=$(word_for "$repl_n")
+
+quantity "commands" "$commands" \
+  '.*\*\*([0-9]+) shell commands\*\*.*' \
+  's/\*\*[0-9]+ shell commands\*\*/**'"$commands"' shell commands**/'
+quantity "subcommands" "$commands" \
+  '.*all ([0-9]+) subcommands.*' \
+  's/all [0-9]+ subcommands/all '"$commands"' subcommands/'
+quantity "commands-through" "$commands" \
+  ".*Omarchy's ([0-9]+) *\|.*" \
+  "s/Omarchy's [0-9]+ \|/Omarchy's $commands |/"
+quantity "commands-upstream" "$commands" \
+  '.*Upstream.s ([0-9]+) commands.*' \
+  's/Upstream.s [0-9]+ commands/Upstream'"'"'s '"$commands"' commands/'
+quantity "pacman-scripts" "$pac" \
+  '.*\*\*([0-9]+) of [0-9]+ scripts\*\*.*' \
+  's/\*\*[0-9]+ of [0-9]+ scripts\*\*/**'"$pac"' of '"$commands"' scripts**/'
+quantity "pacman-replaced" "$repl_word" \
+  '^(Six|Seven|Eight|Nine|Ten|Eleven|Twelve) of those are replaced.*' \
+  's/^(Six|Seven|Eight|Nine|Ten|Eleven|Twelve) of those are replaced/'"$repl_word"' of those are replaced/'
+quantity "apps-total" "$a_total" \
+  '.*\| ([0-9]+) apps in the selection \|.*' \
+  "s/\| [0-9]+ apps in the selection \| [0-9]+ from nixpkgs, [0-9]+ as NixOS modules, [0-9]+ built here, [0-9]+ with no equivalent \|/| $a_total apps in the selection | $a_nixpkgs from nixpkgs, $a_mod as NixOS modules, $a_ours built here, $a_un with no equivalent |/"
+quantity "apps-untouched" "$a_untouched" \
+  '.*\*\*([0-9]+) of the [0-9]+ apps never touch this repo\.\*\*.*' \
+  "s/\*\*[0-9]+ of the [0-9]+ apps never touch this repo\.\*\*/**$a_untouched of the $a_total apps never touch this repo.**/"
+quantity "apps-nixpkgs-row" "$a_untouched" \
+  '.*\| nixpkgs \(([0-9]+) of [0-9]+ apps\) \|.*' \
+  "s/\| nixpkgs \([0-9]+ of [0-9]+ apps\) \|/| nixpkgs ($a_untouched of $a_total apps) |/"
+
+# A floor. Nine quantities are declared above; a run that checked fewer means
+# something stopped matching and this reported calm about numbers it never
+# looked at.
+checked=$(printf '%b' "$report" | grep -c .)
+if [ "$fail" -eq 0 ] && [ "$checked" -lt 9 ]; then
+  echo "::error::only $checked of 9 quantities were accounted for" >&2
+  fail=1
+fi
+
+printf '%b' "$report"
+if [ "$mode" = "--fix" ] && [ "$changed" -eq 1 ]; then
+  echo "README.md updated."
+fi
+exit "$fail"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,68 +251,13 @@ jobs:
           # catch a bin we replace drifting out of the CLI's index.
           result/bin/omarchy commands --check
 
-          # And that the README still quotes the number this reports. The
-          # bound above is a floor, so the figure in the README drifted from
-          # 438 to 429 across a source bump without anything noticing --
-          # a floor catches a catastrophe, not a stale sentence.
-          reported=$(result/bin/omarchy commands --check |
-            sed -n 's/.*(\([0-9]*\) commands).*/\1/p')
-          echo "omarchy commands --check reports: $reported"
-          for claim in $(grep -oE '[0-9]+ (shell commands|subcommands)' README.md |
-            grep -oE '^[0-9]+' | sort -u); do
-            if [ "$claim" != "$reported" ]; then
-              echo "README says $claim commands; the CLI reports $reported" >&2
-              exit 1
-            fi
-          done
+          # The README's numbers were checked here, in three hand-written
+          # blocks with three greps and a word->digit lookup table. They now
+          # belong to .github/scripts/readme-counts.sh, which both checks and
+          # FIXES them -- see that step below and #438. A count has one
+          # correct value; failing the build until a person types it was
+          # asking them to be a calculator.
 
-          # The other two numbers in that paragraph, which were NOT checked and
-          # both went stale.
-          #
-          # Omarchy 4.0.3 moved the command count from 431 to 444 and this
-          # check caught it. It did not catch "24 of 431 scripts actually run
-          # pacman/yay" (really 32) or "Ten of those are replaced outright"
-          # (really 6), because nothing derived them -- they were prose next to
-          # a gated number, which is the most convincing place for a wrong
-          # number to sit. Found only because updating 431 meant reading the
-          # sentence around it.
-          #
-          # Both are one grep. The whole argument of that paragraph is the SIZE
-          # of the distro-coupling surface, so a stale count there is not a
-          # typo, it is the claim being wrong.
-          pac=$(grep -rlE '\b(pacman|yay)\b' result/share/omarchy/bin | wc -l)
-          claim_pac=$(grep -oE '\*\*[0-9]+ of [0-9]+ scripts\*\*' README.md |
-            grep -oE '^\*\*[0-9]+' | grep -oE '[0-9]+')
-          echo "scripts touching pacman/yay: $pac (README says ${claim_pac:-none})"
-          if [ "${claim_pac:-}" != "$pac" ]; then
-            echo "README says $claim_pac scripts run pacman/yay; there are $pac" >&2
-            exit 1
-          fi
-
-          # Of those, the ones this port replaces outright: an exact filename
-          # match against pkgs/omarchy/nix-bin, which is what "replaced" means
-          # here -- a nix-bin file whose name is an upstream bin's name.
-          ls pkgs/omarchy/nix-bin | sort > /tmp/nixbin.txt
-          grep -rlE '\b(pacman|yay)\b' result/share/omarchy/bin |
-            xargs -n1 basename | sort > /tmp/pac.txt
-          repl=$(comm -12 /tmp/pac.txt /tmp/nixbin.txt | wc -l)
-          word=$(grep -oE '^(Six|Seven|Eight|Nine|Ten|Eleven|Twelve) of those are replaced' README.md |
-            awk '{print $1}')
-          case "$word" in
-            Six) n=6 ;; Seven) n=7 ;; Eight) n=8 ;; Nine) n=9 ;;
-            Ten) n=10 ;; Eleven) n=11 ;; Twelve) n=12 ;; *) n="" ;;
-          esac
-          echo "pacman scripts replaced in nix-bin: $repl (README says ${word:-none})"
-          if [ "${n:-}" != "$repl" ]; then
-            echo "README says $word ($n) of them are replaced; it is $repl" >&2
-            echo "The number is spelled as a word in that sentence; update both." >&2
-            exit 1
-          fi
-
-      # The README quotes app counts in four places. They are derivable from
-      # data/apps.nix, and they silently went stale twice -- once when an app
-      # was added, once when RetroArch moved to being built here -- so derive
-      # them and fail rather than trust prose.
       - name: Every check is run by some workflow, on pull requests
         run: |
           # A check in `checks` that no workflow builds is worse than no check:
@@ -641,30 +586,17 @@ jobs:
           done
           echo "the roadmap names every open epic and no closed one"
 
-      - name: Check the README's app counts still match data/apps.nix
-        run: |
-          eval "$(nix eval --raw --impure --expr '
-            let lib = (builtins.getFlake (toString ./.)).inputs.nixpkgs.lib;
-                a = import ./data/apps.nix;
-                c = f: toString (lib.length (lib.attrNames (lib.filterAttrs f a)));
-            in "total=" + toString (lib.length (lib.attrNames a))
-             + " mod=" + c (_: x: x ? option)
-             + " ours=" + c (_: x: x.ours or false)
-             + " un=" + c (_: x: x ? unavailable)
-          ')"
-          nixpkgs=$(( total - mod - ours - un ))
-          free=$(( nixpkgs + mod ))
-          echo "total=$total nixpkgs=$nixpkgs modules=$mod ours=$ours unavailable=$un"
-
-          fail=0
-          check() { grep -qF "$1" README.md || { echo "::error::README is missing: $1"; fail=1; }; }
-          # "in the selection", not "from Omarchy's menu": a preinstall like
-          # obsidian is in data/apps.nix without a menuId, because upstream has
-          # no per-app Install row for one either.
-          check "| $total apps in the selection | $nixpkgs from nixpkgs, $mod as NixOS modules, $ours built here, $un with no equivalent |"
-          check "**$free of the $total apps never touch this repo.**"
-          check "| nixpkgs ($free of $total apps) | "
-          exit $fail
+      # Every number in the README that is derived from this repository --
+      # command counts, app counts, the size of the pacman surface -- checked
+      # by one script instead of six hand-written assertions. They went stale
+      # twice: once when an app was added, once when RetroArch moved to being
+      # built here.
+      #
+      # Fatal here, on purpose: prose edited by hand must not drift. The
+      # Omarchy bump runs the same script with --fix and commits the result,
+      # so a release moves the numbers instead of failing on them.
+      - name: Every derived number in the README
+        run: .github/scripts/readme-counts.sh --check
 
       - name: Verify shebangs were patched
         run: |

--- a/.github/workflows/omarchy.yml
+++ b/.github/workflows/omarchy.yml
@@ -357,6 +357,55 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc "$AGENT_TOOLSDIRECTORY"
           nix build .#checks.x86_64-linux.session --print-build-logs
 
+      # The derived numbers, applied rather than asserted.
+      #
+      # Adopting 4.0.3 hit three count drifts in one bump -- 431 -> 444
+      # commands, and two numbers in the same paragraph that nothing checked
+      # and had been wrong for some time. Each one failed the build, and not
+      # one of them needed a person to decide anything: a count has exactly
+      # one correct value, derivable from this repository.
+      #
+      # So the bump rewrites them and the diff carries the change, the same
+      # way the decision list above carries the questions that DO need
+      # answering. This runs before create-pull-request, which commits
+      # whatever is in the working tree.
+      #
+      # --fix refuses rather than guesses: a pattern that matches nothing, or
+      # a quantity that computes empty, fails this step instead of rewriting
+      # the README to agree with a broken derivation. Which is why a failure
+      # here should stop the bump -- the numbers being unverifiable is the
+      # same class of news as an anchor that no longer matches.
+      - name: Apply the README's derived numbers
+        if: steps.rel.outputs.changed == 'true'
+        id: counts
+        run: |
+          {
+            echo "counts<<COUNTS_EOF"
+            echo "### Derived numbers"
+            echo
+            if .github/scripts/readme-counts.sh --fix > /tmp/counts.txt 2>&1; then
+              if grep -q '(fixed)' /tmp/counts.txt; then
+                echo "Applied automatically -- no decision needed:"
+                echo
+                echo '```'
+                grep '(fixed)' /tmp/counts.txt
+                echo '```'
+              else
+                echo "Every derived number in the README was already correct."
+              fi
+            else
+              echo "**The derived numbers could not be applied.** Read the job log."
+              echo
+              echo '```'
+              cat /tmp/counts.txt
+              echo '```'
+              FAILED=1
+            fi
+            echo "COUNTS_EOF"
+          } >> "$GITHUB_OUTPUT"
+          cat /tmp/counts.txt
+          [ -z "${FAILED:-}" ]
+
       - name: Open a pull request
         if: steps.rel.outputs.changed == 'true'
         id: pr
@@ -410,6 +459,8 @@ jobs:
             ${{ steps.patched.outputs.patched }}
 
             ${{ steps.decisions.outputs.decisions }}
+
+            ${{ steps.counts.outputs.counts }}
 
             If something is wrong anyway, roll back with
             `nixos-rebuild --rollback` or the boot menu, and open an issue.


### PR DESCRIPTION
Closes #438.

Adopting Omarchy 4.0.3 hit **three count drifts in a single bump**: the command count 431 → 444, and two numbers in the same paragraph — 24 scripts running pacman/yay when there were 32, *"Ten of those are replaced"* when it was six — that **nothing checked** and that had been wrong for some time. They were found only because correcting 431 meant reading the sentence around it. Prose sitting next to a checked number is the most convincing place for a wrong number to live.

None of the three needed a person to decide anything. A count has exactly one correct value, derivable from this repository, and failing the release until somebody types it is asking them to be a calculator.

So the six hand-written assertions in `build.yml` — six greps, six error messages, and a word→digit lookup table that breaks the day the count reaches thirteen — become one script owning nine quantities, and a bump **applies** them instead of failing on them:

| mode | who runs it |
|---|---|
| `--check` | what CI does today, still fatal on pull requests, so hand-edited prose cannot drift |
| `--fix` | the Omarchy bump rewrites them, `create-pull-request` commits the result, and the PR body says which numbers moved |

Decisions stay decisions: whether a new Install row is an app is a question for a human, and #437 already made those a checklist rather than a hard failure. Counts simply move from the *fatal* pile to the *applied* pile.

## The risk this script is built around

`--fix` propagates a **wrong derivation** confidently: get a computation wrong and the README is silently rewritten to agree with it. So every quantity refuses rather than fixes when it cannot be computed, every pattern refuses when it matches nothing, and a floor fails the run if fewer than nine quantities were accounted for. *An auto-fixer that cannot refuse is worse than a check.*

## Proven against the real tree, not a fixture

| | |
|---|---|
| nine quantities on `main` | all pass |
| three numbers perturbed, `--check` | three `::error::` lines, non-zero |
| `--fix` | repairs all three; README **byte-identical** to the original again |
| the wording moved, `--fix` | **refuses** — *"nothing matches its pattern, the wording moved. Not guessing."* |

Two smaller things. The stale comment about *"four places"* sat above the coverage-inversion step rather than the app counts it described, and is dropped with them. And the fixed `/tmp` names became `mktemp`: two of the four self-hosted runners share a machine, so two jobs could have read each other's half-written file and disagreed about a number neither computed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5