### PR TITLE
An offline install copies the system instead of building it

### DIFF
--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -822,6 +822,28 @@ in
         "nixarchy-iso".text = ''
           ${inputs.self.shortRev or "dirty"}
         '';
+
+        # The systems this image CARRIES, so an offline install can copy one
+        # instead of building it. Stage 3 of #436.
+        #
+        # Only on the offline image, and that is the whole point: the network
+        # image has somewhere to fetch from, and checks.install runs with
+        # neither marker in a seeded sandbox where building is free. A file
+        # that exists only here keys all three cases correctly, where "no
+        # network marker" would have made the check demand a network.
+        #
+        # Two files rather than one with a flag, because the installer reads
+        # them from shell and `encrypt` is already true or false there.
+        #
+        # These are the SAME configurations seeded into the store above --
+        # referenceConfigs -- so naming their toplevels here adds no closure.
+        # It records a path the image already contains.
+        "nixarchy-reference-true".text = ''
+          ${inputs.self.nixosConfigurations.reference.config.system.build.toplevel}
+        '';
+        "nixarchy-reference-false".text = ''
+          ${inputs.self.nixosConfigurations.reference-unencrypted.config.system.build.toplevel}
+        '';
       }
     else
       {

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2470,10 +2470,57 @@ run_install() {
   # way it happens once, in the store that already holds every dependency,
   # instead of inside a target store that has to have each one copied to it
   # before it can be used.
-  local system
-  system=$(nix "${NIX_FLAGS[@]}" build --no-link --print-out-paths "${SUBSTITUTE_FLAGS[@]}" \
-    "${build_store[@]}" \
-    "/mnt/etc/nixos#nixosConfigurations.$hostname.config.system.build.toplevel") || true
+  local system=""
+
+  # The offline image CARRIES the system, so copy it rather than build it.
+  #
+  # Stage 3 of #436, and the reason the two stages before it existed. Building
+  # the machine's own configuration offline means building whatever differs
+  # from what the image holds, and with no network that ends at the source
+  # bootstrap -- 677 derivations, measured, dying on a Debian patch.
+  #
+  # What makes copying CORRECT rather than merely faster:
+  #
+  #   the hostname   is not in the closure any more (stage 1). The name is
+  #                  applied at first boot from /etc/nixarchy/hostname.
+  #   the password   is a file the installer already wrote, read at activation
+  #                  (#457), so the account is usable.
+  #   the disk       does not matter: disk-config.nix names filesystems
+  #                  by-partlabel, so a toplevel built against /dev/vda is
+  #                  byte-identical to one built against /dev/nvme0n1 --
+  #                  measured, same drvPath.
+  #
+  # What is DELIBERATELY not the same is the username and the detected
+  # hardware-configuration.nix. Both are written to /mnt/etc/nixos and arrive
+  # with the first online rebuild; that is option A on #435, chosen knowing
+  # the machine boots as the reference's account until then.
+  #
+  # Keyed on a file that exists only on the offline image, never on "no
+  # network marker": checks.install runs with neither marker in a seeded
+  # sandbox where building is free and correct.
+  local baked="/etc/nixarchy-reference-$encrypt"
+  local baked_system=""
+  if [ -r "$baked" ]; then
+    local candidate
+    candidate=$(tr -d '[:space:]' <"$baked")
+    # Valid in THIS store, not merely a plausible path. An image that lost the
+    # closure would otherwise hand nixos-install a name it cannot copy, and
+    # the failure would land in nixos-install rather than here.
+    if [ -n "$candidate" ] && nix "${NIX_FLAGS[@]}" path-info "$candidate" >/dev/null 2>&1; then
+      system="$candidate"
+      baked_system="$candidate"
+      echo "nixarchy-install: installing the system this image carries: $system"
+    else
+      echo "nixarchy-install: $baked names $candidate, which is not in this" >&2
+      echo "store. Falling back to building, which offline will be slow." >&2
+    fi
+  fi
+
+  if [ -z "$system" ]; then
+    system=$(nix "${NIX_FLAGS[@]}" build --no-link --print-out-paths "${SUBSTITUTE_FLAGS[@]}" \
+      "${build_store[@]}" \
+      "/mnt/etc/nixos#nixosConfigurations.$hostname.config.system.build.toplevel") || true
+  fi
 
   # Checked, because set -e will not check it here. The whole install runs as
   # `{ ...; } || rc=$?` so the dashboard can report a failure, and inside a
@@ -2502,10 +2549,30 @@ run_install() {
 
   # nixos-install takes --option, not --extra-experimental-features: it is not
   # a nix subcommand and rejects the flag outright.
+  # --max-jobs 0 when the system was COPIED rather than built, and it is the
+  # assertion rather than an optimisation.
+  #
+  # With --system, nixos-install runs no build of its own (nixos-install.sh:266
+  # gates the whole build block on the system being empty). What remains is
+  # `nix-env --store /mnt --set`, which CAN fall back to building a path it
+  # cannot substitute. --max-jobs 0 makes nix refuse to start any build and say
+  # so, instead of quietly compiling for an hour on a machine with no network.
+  #
+  # So an offline install that would have had to build now FAILS LOUDLY, which
+  # is the property #436 asked for: not "the install succeeded" but "nothing
+  # was built". Counting `building '` lines was the alternative and is fragile
+  # -- --log-format is user-overridable -- and `--offline` is not a flag
+  # nixos-install accepts at all; it hits the catch-all and exits 1.
+  #
+  # Only on the copied path. A network install builds on purpose.
+  local no_build=()
+  [ "$system" = "${baked_system:-}" ] && no_build=(--max-jobs 0)
+
   nixos-install --root /mnt --system "$system" --no-root-password \
     --option extra-experimental-features "nix-command flakes" \
     --option extra-substituters "$SUBSTITUTERS" \
     --option extra-trusted-public-keys "$TRUSTED_KEYS" \
+    "${no_build[@]}" \
     "${SUBSTITUTE_FLAGS[@]}"
 }
 


### PR DESCRIPTION
#436 stage 3 — and the reason stages 1 and 2 existed. Building the machine's own configuration with no network means building whatever differs from what the image holds, and that ends at the source bootstrap: **677 derivations**, measured, dying on a Debian patch it cannot fetch.

## What makes copying *correct* rather than merely faster

Each of these was established rather than assumed, and each had to be true first:

| | |
|---|---|
| **the hostname** | not in the closure since stage 1; applied at first boot from `/etc/nixarchy/hostname` |
| **the password** | a file the installer already writes, read at activation (#457), so the reference account can be logged into |
| **the disk** | does not matter — `disk-config.nix` names filesystems **by-partlabel**, so a toplevel built against `/dev/vda` is byte-identical to one against `/dev/nvme0n1`. Measured: same drvPath |
| **the drivers** | the reference initrd now carries every storage driver the ISO does (#465), so it can mount a disk it was not built on |
| **the path** | **is on the image** — `isoImage.storeContents` already seeds `map (r: r.toplevel) references`, and the toplevel this names is verified to be in that list |

Deliberately **not** the same: the username and the detected `hardware-configuration.nix`. Both are written to `/mnt/etc/nixos` and arrive with the first online rebuild — option A on #435, chosen knowing the machine boots as the reference's account until then.

## How the offline path is recognised

```
/etc/nixarchy-reference-true     the encrypted reference toplevel
/etc/nixarchy-reference-false    the unencrypted one
```

Two files rather than one with a flag, because `encrypt` is already `true`/`false` in the installer's shell.

A **positive** marker, never "no network marker": `checks.install` runs with **neither** marker, in a seeded sandbox where building is free and correct, so an inverted test would have made a passing check demand a network. All five cases exercised:

| case | outcome |
|---|---|
| offline, unencrypted | **COPY** |
| offline, encrypted | **COPY** |
| network image | BUILD |
| `checks.install` sandbox | BUILD |
| offline, stale path | BUILD, after saying the path is not in the store |

That last one matters: the path is checked with `nix path-info` before use, so an image that lost the closure falls back to building **here** rather than handing `nixos-install` a name it cannot copy.

## The assertion, not an optimisation

`--max-jobs 0`, and **only on the copied path**.

With `--system`, `nixos-install` runs no build of its own — `nixos-install.sh:266` gates the whole build block on the system being empty. What remains is `nix-env --store /mnt --set`, which *can* fall back to building a path it cannot substitute. `--max-jobs 0` makes nix refuse and say so, rather than quietly compiling for an hour on a machine with no network.

So an offline install that would have had to build now **fails loudly** — which is what #436 asked for: not *"the install succeeded"* but *"nothing was built"*.

Counting `building '` lines was the alternative and is fragile (`--log-format` is user-overridable); `--offline` is not a flag `nixos-install` accepts at all. A network install still builds on purpose, and the flag is scoped so it cannot leak there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5