### PR TITLE
The reference machine had no password at all

### DIFF
--- a/installer/host.nix
+++ b/installer/host.nix
@@ -160,8 +160,25 @@
       "docker"
       "i2c"
     ];
-    # No password here. The installer writes hashedPassword into the generated
-    # configuration.nix; the VM sets a plaintext one as its own definition.
+    # The password is a FILE, not an evaluation input, and that is what makes
+    # the account usable on a machine installed offline.
+    #
+    # It used to say "no password here -- the installer writes hashedPassword
+    # into the generated configuration.nix". True, and it left the REFERENCE
+    # account with no password of any kind: hashedPassword, hashedPasswordFile
+    # and initialPassword all null. That is fine while every install evaluates
+    # the user's own configuration.nix, and a LOCKOUT the moment one installs
+    # the reference closure instead -- which is the whole point of #436.
+    #
+    # Same shape as the hostname below: the installer writes a file
+    # (install.sh:1907, mode 0600, root-owned) and the system reads it at
+    # runtime, so the value never enters a derivation and two machines with
+    # different passwords are still the same closure.
+    #
+    # The generated configuration.nix sets the identical line for the user's
+    # own account. Both may define it because they name the same file, and
+    # hashedPasswordFile merges by equality.
+    hashedPasswordFile = "/var/lib/nixarchy/password.hash";
   };
 
   # The machine's name, kept OUT of the derivation on purpose.

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -524,9 +524,8 @@ let
   #
   # A machine that boots to a login prompt nobody can answer is the worst
   # outcome an installer has, so it is asserted rather than remembered.
-  referencePassword = (
-    inputs.self.nixosConfigurations.reference.config.users.users.omarchy.hashedPasswordFile or null
-  );
+  referencePassword =
+    inputs.self.nixosConfigurations.reference.config.users.users.omarchy.hashedPasswordFile or null;
 
   # ---- the fleet option, both ways --------------------------------------
   #

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -514,6 +514,20 @@ let
       (configWith { flatpaks.uninstallUnmanaged = true; }).services.flatpak.uninstallUnmanaged;
   };
 
+  # ---- the reference account can actually be logged into ----------------
+  #
+  # nixosConfigurations.reference is the machine the ISO seeds and the one an
+  # offline install copies (#436). Its account had NO password of any kind --
+  # hashedPassword, hashedPasswordFile and initialPassword all null -- which is
+  # harmless while every install evaluates the user's own configuration.nix,
+  # and a LOCKOUT the moment one installs the reference closure instead.
+  #
+  # A machine that boots to a login prompt nobody can answer is the worst
+  # outcome an installer has, so it is asserted rather than remembered.
+  referencePassword = (
+    inputs.self.nixosConfigurations.reference.config.users.users.omarchy.hashedPasswordFile or null
+  );
+
   # ---- the fleet option, both ways --------------------------------------
   #
   # Both ends again. What a person sets is programs.nixarchy.fleet; what
@@ -1113,6 +1127,7 @@ pkgs.runCommand "nixarchy-options"
     fleetUrl = fleet.url;
     fleetPersistent = pkgs.lib.boolToString fleet.persistent;
     fleetOnFailure = fleet.onFailure;
+    referencePassword = if referencePassword == null then "" else referencePassword;
     autoUpdateOff = pkgs.lib.boolToString autoUpdate.offByDefault;
     autoUpdateOn = pkgs.lib.boolToString autoUpdate.onWhenAsked;
     autoUpdateDates = autoUpdate.dates;
@@ -1905,6 +1920,25 @@ pkgs.runCommand "nixarchy-options"
             echo "nixos-upgrade has no OnFailure hook (got '$fleetOnFailure')" >&2
             echo "  an upgrade that starts failing stops delivering configuration and" >&2
             echo "  says nothing -- which is what this option exists to survive" >&2
+            exit 1
+            ;;
+        esac
+
+        # ---- and the reference account is not locked out -------------------
+        test -n "$referencePassword" || {
+          echo "the reference machine's account has no password at all" >&2
+          echo "  installer/host.nix must set hashedPasswordFile: the installer" >&2
+          echo "  writes /var/lib/nixarchy/password.hash and the system reads it" >&2
+          echo "  at runtime, so the value never enters a derivation. Without it" >&2
+          echo "  an offline install of the reference closure (#436) boots to a" >&2
+          echo "  login prompt nobody can answer." >&2
+          exit 1
+        }
+        case "$referencePassword" in
+          /var/lib/nixarchy/*) ;;
+          *)
+            echo "the reference password comes from '$referencePassword'," >&2
+            echo "  not the file the installer writes" >&2
             exit 1
             ;;
         esac


### PR DESCRIPTION
#435, stage 2, taking **option A**: the offline image installs a fixed account and the user's own name arrives with the first online rebuild.

Under that choice, the machine an offline install copies **is** `nixosConfigurations.reference`. So I checked whether anyone could log into it:

```
hashedPassword      null
hashedPasswordFile  null
initialPassword     null
```

Nothing. `installer/host.nix` said so in as many words — *"No password here. The installer writes hashedPassword into the generated configuration.nix"* — which is true, and fine while every install evaluates the user's own `configuration.nix`. The moment one installs the reference closure instead, it is **a machine that boots to a login prompt nobody can answer**.

The fix is stage 1's shape exactly: the installer already writes the hash to a **file** (`install.sh:1907`, mode 0600, root-owned), and `hashedPasswordFile` reads it at runtime — so the value never enters a derivation, and two machines with different passwords are still the same closure.

**Verified that both definitions coexist** rather than assuming it: the generated `configuration.nix` sets the identical line for the user's own account, and evaluating a machine with `host.nix` *and* that definition resolves to `/var/lib/nixarchy/password.hash`. `hashedPasswordFile` merges by equality, so naming the same file twice is not a conflict.

## What option A settles — and what it does not

**Asking for the username earlier does not help**, and it is worth writing down so it is not re-proposed: `users.users.${username}` makes the name a *Nix attribute name*. Whatever the user types produces a different closure, and offline there is nothing to build it with. The installer already asks early; question order was never the constraint.

**Renaming a pre-created account at install time does not survive either.** `mutableUsers` is `true`, so `usermod -l` would leave the renamed account in place — but the closure still **declares** `omarchy`, so the next activation re-creates it, and home-manager's unit is `home-manager-omarchy.service` bound to that name. The result: a user logged in as themselves while the entire desktop configuration belongs to a ghost account. Worse than a clear wait.

A rename only works *paired with a rebuild*, which is option A. Automating that first rebuild belongs with #436, where the offline path actually installs the reference — until then it is machinery with nothing to run against.

## Proven red

Remove the line and `checks.options` fails:

```
the reference machine's account has no password at all
  login prompt nobody can answer.
```

The guard also refuses a password sourced from anywhere but the file the installer writes — a literal hash in the closure would pass a naive presence test and reintroduce exactly the per-machine derivation this avoids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5