### PR TITLE
Android apps have an answer in the menu now

### DIFF
--- a/data/services.nix
+++ b/data/services.nix
@@ -114,6 +114,31 @@
     note = "Permanent NixOS sandboxes from a template, booted with no image build and no bootloader -- the host's own /nix/store, shared read-only. Bundled because declaring a machine is what turns on the system user, the kvm group grant, the kernel modules and the microvm CLI; a machine you never declare gets none of them.";
   };
 
+  waydroid = {
+    label = "Waydroid (Android apps)";
+    # Development, as microvm and devenv: the categories in use are Desktop,
+    # Development, Hardware and Network, and a container runtime for another
+    # OS sits with the other virtualisation row rather than inventing a
+    # fifth category for one entry.
+    category = "Development";
+    # Plain, and this file's own bar decides it: "if the answer is one line,
+    # it is plain". NixOS's virtualisation.waydroid module already does the
+    # integration -- the LXC container, the binder module, the systemd
+    # service -- so there is nothing for nixarchy to add and therefore no
+    # nixarchy option. The user gets the line every wiki page will show them.
+    kind = "plain";
+    option = [
+      "virtualisation"
+      "waydroid"
+    ];
+    # The note teaches what turning it on COSTS, and the first sentence is
+    # the one that stops "it installed and the app crashes": Waydroid runs
+    # Android on your own kernel with no CPU emulation, which is why it is
+    # fast and why ARM-only apps -- a large share of the popular ones --
+    # need a translation layer it does not ship and nixpkgs does not carry.
+    note = "Android apps in a container on your own kernel. No CPU emulation, so it is fast -- and ARM-only apps will not run without a translation layer (libhoudini/libndk) that Waydroid does not ship and nixpkgs does not package. Needs the binder kernel module, which mainline has and a custom kernel may not, and ships without the Play Store. For apps that refuse to run in a container at all, scrcpy mirrors a real phone instead.";
+  };
+
   devenv = {
     label = "devenv";
     category = "Development";


### PR DESCRIPTION
Closes #362. The other half of #363 (scrcpy) — and the issue is right that they are **one decision, not two**: scrcpy mirrors a phone you already own, Waydroid runs Android in a container, and they fail in opposite directions.

## `services.nix`, not `apps.nix`

That file draws the line: *an app is a package; a service is a decision about the machine.* Waydroid is a container runtime — an LXC container, the `binder` kernel module, a systemd service — so a row in the app catalogue would install a package that does nothing until a NixOS option nobody mentioned is also set.

## `plain`, by the file's own bar

*"If the answer is one line, it is plain."* NixOS's `virtualisation.waydroid` module already does the integration, so nixarchy has nothing to add and **adds nothing**: no wrapper option, and the generated config gets the real upstream line every wiki page and forum answer will show. RFC 42's argument against copying upstream options applies in full.

Category is **Development**, with `microvm` and `devenv`. The categories in use are Desktop, Development, Hardware and Network — a container runtime for another OS belongs beside the other virtualisation row rather than inventing a fifth category for one entry.

## The note, which is where users actually get hurt

Three things, and the first is the one that produces *"it installed and the app crashes"*:

- **ARM-only apps do not run.** Waydroid runs Android on **your** kernel with no CPU emulation — that is why it is fast — so ARM-only apps, a large share of the popular ones, need a translation layer (libhoudini/libndk) that Waydroid does not ship and nixpkgs does not package.
- **It needs the `binder` kernel module.** Mainline has it; a custom kernel may not.
- **No Play Store by default.**

And it names `scrcpy` for the case Waydroid structurally cannot serve: apps with hardware attestation, which refuse to run in a container at all.

## One correction to the issue

#362 writes `option = "virtualisation.waydroid"` as a string. The field is a **list of path segments** — see `openssh` — so it is `[ "virtualisation" "waydroid" ]`. Checked against the file rather than copied from the issue.

**Verified:** `virtualisation.waydroid.enable` exists at the current pin (*"Whether to enable Waydroid"*, waydroid 1.6.3) · `checks.options` green · menu-mapping still maps all 41 rows · `readme-counts` green (a service row moves no derived number) · fmt and statix clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5