### PR TITLE
The nightly review stops reporting two things that are not true

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,16 +118,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1787094885,
-        "narHash": "sha256-yrC8fITJofWJ2wpZMiaX06UVCMFI4GRg9pGyaTdosHg=",
+        "lastModified": 1789012155,
+        "narHash": "sha256-9s5DeiKzmdbXMnGBmXOSxTdaAp7jBxyd7IgVLxZ717Q=",
         "owner": "MuNeNiCK",
         "repo": "hypr-rdp",
-        "rev": "cf3fbd82e2176070c0860bd53eb87d0b098decd4",
+        "rev": "8744778de2eb9add74224d57fac399aba6039a26",
         "type": "github"
       },
       "original": {
         "owner": "MuNeNiCK",
-        "ref": "v0.1.5",
+        "ref": "v0.1.6",
         "repo": "hypr-rdp",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -74,7 +74,7 @@
 
     # Why: docs/internals/flake.md#the-rdp-server-behind-the-remote-desktop-feature-1
     hypr-rdp = {
-      url = "github:MuNeNiCK/hypr-rdp/v0.1.5";
+      url = "github:MuNeNiCK/hypr-rdp/v0.1.6";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/pkgs/review.sh
+++ b/pkgs/review.sh
@@ -168,17 +168,32 @@ fi
 
 # ------------------------------------------------------------- consistency --
 
-# The tag is written in three places. omarchy.yml rewrites all three now, but
-# it did not always, and a mismatch means the store path names a version the
-# tree is not.
-nvim_version=$(sed -n 's/.*omarchyVersion ? "\([^"]*\)".*/\1/p' \
+# The tag is written in TWO places, and used to be three. The third was a
+# default in pkgs/omarchy-nvim/default.nix -- `omarchyVersion ? "4.0.2"` --
+# removed because a default that flake.nix always overrides is inert and can
+# still go stale, which is the worst pair: nothing could catch it drifting.
+# The comment there explains it at length.
+#
+# This check went on looking for that default. The sed found nothing, compared
+# the empty string against the pin, and reported "one of the three copies is
+# stale" on every run since -- flagging the tree for the shape the fix had
+# removed. It asserted the old model, which is what a check does when the thing
+# it measures moves and it does not.
+#
+# So: the flake's literal must match the flake's own pin, and the nvim argument
+# must stay required. A REINTRODUCED default is now the thing that could drift
+# unnoticed, so that is what is watched.
+nvim_default=$(sed -n 's/.*omarchyVersion ? "\([^"]*\)".*/\1/p' \
   pkgs/omarchy-nvim/default.nix | head -1)
 pkg_version=$(sed -n 's/.*omarchyVersion = "\([^"]*\)".*/\1/p' flake.nix | head -1)
-if [ "$pkg_version" = "${omarchy_pin#v}" ] && [ "$nvim_version" = "${omarchy_pin#v}" ]; then
+if [ -n "$nvim_default" ]; then
+  finding "version literals" "nvim defaults to $nvim_default" "${omarchy_pin#v}" \
+    "omarchy-nvim has a version default again -- inert, and able to go stale"
+elif [ "$pkg_version" = "${omarchy_pin#v}" ]; then
   ok "version literals" "$pkg_version" "match the pin"
 else
-  finding "version literals" "flake $pkg_version / nvim $nvim_version" \
-    "${omarchy_pin#v}" "one of the three copies is stale"
+  finding "version literals" "flake $pkg_version" "${omarchy_pin#v}" \
+    "the flake's omarchyVersion does not match its own pin"
 fi
 
 # Is what main vendors actually released? The bump merges itself, so main can
@@ -289,11 +304,32 @@ while IFS=$'\t' read -r name kind repo at modified; do
       ;;
     ref)
       # A branch that has not moved in four months is either a very quiet
-      # project or a ref that no longer means what it says -- disko's `latest`
-      # is the one to watch here.
+      # project or a ref that no longer means what it says.
+      #
+      # But not every "ref" is a branch, and disko's `latest` is the example
+      # this comment used to hold up. It is an ANNOTATED TAG that upstream
+      # re-points at each release; flake-pins.py classifies by shape -- a bare
+      # name is a ref, `vN.N.N` is a tag -- so it lands here. Age is then taken
+      # from OUR lock, which measured our pin's date and blamed it for
+      # upstream's release cadence: on 2026-09-10 this read "232 days" while
+      # `latest` dereferenced to v1.13.0, the newest tag disko has. There was
+      # nothing to update, and it was a finding on every run.
+      #
+      # So ask the question the shape hides. A ref that resolves to the newest
+      # tag's commit is current no matter how long ago that release was cut --
+      # `gh api commits/<ref>` dereferences an annotated tag for us.
       if [ "$at" != "(default)" ] && [ "$age" -gt 120 ]; then
-        finding "$name" "$at, ${age}d" "-" \
-          "a ref chosen on purpose that has not moved in $age days"
+        newest=$(latest_tag "$repo")
+        ref_commit=$(gh api "repos/$repo/commits/$at" --jq .sha 2>/dev/null)
+        newest_commit=""
+        [ -n "$newest" ] &&
+          newest_commit=$(gh api "repos/$repo/commits/$newest" --jq .sha 2>/dev/null)
+        if [ -n "$ref_commit" ] && [ "$ref_commit" = "$newest_commit" ]; then
+          ok "$name" "$at (${age}d)" "$newest, the newest tag"
+        else
+          finding "$name" "$at, ${age}d" "-" \
+            "a ref chosen on purpose that has not moved in $age days"
+        fi
       else
         ok "$name" "$at" "${age}d old"
       fi


### PR DESCRIPTION
#195 closes itself when the review is green, and it has not been. Three findings — **one real, two the check measuring the wrong thing.**

## hypr-rdp v0.1.5 → v0.1.6 (real)

136 commits; the user-visible ones are fixes — scroll deltas accumulated instead of dropped, `wlr-data-control` bound at v1 to stop leaking primary-selection offers, clipboard pipe transfers bounded with deadlines.

## version literals — the check asserting a shape that was removed

It looked for `omarchyVersion ? "..."` in `pkgs/omarchy-nvim/default.nix`. That default was **deleted on purpose** — its comment says it was inert *and* able to go stale, since `flake.nix` always passes the real value. The sed found nothing, compared the empty string against the pin, and reported *"one of the three copies is stale"* every run since.

There are two copies now, and both match. The check now reads the flake's literal against the flake's own pin, and watches for a **reintroduced** default — the thing that could drift unnoticed now.

## disko — the check blaming us for upstream's cadence

*"a ref chosen on purpose that has not moved in 232 days"*. disko's `latest` is an **annotated tag** upstream re-points each release, not a branch; `flake-pins.py` classifies by shape, so it lands in the ref arm where age comes from *our* lock.

| | |
|---|---|
| `commits/latest` | `de570873` |
| `commits/v1.13.0` | `de570873` |
| our lock | `de570873` |

We are on the newest tag disko has. The ref arm now asks whether the ref resolves to the newest tag's commit and calls that current whatever its age.

I got this wrong first: `git/ref/tags/latest` returns `e92033d8` and I read it as a commit `latest` had moved to. It is the tag *object's* sha — annotated tags have their own — and it dereferences to `de570873`.

## Verified

```
All green -- nothing pinned is behind and every job ran and passed.
| version literals | 4.0.3    | match the pin           | ok |
| disko            | latest (232d) | v1.13.0, the newest tag | ok |
| hypr-rdp         | v0.1.6   | newest                  | ok |
```

shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)