### PR TITLE
Two password options on one account, and the file was silently winning

### DIFF
--- a/tests/free-space.nix
+++ b/tests/free-space.nix
@@ -201,7 +201,17 @@ let
                 enable = false;
                 user = "omarchy";
               };
-              users.users.omarchy.hashedPassword = passwordHash;
+              # hashedPasswordFile, as installer/template/host/configuration.nix
+              # sets it -- this block mirrors that file and the comment above
+              # says to keep them in step. It had drifted to `hashedPassword`,
+              # which nixpkgs now warns about: with both set, and mutableUsers
+              # true, the FILE wins, so the literal here was already dead and
+              # the machine was already logging in with what install.sh wrote.
+              #
+              # The warning appeared when installer/host.nix started setting
+              # the file too (#457), which is what made the drift visible
+              # rather than what caused it.
+              users.users.omarchy.hashedPasswordFile = "/var/lib/nixarchy/password.hash";
             }
           ];
         }

--- a/tests/install.nix
+++ b/tests/install.nix
@@ -215,7 +215,17 @@ let
                 enable = false;
                 user = "omarchy";
               };
-              users.users.omarchy.hashedPassword = passwordHash;
+              # hashedPasswordFile, as installer/template/host/configuration.nix
+              # sets it -- this block mirrors that file and the comment above
+              # says to keep them in step. It had drifted to `hashedPassword`,
+              # which nixpkgs now warns about: with both set, and mutableUsers
+              # true, the FILE wins, so the literal here was already dead and
+              # the machine was already logging in with what install.sh wrote.
+              #
+              # The warning appeared when installer/host.nix started setting
+              # the file too (#457), which is what made the drift visible
+              # rather than what caused it.
+              users.users.omarchy.hashedPasswordFile = "/var/lib/nixarchy/password.hash";
             }
           ];
         }


### PR DESCRIPTION
nixpkgs warns, four times per evaluation:

```
The user 'omarchy' has multiple of the options ... set to a non-null value.
... a specific order of precedence is followed, which can lead to surprising results.
  users.users."omarchy".hashedPassword: "$6$rounds=100000$nixarchytestsalt$..."
  users.users."omarchy".hashedPasswordFile: "/var/lib/nixarchy/password.hash"
```

## What it means, and what it does not

With `mutableUsers` true the order is

```
initialHashedPassword -> initialPassword -> hashedPassword -> password -> hashedPasswordFile
```

so **the file wins**. The literal in `tests/install.nix` and `tests/free-space.nix` was already dead: those machines were logging in with whatever `install.sh` wrote, not with the hash the test names.

Nothing was broken and nothing about behaviour changes here — but **a test that appears to set a password and does not** is the kind of thing that reads as evidence later.

## A drift the warning exposed rather than one it caused

Both blocks carry a comment saying they **mirror** `installer/template/host/configuration.nix` and to keep the two in step. That file sets `hashedPasswordFile`. The mirrors had drifted to `hashedPassword`.

The warning appeared when `installer/host.nix` started setting the file too (#457, so the reference account is usable at all). That made the drift **visible**; it did not create it.

So the mirrors now match the template — which is what their own comment asks for — and each config sets **one** password option instead of two.

## Verified by evaluating both shapes, not by reading the warning

```
old shape   hashedPassword set,  hashedPasswordFile set   <- the warning
new shape   hashedPassword null, hashedPasswordFile set
```

`passwordHash` is still referenced twice in each file, so the binding is not dead and deadnix stays quiet. 58 checks instantiate; fmt, statix and deadnix clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5