### PR TITLE
Following stable nixpkgs stops being a two-line hand edit

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1222,6 +1222,13 @@
             inherit (self.packages.${system}) doctor;
           };
 
+          # nixarchy-channel edits a file the user owns, so the check is mostly
+          # about what it refuses. See tests/channel.nix.
+          channel = import ./tests/channel.nix {
+            pkgs = pkgsFor.${system};
+            omarchy = self.packages.${system}.omarchy;
+          };
+
           # The `try` front door's refusals, each driven with a stubbed
           # environment that lies about KVM, RAM, disk and the build plan.
           # Building tryApp is itself half the assertion: the app evaluates

--- a/pkgs/omarchy/nix-bin/nixarchy-channel
+++ b/pkgs/omarchy/nix-bin/nixarchy-channel
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+
+# nixarchy:new
+# omarchy:summary=Follow stable or unstable nixpkgs
+# omarchy:args=[stable [RELEASE] | unstable]
+# omarchy:examples=nixarchy channel
+# omarchy:examples=nixarchy channel stable
+# omarchy:examples=nixarchy channel stable 25.05
+
+# The generated flake already documents how to follow stable nixpkgs -- as
+# PROSE telling you to hand-edit two inputs. The second one is the half people
+# get wrong: nixpkgs and home-manager are developed as a PAIR, and a machine on
+# stable nixpkgs with a master home-manager is a combination neither project
+# supports. So this does both edits or neither.
+#
+# Precedent for touching a file the user owns is nixarchy-unfreeze, and its
+# rule applies here: only lines this project wrote get rewritten. A flake.nix
+# somebody has reshaped is theirs, and this prints the edit rather than
+# guessing at it.
+#
+# ## The uncomfortable part, said out loud
+#
+# "Stable" sounds safer and here it is LESS TESTED. Nixarchy is developed
+# against unstable -- flake.nix pins nixos-unstable and every check runs
+# against whatever that locks to. Stable is a real answer, not a supported one.
+
+set -euo pipefail
+
+flake="${NIXARCHY_FLAKE:-/etc/nixos}"
+nixfile="$flake/flake.nix"
+
+red() { printf "\033[0;31m%s\033[0m\n" "$1"; }
+dim() { printf "\033[0;90m%s\033[0m\n" "$1"; }
+bold() { printf "\033[1m%s\033[0m\n" "$1"; }
+
+usage() {
+  echo "Usage: nixarchy channel [stable [RELEASE] | unstable]"
+  echo "  (no argument)  report which one this machine follows"
+  echo "  stable         nixos-<latest release>, home-manager release-<same>"
+  echo "  unstable       nixos-unstable, home-manager as nixarchy pins it"
+}
+
+target="${1:-}"
+# An explicit release is allowed and is not only a test seam: following a
+# release OTHER than the newest is a real thing to want -- staying on 25.11
+# while 26.05 settles, or matching a machine you already run. Given one, the
+# lookup below is skipped entirely, which also means `stable` works with no
+# network when you already know the answer.
+want_release="${2:-}"
+case "$target" in
+  "" | stable | unstable) ;;
+  -h | --help) usage; exit 0 ;;
+  *) usage >&2; exit 1 ;;
+esac
+case "$want_release" in
+  "" | [0-9][0-9].[0-9][0-9]) ;;
+  *) red "A release looks like 25.05, not '$want_release'."; exit 1 ;;
+esac
+if [ -n "$want_release" ] && [ "$target" != stable ]; then
+  red "A release only means something with 'stable'."; exit 1
+fi
+
+[ -f "$nixfile" ] || { red "No $nixfile."; exit 1; }
+
+# Read the INTENT, not the lock: the URL is what an update will resolve, and
+# the lock is only where it last landed. A machine mid-edit should report what
+# it is about to become.
+current_url=$(sed -nE "s/^[[:space:]]*nixpkgs\.url[[:space:]]*=[[:space:]]*\"([^\"]+)\".*/\1/p" "$nixfile" | head -1)
+if [ -z "$current_url" ]; then
+  red "Cannot find the nixpkgs.url line in $nixfile."
+  echo
+  echo "This flake has been reshaped, so it is not mine to rewrite."
+  usage
+  exit 1
+fi
+
+case "$current_url" in
+  *nixos-unstable*) current=unstable ;;
+  *nixos-[0-9][0-9].[0-9][0-9]*) current=stable ;;
+  *) current=custom ;;
+esac
+
+# Anchored, because the template carries a COMMENTED example of this very
+# line as the prose telling you to add it by hand. An unanchored match finds
+# that comment, and the consequence is not cosmetic: it makes the rewrite
+# below edit the comment instead of adding a real override, leaving a machine
+# on stable nixpkgs with a master home-manager -- the exact pairing this
+# command exists to prevent, arrived at silently.
+hm_line=$(grep -nE "^[[:space:]]*inputs\.home-manager\.url[[:space:]]*=" "$nixfile" | head -1 || true)
+
+if [ -z "$target" ]; then
+  bold "This machine follows: $current"
+  echo "  nixpkgs        $current_url"
+  if [ -n "$hm_line" ]; then
+    echo "  home-manager   $(printf "%s" "$hm_line" | sed -E "s/.*\"([^\"]+)\".*/\1/")"
+  else
+    echo "  home-manager   whatever nixarchy pins (no override here)"
+  fi
+  echo
+  case "$current" in
+    unstable) dim "This is what nixarchy is developed and tested against." ;;
+    stable) dim "Nixarchy is tested against UNSTABLE. This is a real answer, not a supported one." ;;
+    custom) dim "Neither channel -- nixpkgs points somewhere of your own." ;;
+  esac
+  exit 0
+fi
+
+[ "$target" != "$current" ] || { echo "Already following $target. Nothing to do."; exit 0; }
+
+if [ "$current" = custom ]; then
+  red "nixpkgs.url is neither channel:"
+  echo "  $current_url"
+  echo
+  echo "Switching would discard a choice made deliberately, so it is not done"
+  echo "for you. Edit that line yourself if you want a channel back."
+  exit 1
+fi
+
+[ -w "$nixfile" ] || { red "$nixfile is not writable by $USER."; echo; echo "  chown it to yourself, or run omarchy update which offers to."; exit 1; }
+
+# Ask which release is current rather than guessing.
+#
+# Hardcoding one goes stale within six months, and deriving it from the running
+# version is wrong exactly when it matters -- a machine already on stable would
+# compute its own release and call that the newest. So ask nixpkgs, and REFUSE
+# if that cannot be answered: a wrong release points the whole machine at a
+# branch that does not exist, and offline convenience is not worth that.
+if [ "$target" = stable ]; then
+  # matching-refs, not the branches API and not git ls-remote.
+  #
+  # `?per_page=100` on /branches is wrong: nixpkgs has more than 100 branches,
+  # so page one comes back full and contains no nixos-XX.YY at all -- measured,
+  # exactly 100 names and not one release among them. Paging to find them is
+  # several requests to answer what one filtered request answers.
+  #
+  # git ls-remote does answer it in one, and was the first fix here, but git is
+  # not in the omarchy runtimeDeps -- so on a real machine it would fail as
+  # "command not found", be swallowed, and this would report a NETWORK problem
+  # that is really a missing binary. curl is a runtimeDep; this uses curl.
+  #
+  # `|| true` because set -e with pipefail turns "no matches" into a silent
+  # exit before the refusal below can explain anything. The first version died
+  # with no output at all, which is the worst way to fail.
+  release="$want_release"
+  [ -n "$release" ] || release=$(curl -fsSL "https://api.github.com/repos/NixOS/nixpkgs/git/matching-refs/heads/nixos-2" 2>/dev/null |
+    grep -oE "refs/heads/nixos-[0-9]{2}\.[0-9]{2}\"" |
+    grep -oE "[0-9]{2}\.[0-9]{2}" | sort -V | tail -1 || true)
+  if [ -z "$release" ]; then
+    red "Cannot reach github.com to learn which nixpkgs release is current."
+    echo
+    echo "Not guessing. Try again with a network, or set both by hand:"
+    echo
+    dim "  nixpkgs.url = \"github:NixOS/nixpkgs/nixos-<RELEASE>\";"
+    dim "  inputs.home-manager.url = \"github:nix-community/home-manager/release-<RELEASE>\";"
+    exit 1
+  fi
+  new_nixpkgs="github:NixOS/nixpkgs/nixos-$release"
+  new_hm="github:nix-community/home-manager/release-$release"
+else
+  new_nixpkgs="github:NixOS/nixpkgs/nixos-unstable"
+  new_hm=""
+fi
+
+bold "Switching this machine from $current to $target."
+echo "  nixpkgs        $current_url"
+echo "              -> $new_nixpkgs"
+if [ -n "$new_hm" ]; then
+  echo "  home-manager -> $new_hm"
+  echo
+  dim "Both, because nixpkgs and home-manager move as a pair. Moving one"
+  dim "without the other is the mistake this command exists to prevent."
+else
+  echo "  home-manager -> back to whatever nixarchy pins"
+fi
+echo
+if [ "$target" = stable ]; then
+  red "Nixarchy is developed and tested against UNSTABLE."
+  echo "This combination is not what CI builds. A failed rebuild changes"
+  echo "nothing and a bad activation is one rollback away -- but know it first."
+  echo
+fi
+
+printf "Rewrite %s? [y/N] " "$nixfile"
+read -r reply
+case "$reply" in [yY]*) ;; *) echo "Nothing changed."; exit 0 ;; esac
+
+cp "$nixfile" "$nixfile.pre-channel"
+
+# Checksummed, not trusted: sed exits 0 for a pattern that matched nothing, so
+# an unverified rewrite reports success having changed nothing -- and the
+# re-lock below would then run against a file nobody edited.
+before=$(cksum < "$nixfile")
+
+sed -i -E "s|^([[:space:]]*nixpkgs\.url[[:space:]]*=[[:space:]]*\")[^\"]+(\".*)|\1$new_nixpkgs\2|" "$nixfile"
+
+if [ -n "$new_hm" ]; then
+  if [ -n "$hm_line" ]; then
+    sed -i -E "s|^([[:space:]]*inputs\.home-manager\.url[[:space:]]*=[[:space:]]*\")[^\"]+(\".*)|\1$new_hm\2|" "$nixfile"
+  else
+    # Beside the follows, which is where the template prose says to put it --
+    # so a file edited by this and one edited by hand come out the same shape.
+    sed -i -E "s|^([[:space:]]*)(inputs\.nixpkgs\.follows[[:space:]]*=[[:space:]]*\"nixpkgs\";)|\1\2\n\1inputs.home-manager.url = \"$new_hm\";|" "$nixfile"
+  fi
+elif [ -n "$hm_line" ]; then
+  sed -i -E "/^[[:space:]]*inputs\.home-manager\.url[[:space:]]*=/d" "$nixfile"
+fi
+
+if [ "$before" = "$(cksum < "$nixfile")" ]; then
+  red "Nothing in $nixfile changed."
+  echo "The lines are not the shape this expected, so it has not guessed."
+  mv "$nixfile.pre-channel" "$nixfile"
+  exit 1
+fi
+
+echo
+echo "Rewrote $nixfile (previous copy: $nixfile.pre-channel)"
+echo
+
+# Re-lock only what moved. A bare flake update would move nixarchy too, which
+# is a second decision nobody asked this command to make.
+inputs=(nixpkgs)
+[ -n "$new_hm" ] && inputs+=(home-manager)
+
+echo "Re-locking: ${inputs[*]}"
+if ! nix flake update "${inputs[@]}" --flake "$flake"; then
+  red "Re-locking failed. $nixfile is rewritten; the lock is not."
+  echo "Restore with:  mv $nixfile.pre-channel $nixfile"
+  exit 1
+fi
+
+echo
+bold "Locked. Now rebuild:"
+dim "  nh os switch"

--- a/tests/channel.nix
+++ b/tests/channel.nix
@@ -1,0 +1,125 @@
+{ pkgs, omarchy }:
+# nixarchy-channel rewrites a file the user owns, so what it REFUSES to do
+# matters more than what it does.
+#
+# Every case here runs offline. `stable` takes an optional release argument
+# precisely so it can, and so somebody can follow 25.11 while 26.05 settles --
+# a test seam and a real feature being the same thing is the good case.
+#
+# The fixture is the real installer template with its placeholders filled, not
+# a hand-written flake: the whole risk in this command is sed against a shape,
+# and a fixture written to match the sed would prove nothing about the file
+# users actually have.
+let
+  template = builtins.readFile ../installer/template/flake.nix;
+  filled =
+    builtins.replaceStrings
+      [ "@nixpkgs_url@" "@nixarchy_url@" ]
+      [ "github:NixOS/nixpkgs/nixos-unstable" "github:olafkfreund/nixarchy/release" ]
+      template;
+in
+pkgs.runCommand "nixarchy-channel"
+  {
+    nativeBuildInputs = [
+      pkgs.gnugrep
+      pkgs.gnused
+      pkgs.coreutils
+    ];
+  }
+  ''
+    export HOME=$PWD/home
+    mkdir -p "$HOME"
+    ch=${omarchy}/share/omarchy/bin/nixarchy-channel
+
+    mk() { mkdir -p "$1"; cat > "$1/flake.nix" < ${pkgs.writeText "flake.nix" filled}; }
+
+    fails=0
+    want() {
+      if printf '%s' "$2" | grep -q -- "$3"; then echo "  ok      $1"
+      else
+        echo "  FAILED  $1: no /$3/ in the output"
+        printf '%s\n' "$2" | sed 's/^/          | /'
+        fails=$((fails + 1))
+      fi
+    }
+    wantnot() {
+      if printf '%s' "$2" | grep -q -- "$3"; then
+        echo "  FAILED  $1: /$3/ present and should not be"; fails=$((fails + 1))
+      else echo "  ok      $1"; fi
+    }
+
+    mk plain
+    r=$(NIXARCHY_FLAKE=$PWD/plain $ch 2>&1 || true)
+    want "reports the channel"        "$r" 'follows: unstable'
+    want "and says it is the tested one" "$r" 'developed and tested against'
+    # THE BUG THIS TEST WAS WRITTEN FOR.
+    #
+    # The template carries a COMMENTED example of inputs.home-manager.url -- it
+    # is the prose telling you to add it by hand. An unanchored grep matches that
+    # comment, and the damage is not cosmetic: a switch to stable then rewrites
+    # the COMMENT instead of adding a real override, leaving a machine on stable
+    # nixpkgs with a master home-manager. That is exactly the pairing this
+    # command exists to prevent, arrived at silently and reported as success.
+    want "the commented example is not read as a setting" "$r" 'no override here'
+    wantnot "and its line number never leaks" "$r" '#   inputs.home-manager'
+
+    # Declining must leave the file byte-identical. A backup is not a substitute
+    # for not writing.
+    mk decline
+    before=$(cksum < decline/flake.nix)
+    echo n | NIXARCHY_FLAKE=$PWD/decline $ch stable 25.11 >/dev/null 2>&1 || true
+    if [ "$before" = "$(cksum < decline/flake.nix)" ]; then echo "  ok      declining changes nothing"
+    else echo "  FAILED  declining rewrote the file"; fails=$((fails + 1)); fi
+
+    # A flake reshaped past recognition is not ours to sed. Printing the edit is
+    # the right answer; guessing at it is how a working machine stops booting.
+    mk reshaped
+    grep -v 'nixpkgs.url' plain/flake.nix > reshaped/flake.nix
+    r=$(NIXARCHY_FLAKE=$PWD/reshaped $ch 2>&1 || true)
+    want "a reshaped flake is refused"  "$r" 'has been reshaped'
+
+    mk custom
+    sed -i 's|nixos-unstable|someone/their-own-branch|' custom/flake.nix
+    r=$(NIXARCHY_FLAKE=$PWD/custom $ch stable 25.11 2>&1 || true)
+    want "a deliberate choice is kept"  "$r" 'neither channel'
+    wantnot "and not overwritten"       "$r" 'Rewrote'
+
+    r=$(NIXARCHY_FLAKE=$PWD/plain $ch unstable 2>&1 || true)
+    want "already-on-it is a no-op"     "$r" 'Nothing to do'
+
+    # Arguments that cannot mean anything are refused rather than interpreted.
+    r=$(NIXARCHY_FLAKE=$PWD/plain $ch stable banana 2>&1 || true)
+    want "a bad release is rejected"    "$r" 'looks like 25.05'
+    r=$(NIXARCHY_FLAKE=$PWD/plain $ch unstable 25.11 2>&1 || true)
+    want "a release needs stable"       "$r" "only means something with 'stable'"
+
+    # The rewrite itself, offline. Re-locking needs a network and is not part of
+    # what this asserts; the file's shape is.
+    mk rewrite
+    echo y | NIXARCHY_FLAKE=$PWD/rewrite $ch stable 25.11 >/dev/null 2>&1 || true
+    f=$(cat rewrite/flake.nix)
+    want "nixpkgs moved to the release" "$f" 'github:NixOS/nixpkgs/nixos-25.11'
+    # The pairing is the entire point of the command existing.
+    want "home-manager moved with it"   "$f" 'home-manager/release-25.11'
+    want "beside the follows, as the template's own prose says" \
+      "$f" 'inputs.nixpkgs.follows = "nixpkgs";'
+    if [ -f rewrite/flake.nix.pre-channel ]; then echo "  ok      the previous file is kept"
+    else echo "  FAILED  no .pre-channel backup"; fails=$((fails + 1)); fi
+
+    # Back again, and the override must GO -- not be left pointing at a release
+    # while nixpkgs follows unstable, which is the same broken pairing mirrored.
+    echo y | NIXARCHY_FLAKE=$PWD/rewrite $ch unstable >/dev/null 2>&1 || true
+    f=$(cat rewrite/flake.nix)
+    want "and back to unstable"         "$f" 'nixos-unstable'
+    wantnot "the override is removed"   "$f" 'release-25.11'
+
+    # A floor. Every assertion above fails identically if the command printed
+    # nothing at all, which reads as every rule being wrong rather than as the
+    # binary being missing.
+    [ -x "$ch" ] || { echo "nixarchy-channel is not executable at $ch"; exit 1; }
+
+    echo
+    if [ "$fails" -gt 0 ]; then echo "$fails failed"; exit 1; fi
+    echo "nixarchy-channel: all assertions hold"
+    touch $out
+  ''


### PR DESCRIPTION
#374 item 4.

`installer/template/flake.nix` already documents how to follow stable — as **prose telling you to hand-edit two inputs**. The second is the half people get wrong, because nixpkgs and home-manager are developed as a **pair**. A machine on stable nixpkgs with a master home-manager is a combination neither project supports, and nothing was stopping anyone reaching it.

So `nixarchy channel` does both edits or neither:

```
nixarchy channel                what this machine follows now
nixarchy channel stable         nixos-<newest>, home-manager release-<same>
nixarchy channel stable 25.11   a release of your choosing
nixarchy channel unstable       back, and the override REMOVED
```

The explicit release is not only a test seam — staying on 25.11 while 26.05 settles, or matching a machine you already run, is a real thing to want. Given one, the lookup is skipped, so `stable` also works with **no network**.

## It says the uncomfortable thing before it acts

"Stable" sounds safer and here it is **less tested**. Nixarchy is developed against unstable — `flake.nix` pins `nixos-unstable` and every check runs against whatever that locks to. The command prints that, in red, before the prompt.

## What it refuses

Precedent is `nixarchy-unfreeze`, and its rule holds: only lines this project wrote get rewritten.

| case | behaviour |
|---|---|
| reshaped flake | no `nixpkgs.url` where expected → prints the edit, refuses |
| a custom URL | neither channel → a deliberate choice, kept |
| already on it | says so, changes nothing |
| bad arguments | `banana` is not a release; a release without `stable` means nothing |
| release unknown | cannot reach GitHub → **refuses**. A wrong release points the machine at a branch that does not exist |
| sed matched nothing | checksummed before/after; restores the backup rather than re-locking a file nobody edited |

## Three bugs found by running it, not by reading it

**1. The template carries a *commented* example of `inputs.home-manager.url`** — the prose telling you to add it by hand. An unanchored grep matches that comment, and the damage is not cosmetic: the rewrite then edits the **comment** instead of adding a real override, so the machine ends up on stable nixpkgs with a master home-manager. The exact pairing this command exists to prevent, reached silently and reported as success.

Proven red on precisely this — un-anchor the grep and three assertions fail:

```
FAILED  the commented example is not read as a setting
FAILED  and its line number never leaks
FAILED  home-manager moved with it            <- the real damage
```

**2. `/branches?per_page=100` never contains a release branch.** nixpkgs has more than 100 branches; measured, page one returns exactly 100 names and not one `nixos-XX.YY` among them.

**3. `git ls-remote` answers it in one request and was the first fix — but `git` is not in omarchy's `runtimeDeps`.** On a real machine it fails as "command not found", gets swallowed, and the command reports a **network** problem that is really a missing binary. Now uses `curl` with `matching-refs`, which is server-filtered and needs only what is already there.

And `set -e` with `pipefail` turned "no matches" into a silent exit *before* the refusal could explain anything — the first version died printing nothing at all.

## The fixture is the real template

`tests/channel.nix` fills `installer/template/flake.nix`'s own placeholders rather than hand-writing a flake. The whole risk here is sed against a shape, and a fixture written to match the sed would prove nothing about the file users actually have. **17 assertions, every one offline.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5