### PR TITLE
One fewer copy of the Omarchy version, and the two that remain are checked

### DIFF
--- a/.github/workflows/omarchy.yml
+++ b/.github/workflows/omarchy.yml
@@ -60,17 +60,32 @@ jobs:
           sed -i "s|github:basecamp/omarchy/[^\"]*|github:basecamp/omarchy/${{ steps.rel.outputs.latest }}|" flake.nix
           nix flake update omarchy
 
-          # The tag is written in three places, and this used to move one of
-          # them. omarchyVersion is what the package calls itself and what
-          # omarchy-nvim defaults to, so an auto-merged bump left both naming
-          # the version before it -- the store path said 4.0.1 while the tree
-          # was 4.0.2. Rewritten here rather than reported later, because the
-          # place to fix a stale copy is the thing that made it stale.
+          # The tag was written in three places and this used to move one of
+          # them, so an auto-merged bump left the others naming the version
+          # before it -- the store path said 4.0.1 while the tree was 4.0.2.
+          #
+          # It is TWO places now. pkgs/omarchy-nvim/default.nix had
+          # `omarchyVersion ? "4.0.2"`, a default this sed also had to chase;
+          # the default is gone and the argument is required, so a caller that
+          # forgets fails at evaluation instead of producing a package labelled
+          # with whatever release was current when the line was written. One
+          # fewer copy to keep in step beats one more sed keeping it there.
           ver="${{ steps.rel.outputs.latest }}"
           ver="${ver#v}"
           sed -i "s|omarchyVersion = \"[^\"]*\"|omarchyVersion = \"$ver\"|" flake.nix
-          sed -i "s|omarchyVersion ? \"[^\"]*\"|omarchyVersion ? \"$ver\"|" \
-            pkgs/omarchy-nvim/default.nix
+
+          # And prove the two that remain agree, rather than trusting two seds
+          # to have both matched. A sed that matches nothing exits 0.
+          url_ver=$(sed -nE 's|.*github:basecamp/omarchy/v([^"]*)".*|\1|p' flake.nix | head -1)
+          lit_ver=$(sed -nE 's|.*omarchyVersion = "([^"]*)".*|\1|p' flake.nix | head -1)
+          if [ "$url_ver" != "$lit_ver" ] || [ "$lit_ver" != "$ver" ]; then
+            echo "::error::version copies disagree after the bump:" >&2
+            echo "::error::  input url  $url_ver" >&2
+            echo "::error::  literal    $lit_ver" >&2
+            echo "::error::  wanted     $ver" >&2
+            exit 1
+          fi
+          echo "omarchy $ver, and both copies in flake.nix agree"
 
       # Everything below is the same set of assertions build.yml makes, run
       # against the new Omarchy rather than the pinned one. Each answers a

--- a/pkgs/omarchy-nvim/default.nix
+++ b/pkgs/omarchy-nvim/default.nix
@@ -27,7 +27,18 @@
 {
   lib,
   stdenvNoCC,
-  omarchyVersion ? "4.0.2",
+  # No default, deliberately.
+  #
+  # It was `? "4.0.2"`, and by 4.0.3 that was a version literal two releases
+  # stale -- the nightly review flagged it as "one of the three copies is
+  # stale". It never actually applied, because flake.nix passes the real
+  # version, so it was inert AND wrong: the worst combination, since nothing
+  # could ever catch it drifting.
+  #
+  # Required instead. A caller that forgets now fails at evaluation rather than
+  # silently producing a package labelled with whatever release happened to be
+  # current when this line was written.
+  omarchyVersion,
 }:
 stdenvNoCC.mkDerivation {
   pname = "omarchy-nvim-config";


### PR DESCRIPTION
The nightly review (#195) has reported *"version literals: flake 4.0.3 / nvim 4.0.2 — one of the three copies is stale"* since the 4.0.3 bump.

`pkgs/omarchy-nvim/default.nix` declared `omarchyVersion ? "4.0.2"`. It **never applied** — `flake.nix` passes the real version and the built package correctly says `4.0.3` — so it was **inert and wrong**, which is the worst pair: nothing could catch it drifting, because nothing used it.

The default is gone and the argument is required. A caller that forgets now fails at evaluation:

```
error: called without required argument "omarchyVersion"
```

rather than silently producing a package labelled with whatever release was current when the line was written.

## The coupling that made this more than a one-line change

`omarchy.yml`'s bump step **sed'd that default**. Removing it without touching the bot would have left a sed matching nothing — and **a sed that matches nothing exits 0**, so the bump would have gone on reporting success while doing one thing fewer. Precisely the failure the version literals had in the first place.

So the sed is gone too, and in its place the bump **proves** the copies agree rather than trusting two seds to have both matched:

| | source |
|---|---|
| `url_ver` | `github:basecamp/omarchy/vX` in `flake.nix` |
| `lit_ver` | `omarchyVersion = "X"` |
| `ver` | what the bump is moving to |

with an `::error::` naming all three when they disagree. Tested both ways against the real file — they agree today, and perturbing the literal to `4.0.1` is caught.

Deriving the literal from the input would be better still, and is not available: `inputs.omarchy.original` is not exposed at evaluation, so the ref cannot be read back out of the flake. Two *checked* copies is the best shape reachable today.

**Verified:** the package still evaluates to `4.0.3` through the overlay · the required argument bites · `nix build .#omarchy` green · actionlint, statix and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5