### PR TITLE
main is red: nixarchy-channel arrived without a ledger row

### DIFF
--- a/data/bin-ledger.nix
+++ b/data/bin-ledger.nix
@@ -44,6 +44,11 @@
     class = "new";
     reason = "Not in upstream. Wraps omarchy-agent-prompt with prompts that name the skill and insist on measure-then-propose, so routing is fixed here rather than re-guessed on every invocation.";
   };
+  "nixarchy-channel" = {
+    class = "new";
+    reason = "Not in upstream. The generated flake documents following stable as prose telling you to hand-edit nixpkgs AND home-manager; this does both or neither, because moving one without the other is the pairing that breaks.";
+  };
+
   "nixarchy-config-repo" = {
     class = "new";
     reason = "Not in upstream. The installer leaves /etc/nixos as a git repository with a staged tree and no commit; this commits it, adds a remote and CI, and is idempotent on a re-run.";


### PR DESCRIPTION
```
nixarchy-channel: shipped as `new` and has no row.
```

The bin ledger doing exactly what it was written for, within hours of landing.

## Why neither pull request could have caught it

**#454** added the ledger; **#451** added `nixarchy-channel`. They were developed in parallel, so #451's CI ran against a tree with no ledger and #454's ran against a tree with no `nixarchy-channel`. **Both green alone, red together** — and the failure appears on `main`, where nothing was tested.

That is inherent to parallel merges rather than a mistake in either change. It is also the argument for the check living in `checks` rather than only in the bump workflow: a new command reaches `main` by more routes than an Omarchy release.

## The row

`nixarchy-channel` is `new` — no upstream counterpart — so the reason says what it does and why this port has it: the generated flake documents following stable as *prose telling you to hand-edit nixpkgs and home-manager*, and moving one without the other is the pairing that breaks.

```
455 commands: 11 new, 28 patch, 20 replace, 396 vendor. 78 rows, all true.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5