### PR TITLE
Nothing reached the cache because the runners' stores were too warm

### DIFF
--- a/.github/scripts/cachix-push.sh
+++ b/.github/scripts/cachix-push.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Push the closure of named flake outputs to cachix, explicitly.
+#
+#   cachix-push.sh .#omarchy .#nixosConfigurations.vm.config.system.build.toplevel
+#
+# ## Why this exists, and why cachix-action is not enough
+#
+# cachix-action pushes the STORE DIFF: it snapshots the store when the job
+# starts and uploads whatever appeared while the job ran. That is exactly right
+# on a GitHub-hosted runner, whose store begins empty.
+#
+# Ours are self-hosted NixOS machines with WARM stores. A path built by any
+# previous run already exists, so it falls outside the diff and is never
+# uploaded -- and having been built once it can never become new again, so it
+# is skipped forever. Measured on main at 8053b82a: 23684 skipped, 32 pushed,
+# and omarchy's own path not even a candidate. nixarchy.cachix.org answered 404
+# for it while every step of that job reported success, because pushing nothing
+# IS success by the store-diff definition (#439).
+#
+# The perverse part: the better the local store works, the less reaches the
+# cache users pull from.
+#
+# So this names what to push instead of inferring it. `-r` because the closure
+# is the point -- a narinfo hit on omarchy alone still leaves a user building
+# every one of its dependencies.
+set -uo pipefail
+
+[ $# -gt 0 ] || { echo "usage: $0 <flake-attr>..." >&2; exit 2; }
+
+# A fork PR has no secret, and that is not a failure -- it is a PR that cannot
+# push and does not need to. Said out loud rather than failing obscurely deep
+# inside cachix.
+if [ -z "${CACHIX_AUTH_TOKEN:-}" ]; then
+  echo "no CACHIX_AUTH_TOKEN; not pushing (expected on a fork PR)"
+  exit 0
+fi
+
+fail=0
+for attr in "$@"; do
+  # Already built by an earlier step in the same job -- this resolves the
+  # output path without building, and says so plainly if it is missing rather
+  # than silently pushing an empty list.
+  if ! out=$(nix path-info "$attr" 2>/dev/null); then
+    echo "::error::$attr is not built; push it from the job that builds it" >&2
+    fail=1
+    continue
+  fi
+
+  n=$(nix path-info -r "$attr" 2>/dev/null | wc -l)
+  # A closure of zero is the failure this whole script exists to stop being
+  # invisible. `nix path-info` above can succeed while `-r` yields nothing, and
+  # piping that into cachix pushes an empty list and reports success -- which is
+  # exactly how #439 stayed hidden through every green run.
+  if [ "$n" -eq 0 ]; then
+    echo "::error::$attr resolved to an EMPTY closure; refusing to call that a push" >&2
+    fail=1
+    continue
+  fi
+  echo "pushing $attr ($n paths in its closure)"
+  if ! nix path-info -r "$attr" 2>/dev/null | cachix push nixarchy; then
+    # Not fatal on its own: a cache upload failing must not fail a build that
+    # succeeded (#235, and the reason every cachix step here is
+    # continue-on-error). But it must be VISIBLE, because "pushed nothing" and
+    # "push failed" looked identical for long enough to hide #439 completely.
+    echo "::warning::pushing $attr to cachix failed" >&2
+    fail=1
+  fi
+  echo "  $out"
+done
+
+exit "$fail"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,6 +237,19 @@ jobs:
       - name: Build the vendored Omarchy tree
         run: nix build .#omarchy --print-build-logs
 
+      # cachix-action pushes the store DIFF, and these runners have warm
+      # stores -- so a path built by any earlier run is skipped, forever, and
+      # the cache users pull from never receives it. Measured on 8053b82a:
+      # 23684 skipped, 32 pushed, omarchy itself not even a candidate, and its
+      # narinfo answering 404 while every step reported success (#439).
+      #
+      # So name what to push rather than inferring it.
+      - name: Push the Omarchy closure to cachix
+        continue-on-error: true
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: .github/scripts/cachix-push.sh .#omarchy
+
       - name: Verify the CLI sees its subcommands
         run: |
           # bin/omarchy discovers subcommands by grepping sibling scripts for
@@ -1178,6 +1191,19 @@ jobs:
         # bootloader and disko filesystems. Built here so the install path
         # cannot rot unnoticed between releases.
         run: .github/scripts/build-unless-proven.sh .#checks.x86_64-linux.reference-toplevel
+
+      # The two closures that decide whether somebody's rebuild downloads or
+      # compiles. Same reason as the omarchy push above (#439); this is the
+      # half users feel.
+      - name: Push the system closures to cachix
+        if: needs.gate.outputs.relevant == 'true'
+        continue-on-error: true
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: |
+          .github/scripts/cachix-push.sh \
+            .#checks.x86_64-linux.vm-toplevel \
+            .#checks.x86_64-linux.reference-toplevel
 
       - name: Read a MicroVM runner without booting it
         if: needs.gate.outputs.relevant == 'true'


### PR DESCRIPTION
Closes #439.

`nixarchy.cachix.org` did not have `main`'s omarchy. Verified rather than assumed:

```
hash xfbxvlsqm6h607clyb3p0jj024pp82v7
https://nixarchy.cachix.org/$hash.narinfo -> HTTP 404
```

**It is not the token** — which was the standing hypothesis; `nightly.yml:229` still says *"likely cause is CACHIX_AUTH_TOKEN: cachix exits 0 when a token is rejected"*. The log disproves it: the push ran, authenticated and uploaded, with no 403 anywhere. From the `omarchy` job on `8053b82a`:

```
23684  [Info] Skipping /nix/store/...
   32  [Info] Pushed   /nix/store/...
```

omarchy's own hash appears **nowhere** in that log. Not pushed, not skipped by name — never a candidate at all.

## Why

`cachix-action` pushes the **store diff**: it snapshots the store as the job starts and uploads what appeared while it ran. That is exactly right on a GitHub-hosted runner, whose store begins empty.

Ours are self-hosted NixOS machines with **warm stores** — `nightly.yml:52` says so in as many words. A path built by any previous run already exists, falls outside the diff, and is never uploaded. Having been built once, it can never become new again, so it is skipped forever.

The perverse part: **the better the local store works, the less reaches the cache users pull from.** And it is invisible, because every step reports success — pushing nothing *is* success by the store-diff definition.

## The fix

Name what to push instead of inferring it. `cachix-push.sh` takes flake attrs and pushes their **closures** (`-r`) — a narinfo hit on omarchy alone still leaves a user building all 33 of its dependencies.

Wired where the artefacts are already built, so nothing is rebuilt in order to push it:

| job | pushes |
|---|---|
| `omarchy` | the vendored tree |
| `system` | `vm-toplevel` and `reference-toplevel` — the two closures that decide whether a rebuild downloads or compiles |

## Three failure modes, each proven by running it

| case | behaviour |
|---|---|
| no `CACHIX_AUTH_TOKEN` | exits 0 saying so — a fork PR cannot push and shouldn't read as an error |
| attr not built | `::error::` naming the attr, instead of pushing an empty list from the wrong job |
| **empty closure** | `::error::` and refuses to call it a push |

That last guard is the whole lesson of this bug. `nix path-info` can succeed while `-r` yields nothing, and piping that into cachix reports success — which is precisely how #439 survived every green run. **A push step that cannot fail proves nothing**, so "pushed nothing" and "push failed" stop being the same outcome.

Kept `continue-on-error`: a cache upload failing must not fail a build that succeeded (#235). *Visible* is not the same as *fatal*.

The probe #442 repaired is the check that catches a regression here — it queries the narinfo at the same commit that pushed, so it would have gone red on this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5