### PR TITLE
Copilot gets nix, a scope, and three issues it can actually finish

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,82 @@
+# Copilot on nixarchy
+
+You already read `AGENTS.md`, so this does not repeat it. This is the part
+that is specific to *your* environment, and most of it is about what you
+cannot do here — because the expensive mistake in this repo is a change that
+looks verified and is not.
+
+## What your environment has
+
+`.github/workflows/copilot-setup-steps.yml` installs **nix** with this
+flake's binary caches before your session starts. So you can run checks, and
+you are expected to.
+
+## Checks you can run, and may claim
+
+These finish in seconds to a couple of minutes:
+
+```bash
+nix fmt -- --ci
+nix run --inputs-from . nixpkgs#statix -- check .
+nix run --inputs-from . nixpkgs#deadnix -- .
+nix run --inputs-from . nixpkgs#shellcheck -- <script>
+nix run --inputs-from . nixpkgs#actionlint -- .github/workflows/<file>.yml
+
+nix build .#checks.x86_64-linux.options       # the broad eval check
+nix build .#checks.x86_64-linux.bin-ledger
+nix build .#checks.x86_64-linux.doc-options
+.github/scripts/readme-counts.sh --check
+```
+
+## Checks you cannot run, and must not imply
+
+| | why |
+|---|---|
+| `checks.session`, `coexist`, `plugin`, `integration` | boot VMs; one attempt can eat your whole 59-minute session |
+| `checks.install`, `free-space` | **self-hosted runners you cannot reach** — Copilot supports self-hosted only via ARC, and these are bare NixOS |
+| `checks.install-iso` | nightly only, ~3 hours, builds a 5.6 GB image |
+
+If your change touches anything these cover — the installer, the session, the
+ISO, the initrd — **say so in the PR, in words**: which check would prove it,
+and that you could not run it. A PR that is silent about this reads as
+verified, and someone merges it on that reading.
+
+## The rule that most affects you
+
+`AGENTS.md` §1: **a check must be proven able to fail.** If you add or change
+a check, break the thing it guards, run it, and paste the red output into the
+PR. Then fix it and show it green.
+
+You can honour this for every check in the first list. You cannot for the
+second. Do not pretend otherwise — an unverifiable claim is worse than an
+admitted gap, because the gap gets covered and the claim does not.
+
+## Never touch these
+
+`AGENTS.md` §11 in full, and these specifically, because they have bitten:
+
+- **`.github/workflows/**`** — CI gates are the repo's immune system. Propose in the PR body; a human wires it.
+- **Labels, milestones, the board, repository settings.**
+- **The `epic` label.** Opening an epic without a matching row in README's
+  Roadmap table turns `main` red and fails **every** subsequent PR until
+  somebody notices. It has caught five people. Do not file epics.
+- **Anything in another repository.** Upstream is `basecamp/omarchy`; a fix to
+  how Omarchy itself behaves belongs there, not patched here.
+
+## What good work looks like here
+
+The shapes that fit your environment, because a cheap check proves them:
+
+- a row in `data/apps.nix`, `data/services.nix`, `data/flatpaks.nix`
+- a row in `data/bin-ledger.nix` for a command that shipped without one
+- a stale string, a wrong line number in a comment, a derived number
+- a test fixture where the fixture check is itself the proof
+
+The shape that does not fit: anything whose proof needs a VM.
+
+## Two more things
+
+- **Commit subjects are full sentences.** No `conventional-commits` prefixes.
+  Read `git log --oneline -10` for the register.
+- **A local hook reformats `.nix` files.** If `nix fmt -- --ci` disagrees with
+  what you just wrote, run it twice before assuming a bug.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,10 +19,56 @@ on:
     paths: [.github/workflows/copilot-setup-steps.yml]
 
 jobs:
+  # The name is not a choice: Copilot looks for a job called exactly
+  # `copilot-setup-steps` and ignores everything else in the file.
   copilot-setup-steps:
     runs-on: ubuntu-latest
+    # Copilot caps its whole session at 59 minutes, and that budget covers the
+    # agent reading, editing and iterating as well as this job. Ten minutes is
+    # generous for a cached nix install and leaves the session for work.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+
+      # nix, so the agent can RUN a check rather than reason about one.
+      #
+      # AGENTS.md 1 asks for a check proven able to fail, and an agent with no
+      # nix cannot honour it -- it can only write something plausible and hope.
+      # With this it can run the cheap tier itself: nix fmt --ci, statix,
+      # deadnix, checks.options, and the fixture checks that finish in seconds
+      # (bin-ledger, package-delta, config-delta, patched-files). That is
+      # exactly the tier covering the data-row and docs work Copilot is
+      # actually suited to.
+      #
+      # The composite, not a hand-rolled install: it writes this flake's caches
+      # into the SYSTEM nix.conf, and the reason that matters is written in the
+      # action itself -- accept-flake-config makes them client-specified
+      # settings, which the daemon discards for anyone not in trusted-users,
+      # and the last time that happened every build compiled Hyprland from
+      # source.
+      #
+      # Copilot's firewall must allow cache.nixos.org, channels.nixos.org,
+      # install.determinate.systems and nixarchy.cachix.org, or nix quietly
+      # falls back to building everything and this job times out instead of
+      # failing with a reason. That allowlist is a repository setting and is
+      # NOT set here.
+      #
+      # What this does NOT buy: the VM checks. checks.session and its siblings
+      # need KVM and minutes this session does not have, and checks.install and
+      # install-iso run on self-hosted runners Copilot cannot reach at all --
+      # it supports self-hosted only through ARC, and ours are bare NixOS. A
+      # Copilot PR touching anything VM-verified is unverified by construction
+      # and must say so.
+      - uses: ./.github/actions/setup-nix
+
+      - name: Prove nix works here, rather than assuming it
+        run: |
+          nix --version
+          # Cheap and real: it evaluates the flake and touches the caches, so a
+          # firewall that is starving nix fails HERE with a reason, rather than
+          # forty minutes later inside the agent's session.
+          nix flake metadata --json > /dev/null
+          echo "nix can evaluate this flake"
 
       - name: Install the agent-bus MCP server
         run: |


### PR DESCRIPTION
Copilot **code review** is already the most-used thing here — 250 successful runs, on essentially every PR push. The **coding agent** has run three times, all on 2026-09-08, all agent-bus smoke tests with **zero files changed**. The plumbing is proven end to end; it has never done real work.

These three changes aim it at what it can verify and fence off what it cannot.

## nix in `copilot-setup-steps.yml`

Through the existing `.github/actions/setup-nix` rather than a twelfth hand-rolled copy.

Without nix the agent cannot **run** a check, so it cannot honour `AGENTS.md` §1 — it can only write something plausible. With it, the cheap tier is available: fmt, statix, deadnix, `checks.options`, and the fixture checks that finish in seconds.

Plus a step that evaluates the flake, so **a firewall starving nix fails there with a reason** rather than forty minutes later inside the agent's session.

> **Needs you:** the allowlist is a repository setting (§11). Copilot → Internet access needs `cache.nixos.org`, `channels.nixos.org`, `install.determinate.systems` and `nixarchy.cachix.org`. Without it nix silently falls back to building everything.

## `.github/copilot-instructions.md`

A **delta, not a duplicate** — Copilot has read `AGENTS.md` since 2025-08-28, and code review since 2026-06-18, so a second copy would only drift.

What it adds is the environment and its limits: what may be claimed, what may not, and a requirement to **say in the PR** when a change is covered only by a check it could not run. A PR silent about that reads as verified, and gets merged on that reading.

`checks.install` and `install-iso` are unreachable **in principle**: Copilot supports self-hosted runners only via ARC, and ours are bare NixOS. Infrastructure, not policy.

## Three issues, and one I filed wrongly

#505, #506, #507 — `good first issue` + a new `copilot-ready` label, each naming the check that proves it and asking for the red output first.

**#504 I got wrong.** I filed *"the bin ledger has no row for nixarchy-android"* without checking, and the row was already there from #477. Closed it rather than leaving a trap — a session spent confirming something is already true is a session not spent on the real work. The other three had their premises checked: `android.md` really is absent from `docs/_config.yml`'s nav, and `installer/AGENTS.md` really does predate #436.

## Verified

`checks.bin-ledger`, `checks.doc-options`, `readme-counts.sh --check`, `nix fmt -- --ci` all pass — i.e. every check the instructions promise Copilot can run, actually runs. `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)