### PR TITLE
The second-machine assertion contradicted the fix that made it possible

### DIFF
--- a/tests/install.nix
+++ b/tests/install.nix
@@ -819,11 +819,46 @@ pkgs.testers.runNixOSTest {
         f"adding a host directory gave {names!r}, not 'installed spare' -- "
         "flake.nix is not finding machines by reading ./hosts")
 
-    # And it is a different machine, not the same one twice.
-    spare = target.succeed(
-        "cd /etc/nixos && nix --extra-experimental-features 'nix-command flakes'"
-        " eval --raw .#nixosConfigurations.spare.config.networking.hostName").strip()
-    assert spare == "spare", f"the second host is called {spare!r}"
+    # And the second machine is REAL -- it evaluates to a system of its own.
+    #
+    # This used to assert `networking.hostName == "spare"`, and that assertion
+    # is now unsatisfiable BY DESIGN. Offline-install stage 1 took the hostname
+    # out of evaluation entirely (installer/host.nix): it is "" for every
+    # machine and applied at first boot by nixarchy-set-hostname from
+    # /etc/nixarchy/hostname. hosts/<name>/default.nix still passes
+    # `hostname = "@hostname@"` and host.nix deliberately ignores it -- the
+    # `# deadnix: skip` on that parameter is the note saying so.
+    #
+    # It failed on main, not on the pull request, because #434 was merged with
+    # --admin while its install job was still running. The one check that would
+    # have caught this is the one that was skipped.
+    #
+    # So assert what stage 1 actually promises, which is the OPPOSITE of the
+    # old claim and a stronger thing to know: two machines differing only by
+    # name build the SAME system. That is what makes an offline install
+    # possible at all -- a per-machine closure would have to be built on a
+    # machine with no network.
+    spare_top, installed_top = (
+        target.succeed(
+            "cd /etc/nixos && nix --extra-experimental-features"
+            " 'nix-command flakes' eval --raw"
+            f" .#nixosConfigurations.{h}.config.system.build.toplevel.drvPath"
+        ).strip()
+        for h in ("spare", "installed")
+    )
+    assert spare_top == installed_top, (
+        "two machines differing only by directory name evaluate to DIFFERENT "
+        f"systems:\n  spare     {spare_top}\n  installed {installed_top}\n"
+        "The name has re-entered the closure, so an offline install of the "
+        "second machine would have to BUILD it, with no network. See #404.")
+
+    # The name is not lost, it moved to runtime -- so check it is actually
+    # applied, which is the half a caller notices.
+    running = target.succeed("hostname").strip()
+    assert running == "installed", (
+        f"the machine calls itself {running!r}; nixarchy-set-hostname did not "
+        "apply /etc/nixarchy/hostname")
+    target.succeed("test -s /etc/nixarchy/hostname")
     target.succeed("git -C /etc/nixos rm -r --cached -q hosts/spare")
     target.succeed("rm -rf /etc/nixos/hosts/spare")
     print("a second machine is a second directory")


### PR DESCRIPTION
#404's install half — and it is a test that stage 1 made **unsatisfiable**.

The nightly, and every run since, has failed here:

```
File "<string>", line 364, in <module>
AssertionError: the second host is called ''
```

`tests/install.nix` copied `hosts/installed` to `hosts/spare` and asserted `nixosConfigurations.spare.config.networking.hostName == "spare"`.

That is now false **by design**. Offline-install stage 1 (#434) took the hostname out of evaluation entirely: `installer/host.nix` sets `networking.hostName = ""` for every machine, and `nixarchy-set-hostname` applies the real one at first boot from `/etc/nixarchy/hostname`, which `install.sh:1900` writes. `hosts/<name>/default.nix` still passes `hostname = "@hostname@"` and `host.nix` deliberately ignores it — the `# deadnix: skip` on that parameter is the note saying exactly this.

**So the assertion asks for the thing stage 1 exists to prevent.**

## Why nothing caught it

It failed on `main` and not on the pull request, because **#434 was merged with `--admin` while its install job was still running**. The one check that could have caught this is the one that was skipped. Worth saying plainly: the job was bypassed on the grounds that the delay was worse than the risk, and this is what the risk looked like.

## What it asserts now

The **opposite** of the old claim, and a stronger thing to know: two machines differing only by directory name evaluate to the **same toplevel**. That is what makes an offline install possible at all — a per-machine closure would have to be *built* on a machine with no network, which is the whole of #404.

If the name ever re-enters the closure this fails naming both store paths, which is the failure that matters rather than a string comparison.

And the name is not lost, it moved to runtime — so the running hostname and `/etc/nixarchy/hostname` are checked too. Losing the mechanism that applies it would otherwise pass silently now that evaluation no longer carries it.

## About the 90 minutes

The job did **not** time out because it was slow. It sat for 27 minutes after the assertion with nothing in the log but fcitx5 autosave and the snapper timeline firing on an idle target, then hit the cap. For comparison, **#444's install finished in 17 minutes on the same runner** earlier today. The cap is not the problem and should not be raised for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5