### PR TITLE
The doctor names the Broadcom driver, its CVEs, and the string that goes stale

### DIFF
--- a/pkgs/doctor.sh
+++ b/pkgs/doctor.sh
@@ -730,6 +730,12 @@ say "${bold}Wireless${off}"
 # creates it for every driver that registers a wiphy, so this is the one test
 # that does not need a vendor table.
 : "${NIXARCHY_SYSFS_NET:=/sys/class/net}"
+
+# The Broadcom advice below has to print the RUNNING kernel's version, because
+# the permittedInsecurePackages entry it recommends contains it. Overridable
+# for the same reason the sysfs roots above are: the test pins it rather than
+# asserting on whatever kernel the VM happens to boot.
+: "${NIXARCHY_KERNEL_RELEASE:=$(uname -r)}"
 wlan=""
 for n in "$NIXARCHY_SYSFS_NET"/*/; do
   [ -d "$n/wireless" ] || [ -e "$n/phy80211" ] || continue
@@ -782,8 +788,27 @@ elif [ -z "$wifi_bound" ]; then
   say "     wireless tool -- nmtui, iwctl, wpa_cli -- will show the same nothing."
   case "$wifi_make" in
     Broadcom)
-      notes+=("Broadcom wireless needs firmware outside the redistributable set. hardware.enableAllFirmware pulls in b43 and brcm, and needs nixpkgs.config.allowUnfree. Older BCM43xx cards want boot.extraModulePackages = [ config.boot.kernelPackages.broadcom_sta ] instead, and that one conflicts with b43 -- pick one.")
+      # Firmware first, and it is genuinely first: every recent Broadcom card
+      # is FullMAC and served by the in-tree brcmfmac, which needs only the
+      # blob. Leading with the out-of-tree driver would send someone after an
+      # unmaintained module for a card the kernel already supports.
+      notes+=("Broadcom wireless needs firmware outside the redistributable set. hardware.enableAllFirmware pulls in b43 and brcm, and needs nixpkgs.config.allowUnfree. TRY THIS FIRST -- it is in-tree, maintained, and it is the answer for every recent Broadcom card.")
       snippet+=("  hardware.enableAllFirmware = true; # Broadcom wireless; needs allowUnfree")
+
+      # And only then the old chips. Upstream Omarchy ships broadcom-wl-dkms
+      # for exactly these; this port does not, and #446 is where that decision
+      # lives. What the doctor can do is name the driver, the security cost,
+      # and the one string nobody can guess.
+      notes+=("If firmware leaves it dead, this is one of the old chips -- BCM4360, BCM4352, BCM43142, BCM4331 -- that only Broadcom's out-of-tree wl driver supports. nixpkgs has it as config.boot.kernelPackages.broadcom_sta. Treat it as a LAST RESORT: it is unmaintained, and it carries CVE-2019-9501 and CVE-2019-9502 -- heap overflows a crafted wifi packet can turn into remote code execution, on the one interface that faces networks you do not control.")
+      # The maintenance trap, which is the part that actually bites people: the
+      # allowlist entry names the kernel, so it is correct until the next
+      # kernel bump and then fails the rebuild with an error about an insecure
+      # package, saying nothing about wifi.
+      notes+=("Two things about broadcom_sta that are not guessable. nixpkgs refuses to build it until you name it in permittedInsecurePackages, and THAT STRING CONTAINS THE KERNEL VERSION -- so it goes stale on every kernel bump and your next rebuild fails complaining about an insecure package rather than about wireless. On this machine today it is broadcom-sta-6.30.223.271-63-$NIXARCHY_KERNEL_RELEASE; when a rebuild refuses, the error names the string it wants, so paste that one rather than editing this by hand. And wl binds by PCI CLASS, not by device id -- its only modalias is pci:v*d*sv*sd*bc02sc80i* -- so it takes the card from b43 and brcmsmac whether or not you meant it to, which is why they have to be blacklisted rather than merely left alone.")
+      snippet+=("  # Last resort, and only if enableAllFirmware left it dead -- read the notes.")
+      snippet+=("  # boot.extraModulePackages = [ config.boot.kernelPackages.broadcom_sta ];")
+      snippet+=("  # boot.blacklistedKernelModules = [ \"b43\" \"bcma\" \"brcmsmac\" \"ssb\" ];")
+      snippet+=("  # nixpkgs.config.permittedInsecurePackages = [ \"broadcom-sta-6.30.223.271-63-$NIXARCHY_KERNEL_RELEASE\" ];")
       ;;
     Realtek)
       notes+=("Several Realtek cards (8821CE, 8852BE, 8852BU) have no in-tree driver and need an out-of-tree module. nixpkgs packages them under config.boot.kernelPackages -- rtl8821ce, rtl8852bu, rtw88 -- and which one is right depends on device $wifi_id, not on the vendor.")

--- a/pkgs/omarchy/skills/nixarchy/SKILL.md
+++ b/pkgs/omarchy/skills/nixarchy/SKILL.md
@@ -356,6 +356,123 @@ omarchy system reboot           # Reboot
 **IMPORTANT:** Always run `omarchy debug` with `--no-sudo --print` flags to avoid
 interactive sudo prompts that will hang the terminal.
 
+## What Version Am I On, and What Changed?
+
+This is the most common question reaching the **Ask** menu entry, and it has a
+precise answer that guessing gets wrong.
+
+### Step 1 — what this machine actually is
+
+```bash
+nixarchy-version
+```
+
+```
+Omarchy   4.0.3
+nixarchy  8053b82a1f...  2026-09-09
+```
+
+Two separate facts, and conflating them is the usual mistake:
+
+- **Omarchy** is the upstream desktop version this build vendors.
+- **nixarchy** is the revision of *this port*, plus the date it was built.
+
+Two machines can both report Omarchy `4.0.3` and differ by every commit in this
+port. `omarchy --version` answers only the first, which is why
+`nixarchy-version` exists.
+
+**It prints a revision, not a tag, and that is deliberate** — a flake cannot
+know its own tag, and most machines are not on one. Do not invent a version
+number from the rev.
+
+### Step 2 — what shipped since then
+
+Releases carry the notes. Match on the **date**, since the machine reports a
+rev rather than a tag:
+
+```bash
+# Every release, newest first: tag, date, and notes
+curl -fsSL https://api.github.com/repos/olafkfreund/nixarchy/releases \
+  | jq -r '.[] | "\(.tag_name)  \(.published_at[0:10])\n\(.body)\n---"'
+
+# Just the newest tag
+curl -fsSL 'https://api.github.com/repos/olafkfreund/nixarchy/releases?per_page=1' \
+  | jq -r '.[0].tag_name'
+```
+
+**Use the list endpoint, never `/releases/latest`.** Every nixarchy release is
+published with `--prerelease` and a human promotes it once it has been proven
+on real hardware — and GitHub's `/latest` *skips prereleases*. So `/latest`
+answers with an older tag than the newest release, and a user on the current
+release would be told they are behind something they already have. Verified on
+2026-09-09: `/latest` returned `v4.0.2-12` while `v4.0.3-1` was published.
+`installer/try.sh` uses the list endpoint for this same reason.
+
+A release still carrying the prerelease flag has not yet been confirmed on
+physical hardware. That is worth saying when recommending an upgrade — it is
+not a reason to avoid it, it is what "(experimental)" in the title means.
+
+Anything published **after** the date `nixarchy-version` printed is a change
+this machine does not have yet. Summarise those release bodies — they are
+written to be read by users and already say what was added, changed and fixed.
+
+Tags read `v4.0.3-1`: the first component is the **Omarchy** version vendored,
+and the `-1` counts this port's packaging revisions against an unchanged
+upstream. So `v4.0.2-12` → `v4.0.3-1` is an upstream desktop bump, while
+`v4.0.2-11` → `v4.0.2-12` is this port changing alone.
+
+If the network is unavailable, say so rather than guessing — the machine's own
+rev is still answerable offline, the release notes are not.
+
+### Step 3 — what an update would actually move
+
+Installed machines follow the `release` branch, which moves only when a release
+is cut. So a user is never "behind main" in a way that matters; they are behind
+the newest **release**.
+
+```bash
+omarchy update              # both: package set and desktop
+omarchy update --system     # nixpkgs only -- your packages, not the desktop
+omarchy update --nixarchy   # nixarchy only -- the desktop, on the packages you have
+```
+
+Those two axes are independent by design. `--system` is the one that moves the
+**kernel**, which matters for anything hardware-related (see below).
+
+### Answering "is my problem already fixed?"
+
+The useful shape of the answer, in order:
+
+1. `nixarchy-version` — what they have
+2. Release notes newer than that date — what they would get
+3. Whether any of those notes names their symptom
+4. If yes: `omarchy update` (or `--nixarchy` to move only the desktop)
+5. If no: it is unreported — `omarchy debug --no-sudo --print` produces the
+   report to attach to an issue
+
+Never claim a fix landed without finding it in a release body. "It may have
+been fixed" sends someone through a rebuild for nothing.
+
+## Hardware and Drivers
+
+Driver and hardware questions are **not** this skill — they are system
+configuration. Use `nixos-doctor`, which has the wireless and out-of-tree
+driver material, including the Broadcom `broadcom_sta` case and how to keep it
+working across kernel updates.
+
+Start every hardware question the same way regardless:
+
+```bash
+nixarchy doctor
+```
+
+It reports graphics, wireless, Bluetooth and audio from sysfs and names which
+of several similar-looking situations the machine is actually in. One thing
+worth knowing here: **kernel updates arrive through `omarchy update --system`**,
+not through the desktop half, so "my Wi-Fi broke after an update" is almost
+always a nixpkgs move rather than a nixarchy one — and
+`nixos-rebuild --rollback` puts the previous kernel back immediately.
+
 ## Troubleshooting
 
 ```bash

--- a/pkgs/omarchy/skills/nixos-doctor/SKILL.md
+++ b/pkgs/omarchy/skills/nixos-doctor/SKILL.md
@@ -79,6 +79,112 @@ journalctl --user -b -u hyprland --no-pager | tail -40
 journalctl -b | grep -iE 'drm|amdgpu|nvidia|gpu hang'
 ```
 
+## Wireless: Firmware, Drivers, and the Out-of-Tree Trap
+
+`nixarchy doctor` has a **Wireless** section that separates the three cases a
+user cannot tell apart from nmtui, because they have three different fixes:
+
+| doctor says | meaning | fix |
+|---|---|---|
+| "interface `wlpXsY` is up" | working | nothing — if they cannot see networks, that is NetworkManager, not the driver |
+| "No PCI wireless card here" | nothing on the PCI bus | a USB adapter, which the doctor does not see — check `lsusb` |
+| "a card with no driver" | no module claimed it | firmware or an out-of-tree driver, below |
+| "driver loaded, but no interface" | module bound then failed | almost always a missing firmware blob — `journalctl -b -k \| grep -i firmware` names the file |
+
+Run the doctor first. It prints the vendor, the device id, and a pasteable
+snippet, and those three facts decide everything below.
+
+### There is no `wlan0`
+
+Before anything else, rule this out — it is free and it is usually the answer.
+systemd renames interfaces after the PCI slot, so an Intel card at `00:14.3`
+becomes `wlp0s20f3`. Someone searching for "wlan0" finds nothing on a machine
+whose Wi-Fi is perfect. `ip link` settles it.
+
+### Firmware first
+
+Most "no driver" cases are a missing blob, not a missing driver:
+
+```nix
+hardware.enableRedistributableFirmware = true;   # default since v4.0.2-11
+hardware.enableAllFirmware = true;               # adds b43, brcm; needs allowUnfree
+```
+
+`enableAllFirmware` requires `nixpkgs.config.allowUnfree = true`, which the
+installer-generated configuration already sets.
+
+### Broadcom, and why it is a special case
+
+Upstream Omarchy ships `broadcom-wl-dkms`. This port does not, and the doctor
+names the equivalent instead. **Try `enableAllFirmware` first** — every recent
+Broadcom card is FullMAC and served by the in-tree `brcmfmac`, so the blob is
+the whole fix.
+
+Only if that leaves the card dead is it one of the old chips — BCM4360,
+BCM4352, BCM43142, BCM4331 — that need Broadcom's out-of-tree `wl` driver.
+nixpkgs has it:
+
+```nix
+boot.extraModulePackages = [ config.boot.kernelPackages.broadcom_sta ];
+boot.blacklistedKernelModules = [ "b43" "bcma" "brcmsmac" "ssb" ];
+nixpkgs.config.permittedInsecurePackages = [
+  "broadcom-sta-6.30.223.271-63-<KERNEL>"   # <KERNEL> is `uname -r`
+];
+```
+
+**Say the cost out loud before recommending it.** It is unmaintained and
+carries CVE-2019-9501 and CVE-2019-9502 — heap overflows a crafted Wi-Fi packet
+can turn into remote code execution, on the one interface facing networks the
+user does not control. It is a last resort for hardware that otherwise has no
+Wi-Fi at all, not a default.
+
+Three things about it that are not guessable, and each produces a different
+confusing failure if you omit it:
+
+1. **The blacklist is mandatory, not tidiness.** `wl` binds by PCI *class*, not
+   by device id — its only modalias is `pci:v*d*sv*sd*bc02sc80i*` — so it takes
+   the card from `b43` and `brcmsmac` whether or not that was intended. Without
+   the blacklist the machine builds fine and still has no Wi-Fi, which is the
+   failure that looks like the fix.
+2. **The allowlist string contains the kernel version**, so it is correct today
+   and stale after the next kernel bump.
+3. **The package version can move too.** `6.30.223.271-63` is what nixpkgs
+   carries now; when it changes, the string changes with it.
+
+### Maintaining it across kernel updates — the part that actually bites
+
+This is the follow-up question, and it arrives weeks later looking like an
+unrelated bug. After `omarchy update` moves nixpkgs, the kernel moves, and the
+rebuild fails like this:
+
+```
+Package 'broadcom-sta-6.30.223.271-63-6.18.50' ... has known security issues
+```
+
+It says nothing about Wi-Fi. The user's mental model is "my update broke", and
+the string in their config names a kernel they no longer run.
+
+**The fix is always the same, and the error hands it over:** the message names
+the exact string it wants. Paste *that* into `permittedInsecurePackages`,
+replacing the old one, and rebuild. Never hand-edit the version guessing —
+both halves can move.
+
+Two ways to stop it recurring, and the honest recommendation is the first:
+
+- **Replace the card.** A £10 Intel AX200 removes an unmaintained RCE-prone
+  driver from a machine permanently and needs no configuration at all. nixpkgs'
+  own metadata says "heavily recommended to replace the hardware".
+- **Pin the kernel** so the string stops moving —
+  `boot.kernelPackages = pkgs.linuxPackages_6_12;` — at the cost of not getting
+  kernel security updates, which for a driver with remote code execution is a
+  poor trade. Say so if suggesting it.
+
+If the user asks "why does Arch handle this and NixOS does not": Arch's DKMS
+rebuilds the module on kernel change without a version string in the config,
+and Arch does not gate insecure packages. NixOS makes the same driver
+available and makes its cost explicit. The driver is identical — same Broadcom
+tarball, same rpmfusion patch set.
+
 ## Reading the Journal Properly
 
 The journal is the whole logging story on NixOS — there are no per-service files

--- a/tests/doctor-wireless.nix
+++ b/tests/doctor-wireless.nix
@@ -54,6 +54,13 @@ pkgs.runCommand "nixarchy-doctor-wireless" { nativeBuildInputs = [ pkgs.gnugrep 
 
   run() { # run <pci fixture> <net fixture>
     ( export NIXARCHY_SYSFS_PCI="$PWD/fix/$1" NIXARCHY_SYSFS_NET="$PWD/net/$2"
+      # A kernel version this build can never accidentally have. The Broadcom
+      # advice interpolates the running kernel into a permittedInsecurePackages
+      # string, and asserting on the BUILDER's kernel would be asserting on
+      # whatever the runner booted -- green on one machine, red on another, and
+      # the assertion would pass equally if the interpolation were dropped and
+      # the two versions happened to match.
+      export NIXARCHY_KERNEL_RELEASE=9.9.9-test
       ${doctor}/bin/nixarchy-doctor 2>&1 ) || true
   }
 
@@ -104,9 +111,34 @@ pkgs.runCommand "nixarchy-doctor-wireless" { nativeBuildInputs = [ pkgs.gnugrep 
   want    "its device id is printed"   "$b" '0x43a0'
   want    "the fix is pasteable"       "$b" 'hardware.enableAllFirmware = true'
   want    "allowUnfree is mentioned"   "$b" 'allowUnfree'
-  # broadcom_sta and b43 cannot both load. Advice that omits the conflict is
-  # advice that produces a machine which builds and still has no wifi.
-  want    "the conflict is named"      "$b" 'pick one'
+  # Firmware is offered BEFORE the out-of-tree driver, and that order is the
+  # advice: every recent Broadcom card is FullMAC and served by in-tree
+  # brcmfmac, so leading with broadcom_sta would send someone after an
+  # unmaintained module for hardware the kernel already handles.
+  want    "the last resort is marked"  "$b" 'Last resort'
+  want    "the driver is named"        "$b" 'broadcom_sta'
+
+  # The three things about broadcom_sta that a user cannot work out alone, and
+  # each of which produces a different silent failure if omitted.
+  #
+  # 1. It is an unmaintained driver with remote code execution CVEs, on the
+  #    interface that faces untrusted networks. Recommending it without
+  #    saying so is the part that would be indefensible.
+  want    "the CVEs are stated"        "$b" 'CVE-2019-9501'
+  want    "and what they mean"         "$b" 'remote code execution'
+  # 2. nixpkgs refuses to build it until it is named in permittedInsecurePackages,
+  #    and THAT STRING CONTAINS THE KERNEL VERSION -- so it goes stale on every
+  #    kernel bump and the rebuild then fails talking about an insecure
+  #    package, never mentioning wireless. Pinned kernel, exact string.
+  want    "the allowlist is named"     "$b" 'permittedInsecurePackages'
+  want    "with THIS kernel in it"     "$b" 'broadcom-sta-6.30.223.271-63-9.9.9-test'
+  want    "and the staleness warned"   "$b" 'stale on every kernel bump'
+  # 3. wl binds by PCI CLASS, not device id -- its only modalias is
+  #    pci:v*d*sv*sd*bc02sc80i* -- so it claims the card out from under the
+  #    in-tree drivers. Advice without the blacklist builds a machine that
+  #    still has no wifi, which is the failure that looks like the fix.
+  want    "the blacklist is given"     "$b" 'blacklistedKernelModules'
+  want    "and why it is needed"       "$b" 'binds by PCI CLASS'
 
   r=$(run realtek empty)
   want    "realtek named as unbound"   "$r" 'Realtek wireless card with no driver'


### PR DESCRIPTION
Refs #446.

Omarchy 4.0.3's only package change was `broadcom-wl` → `broadcom-wl-dkms`, and this port ships neither. What it *can* do — without putting an unmaintained driver with remote code execution in anyone's closure — is tell the person whose card is dead exactly what their options cost.

## Researched, not remembered

I built it to be sure it was real:

```
/nix/store/...-broadcom-sta-6.30.223.271-63-7.2.4/lib/modules/7.2.4/kernel/net/wireless/wl.ko
```

It **exists and builds on our kernel** — the rpmfusion patch set is carried right up to us (patch 036 is the 7.1 adaptation, 038 the 7.2 one). Three things then decide whether it is usable, and the branch mentioned none of them:

- **CVE-2019-9501 / CVE-2019-9502** — heap overflows a crafted Wi-Fi packet turns into remote code execution, on the interface facing networks the user does not control.
- **nixpkgs refuses to build it** until it is named in `permittedInsecurePackages`, and **that string contains the kernel version**.
- **`wl` binds by PCI *class*, not device id.** Taken from the module rather than from documentation — `modinfo wl.ko` has exactly one alias:

  ```
  pci:v*d*sv*sd*bc02sc80i*
  ```

  It takes the card from `b43` and `brcmsmac` whether or not that was meant, which is why the blacklist is **mandatory rather than tidiness**. Advice without it builds a machine that compiles fine and still has no Wi-Fi — the failure that looks like the fix.

## The one that actually bites

The allowlist string goes stale on every kernel bump, and it fails *weeks later looking like an unrelated bug*:

```
Package 'broadcom-sta-6.30.223.271-63-6.18.50' ... has known security issues
```

Nothing about Wi-Fi. The user's model is "my update broke", and the string in their config names a kernel they no longer run.

## What changed

**Firmware first, and the order is the advice** — every recent Broadcom card is FullMAC and served by in-tree `brcmfmac`, so leading with the out-of-tree driver would send someone after an unmaintained module for hardware the kernel already handles. Only then `broadcom_sta`, marked last resort, CVEs stated, blacklist given, and the allowlist string interpolated from the **running** kernel.

`NIXARCHY_KERNEL_RELEASE` joins the `NIXARCHY_SYSFS_*` overrides so the test can pin it. Asserting on the builder's kernel would be asserting on whatever the runner booted — green on one machine, red on another, and passing equally if the interpolation were dropped and the versions happened to coincide.

## Two skills, because the question arrives in two shapes

- **`nixos-doctor`** — wireless and out-of-tree drivers, including the maintenance story: what the error looks like after a kernel bump, that the error itself names the string to paste, and the two ways to stop it recurring (replace the card — nixpkgs' own metadata says *"heavily recommended"* — or pin the kernel and give up kernel security updates for a driver with RCE).
- **`nixarchy`** — *"what version am I on, and what changed"*, which is what the **Ask** menu entry gets asked most: `nixarchy-version` for the machine's own rev and date, the releases API for what shipped after it, and the two independent update axes (`--system` moves the kernel, `--nixarchy` moves the desktop).

### A correction found by running the command instead of trusting it

The skill first said `/releases/latest` — which **skips prereleases**. Every nixarchy release is published with `--prerelease` until a human promotes it, so `/latest` returned `v4.0.2-12` while `v4.0.3-1` was published. It would have told someone on the current release that they were behind something they already had. It uses the list endpoint now, which is what `installer/try.sh` already did.

## Proven red

Nine new assertions, and the one that matters was proven to fail — replacing the interpolated kernel with a literal makes it fail naming the string it wanted:

```
FAILED  with THIS kernel in it: no /broadcom-sta-6.30.223.271-63-9.9.9-test/ in the output
```

29 assertions pass with the change; the existing 20 are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5