### PR TITLE
The installer image answers two questions nixpkgs asks on every eval

### DIFF
--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -346,6 +346,32 @@ in
   boot = {
     loader.timeout = lib.mkForce 0;
 
+    # Both of these silence an evaluation warning by ANSWERING it, which is
+    # the only reason they are here -- nixpkgs asks a question the installer
+    # profile leaves unanswered, and an unanswered question that prints on
+    # every eval trains everyone to read past warnings.
+    #
+    # zfs: nixpkgs is changing this default to false in 26.11 and warns while
+    # nobody has stated an opinion (zfs.nix:710 tests whether the only
+    # definition is its own). false is the recommended value and the safer
+    # one -- it stops a pool being force-imported when it may still be in use
+    # elsewhere. Nothing is lost here in any case: ZFS is on this image so the
+    # installer can reach an existing pool, and this image's own root is a
+    # squashfs, so there is no root pool to import at all.
+    zfs.forceImportRoot = false;
+
+    # mdadm: swraid.nix:62 warns that mdmon crashes with neither MAILADDR nor
+    # PROGRAM set, and the installer profile enables swraid without setting
+    # either. Answered rather than disabled: turning boot.swraid.enable off
+    # would silence it too, but it would also take mdadm and the md/raid
+    # initrd modules off the image, and a user with an existing array would
+    # then have an installer that cannot see their disks.
+    #
+    # root is where NixOS mail goes with no MTA configured, and on a live
+    # image that is the point -- this exists so mdmon starts, not so anyone
+    # reads it.
+    swraid.mdadmConf = "MAILADDR root";
+
     # OFF on the installer image, and this is a reversal worth reading.
     #
     # Two users could not boot v4.0.2-8 on real hardware -- a ThinkPad E15 --


### PR DESCRIPTION
```
evaluation warning: `boot.zfs.forceImportRoot` is using the default value of `true`...
evaluation warning: mdadm: Neither MAILADDR nor PROGRAM has been set. This will cause the `mdmon` service to crash.
```

Both come from nixpkgs' installer profile, not from anything this repo sets — `config.warnings` on the `iso` configuration printed them and the `reference` configuration printed nothing. **Answered rather than muted:** a warning that prints on every eval and is meant to be ignored teaches everyone to read past warnings, which is how the next real one gets missed.

**zfs** — nixpkgs flips this default to `false` in 26.11 and warns only while nobody has stated an opinion (`zfs.nix:710` tests whether the sole definition is its own). `false` is the recommendation and the safer value, and costs nothing here: ZFS is on the image so the installer can reach an existing pool, and the image's own root is a squashfs — there is no root pool to force-import.

**mdadm** — answered with `MAILADDR`, not disabled. `boot.swraid.enable = false` would silence it too, and would take mdadm and the md/raid initrd modules off the image, leaving a user with an existing array holding an installer that cannot see their disks.

That choice is load-bearing. The ISO's initrd list is what `tests/reference-initrd.nix` compares against, and `md_mod` + `raid0/1/10/456` are excluded there **by name**. Disabling swraid would empty those five exclusions and the check fails loudly on exclusions that exclude nothing.

## Verified

- `config.warnings` on `iso` is now `[]`
- ISO initrd unchanged: 103 modules, `md_mod raid0 raid1 raid10 raid456` still present
- `checks.reference-initrd` green (it builds the real initrd, so a bad module name fails there)
- `nix fmt --ci`: 0 changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5