### PR TITLE
Android apps from the phone you already own

### DIFF
--- a/.github/scripts/readme-counts.sh
+++ b/.github/scripts/readme-counts.sh
@@ -147,9 +147,13 @@ if [ -n "$a_total" ] && [ -n "$a_mod" ] && [ -n "$a_ours" ] && [ -n "$a_un" ]; t
   # "never touch this repo" is the nixpkgs ones plus the module-backed ones:
   # both come from upstream nixpkgs, neither is built here.
   a_untouched=$((a_nixpkgs + a_mod))
+  # Everything with a nixpkgs equivalent -- the search index cannot carry the
+  # ones that have none, which is what the sentence itself says.
+  a_indexed=$((a_total - a_un))
 else
   a_nixpkgs=""
   a_untouched=""
+  a_indexed=""
 fi
 
 pac=$(grep -rlE '\b(pacman|yay)\b' "$omarchy/share/omarchy/bin" 2>/dev/null | wc -l)
@@ -197,16 +201,33 @@ quantity "apps-total" "$a_total" \
 quantity "apps-untouched" "$a_untouched" \
   '.*\*\*([0-9]+) of the [0-9]+ apps never touch this repo\.\*\*.*' \
   "s/\*\*[0-9]+ of the [0-9]+ apps never touch this repo\.\*\*/**$a_untouched of the $a_total apps never touch this repo.**/"
+# The two figures #363 warned about: derived numbers sitting in PROSE, which
+# nothing asserted and which therefore went stale silently. That is the exact
+# trap this script exists for -- prose beside a checked number is the most
+# convincing place for a wrong number to live -- so they become quantities
+# rather than being hand-patched and left to rot again.
+#
+# "N applications are selectable that way" is the whole catalogue, not the
+# menu-mapped subset: git history has it moving 56 -> 60 when #337 added four
+# apps, in step with the total.
+quantity "apps-selectable" "$a_total" \
+  '.*\*\*([0-9]+) applications\*\* are selectable.*' \
+  "s/\*\*[0-9]+ applications\*\* are selectable/**$a_total applications** are selectable/"
+# "N of the M apps" in the search-index sentence, whose own parenthetical
+# states the rule: the ones with no nixpkgs equivalent cannot be indexed.
+quantity "apps-indexed" "$a_indexed" \
+  '.*and ([0-9]+) of the [0-9]+ apps.*' \
+  "s/and [0-9]+ of the [0-9]+ apps/and $a_indexed of the $a_total apps/"
 quantity "apps-nixpkgs-row" "$a_untouched" \
   '.*\| nixpkgs \(([0-9]+) of [0-9]+ apps\) \|.*' \
   "s/\| nixpkgs \([0-9]+ of [0-9]+ apps\) \|/| nixpkgs ($a_untouched of $a_total apps) |/"
 
-# A floor. Nine quantities are declared above; a run that checked fewer means
+# A floor. Eleven quantities are declared above; a run that checked fewer means
 # something stopped matching and this reported calm about numbers it never
 # looked at.
 checked=$(printf '%b' "$report" | grep -c .)
-if [ "$fail" -eq 0 ] && [ "$checked" -lt 9 ]; then
-  echo "::error::only $checked of 9 quantities were accounted for" >&2
+if [ "$fail" -eq 0 ] && [ "$checked" -lt 11 ]; then
+  echo "::error::only $checked of 11 quantities were accounted for" >&2
   fail=1
 fi
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Tracking an upstream release is a source bump, not a re-port.
 > `omarchy bug-report` collects the useful details for you.
 
 What that buys you: the Install menu writes to a Nix config instead of running
-pacman, **60 applications** are selectable that way, **every other package and
+pacman, **63 applications** are selectable that way, **every other package and
 NixOS option is one `Install ▸ Search` away**, plugins and themes still install
 from a git URL at runtime the way upstream intends, and every command that
 assumed `/usr` either points at what NixOS uses or says why it cannot.
@@ -66,7 +66,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | **`nixarchy` command** | this port's own commands, and a way through to Omarchy's 444 |
 | **Remove menu** | deselects apps, never touches your own config |
 | **Update menu** | `nh os switch --update <flake>` |
-| 62 apps in the selection | 47 from nixpkgs, 4 as NixOS modules, 9 built here, 2 with no equivalent |
+| 63 apps in the selection | 48 from nixpkgs, 4 as NixOS modules, 9 built here, 2 with no equivalent |
 | Learn menu | NixOS wiki, `search.nixos.org` packages and options |
 | Shell functions | bash and zsh source the chain; fish derives it from the same files |
 | RetroArch | 13 libretro cores, resolved from the store rather than `/usr/lib` |
@@ -459,7 +459,7 @@ from a terminal:
   enter to select · tab for several · esc to cancel
 ```
 
-**137,599 rows: 25,102 NixOS options, 112,443 packages, and 57 of the 59 apps
+**137,599 rows: 25,102 NixOS options, 112,443 packages, and 61 of the 63 apps
 (the two with no nixpkgs equivalent cannot be indexed).** Three kinds,
 one picker, because you should not have to know which kind you want before you
 can look. They are not interchangeable and the rows say so — picking Tailscale
@@ -1491,7 +1491,7 @@ done
 
 Almost nothing here waits on a maintainer.
 
-**51 of the 62 apps never touch this repo.** Brave, VSCode, Signal and the rest
+**52 of the 63 apps never touch this repo.** Brave, VSCode, Signal and the rest
 are installed as `pkgs.<name>` from **your** nixpkgs, and the five
 module-backed ones (Steam, 1Password, Tailscale, Firefox, Xbox controllers)
 come from there too — the module is NixOS', not this repo's. Your own
@@ -1550,7 +1550,7 @@ Most of it is not our job, and should not be:
 
 | where the app comes from | who updates it |
 |---|---|
-| nixpkgs (51 of 62 apps) | **nobody** — your own `nix flake update` |
+| nixpkgs (52 of 63 apps) | **nobody** — your own `nix flake update` |
 | pinned in this repo (2) | a nightly bot, opening a PR |
 | `zen` | upstream's own flake |
 | `retroarch` | nixpkgs, via this flake's own pin — it is a rebuild with cores |

--- a/data/apps.nix
+++ b/data/apps.nix
@@ -453,6 +453,28 @@
     attr = "omacalc";
     ours = true;
   };
+  scrcpy = {
+    # Android apps from the phone you already own, and NOT emulation: it
+    # mirrors and controls a device over USB or Wi-Fi, so everything works --
+    # including apps with hardware attestation, which refuse to run in a
+    # container and are exactly the class Waydroid (#362) cannot help with.
+    #
+    # No menuId, and that is not an oversight. The row generator FAILS on a
+    # menuId upstream does not ship, and the vendored omarchy-menu.jsonc has no
+    # install row for scrcpy, android or phone. So it is reachable as
+    # programs.nixarchy.apps.scrcpy and through nixarchy-app-enable, and gains
+    # a menu row for free if upstream ever adds one.
+    #
+    # No arch either. That field maps an Arch package name onto our id so the
+    # generator can rewrite upstream's remove.* rows, which name their target
+    # with `omarchy-pkg-present <arch>`. With no upstream row there is nothing
+    # to match, and a plausible-looking name would not be inert -- it would
+    # fire on somebody else's package.
+    label = "scrcpy";
+    category = "Utility";
+    attr = "scrcpy";
+  };
+
   omacut = {
     # As omawrite and omacalc. Needs ffmpeg at runtime, which the package wraps
     # in rather than adding to systemPackages -- see pkgs/apps/omacut.nix.


### PR DESCRIPTION
Closes #363.

`scrcpy` joins the catalogue as a **Utility**. It is **not emulation** — it mirrors and controls a phone that is already yours over USB or Wi-Fi, so every app works, *including anything with hardware attestation*, which refuses to run in a container and is exactly the class Waydroid (#362) cannot help with. No kernel module, no container, no ARM translation layer.

nixpkgs has it at the current pin: **scrcpy 4.1, Apache-2.0**, so no `unfree` flag.

## The two fields that are absent on purpose

**No `menuId`.** The row generator *fails* on a `menuId` upstream does not ship — which is how `t3-code`'s absence was originally found — and the vendored `omarchy-menu.jsonc` has no install row for scrcpy, android or phone. So it is reachable as `programs.nixarchy.apps.scrcpy` and through `nixarchy-app-enable`, and gains a menu row for free if upstream ever adds one.

**No `arch`.** That field maps an Arch package name onto our id so the generator can rewrite upstream's `remove.*` rows, which name their target with `omarchy-pkg-present <arch>`. With no upstream row there is nothing to match — and a plausible-looking AUR name would not be inert, it would **fire on somebody else's package**.

## The README counts, cheaper than the issue expected

#363 says three exact strings must be hand-edited and warns that this coupling cost a red run last time. It no longer needs a person — `readme-counts.sh` (#438) derives them, caught all three, and fixed them:

```
apps-total       62 -> 63
apps-untouched   51 -> 52
apps-nixpkgs-row 51 -> 52
```

The issue's own numbers were stale (59 → 60), which rather makes its point.

## And the two it said nothing asserts

#363 also names two figures in **prose** that nothing checked and that *"go stale silently"*:

| | was | is |
|---|---|---|
| `**60 applications** are selectable that way` | 60 | **63** |
| `57 of the 59 apps (the two with no nixpkgs equivalent cannot be indexed)` | 57 of 59 | **61 of the 63** |

Both were indeed stale. They are **quantities** now rather than hand-patched, because prose beside a checked number is the most convincing place for a wrong number to live — the entire argument of #438 — and leaving these out would have left the trap open on the very lines that warned about it.

Both derived, not guessed:

- **`apps-indexed`** is total minus the ones with no nixpkgs equivalent, which is what the sentence's own parenthetical states.
- **`apps-selectable`** is the whole catalogue rather than the menu-mapped subset — checked against git history, where it moves `56 → 60` as #337 adds four apps, in step with the **total** and not with `menuId` (51 today).

The floor moves 9 → 11 with them, or it stops meaning anything.

**Verified:** eleven quantities green · `scrcpy` resolves with `mainProgram` `scrcpy` · menu-mapping still maps all 41 rows · `checks.options` green · statix and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5