### PR TITLE
A single machine can follow security updates without following the desktop

### DIFF
--- a/modules/auto-update.nix
+++ b/modules/auto-update.nix
@@ -1,0 +1,186 @@
+# A single machine that keeps its own package set current, unattended.
+#
+# The sibling of fleet.nix and deliberately not the same thing. fleet.nix
+# points a machine at a REMOTE flake, which is right for a fleet and wrong for
+# a laptop: its own warning says local edits under /etc/nixos "are reverted at
+# the next pull, silently and without asking". For a machine whose
+# configuration IS /etc/nixos, that is not a trade-off, it is data loss.
+#
+# So this pulls nothing. It moves ONE input in the flake the machine already
+# has, and rebuilds from it.
+#
+# ## Why nixpkgs only, and not "update everything"
+#
+# The two axes are independent by design (installer/mkFlake.nix makes nixpkgs a
+# root input and has nixarchy follow it), and they mean different things:
+#
+#   nixpkgs   your package set -- kernel, openssl, browsers. Security updates.
+#   nixarchy  the desktop
+#
+# An unattended nixpkgs bump is what "follow NixOS" means to most people. An
+# unattended nixarchy bump changes the desktop under someone who did not ask,
+# possibly while they are using it. One of those is a background task and the
+# other is a decision, so only the first is on offer here. `omarchy update
+# --nixarchy` remains the way to take the other, when you choose to.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.nixarchy.autoUpdate;
+  fleet = config.programs.nixarchy.fleet;
+in
+{
+  options.programs.nixarchy.autoUpdate = {
+    enable = lib.mkEnableOption ''
+      moving this machine's nixpkgs forward on a timer and rebuilding.
+
+      OFF by default. A machine that rebuilds itself unattended is not
+      something to switch on for somebody.
+
+      Only nixpkgs moves -- your package set, which is where security updates
+      live. Nixarchy itself is left where it is, because changing the desktop
+      under someone who did not ask is a decision rather than maintenance;
+      `omarchy update --nixarchy` takes that one deliberately.
+
+      Nothing is pulled from anywhere: this rebuilds the flake already on the
+      machine
+    '';
+
+    dates = lib.mkOption {
+      type = lib.types.str;
+      default = "daily";
+      example = "Sun 04:00";
+      description = "systemd calendar expression for when to update.";
+    };
+
+    flake = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/nixos";
+      description = "The machine's own flake directory. Rebuilt in place, never replaced.";
+    };
+
+    allowDirty = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Rebuild even when the flake directory has uncommitted changes.
+
+        Off by default, and this is the safety that matters. /etc/nixos is a
+        git repository the user edits by hand, so an unattended rebuild of a
+        dirty tree deploys whatever was half-finished when they walked away --
+        at 03:00, with nobody watching, and the failure arrives as a machine
+        that booted into an edit nobody meant to apply.
+
+        Refusing is recorded, not silent: the reason lands in
+        /var/lib/nixarchy/upgrade-failed and the doctor reads it.
+      '';
+    };
+  };
+
+  config = lib.mkIf (config.programs.nixarchy.enable && cfg.enable) {
+    assertions = [
+      {
+        # Both would drive this machine from two different flakes on two
+        # timers. Whichever ran last would win and the other would look
+        # intermittently broken.
+        assertion = !fleet.enable;
+        message =
+          "programs.nixarchy.autoUpdate and .fleet are both enabled. "
+          + "fleet pulls a REMOTE flake and reverts local edits; autoUpdate "
+          + "rebuilds this machine's OWN flake. Pick one.";
+      }
+    ];
+
+    systemd.services.nixarchy-auto-update = {
+      description = "Move nixpkgs forward and rebuild this machine";
+      # Not wantedBy anything: the timer is the only thing that starts it. A
+      # boot-time trigger would rebuild a machine somebody just booted because
+      # they needed it.
+      serviceConfig = {
+        Type = "oneshot";
+        StateDirectory = "nixarchy";
+      };
+      unitConfig.OnFailure = "nixarchy-upgrade-failed.service";
+
+      path = with pkgs; [
+        nix
+        git
+        config.system.build.nixos-rebuild
+        coreutils
+        gnutar
+        gzip
+        openssh
+      ];
+
+      script = ''
+        set -euo pipefail
+        flake=${lib.escapeShellArg cfg.flake}
+
+        note() {
+          printf '%s %s\n' "$(date -Is)" "$1" >> /var/lib/nixarchy/upgrade-failed
+        }
+
+        if [ ! -d "$flake" ]; then
+          note "auto-update: $flake does not exist"
+          echo "no flake at $flake" >&2
+          exit 1
+        fi
+
+        ${lib.optionalString (!cfg.allowDirty) ''
+          # The whole reason this is off by default. A dirty tree is somebody's
+          # unfinished edit, and rebuilding it unattended deploys that edit.
+          # Reported rather than ignored: an unattended job that stops working
+          # and says nothing looks exactly like one that is up to date.
+          if [ -d "$flake/.git" ] && ! git -C "$flake" diff --quiet HEAD 2>/dev/null; then
+            note "auto-update: $flake has uncommitted changes; not rebuilding"
+            echo "$flake is dirty; commit it or set autoUpdate.allowDirty" >&2
+            exit 1
+          fi
+        ''}
+
+        # ONE input. A bare flake update moves nixarchy too, which is the
+        # decision this module deliberately does not make.
+        nix flake update nixpkgs --flake "$flake"
+
+        # switch, not boot: a package-set update that needs a reboot to take
+        # effect is one the user never notices they received.
+        nixos-rebuild switch --flake "$flake"
+      '';
+    };
+
+    # Same failure the sibling exists to survive, for the same reason: an
+    # unattended job that starts failing stops delivering security updates and
+    # says nothing, and a machine that has quietly stopped updating is
+    # indistinguishable from one that is current. A file rather than only a log
+    # line, because journald rotates and "when did this last work" should
+    # outlive that. See nixpkgs#349734.
+    systemd.services.nixarchy-upgrade-failed = {
+      description = "Record that the unattended update failed";
+      serviceConfig = {
+        Type = "oneshot";
+        StateDirectory = "nixarchy";
+      };
+      script = ''
+        printf '%s unattended update failed\n' "$(${pkgs.coreutils}/bin/date -Is)" \
+          >> /var/lib/nixarchy/upgrade-failed
+      '';
+    };
+
+    systemd.timers.nixarchy-auto-update = {
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.dates;
+        # A laptop asleep at the hour is the machine that most needs to catch
+        # up and the one a non-persistent timer never reaches.
+        Persistent = true;
+        # Not about server load, since this is not a fleet -- about not
+        # starting a multi-gigabyte download the same second every machine in
+        # the house wakes.
+        RandomizedDelaySec = "45min";
+      };
+    };
+  };
+}

--- a/modules/auto-update.nix
+++ b/modules/auto-update.nix
@@ -94,92 +94,94 @@ in
       }
     ];
 
-    systemd.services.nixarchy-auto-update = {
-      description = "Move nixpkgs forward and rebuild this machine";
-      # Not wantedBy anything: the timer is the only thing that starts it. A
-      # boot-time trigger would rebuild a machine somebody just booted because
-      # they needed it.
-      serviceConfig = {
-        Type = "oneshot";
-        StateDirectory = "nixarchy";
-      };
-      unitConfig.OnFailure = "nixarchy-upgrade-failed.service";
+    systemd = {
+      services.nixarchy-auto-update = {
+        description = "Move nixpkgs forward and rebuild this machine";
+        # Not wantedBy anything: the timer is the only thing that starts it. A
+        # boot-time trigger would rebuild a machine somebody just booted because
+        # they needed it.
+        serviceConfig = {
+          Type = "oneshot";
+          StateDirectory = "nixarchy";
+        };
+        unitConfig.OnFailure = "nixarchy-upgrade-failed.service";
 
-      path = with pkgs; [
-        nix
-        git
-        config.system.build.nixos-rebuild
-        coreutils
-        gnutar
-        gzip
-        openssh
-      ];
+        path = with pkgs; [
+          nix
+          git
+          config.system.build.nixos-rebuild
+          coreutils
+          gnutar
+          gzip
+          openssh
+        ];
 
-      script = ''
-        set -euo pipefail
-        flake=${lib.escapeShellArg cfg.flake}
+        script = ''
+          set -euo pipefail
+          flake=${lib.escapeShellArg cfg.flake}
 
-        note() {
-          printf '%s %s\n' "$(date -Is)" "$1" >> /var/lib/nixarchy/upgrade-failed
-        }
+          note() {
+            printf '%s %s\n' "$(date -Is)" "$1" >> /var/lib/nixarchy/upgrade-failed
+          }
 
-        if [ ! -d "$flake" ]; then
-          note "auto-update: $flake does not exist"
-          echo "no flake at $flake" >&2
-          exit 1
-        fi
-
-        ${lib.optionalString (!cfg.allowDirty) ''
-          # The whole reason this is off by default. A dirty tree is somebody's
-          # unfinished edit, and rebuilding it unattended deploys that edit.
-          # Reported rather than ignored: an unattended job that stops working
-          # and says nothing looks exactly like one that is up to date.
-          if [ -d "$flake/.git" ] && ! git -C "$flake" diff --quiet HEAD 2>/dev/null; then
-            note "auto-update: $flake has uncommitted changes; not rebuilding"
-            echo "$flake is dirty; commit it or set autoUpdate.allowDirty" >&2
+          if [ ! -d "$flake" ]; then
+            note "auto-update: $flake does not exist"
+            echo "no flake at $flake" >&2
             exit 1
           fi
-        ''}
 
-        # ONE input. A bare flake update moves nixarchy too, which is the
-        # decision this module deliberately does not make.
-        nix flake update nixpkgs --flake "$flake"
+          ${lib.optionalString (!cfg.allowDirty) ''
+            # The whole reason this is off by default. A dirty tree is somebody's
+            # unfinished edit, and rebuilding it unattended deploys that edit.
+            # Reported rather than ignored: an unattended job that stops working
+            # and says nothing looks exactly like one that is up to date.
+            if [ -d "$flake/.git" ] && ! git -C "$flake" diff --quiet HEAD 2>/dev/null; then
+              note "auto-update: $flake has uncommitted changes; not rebuilding"
+              echo "$flake is dirty; commit it or set autoUpdate.allowDirty" >&2
+              exit 1
+            fi
+          ''}
 
-        # switch, not boot: a package-set update that needs a reboot to take
-        # effect is one the user never notices they received.
-        nixos-rebuild switch --flake "$flake"
-      '';
-    };
+          # ONE input. A bare flake update moves nixarchy too, which is the
+          # decision this module deliberately does not make.
+          nix flake update nixpkgs --flake "$flake"
 
-    # Same failure the sibling exists to survive, for the same reason: an
-    # unattended job that starts failing stops delivering security updates and
-    # says nothing, and a machine that has quietly stopped updating is
-    # indistinguishable from one that is current. A file rather than only a log
-    # line, because journald rotates and "when did this last work" should
-    # outlive that. See nixpkgs#349734.
-    systemd.services.nixarchy-upgrade-failed = {
-      description = "Record that the unattended update failed";
-      serviceConfig = {
-        Type = "oneshot";
-        StateDirectory = "nixarchy";
+          # switch, not boot: a package-set update that needs a reboot to take
+          # effect is one the user never notices they received.
+          nixos-rebuild switch --flake "$flake"
+        '';
       };
-      script = ''
-        printf '%s unattended update failed\n' "$(${pkgs.coreutils}/bin/date -Is)" \
-          >> /var/lib/nixarchy/upgrade-failed
-      '';
-    };
 
-    systemd.timers.nixarchy-auto-update = {
-      wantedBy = [ "timers.target" ];
-      timerConfig = {
-        OnCalendar = cfg.dates;
-        # A laptop asleep at the hour is the machine that most needs to catch
-        # up and the one a non-persistent timer never reaches.
-        Persistent = true;
-        # Not about server load, since this is not a fleet -- about not
-        # starting a multi-gigabyte download the same second every machine in
-        # the house wakes.
-        RandomizedDelaySec = "45min";
+      # Same failure the sibling exists to survive, for the same reason: an
+      # unattended job that starts failing stops delivering security updates and
+      # says nothing, and a machine that has quietly stopped updating is
+      # indistinguishable from one that is current. A file rather than only a log
+      # line, because journald rotates and "when did this last work" should
+      # outlive that. See nixpkgs#349734.
+      services.nixarchy-upgrade-failed = {
+        description = "Record that the unattended update failed";
+        serviceConfig = {
+          Type = "oneshot";
+          StateDirectory = "nixarchy";
+        };
+        script = ''
+          printf '%s unattended update failed\n' "$(${pkgs.coreutils}/bin/date -Is)" \
+            >> /var/lib/nixarchy/upgrade-failed
+        '';
+      };
+
+      timers.nixarchy-auto-update = {
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          OnCalendar = cfg.dates;
+          # A laptop asleep at the hour is the machine that most needs to catch
+          # up and the one a non-persistent timer never reaches.
+          Persistent = true;
+          # Not about server load, since this is not a fleet -- about not
+          # starting a multi-gigabyte download the same second every machine in
+          # the house wakes.
+          RandomizedDelaySec = "45min";
+        };
       };
     };
   };

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -63,6 +63,7 @@ in
     (import ./apps.nix inputs)
     ./local-ai.nix
     ./fleet.nix
+    ./auto-update.nix
     (import ./services inputs)
     ./flatpaks.nix
     inputs.nix-flatpak.nixosModules.nix-flatpak

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -541,6 +541,32 @@ let
     onFailure = on.systemd.services.nixos-upgrade.unitConfig.OnFailure or "";
   };
 
+  # ---- the single-machine unattended update, both ways -------------------
+  #
+  # fleet's sibling and the mirror of its risk. fleet reverts unpushed work;
+  # this one DEPLOYS it -- /etc/nixos is a git repository somebody edits by
+  # hand, so an unattended rebuild of a dirty tree ships whatever was
+  # half-finished when they walked away, at 03:00, with nobody watching.
+  #
+  # So the off case is again the one that matters, and the dirty guard is
+  # asserted by its presence in the script: a refactor that dropped it would
+  # leave a module that still works, still updates, and quietly acquires the
+  # one behaviour it was written to prevent.
+  autoUpdate = rec {
+    offByDefault = (configWith { }).systemd.timers ? nixarchy-auto-update;
+    on = configWith {
+      autoUpdate = {
+        enable = true;
+        dates = "Sun 04:00";
+      };
+    };
+    onWhenAsked = on.systemd.timers ? nixarchy-auto-update;
+    dates = on.systemd.timers.nixarchy-auto-update.timerConfig.OnCalendar or "";
+    persistent = on.systemd.timers.nixarchy-auto-update.timerConfig.Persistent or false;
+    script = on.systemd.services.nixarchy-auto-update.script or "";
+    onFailure = on.systemd.services.nixarchy-auto-update.unitConfig.OnFailure or "";
+  };
+
   # ---- devenv, both halves --------------------------------------------
   #
   # The half that breaks quietly is "off". devenv is a package plus a line in
@@ -1087,6 +1113,12 @@ pkgs.runCommand "nixarchy-options"
     fleetUrl = fleet.url;
     fleetPersistent = pkgs.lib.boolToString fleet.persistent;
     fleetOnFailure = fleet.onFailure;
+    autoUpdateOff = pkgs.lib.boolToString autoUpdate.offByDefault;
+    autoUpdateOn = pkgs.lib.boolToString autoUpdate.onWhenAsked;
+    autoUpdateDates = autoUpdate.dates;
+    autoUpdatePersistent = pkgs.lib.boolToString autoUpdate.persistent;
+    autoUpdateScript = autoUpdate.script;
+    autoUpdateOnFailure = autoUpdate.onFailure;
     flatpakOurs = pkgs.lib.boolToString flatpakDefaults.ours;
     flatpakTheirs = pkgs.lib.boolToString flatpakDefaults.theirs;
     flatpakOn = pkgs.lib.boolToString flatpakDefaults.onWhenAsked;
@@ -1873,6 +1905,51 @@ pkgs.runCommand "nixarchy-options"
             echo "nixos-upgrade has no OnFailure hook (got '$fleetOnFailure')" >&2
             echo "  an upgrade that starts failing stops delivering configuration and" >&2
             echo "  says nothing -- which is what this option exists to survive" >&2
+            exit 1
+            ;;
+        esac
+
+        # ---- and a single machine updates only when asked ------------------
+        test "$autoUpdateOff" = false || {
+          echo "an unattended update timer exists without autoUpdate.enable" >&2
+          echo "  a machine nobody asked must not rebuild itself at 03:00" >&2
+          exit 1
+        }
+        test "$autoUpdateOn" = true || {
+          echo "autoUpdate.enable produced no timer; nothing would ever run" >&2; exit 1; }
+        test "$autoUpdateDates" = "Sun 04:00" || {
+          echo "autoUpdate.dates did not reach the timer: got '$autoUpdateDates'" >&2; exit 1; }
+        test "$autoUpdatePersistent" = true || {
+          echo "the update timer is not persistent; a laptop asleep at the hour never catches up" >&2
+          exit 1
+        }
+        # ONE input. A bare `nix flake update` moves nixarchy too, which would
+        # change somebody's desktop overnight -- the decision this module
+        # deliberately does not make, and a one-word regression away.
+        case "$autoUpdateScript" in
+          *"flake update nixpkgs"*) ;;
+          *)
+            echo "the unattended update does not move nixpkgs specifically" >&2
+            echo "  a bare 'nix flake update' moves nixarchy too and changes the" >&2
+            echo "  desktop under someone who asked only for security updates" >&2
+            exit 1
+            ;;
+        esac
+        case "$autoUpdateScript" in
+          *"uncommitted changes"*) ;;
+          *)
+            echo "the dirty-tree guard is gone from the unattended update" >&2
+            echo "  /etc/nixos is edited by hand; rebuilding it unattended would" >&2
+            echo "  deploy whatever was half-finished, unwatched, at 03:00" >&2
+            exit 1
+            ;;
+        esac
+        case "$autoUpdateOnFailure" in
+          *nixarchy-upgrade-failed*) ;;
+          *)
+            echo "the unattended update has no OnFailure hook" >&2
+            echo "  one that starts failing stops delivering security updates and" >&2
+            echo "  looks exactly like a machine that is up to date" >&2
             exit 1
             ;;
         esac


### PR DESCRIPTION
#374 item 5.

`fleet.nix` already does unattended updates — for a **fleet**. It points a machine at a remote flake, and its own warning says local edits under `/etc/nixos` *"are reverted at the next pull, silently and without asking"*. Right for a fleet. For a machine whose configuration **is** `/etc/nixos`, that is not a trade-off, it is data loss.

So `programs.nixarchy.autoUpdate` pulls nothing. It moves **one input** in the flake the machine already has, and rebuilds from it.

## Why nixpkgs only

The two axes are independent by design — `installer/mkFlake.nix` makes nixpkgs a root input and has nixarchy follow it — and they mean different things:

| | |
|---|---|
| **nixpkgs** | the package set: kernel, openssl, browsers. **Security updates.** |
| **nixarchy** | the desktop |

An unattended nixpkgs bump is what "follow NixOS" means to most people. An unattended nixarchy bump changes the desktop under someone who did not ask, possibly while they are using it. One is a background task, the other is a decision — so only the first is on offer. `omarchy update --nixarchy` takes the other, deliberately.

## The risk is the mirror of fleet's, and so is the guard

fleet **reverts** unpushed work. This one would **deploy** it: `/etc/nixos` is a git repository somebody edits by hand, so an unattended rebuild of a dirty tree ships whatever was half-finished when they walked away — at 03:00, unwatched, arriving as a machine that booted into an edit nobody meant to apply.

So a dirty tree **refuses**, and the refusal is *recorded* rather than silent: `/var/lib/nixarchy/upgrade-failed`, the same file fleet writes and the doctor reads. `allowDirty` exists for anyone who wants the other behaviour and has to ask for it by name.

An unattended job that starts failing and says nothing looks exactly like one that is up to date — which is why `OnFailure` writes a file, not just a log line. journald rotates; *"when did this last work"* should outlive that.

## Both enabled is an assertion, not a race

fleet and autoUpdate would drive one machine from two flakes on two timers, and whichever ran last would win while the other looked intermittently broken. Asserted, with a message saying which does what.

## Covered both ways, and proven red

`tests/options.nix` in the shape its fleet block already set — off by default, on when asked, `dates` reaches the timer, persistent, `OnFailure` hooked. Plus the two that are about *this* module rather than about timers:

- **the script moves nixpkgs specifically** — a bare `nix flake update` is one word away and would change the desktop overnight
- **the dirty guard is present** — a refactor that dropped it leaves a module that still works, still updates, and quietly acquires the one behaviour it was written to prevent

Proven red on the first:

```
the unattended update does not move nixpkgs specifically
  desktop under someone who asked only for security updates
error: Cannot build nixarchy-options.drv
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5