### PR TITLE
A row can name its command, so adb can be in the catalogue

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Tracking an upstream release is a source bump, not a re-port.
 > `omarchy bug-report` collects the useful details for you.
 
 What that buys you: the Install menu writes to a Nix config instead of running
-pacman, **63 applications** are selectable that way, **every other package and
+pacman, **64 applications** are selectable that way, **every other package and
 NixOS option is one `Install ▸ Search` away**, plugins and themes still install
 from a git URL at runtime the way upstream intends, and every command that
 assumed `/usr` either points at what NixOS uses or says why it cannot.
@@ -66,7 +66,7 @@ More in [`docs/screenshots/`](docs/screenshots).
 | **`nixarchy` command** | this port's own commands, and a way through to Omarchy's 444 |
 | **Remove menu** | deselects apps, never touches your own config |
 | **Update menu** | `nh os switch --update <flake>` |
-| 63 apps in the selection | 48 from nixpkgs, 4 as NixOS modules, 9 built here, 2 with no equivalent |
+| 64 apps in the selection | 49 from nixpkgs, 4 as NixOS modules, 9 built here, 2 with no equivalent |
 | Learn menu | NixOS wiki, `search.nixos.org` packages and options |
 | Shell functions | bash and zsh source the chain; fish derives it from the same files |
 | RetroArch | 13 libretro cores, resolved from the store rather than `/usr/lib` |
@@ -459,7 +459,7 @@ from a terminal:
   enter to select · tab for several · esc to cancel
 ```
 
-**137,599 rows: 25,102 NixOS options, 112,443 packages, and 61 of the 63 apps
+**137,599 rows: 25,102 NixOS options, 112,443 packages, and 62 of the 64 apps
 (the two with no nixpkgs equivalent cannot be indexed).** Three kinds,
 one picker, because you should not have to know which kind you want before you
 can look. They are not interchangeable and the rows say so — picking Tailscale
@@ -1491,7 +1491,7 @@ done
 
 Almost nothing here waits on a maintainer.
 
-**52 of the 63 apps never touch this repo.** Brave, VSCode, Signal and the rest
+**53 of the 64 apps never touch this repo.** Brave, VSCode, Signal and the rest
 are installed as `pkgs.<name>` from **your** nixpkgs, and the five
 module-backed ones (Steam, 1Password, Tailscale, Firefox, Xbox controllers)
 come from there too — the module is NixOS', not this repo's. Your own
@@ -1550,7 +1550,7 @@ Most of it is not our job, and should not be:
 
 | where the app comes from | who updates it |
 |---|---|
-| nixpkgs (52 of 63 apps) | **nobody** — your own `nix flake update` |
+| nixpkgs (53 of 64 apps) | **nobody** — your own `nix flake update` |
 | pinned in this repo (2) | a nightly bot, opening a PR |
 | `zen` | upstream's own flake |
 | `retroarch` | nixpkgs, via this flake's own pin — it is a rebuild with cores |

--- a/data/apps.nix
+++ b/data/apps.nix
@@ -453,6 +453,28 @@
     attr = "omacalc";
     ours = true;
   };
+  android-tools = {
+    # adb, for the wireless pairing dance scrcpy needs over Wi-Fi (#364).
+    #
+    # scrcpy over USB needs nothing else: it is a wrapper that puts adb on the
+    # path of ITS OWN process. That is also why this row exists -- `adb` is
+    # then not on the user's PATH, so `adb pair` is command-not-found on a
+    # machine where scrcpy works perfectly.
+    #
+    # `binary`, because the attribute is not a command. This package ships adb,
+    # fastboot, mkbootimg and a dozen more, so nixpkgs states no mainProgram --
+    # correctly -- and without this the catalogue would answer "android-tools"
+    # and report the app missing on a machine that has it.
+    #
+    # No menuId: upstream ships no Install row for it. No arch: with no
+    # upstream row there is nothing for `omarchy-pkg-present` to match, and a
+    # plausible name would fire on somebody else's package.
+    label = "Android platform tools (adb)";
+    category = "Utility";
+    attr = "android-tools";
+    binary = "adb";
+  };
+
   scrcpy = {
     # Android apps from the phone you already own, and NOT emulation: it
     # mirrors and controls a device over USB or Wi-Fi, so everything works --

--- a/flake.nix
+++ b/flake.nix
@@ -214,7 +214,19 @@
                           if p == null then null else (p.meta.mainProgram or null)
                         );
                       in
-                      if probe.success && probe.value != null then probe.value else name;
+                      # An explicit `binary` on the row wins, because the
+                      # fallback below is right by luck and wrong in a way that
+                      # is invisible: it answers with the ATTRIBUTE name when a
+                      # package states no mainProgram, which was `zen` for one
+                      # installing zen-beta and `hey-cli` for one installing
+                      # hey -- both reported absent on machines that had them.
+                      #
+                      # android-tools is the case that made a field necessary
+                      # rather than another special case: it ships adb,
+                      # fastboot and a dozen others, so no single mainProgram
+                      # is correct upstream, and the attribute is not a command
+                      # at all.
+                      app.binary or (if probe.success && probe.value != null then probe.value else name);
                   in
                   final.lib.concatStringsSep "\n" (
                     final.lib.mapAttrsToList (n: a: "${binaryOf n a}\t${a.label or n}") usable


### PR DESCRIPTION
#364's tools half — and the general fix it needed rather than a special case.

## The trap this retires

`flake.nix` derives an app's command from `meta.mainProgram` and falls back to the **attribute name**. `build.yml` already documents what that costs: *"right by luck when the attribute matches the binary and wrong when it does not"* — it answered `zen` for a package installing `zen-beta` and `hey-cli` for one installing `hey`, and both were reported **absent on machines that had them**.

A row can now say `binary`, which wins over both.

## Why android-tools is what made a field necessary

It ships `adb`, `fastboot`, `mkbootimg` and a dozen more, so nixpkgs states **no** `mainProgram` — correctly — and `android-tools` is not a command at all. Listed without this, the catalogue would have answered `android-tools` and told anyone who installed it that they hadn't.

**Verified in the built artefact**, not by reading the expression. The doctor's embedded table now carries

```
adb	Android platform tools (adb)
```

and the string `android-tools` appears in it **zero** times.

## Why it belongs in the catalogue

scrcpy over USB needs nothing else, because scrcpy is a wrapper that puts `adb` on the path of **its own process**. That is exactly why this row exists: `adb` is then *not* on the user's PATH, so the wireless pairing dance — `adb pair`, two ports, a code on a timer — is command-not-found on a machine where scrcpy works perfectly. The `nixos-android` skill (#459) documents that dance and had to tell people to add the package by hand.

No `menuId` (upstream ships no Install row), no `arch` (nothing for `omarchy-pkg-present` to match, and a plausible name would fire on somebody else's package). Fully free — `asl20`, `unicode-dfs-2015`, `mit` — so no unfree flag.

## The derived numbers moved themselves

```
apps-total       63 -> 64
apps-untouched   52 -> 53
apps-selectable  63 -> 64
apps-indexed     61 -> 62
apps-nixpkgs-row 52 -> 53
```

Including the two that were **prose** until #455 made them quantities. Both would have gone stale here, silently — which is what that change was for.

**Verified:** every app attr resolves · menu-mapping maps all 41 rows · `checks.options` green · fmt, statix, deadnix clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5