### PR TITLE
The cache canary asks a question only main can answer

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -209,6 +209,18 @@ jobs:
       - uses: ./.github/actions/setup-nix
 
       - name: The cache holds what main last built
+        # main only, because the question is only meaningful there. The
+        # comment above says a path evaluated from any other tree is a
+        # DIFFERENT path -- the omarchy derivation depends on the flake's own
+        # rev -- so on a branch this probes a path nothing ever pushed and
+        # 404s by construction. That happened on 2026-09-09: two
+        # workflow_dispatch runs against a branch filed #473 against a cache
+        # that was serving main's omarchy with HTTP 200 the whole time, and
+        # the failure text below sent the reader to check the token.
+        #
+        # Skipped rather than made to pass, since there is no branch-shaped
+        # version of "what main last built".
+        if: github.ref == 'refs/heads/main'
         run: |
           path=$(nix eval --raw ".#omarchy.outPath")
           hash=$(basename "$path" | cut -d- -f1)
@@ -229,6 +241,13 @@ jobs:
           echo "likely cause is CACHIX_AUTH_TOKEN: cachix exits 0 when a token"
           echo "is rejected, so no job has failed and none will. Check the"
           echo "token before looking anywhere else."
+          echo
+          echo "Before that: confirm this ran on main. The omarchy derivation"
+          echo "depends on the flake's rev, so a path evaluated from any other"
+          echo "tree is a path nobody ever pushed, and 404s for a reason that"
+          echo "has nothing to do with the cache. The step is gated on main"
+          echo "for that reason; if you are reading this from somewhere else,"
+          echo "the gate is what broke, not the token."
           exit 1
 
       - name: The cache holds the MicroVM template runners


### PR DESCRIPTION
Two `workflow_dispatch` runs against a branch filed #473 — *"nothing is reaching the binary cache"* — against a cache that was serving main's omarchy with HTTP 200 the whole time:

| path | tree | cachix |
|---|---|---|
| `kil7jj5…` | branch `586e78f` — what the job probed | 404 |
| `fgchngz…` | `main` `10c36b1` | **200** |
| `8v7yz…` | `main`, earlier that day | **200** |

The job's own comment already explained it: the omarchy derivation depends on the flake's rev, so a path evaluated from any other tree is a path nobody ever pushed. The step just didn't act on it — a bare `actions/checkout` takes whatever ref dispatched the run.

Gated on `main` rather than made to work, since there is no branch-shaped version of *"what main last built"*.

The failure text gets the same correction. It asserted the cause is `CACHIX_AUTH_TOKEN` and said to check the token *before looking anywhere else* — the wrong first move on a branch dispatch, and it cost a diagnosis before the three-way probe settled it. It now says to confirm the ref first.

actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)