### PR TITLE
One install VM at a time, because a guest timeout is a concurrency limit

### DIFF
--- a/.github/workflows/install-check.yml
+++ b/.github/workflows/install-check.yml
@@ -143,6 +143,43 @@ jobs:
     name: install
     needs: gate
 
+    # One install VM at a time, machine-wide.
+    #
+    # This job boots a nested QEMU VM and runs an installer inside it against a
+    # THIRTY MINUTE budget -- tests/install.nix:495, `timeout=1800`. That budget
+    # is wall-clock INSIDE THE GUEST, and a guest gets slower when the host is
+    # contended. So concurrency here does not merely slow installs down, it
+    # converts them into failures, and the failure names the installer rather
+    # than the contention:
+    #
+    #   AssertionError: nixarchy-install exited 124
+    #
+    # Measured on 2026-09-09, when the runner pool went from two to four on one
+    # machine:
+    #
+    #   2 concurrent install jobs   both SUCCEEDED, ~36 min wall
+    #   3-4 concurrent              every one FAILED at the in-VM timeout
+    #
+    # One of those failures was on `main` rather than a pull request, so no
+    # change under test could explain it, and one was on an established runner
+    # rather than a new one, so it was not a cold store either.
+    #
+    # cancel-in-progress is FALSE here on purpose, unlike the workflow-level
+    # group above. That one cancels superseded runs of the SAME branch, which
+    # is right. This one queues DIFFERENT branches behind each other, and
+    # cancelling would throw away a run that was going to pass.
+    #
+    # The other three runners keep working: this caps the one job that boots a
+    # VM, not the build, system, box or omarchy jobs that run beside it. Adding
+    # runners still helps everything except this.
+    #
+    # Raising the in-VM timeout was the obvious alternative and is worse: it
+    # would hide a real slowdown, and the number it hid would be the one that
+    # tells you the host is oversubscribed.
+    concurrency:
+      group: nixarchy-install-vm
+      cancel-in-progress: false
+
     # No `if:` on this job, and that is the whole fix -- measured, not assumed.
     # A probe run with three jobs reported: a job skipped by a job-level `if:`
     # appears as a check-run with conclusion `skipped`, and `skipped` is not


### PR DESCRIPTION
Every install check is failing:

```
AssertionError: nixarchy-install exited 124
```

**124 is a timeout.** `tests/install.nix:495` gives the in-VM install `timeout=1800` — thirty minutes, **wall-clock inside the guest**. A guest gets slower when the host is contended, so concurrency here does not merely slow installs down, it **converts them into failures** — and the failure names the installer rather than the contention.

Measured today, when the runner pool went from two to four on one machine:

| concurrent install jobs | outcome |
|---|---|
| **2** | both **succeeded**, ~36 min wall |
| **3–4** | every one **failed** at the in-VM timeout |

Two facts rule out the obvious alternatives: **one failure was on `main`**, not a PR, so nothing under test explains it; and **one was on `p620-nixarchy-2`**, an established runner, so it is not a cold store on the new ones either.

## Why a cap rather than a bigger timeout

Raising the in-VM timeout is the one-word fix and it is worse: the number it would hide is exactly the number that says the host is oversubscribed. A test that gets slower under load should say so.

## Why job-level, and why `cancel-in-progress: false`

The workflow-level group is per-ref with cancelling **on** for pull requests, and that is right — it reaps runs of the *same* branch that a newer push superseded. This one is different: it queues **different** branches behind each other, and cancelling would throw away a run that was going to pass.

**Only the install job is capped.** `build`, `system`, `box` and `omarchy` still run in parallel across all four runners, so the added capacity still helps everything except the one job that boots a nested VM.

Verified the nesting rather than trusting indentation, since a misplaced `concurrency` silently does nothing:

```
jobs.install.concurrency   group nixarchy-install-vm, cancel-in-progress false
workflow concurrency       install-check-${{ github.ref }}, unchanged
gate                       unaffected
```

## A correction this carries

I reported p510 earlier as zero-for-three on install jobs and inferred a bad machine, which fed the decision to stop its runners. **`p510-nixarchy` succeeded in 28 minutes at 12:39 today.** Its earlier timeouts were very likely this same contention, and my sample was confounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5