### PR TITLE
The ISO module takes the machines it carries as an argument

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -890,13 +890,42 @@
       # Smoke-test VM. Not a daily driver -- it exists to prove the QuickShell
       # bar comes up against Hyprland's Lua config before any packaging effort
       # is spent on the long tail.
-      nixosConfigurations = {
+      nixosConfigurations = rec {
+        # Whose machines the images below carry.
+        #
+        # Named here rather than inside installer/cd.nix so that a user's own
+        # image (#478) is the same module with a different `source` -- their
+        # flake, their machines, their rev -- instead of a second copy of a
+        # 900-line file. What stays nixarchy's either way is the installer
+        # itself: the script, the version and the branding come from
+        # `inputs.self` inside cd.nix, whoever is being installed.
+        #
+        # `rec` so the three configurations below can be named without
+        # repeating `self.nixosConfigurations`. They are defined further down
+        # this attrset.
+        isoSource = {
+          flake = inputs.self;
+          configs = [
+            reference
+            reference-unencrypted
+
+            # The hardware the reference machine does not have. #382: a real
+            # laptop's hardware-configuration.nix is not the reference's, and
+            # where the difference is a PACKAGE the "a few dozen text
+            # derivations" argument stops holding -- building a package with
+            # no compiler on the image is the source bootstrap. This exists so
+            # those packages are on the medium; nobody installs it.
+            reference-hardware
+          ];
+        };
+
         # The live image. See installer/cd.nix.
         iso = nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
           specialArgs = {
             inherit inputs;
             offline = true;
+            source = isoSource;
           };
           modules = [ ./installer/cd.nix ];
         };
@@ -908,6 +937,7 @@
           specialArgs = {
             inherit inputs;
             offline = false;
+            source = isoSource;
           };
           modules = [ ./installer/cd.nix ];
         };
@@ -1239,6 +1269,14 @@
           channel = import ./tests/channel.nix {
             pkgs = pkgsFor.${system};
             omarchy = self.packages.${system}.omarchy;
+          };
+
+          # The shipped images carry the reference machines, and the network
+          # image carries none of them. Guards the `source` argument #479
+          # added to installer/cd.nix. See tests/iso-source.nix.
+          iso-source = import ./tests/iso-source.nix {
+            inherit inputs;
+            pkgs = pkgsFor.${system};
           };
 
           # nixarchy-android turns what the network says into a host:port, so

--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -4,6 +4,29 @@
   lib,
   pkgs,
   modulesPath,
+  # Whose machines this image carries.
+  #
+  # Defaults to this flake, which is every image nixarchy itself builds -- so
+  # the reference ISO is unchanged by this parameter existing, and CI proves
+  # that by comparing the derivation rather than by asserting it.
+  #
+  # A user's image (#478) passes their own flake instead: their
+  # nixosConfigurations get baked, their inputs get collected, and their rev
+  # names the file. What does NOT come from here is the installer itself --
+  # the script, the version, the branding are nixarchy's whoever is being
+  # installed, and they keep reading `inputs.self` below.
+  #
+  # `configs` is a list of nixosConfigurations rather than names, because a
+  # user's machines are called whatever they called them; the reference set is
+  # three configurations that happen to have fixed names, which is a fact
+  # about this repository and not about the shape of an image.
+  # Passed through specialArgs, NOT defaulted here with `?`. A module argument
+  # missing from specialArgs is resolved through `_module.args` rather than by
+  # the function default, so `source ? {...}` evaluates to
+  # `error: attribute 'source' missing` -- confusing, because the default is
+  # right there in the signature. It belongs at the call site anyway, beside
+  # `offline`, which is the other per-image decision.
+  source,
   # Whether this image carries the desktop or downloads it. True is the real
   # product -- see the header. False builds the same installer over the network
   # instead, which is the same install path the `install` check has always
@@ -66,7 +89,7 @@ let
   collectInputs =
     flake: [ flake.outPath ] ++ lib.concatMap collectInputs (lib.attrValues (flake.inputs or { }));
 
-  inputSources = lib.unique (collectInputs inputs.self);
+  inputSources = lib.unique (collectInputs source.flake);
 
   # Both disk modes, because the installer offers both.
   #
@@ -99,18 +122,9 @@ let
   # Kept in step with tests/generate-config-surface.nix, which reads the same
   # three and fails if a generate-config attribute adds a package none of them
   # carries.
-  referenceConfigs = map (c: c.config) [
-    inputs.self.nixosConfigurations.reference
-    inputs.self.nixosConfigurations.reference-unencrypted
-
-    # The hardware the reference machine does not have. #382: a real laptop's
-    # hardware-configuration.nix is not the reference's, and where the
-    # difference is a PACKAGE the argument above -- "a few dozen text
-    # derivations" -- stops holding, because building a package with no
-    # compiler on the image is the source bootstrap. This one exists so those
-    # packages are on the medium; it is not a machine anyone installs.
-    inputs.self.nixosConfigurations.reference-hardware
-  ];
+  # The default set, and why it is what it is, is documented on the `source`
+  # argument at the top of this file.
+  referenceConfigs = map (c: c.config) source.configs;
 
   references = map (c: c.system.build) referenceConfigs;
 
@@ -549,7 +563,7 @@ in
   # The version comes from the omarchy package rather than a second binding,
   # so it cannot drift from what is actually on the image.
   image.baseName = lib.mkForce "nixarchy-${version}${variant}-${
-    inputs.self.shortRev or "dirty"
+    source.flake.shortRev or "dirty"
   }-x86_64";
 
   # A volume ID that overflows 32 characters or carries a character outside

--- a/tests/iso-source.nix
+++ b/tests/iso-source.nix
@@ -1,0 +1,95 @@
+{ inputs, pkgs }:
+# The shipped images carry the reference machines, and nothing else does.
+#
+# installer/cd.nix used to name `inputs.self.nixosConfigurations.reference`
+# directly. Since #479 it takes a `source` argument instead, so that a user can
+# build an image carrying THEIR machines (#478) from the same module rather
+# than a second copy of a 900-line file.
+#
+# That parameter is the risk this check exists for. `source` is passed from
+# flake.nix, and a wrong value there does not fail to evaluate -- it produces a
+# perfectly good ISO carrying the wrong closure. The failure would surface as
+# an install that builds the world on a machine with no network, which is
+# #436's symptom and took three days to diagnose the last time.
+#
+# The refactor itself was proven not to change the shipped image, by evaluating
+# the old and new modules in the SAME tree and comparing derivations:
+#
+#   old: /nix/store/ph0kzibybvalwvndh846xxxav28jic4c-...-x86_64.iso.drv
+#   new: /nix/store/ph0kzibybvalwvndh846xxxav28jic4c-...-x86_64.iso.drv
+#
+# Same tree matters. Comparing across commits cannot work here and it is worth
+# writing down why: `inputSources` carries `flake.outPath`, so the source
+# tree's own store path is in the closure, and it changes with every commit.
+# A cross-commit comparison is confounded by construction, and the first
+# attempt at this check read that noise as a real difference.
+let
+  inherit (pkgs) lib;
+
+  iso = inputs.self.nixosConfigurations.iso.config;
+  isoNet = inputs.self.nixosConfigurations.iso-net.config;
+
+  # Named rather than derived from `source`, on purpose: deriving the
+  # expectation from the thing under test is how a check comes to assert that
+  # a value equals itself. These three are a decision recorded in flake.nix,
+  # and this is the copy that disagrees when somebody changes it.
+  expected = map (n: inputs.self.nixosConfigurations.${n}.config.system.build.toplevel) [
+    "reference"
+    "reference-unencrypted"
+    "reference-hardware"
+  ];
+
+  missingFrom = sc: builtins.filter (t: !(builtins.elem t sc)) expected;
+in
+pkgs.runCommand "nixarchy-iso-source"
+  {
+    offlineMissing = lib.concatStringsSep " " (missingFrom iso.isoImage.storeContents);
+    offlineCount = toString (builtins.length iso.isoImage.storeContents);
+
+    # The network image carries no toplevels -- it fetches them -- so the
+    # assertion is the opposite one. Both directions, because a `source` that
+    # silently emptied the offline image and a `source` that silently filled
+    # the network one are the same mistake seen from two sides.
+    netCount = toString (builtins.length isoNet.isoImage.storeContents);
+    netHasToplevels = lib.concatStringsSep " " (
+      builtins.filter (t: builtins.elem t isoNet.isoImage.storeContents) expected
+    );
+  }
+  ''
+    echo "offline storeContents: $offlineCount entries"
+    echo "network storeContents: $netCount entries"
+
+    if [ -n "$offlineMissing" ]; then
+      echo "::error::the offline image does not carry the reference machines:" >&2
+      for t in $offlineMissing; do echo "  $t" >&2; done
+      echo >&2
+      echo "  installer/cd.nix bakes whatever `source.configs` names, and" >&2
+      echo "  flake.nix decides that. An image missing a reference toplevel" >&2
+      echo "  installs a machine that has to BUILD it -- with no network, that" >&2
+      echo "  is the source bootstrap, which is #436." >&2
+      exit 1
+    fi
+
+    if [ -n "$netHasToplevels" ]; then
+      echo "::error::the NETWORK image is carrying system closures:" >&2
+      for t in $netHasToplevels; do echo "  $t" >&2; done
+      echo "  It is meant to fetch them. Carrying them makes it the size of" >&2
+      echo "  the offline image for no benefit -- checks.iso-budget will" >&2
+      echo "  notice eventually, this notices now and says why." >&2
+      exit 1
+    fi
+
+    # A floor. Both lists coming back empty satisfies every test above while
+    # proving nothing, which is the failure this repository has been bitten by
+    # more than once.
+    if [ "$offlineCount" -lt 3 ]; then
+      echo "::error::the offline image has $offlineCount storeContents entries," >&2
+      echo "  which cannot include three toplevels. The check is refusing" >&2
+      echo "  rather than passing on an answer it did not get." >&2
+      exit 1
+    fi
+
+    echo "the offline image carries all three reference machines"
+    echo "the network image carries none of them"
+    touch $out
+  ''


### PR DESCRIPTION
First of #478. Closes #479.

`installer/cd.nix` names `inputs.self.nixosConfigurations.reference` directly, so the only image it can build is nixarchy's own. A user's reinstall image is the same 900 lines with three names changed — and copying the file to change them is how the copy goes stale.

So `source` — which flake, which machines, which rev — comes in through `specialArgs`, and `flake.nix` passes the reference set. What does **not** come from it is the installer: the script, the version and the branding read `inputs.self` whoever is being installed.

## Proven not to change what ships

#479 asked for exactly this, and it is the whole risk — the feature is new, the ISO is not.

```
old: /nix/store/ph0kzibybvalwvndh846xxxav28jic4c-...-x86_64.iso.drv
new: /nix/store/ph0kzibybvalwvndh846xxxav28jic4c-...-x86_64.iso.drv
```

Same tree, both modules, identical derivation.

**"Same tree" is load-bearing, and it cost me the first attempt.** I captured baselines at `d271bf8`, refactored, committed, compared — and they differed. Not because of the refactor: `inputSources` carries `flake.outPath`, so the source tree's own store path is in the closure and **changes with every commit**. A cross-commit comparison is confounded by construction, and I read that noise as a real difference before working out why.

Also learned: **`source ? { ... }` does not work.** A module argument absent from `specialArgs` resolves through `_module.args`, not the function default — so the default sits visibly in the signature while evaluation fails with `attribute 'source' missing`.

## `checks.iso-source`

The derivation comparison proves *this* change. It cannot prove the next one, so the parameter gets a permanent guard: the offline image carries all three reference machines, the network image carries none.

Both directions, because a `source` that empties the offline image and one that fills the network image are the same mistake from two sides. The expectation is written out rather than derived from `source` — deriving it from the thing under test is how a check comes to assert that a value equals itself. Plus a floor, so two empty lists cannot pass.

**Proven able to fail** (§1): dropping `reference-hardware` turns it red naming the missing toplevel; restoring turns it green.

## Noted, not fixed

Evaluating `reference-hardware` still emits the mdadm `MAILADDR` warning. #472 fixed that for the `iso` configuration and verified its warnings were empty; `reference-hardware` was never checked and still warns. Separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5