### PR TITLE
The reference initrd could not have mounted most people's disks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1420,6 +1420,14 @@
             pkgs = pkgsFor.${system};
           };
 
+          # The reference initrd can mount a disk it was not built on, which is
+          # a precondition for offline install stage 3. See
+          # tests/reference-initrd.nix and #436.
+          reference-initrd = import ./tests/reference-initrd.nix {
+            inherit inputs;
+            pkgs = pkgsFor.${system};
+          };
+
           # The other half of that: every option path the README and the manual
           # quote, checked against the option set they claim to describe. See
           # tests/doc-options.nix and #214.

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -1121,6 +1121,37 @@ in
       #
       # mkDefault, so an adopter who has a reason to ship no blobs still wins.
       enableRedistributableFirmware = lib.mkDefault true;
+
+      # Every storage driver in the initrd, not the handful this machine needs.
+      #
+      # The same "agree by construction" argument as the microcode above, and
+      # for a sharper reason: offline install stage 3 (#436) installs the
+      # REFERENCE closure rather than one built from the machine's own detected
+      # hardware-configuration.nix. So the machine boots the reference's
+      # initrd, and whatever is not in it cannot be mounted.
+      #
+      # Measured before adding this. The ISO carries 103 initrd modules --
+      # installation-cd-minimal.nix pulls them in -- and the reference carried
+      # 63. The 61 missing were not obscure:
+      #
+      #   md_mod raid0 raid1 raid10 raid456     software RAID
+      #   hpsa 3w-9xxx arcmsr aic79xx aic7xxx   HP Smart Array, SCSI RAID
+      #   hv_storvsc                            Hyper-V
+      #   vmw_* vmxnet3                         VMware
+      #   pata_* sata_* (30-odd)                legacy controllers
+      #
+      # A machine on any of those, installed from an image that copies the
+      # reference, would come up in an initrd that cannot find its root. That
+      # the ISO has them is no help: an installed machine boots its own initrd,
+      # not the installer's.
+      #
+      # It costs modules in the initrd and nothing else -- it pulls no unfree
+      # firmware, so allowUnfree is not needed and enableAllFirmware stays off
+      # (see the paragraph above about naming blobs per-card instead).
+      #
+      # profiles/all-hardware.nix is only a shim for this option now; its
+      # entire content is `hardware.enableAllHardware = true`.
+      enableAllHardware = lib.mkDefault true;
     };
 
     # Why: modules/AGENTS.md#our-own-splash-in-the-theme-directory-upstreams-oc

--- a/tests/reference-initrd.nix
+++ b/tests/reference-initrd.nix
@@ -1,0 +1,110 @@
+{ inputs, pkgs }:
+# The reference machine's initrd can mount a disk it was not built on.
+#
+# This is a precondition for offline install stage 3 (#436), and it is the kind
+# that is invisible until it is fatal. Stage 3 installs the REFERENCE closure
+# rather than one built from the machine's own detected hardware-configuration
+# .nix -- that is the whole point, since a per-machine closure is a per-machine
+# BUILD and offline there is nothing to build with. So the installed machine
+# boots the reference's initrd, and whatever is not in it cannot be mounted.
+#
+# Measured before `hardware.enableAllHardware` was set: the ISO carried 103
+# initrd modules and the reference carried 63. The 61 missing included md_mod
+# and raid0/1/10/456, hpsa, 3w-9xxx, arcmsr, aic79xx, hv_storvsc, vmxnet3 and
+# thirty-odd pata_/sata_ controllers. A machine on any of those would have come
+# up in an initrd with no driver for its root device.
+#
+# That the ISO has them is no help at all, and the distinction is the reason
+# this check exists: an installed machine boots ITS OWN initrd, not the
+# installer's. The two are different closures and only one of them is on the
+# disk afterwards.
+#
+# The ISO is the yardstick because it is the one configuration in this repo
+# that already aims at "any hardware someone might have" -- nixpkgs maintains
+# that list in installation-cd-minimal.nix, so comparing against it means the
+# floor rises when nixpkgs raises it, rather than when somebody remembers to
+# edit a list here.
+let
+  inherit (pkgs) lib;
+
+  iso = inputs.self.nixosConfigurations.iso.config.boot.initrd.availableKernelModules;
+  reference = inputs.self.nixosConfigurations.reference.config.boot.initrd.availableKernelModules;
+
+  # Modules the ISO carries that an installed machine provably does not need.
+  # Each is excluded for a stated reason, and the reasons are checkable rather
+  # than assertions of taste -- an exclusion list without them is where a real
+  # gap hides as a deliberate one.
+  excluded = {
+    # The live medium itself. An installed machine boots from a disk.
+    iso9660 = "the ISO's own filesystem";
+    squashfs = "the ISO's compressed store";
+    overlay = "the ISO's writable overlay";
+
+    # Software RAID. installer/disk-config.nix contains no RAID of any kind --
+    # it lays down a single-disk btrfs layout and nothing else -- so this
+    # installer cannot produce a machine whose root is on mdraid, and an initrd
+    # driver for one would be covering a case that cannot arise.
+    #
+    # These do NOT come from hardware.enableAllHardware in any case; they come
+    # from boot.swraid.enable, which is a different decision with mdadm
+    # attached. If this installer ever grows a RAID layout, that option is what
+    # to turn on, and this list is where the reason it was excluded is written.
+    md_mod = "boot.swraid.enable, and disk-config.nix creates no RAID";
+    raid0 = "boot.swraid.enable, and disk-config.nix creates no RAID";
+    raid1 = "boot.swraid.enable, and disk-config.nix creates no RAID";
+    raid10 = "boot.swraid.enable, and disk-config.nix creates no RAID";
+    raid456 = "boot.swraid.enable, and disk-config.nix creates no RAID";
+  };
+
+  missing = builtins.filter (m: !(builtins.elem m reference)) iso;
+  unexplained = builtins.filter (m: !(excluded ? ${m})) missing;
+
+  # An exclusion for a module the ISO no longer carries is a stale entry, and
+  # stale entries are how a list stops describing anything. Loud in both
+  # directions, as every other manifest in this repo is.
+  stale = builtins.filter (m: !(builtins.elem m iso)) (builtins.attrNames excluded);
+in
+pkgs.runCommand "nixarchy-reference-initrd"
+  {
+    isoCount = toString (builtins.length iso);
+    refCount = toString (builtins.length reference);
+    unexplained = builtins.concatStringsSep " " unexplained;
+    stale = builtins.concatStringsSep " " stale;
+    reasons = lib.concatStringsSep "\n" (lib.mapAttrsToList (m: why: "  ${m}: ${why}") excluded);
+  }
+  ''
+    echo "initrd modules: ISO $isoCount, reference $refCount"
+
+    # A floor. Both lists coming back empty would satisfy every test below
+    # while proving nothing at all -- the failure mode this repo has been bitten
+    # by more than once.
+    if [ "$isoCount" -lt 50 ] || [ "$refCount" -lt 50 ]; then
+      echo "one of the module lists is implausibly short; the check cannot" >&2
+      echo "answer anything and is refusing rather than passing." >&2
+      exit 1
+    fi
+
+    if [ -n "$unexplained" ]; then
+      echo "::error::the reference initrd lacks modules the ISO carries:" >&2
+      for m in $unexplained; do echo "  $m" >&2; done
+      echo >&2
+      echo "  Offline install (#436) copies the reference closure, so an" >&2
+      echo "  installed machine boots THIS initrd. A missing storage driver" >&2
+      echo "  is a machine that cannot find its root filesystem." >&2
+      echo "  Fix: hardware.enableAllHardware in modules/nixos.nix, or add" >&2
+      echo "  the module to the exclusion list in this file WITH a reason." >&2
+      exit 1
+    fi
+
+    if [ -n "$stale" ]; then
+      echo "::error::these exclusions name modules the ISO no longer has:" >&2
+      for m in $stale; do echo "  $m" >&2; done
+      echo "  Remove them: an exclusion that excludes nothing hides the next" >&2
+      echo "  real gap behind a list that looks considered." >&2
+      exit 1
+    fi
+
+    echo "every ISO module is in the reference, or excluded with a reason:"
+    printf '%s\n' "$reasons"
+    touch $out
+  ''


### PR DESCRIPTION
#436, step 1 — and the review that produced it found this is a **precondition**, not the step-3 detail the issue filed it as.

Stage 3 installs the **reference** closure rather than one built from the machine's own `hardware-configuration.nix` — that is the point, since a per-machine closure is a per-machine *build* and offline there is nothing to build with. So the installed machine boots the **reference's** initrd.

Measured:

```
ISO initrd modules        103
reference initrd modules   63
```

The 61 missing were not obscure:

| | |
|---|---|
| `md_mod raid0 raid1 raid10 raid456` | software RAID |
| `hpsa 3w-9xxx 3w-xxxx arcmsr aic79xx` | HP Smart Array, SCSI RAID |
| `hv_storvsc` | Hyper-V |
| `vmw_* vmxnet3` | VMware |
| `pata_* sata_*` (30-odd) | legacy controllers |

**A machine on any of those, installed from an image that copies the reference, would have come up in an initrd with no driver for its root device.**

## The issue's own sentence about this is wrong

> *"a fat initrd covers hardware the reference does not have (`profiles/all-hardware.nix` exists for exactly this and **the ISO already uses it**)"*

The ISO does have it, via `installation-cd-minimal.nix`. **That is irrelevant** — an installed machine boots its own initrd, not the installer's. They are different closures and only one ends up on the disk. Read as reassurance, that sentence would have carried this straight into stage 3.

## The fix is one option

`profiles/all-hardware.nix` is now only a shim; its entire content is `hardware.enableAllHardware = true`. Set in `modules/nixos.nix` beside the microcode options, which already carry the same argument: reference and installed agree **by construction** rather than by a generated import.

```
reference initrd modules  63 -> 116, above the ISO's 103
unfree firmware pulled    none — enableAllFirmware stays false,
                          so allowUnfree is still not required
```

## The check, and why the ISO is the yardstick

nixpkgs maintains "any hardware someone might have" in `installation-cd-minimal.nix`, so comparing against the ISO means **the floor rises when nixpkgs raises it**, rather than when somebody remembers to edit a list here.

Eight ISO modules remain absent, each excluded **with a reason** — an exclusion list without them is where a real gap hides as a deliberate one:

| excluded | why |
|---|---|
| `iso9660 squashfs overlay` | the live medium; an installed machine boots a disk |
| `md_mod raid0/1/10/456` | `boot.swraid.enable`, a different option with mdadm attached — and `installer/disk-config.nix` contains **no RAID at all**, so this installer cannot produce a machine whose root is on mdraid |

**Proven red both ways:** remove `enableAllHardware` and it fails naming the missing drivers and what that means; add an exclusion for a module the ISO does not carry and it fails as stale. Plus a floor, since two empty lists would satisfy every assertion while proving nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5