### PR TITLE
The initrd gets every storage driver, and firmware stays the adopter's choice

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1420,6 +1420,14 @@
             pkgs = pkgsFor.${system};
           };
 
+          # The reference initrd can mount a disk it was not built on, which is
+          # a precondition for offline install stage 3. See
+          # tests/reference-initrd.nix and #436.
+          reference-initrd = import ./tests/reference-initrd.nix {
+            inherit inputs;
+            pkgs = pkgsFor.${system};
+          };
+
           # The other half of that: every option path the README and the manual
           # quote, checked against the option set they claim to describe. See
           # tests/doc-options.nix and #214.

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -8,6 +8,59 @@ inputs:
 let
   cfg = config.programs.nixarchy;
 
+  # Every storage driver nixpkgs would put in a "supports most hardware"
+  # initrd, taken from nixpkgs rather than copied out of it.
+  #
+  # Offline install stage 3 (#436) installs the REFERENCE closure rather than
+  # one built from the machine's own detected hardware-configuration.nix. So
+  # the installed machine boots the reference's initrd, and whatever is not in
+  # it cannot be mounted. Measured before this existed: the ISO carried 103
+  # initrd modules and the reference 63, the 61 missing including md_mod and
+  # raid0/1/10/456, hpsa, arcmsr, aic79xx, hv_storvsc, vmxnet3 and thirty-odd
+  # pata_/sata_ controllers.
+  #
+  # ## Why not `hardware.enableAllHardware = true`
+  #
+  # Because it also sets `hardware.enableRedistributableFirmware = true` at
+  # NORMAL priority (nixos/modules/hardware/all-hardware.nix:175), and this
+  # module sets that same option at mkDefault so an adopter can turn blobs off
+  # with a plain `false`. tests/firmware-guard.nix asserts exactly that, and
+  # says why: "a guard that only checked the value would pass on an mkForce
+  # that takes their choice away".
+  #
+  # Two normal-priority definitions cannot be reconciled by adding a third at
+  # any priority -- anything that wins over all-hardware wins over the adopter
+  # too. So enabling the option is incompatible with the guarantee, and it was
+  # tried: it failed evaluation with "hardware.enableRedistributableFirmware
+  # has conflicting definition values".
+  #
+  # ## So the list is asked for instead of the option
+  #
+  # A minimal machine, evaluated only to be asked what all-hardware adds, and
+  # its answer used here. The list stays nixpkgs-maintained -- it rises when
+  # they raise it -- while the firmware decision stays ours.
+  #
+  # It deliberately does NOT import nixarchy's own module: this is evaluated
+  # from inside it, and importing it would recurse. It needs no packages
+  # either, so it is cheap -- measured at 0.9s, against a flake evaluation
+  # that already builds several systems.
+  allHardwareInitrdModules =
+    (inputs.nixpkgs.lib.nixosSystem {
+      inherit (pkgs.stdenv.hostPlatform) system;
+      modules = [
+        {
+          nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system;
+          boot.loader.grub.device = "nodev";
+          fileSystems."/" = {
+            device = "/dev/null";
+            fsType = "ext4";
+          };
+          system.stateVersion = config.system.stateVersion;
+          hardware.enableAllHardware = true;
+        }
+      ];
+    }).config.boot.initrd.availableKernelModules;
+
   # Where the resolved-path half of the flake's safe.directory entry lives.
   #
   # Under /var/lib rather than /etc: /etc/gitconfig is a store symlink that
@@ -1160,21 +1213,27 @@ in
     # newest kernel in the current pin. When a future pin breaks that, it
     # breaks at evaluation with the package named, which is a better failure
     # than a machine that cannot see its screen.
-    boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
+    boot = {
+      # See allHardwareInitrdModules above: the drivers, without the firmware
+      # decision that hardware.enableAllHardware would take away.
+      initrd.availableKernelModules = allHardwareInitrdModules;
 
-    boot.plymouth = lib.mkMerge [
-      (lib.mkIf (cfg.bootSplash != "off") {
-        enable = lib.mkDefault true;
-      })
-      (lib.mkIf (cfg.bootSplash == "defer") {
-        themePackages = lib.mkDefault [ cfg.package ];
-        theme = lib.mkDefault "omarchy";
-      })
-      (lib.mkIf (cfg.bootSplash == "force") {
-        themePackages = lib.mkForce [ cfg.package ];
-        theme = lib.mkForce "omarchy";
-      })
-    ];
+      kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
+
+      plymouth = lib.mkMerge [
+        (lib.mkIf (cfg.bootSplash != "off") {
+          enable = lib.mkDefault true;
+        })
+        (lib.mkIf (cfg.bootSplash == "defer") {
+          themePackages = lib.mkDefault [ cfg.package ];
+          theme = lib.mkDefault "omarchy";
+        })
+        (lib.mkIf (cfg.bootSplash == "force") {
+          themePackages = lib.mkForce [ cfg.package ];
+          theme = lib.mkForce "omarchy";
+        })
+      ];
+    };
 
     # Why: modules/AGENTS.md#default-fontconfig-conf-avail-50-omarchy-conf-whic
     fonts.fontconfig.localConf = lib.mkDefault (

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -56,6 +56,25 @@ let
             fsType = "ext4";
           };
           system.stateVersion = config.system.stateVersion;
+
+          # THE SAME KERNEL this machine runs, and it is load-bearing.
+          #
+          # all-hardware.nix gates part of its list on the kernel version --
+          # `pata_qdi` only for versions older than 7.0, at line 108. A probe
+          # on nixpkgs' default kernel therefore asked for a module that does
+          # not exist in 7.2.4, and the failure surfaced three derivations
+          # away, in modules-shrunk:
+          #
+          #   root module: pata_qdi
+          #   modprobe: FATAL: Module pata_qdi not found in directory
+          #             .../linux-7.2.4-modules/lib/modules/7.2.4
+          #
+          # config.boot.kernelPackages rather than a literal, so an adopter who
+          # pins a different kernel gets a list computed for THEIR kernel. No
+          # cycle: the probe produces initrd module names and reads only the
+          # kernel, which does not depend on them.
+          boot.kernelPackages = config.boot.kernelPackages;
+
           hardware.enableAllHardware = true;
         }
       ];

--- a/tests/reference-initrd.nix
+++ b/tests/reference-initrd.nix
@@ -70,6 +70,23 @@ pkgs.runCommand "nixarchy-reference-initrd"
     refCount = toString (builtins.length reference);
     unexplained = builtins.concatStringsSep " " unexplained;
     stale = builtins.concatStringsSep " " stale;
+
+    # The initrd itself, BUILT.
+    #
+    # Comparing names is not enough and this check learned that the hard way:
+    # it passed while the machine could not build, because all-hardware gates
+    # part of its list on the kernel version -- `pata_qdi` only below 7.0 --
+    # and a list computed for the wrong kernel names a module that does not
+    # exist. modprobe said so three derivations away, in modules-shrunk:
+    #
+    #   root module: pata_qdi
+    #   modprobe: FATAL: Module pata_qdi not found in directory
+    #             .../linux-7.2.4-modules/lib/modules/7.2.4
+    #
+    # So this depends on the real initrd. A name that no kernel module backs
+    # now fails HERE, naming the initrd, instead of in whichever job happened
+    # to build a toplevel first.
+    initrd = inputs.self.nixosConfigurations.reference.config.system.build.initialRamdisk;
     reasons = lib.concatStringsSep "\n" (lib.mapAttrsToList (m: why: "  ${m}: ${why}") excluded);
   }
   ''
@@ -103,6 +120,9 @@ pkgs.runCommand "nixarchy-reference-initrd"
       echo "  real gap behind a list that looks considered." >&2
       exit 1
     fi
+
+    # Named so a reader sees WHY the check depends on a 60 MB build.
+    echo "the reference initrd builds: $initrd"
 
     echo "every ISO module is in the reference, or excluded with a reason:"
     printf '%s\n' "$reasons"

--- a/tests/reference-initrd.nix
+++ b/tests/reference-initrd.nix
@@ -1,0 +1,110 @@
+{ inputs, pkgs }:
+# The reference machine's initrd can mount a disk it was not built on.
+#
+# This is a precondition for offline install stage 3 (#436), and it is the kind
+# that is invisible until it is fatal. Stage 3 installs the REFERENCE closure
+# rather than one built from the machine's own detected hardware-configuration
+# .nix -- that is the whole point, since a per-machine closure is a per-machine
+# BUILD and offline there is nothing to build with. So the installed machine
+# boots the reference's initrd, and whatever is not in it cannot be mounted.
+#
+# Measured before `hardware.enableAllHardware` was set: the ISO carried 103
+# initrd modules and the reference carried 63. The 61 missing included md_mod
+# and raid0/1/10/456, hpsa, 3w-9xxx, arcmsr, aic79xx, hv_storvsc, vmxnet3 and
+# thirty-odd pata_/sata_ controllers. A machine on any of those would have come
+# up in an initrd with no driver for its root device.
+#
+# That the ISO has them is no help at all, and the distinction is the reason
+# this check exists: an installed machine boots ITS OWN initrd, not the
+# installer's. The two are different closures and only one of them is on the
+# disk afterwards.
+#
+# The ISO is the yardstick because it is the one configuration in this repo
+# that already aims at "any hardware someone might have" -- nixpkgs maintains
+# that list in installation-cd-minimal.nix, so comparing against it means the
+# floor rises when nixpkgs raises it, rather than when somebody remembers to
+# edit a list here.
+let
+  inherit (pkgs) lib;
+
+  iso = inputs.self.nixosConfigurations.iso.config.boot.initrd.availableKernelModules;
+  reference = inputs.self.nixosConfigurations.reference.config.boot.initrd.availableKernelModules;
+
+  # Modules the ISO carries that an installed machine provably does not need.
+  # Each is excluded for a stated reason, and the reasons are checkable rather
+  # than assertions of taste -- an exclusion list without them is where a real
+  # gap hides as a deliberate one.
+  excluded = {
+    # The live medium itself. An installed machine boots from a disk.
+    iso9660 = "the ISO's own filesystem";
+    squashfs = "the ISO's compressed store";
+    overlay = "the ISO's writable overlay";
+
+    # Software RAID. installer/disk-config.nix contains no RAID of any kind --
+    # it lays down a single-disk btrfs layout and nothing else -- so this
+    # installer cannot produce a machine whose root is on mdraid, and an initrd
+    # driver for one would be covering a case that cannot arise.
+    #
+    # These do NOT come from hardware.enableAllHardware in any case; they come
+    # from boot.swraid.enable, which is a different decision with mdadm
+    # attached. If this installer ever grows a RAID layout, that option is what
+    # to turn on, and this list is where the reason it was excluded is written.
+    md_mod = "boot.swraid.enable, and disk-config.nix creates no RAID";
+    raid0 = "boot.swraid.enable, and disk-config.nix creates no RAID";
+    raid1 = "boot.swraid.enable, and disk-config.nix creates no RAID";
+    raid10 = "boot.swraid.enable, and disk-config.nix creates no RAID";
+    raid456 = "boot.swraid.enable, and disk-config.nix creates no RAID";
+  };
+
+  missing = builtins.filter (m: !(builtins.elem m reference)) iso;
+  unexplained = builtins.filter (m: !(excluded ? ${m})) missing;
+
+  # An exclusion for a module the ISO no longer carries is a stale entry, and
+  # stale entries are how a list stops describing anything. Loud in both
+  # directions, as every other manifest in this repo is.
+  stale = builtins.filter (m: !(builtins.elem m iso)) (builtins.attrNames excluded);
+in
+pkgs.runCommand "nixarchy-reference-initrd"
+  {
+    isoCount = toString (builtins.length iso);
+    refCount = toString (builtins.length reference);
+    unexplained = builtins.concatStringsSep " " unexplained;
+    stale = builtins.concatStringsSep " " stale;
+    reasons = lib.concatStringsSep "\n" (lib.mapAttrsToList (m: why: "  ${m}: ${why}") excluded);
+  }
+  ''
+    echo "initrd modules: ISO $isoCount, reference $refCount"
+
+    # A floor. Both lists coming back empty would satisfy every test below
+    # while proving nothing at all -- the failure mode this repo has been bitten
+    # by more than once.
+    if [ "$isoCount" -lt 50 ] || [ "$refCount" -lt 50 ]; then
+      echo "one of the module lists is implausibly short; the check cannot" >&2
+      echo "answer anything and is refusing rather than passing." >&2
+      exit 1
+    fi
+
+    if [ -n "$unexplained" ]; then
+      echo "::error::the reference initrd lacks modules the ISO carries:" >&2
+      for m in $unexplained; do echo "  $m" >&2; done
+      echo >&2
+      echo "  Offline install (#436) copies the reference closure, so an" >&2
+      echo "  installed machine boots THIS initrd. A missing storage driver" >&2
+      echo "  is a machine that cannot find its root filesystem." >&2
+      echo "  Fix: hardware.enableAllHardware in modules/nixos.nix, or add" >&2
+      echo "  the module to the exclusion list in this file WITH a reason." >&2
+      exit 1
+    fi
+
+    if [ -n "$stale" ]; then
+      echo "::error::these exclusions name modules the ISO no longer has:" >&2
+      for m in $stale; do echo "  $m" >&2; done
+      echo "  Remove them: an exclusion that excludes nothing hides the next" >&2
+      echo "  real gap behind a list that looks considered." >&2
+      exit 1
+    fi
+
+    echo "every ISO module is in the reference, or excluded with a reason:"
+    printf '%s\n' "$reasons"
+    touch $out
+  ''


### PR DESCRIPTION
#436 step 1, taking the **first** of the three options recorded on #462: source the module list through an evaluation and set `boot.initrd.availableKernelModules` directly, leaving firmware alone.

## Why the obvious version does not work

`hardware.enableAllHardware = true` is the one-line answer, and #462 tried it. It **also** sets `hardware.enableRedistributableFirmware = true` at **normal priority** (`nixos/modules/hardware/all-hardware.nix:175`), while this module sets that option at `mkDefault` so an adopter can turn blobs off with a plain `false`. `tests/firmware-guard.nix` asserts exactly that, and says why:

> *"a guard that only checked the value would pass on an mkForce that takes their choice away"*

Two normal-priority definitions cannot be reconciled by a third at any priority — anything that wins over all-hardware wins over the adopter too. It failed evaluation with `hardware.enableRedistributableFirmware has conflicting definition values`, and **that guard was right to stop it**.

## So the list is asked for rather than the option enabled

A minimal machine, evaluated only to be asked what all-hardware adds, and its answer used here. It does not import nixarchy's own module — this runs from inside it and would recurse — and needs no packages, so it costs **0.9s** against a flake evaluation that already builds several systems.

The list stays **nixpkgs-maintained**: it rises when they raise it, the same argument `tests/reference-initrd.nix` makes for using the ISO as its yardstick. A hand-copied list would work today and go stale.

## Both properties now hold at once

| | |
|---|---|
| reference initrd modules | **63 → 120**, above the ISO's 103 |
| `hardware.enableAllHardware` | `false` |
| `enableRedistributableFirmware` | `true`, still at `mkDefault` |
| adopter sets it `false` | **it takes — and they keep all 120 modules** |

That last row is the whole point. Under #462 the override was impossible; here the drivers and the firmware decision are independent.

`firmware-guard` passes, and its derivation is **byte-identical to `main`'s** — it substituted from cachix rather than rebuilding, which is stronger evidence than a green tick that firmware behaviour is untouched.

## Why this matters for stage 3

Stage 3 installs the **reference** closure rather than one built from the machine's own `hardware-configuration.nix`, so the installed machine boots the reference's initrd. The 61 modules it lacked included `md_mod` and `raid0/1/10/456`, `hpsa`, `arcmsr`, `aic79xx`, `hv_storvsc`, `vmxnet3` and thirty-odd `pata_`/`sata_` controllers. A machine on any of those could not have found its root filesystem.

**Proven red:** remove the assignment and `reference-initrd` fails naming the missing drivers and what that means.

statix wanted the three `boot.*` keys merged once mine made a third — I checked the warning was mine and not pre-existing, merged them, and verified all three settings survive: 120 modules, kernel 7.2.4, plymouth still enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5