### PR TITLE
The reinstall image gets its front door: the script, its preflights, and the menu row that is honest about the name

### DIFF
--- a/data/bin-ledger.nix
+++ b/data/bin-ledger.nix
@@ -66,6 +66,10 @@
     class = "new";
     reason = "Not in upstream. programs.nixarchy.localAi enables the service but deliberately downloads no weights; this pulls a model at runtime and sizes it against VRAM, which Nix cannot read.";
   };
+  "nixarchy-reinstall-iso" = {
+    class = "new";
+    reason = "Not in upstream, whose recovery story is snapper snapshots on the same disk. Builds a bootable image from this machine's own configuration -- the system closure and /etc/nixos, never /home or secrets -- after refusing on low disk, an uncommitted tree, or a running system that drifted from the flake.";
+  };
   "nixarchy-rollback" = {
     class = "new";
     reason = "Not in upstream, whose undo is omarchy-snapshot via snapper and limine. Lists and switches NixOS system generations, which are the bootable snapshot every rebuild already leaves behind.";

--- a/flake.nix
+++ b/flake.nix
@@ -1233,6 +1233,13 @@
             installScript = ./installer/install.sh;
           };
 
+          # nixarchy-reinstall-iso's preflights, with a df, git and eval that
+          # lie -- plus the #478 honesty strings. See tests/reinstall-iso.nix.
+          reinstall-iso = import ./tests/reinstall-iso.nix {
+            pkgs = pkgsFor.${system};
+            reinstallScript = ./pkgs/omarchy/nix-bin/nixarchy-reinstall-iso;
+          };
+
           installer-store-space = import ./tests/installer-store-space.nix {
             pkgs = pkgsFor.${system};
             installScript = ./installer/install.sh;

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -365,6 +365,18 @@ let
           description = "Copy your bar, keybindings and themes back out of the backup. Works on a new machine";
         };
 
+        # Deliberately not called "backup" -- #478 names the trap: someone
+        # loses a disk, boots the "backup", and gets a clean machine with
+        # none of their files. The image reinstalls the SYSTEM; files come
+        # back from the two rows above.
+        "trigger.reinstall-iso" = {
+          icon = "󰗮";
+          label = "Build reinstall image";
+          when = "nixarchy-reinstall-iso --check";
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-reinstall-iso";
+          description = "A bootable image that reinstalls this machine's system on new hardware. Not a backup: it carries none of your files";
+        };
+
         "install.aur" = {
           when = "false";
         };

--- a/pkgs/omarchy/nix-bin/nixarchy-reinstall-iso
+++ b/pkgs/omarchy/nix-bin/nixarchy-reinstall-iso
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+
+# nixarchy:new
+# omarchy:summary=Build a bootable image that reinstalls this machine's system. Not a backup.
+# omarchy:args=[--check]
+# omarchy:examples=nixarchy reinstall iso
+
+# The fifth leg of getting back (#478): generations cover a bad change,
+# snapshots cover files on the same disk, the two git repos cover dotfiles and
+# /etc/nixos off-disk -- and none of them survives losing the disk entirely.
+# This builds a bootable image from THIS machine's own configuration, so the
+# machine can be rebuilt on new hardware.
+#
+# ## It is NOT a backup, and every string here says so
+#
+# The image carries the system closure and /etc/nixos. It carries no /home,
+# no service state, no secrets, no browser profiles -- and booting it ERASES
+# the target disk. A menu row called "Backup" would be a trap: someone loses
+# a disk, boots the "backup", and gets a clean machine with none of their
+# files. Your files come back from your backups, not from this.
+#
+# ## The preflights (#482), each refusing with a sentence
+#
+# Space: the image is 6-10+ GB and the build wants roughly 2x the closure in
+# transient disk. This repo has had ENOSPC deaths that surfaced three levels
+# from the cause; check before starting.
+#
+# Committed: the embedded flake pins by commit, and installer/mkFlake.nix
+# refuses a tree without self.rev -- `git add` is not enough. Refuse here,
+# where the sentence can say what to do, rather than minutes in.
+#
+# Drift: /run/current-system can differ from what /etc/nixos evaluates to --
+# uncommitted edits, un-switched changes. Baking a system that differs from
+# the flake embedded beside it is silently wrong: warn and ask, never
+# silently proceed. Warn rather than refuse, because building the image of
+# what the CONFIG says (not what happens to be running) is a legitimate
+# thing to want -- it just must not happen without being said.
+
+set -euo pipefail
+
+FLAKE="${NIXARCHY_FLAKE:-/etc/nixos}"
+
+# The flake output that builds the image. #480 parameterises installer/cd.nix
+# over a foreign flake's machines and the generated flake grows an output
+# exposing it; until that lands this attribute does not exist, and the build
+# step fails with nix's own "does not provide attribute" -- after every
+# preflight above it has had its say. Overridable for the day the output is
+# named differently, and for the tests.
+REINSTALL_ATTR="${NIXARCHY_REINSTALL_ATTR:-$FLAKE#reinstall-iso}"
+
+red() { printf "\033[0;31m%s\033[0m\n" "$1"; }
+dim() { printf "\033[0;90m%s\033[0m\n" "$1"; }
+bold() { printf "\033[1m%s\033[0m\n" "$1"; }
+
+usage() {
+  echo "Usage: nixarchy-reinstall-iso [--check]"
+  echo "  (no argument)  build the image, after the preflights"
+  echo "  --check        exit 0 if this machine is one nixarchy installed. Prints nothing."
+}
+
+# ---------------------------------------------------------------------------
+# The ownership gate, verbatim from nixarchy-home-backup and for the same
+# reason: mkFlake.nix writes .nixarchy-url into the flake it generates, and
+# nothing else creates that file. A configuration somebody owns is not ours
+# to build images from the shape of.
+# ---------------------------------------------------------------------------
+
+installed_by_nixarchy() { [ -f "$FLAKE/.nixarchy-url" ]; }
+
+# ---------------------------------------------------------------------------
+# Preflight probes. Each returns a word or a verdict, takes its inputs as
+# arguments or stubbable commands, and touches neither nix nor the terminal
+# -- tests/reinstall-iso.nix drives every one with an environment that lies.
+# ---------------------------------------------------------------------------
+
+# The same probe installer/try.sh runs, for the same reason: running out of
+# disk mid-build dies several levels from the cause, under errors that name
+# none of this. And on a tmpfs the number df prints is RAM, not disk -- which
+# is exactly what a live ISO's store is, and a 12 GB build into RAM takes the
+# machine down with it.
+check_disk() {
+  local dir=$1 need_mb=$2 what=$3 fstype avail
+  read -r fstype avail < <(df --output=fstype,avail -BM "$dir" 2>/dev/null | tail -n1) || :
+  # A probe that cannot read must not invent a refusal (the tolerance rule
+  # tests/installer-store-space.nix states): no df answer, no verdict.
+  [ -n "${avail:-}" ] || return 0
+  avail=${avail%M}
+  case "$fstype" in
+    tmpfs | ramfs)
+      red "$dir is on $fstype -- RAM, not disk."
+      echo "  $what would be written there, and df's 'free' figure is memory."
+      echo "  Build this from an installed machine, not a live session."
+      return 1
+      ;;
+  esac
+  if [ "$avail" -lt "$need_mb" ]; then
+    red "Not enough disk space for $what."
+    echo "  It needs roughly ${need_mb} MB and $dir has ${avail} MB free."
+    echo "  Free some space (nix-collect-garbage reclaims old generations)"
+    echo "  and run this again. Nothing was started."
+    return 1
+  fi
+}
+
+# repo-missing | no-commit | dirty | clean. A word, not a refusal, so the
+# caller owns the sentences and a test owns the truth table.
+committed_verdict() {
+  local flake=$1
+  git -C "$flake" rev-parse --git-dir >/dev/null 2>&1 || { echo repo-missing; return; }
+  git -C "$flake" rev-parse HEAD >/dev/null 2>&1 || { echo no-commit; return; }
+  if [ -n "$(git -C "$flake" status --porcelain 2>/dev/null)" ]; then
+    echo dirty
+  else
+    echo clean
+  fi
+}
+
+# clean | drift | unknown. $2 empty means the evaluation could not answer.
+drift_verdict() {
+  local running=$1 evaluated=$2
+  if [ -z "$evaluated" ]; then
+    echo unknown
+  elif [ "$running" = "$evaluated" ]; then
+    echo clean
+  else
+    echo drift
+  fi
+}
+
+# Closure size of the running system in MB, empty when it cannot be read.
+closure_mb() {
+  local bytes
+  bytes=$(nix path-info -S /run/current-system 2>/dev/null | awk '{ print $2 }' | head -1 || :)
+  case "$bytes" in
+    '' | *[!0-9]*) echo "" ;;
+    *) echo $((bytes / 1048576)) ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Flags
+# ---------------------------------------------------------------------------
+
+case "${1:-}" in
+  "") ;;
+  --check)
+    installed_by_nixarchy || exit 1
+    exit 0
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac
+
+if ! installed_by_nixarchy; then
+  red "This machine was not installed by nixarchy."
+  echo
+  echo "  no $FLAKE/.nixarchy-url"
+  echo
+  echo "The image embeds $FLAKE and reinstalls from it. On a configuration"
+  echo "nixarchy did not generate, that shape is not one this can promise to"
+  echo "rebuild -- so it does not guess."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# What this is, before any question. Every word of the uncomfortable part.
+# ---------------------------------------------------------------------------
+
+bold "A reinstall image for this machine"
+echo
+echo "A bootable image carrying this machine's system and its /etc/nixos,"
+echo "so the machine can be reinstalled exactly -- on this hardware or on a"
+echo "replacement -- after a total disk loss."
+echo
+red "It is NOT a backup."
+echo "  It carries no /home, no service state, no secrets, no browser"
+echo "  profiles. Booting it ERASES the disk it installs to. Your files"
+echo "  come back from your backups -- omarchy-snapshot, nixarchy-home-backup"
+echo "  -- not from this."
+echo
+dim "It also goes stale: rebuild it after meaningful configuration changes."
+echo
+
+# ---------------------------------------------------------------------------
+# Preflight 1: space. ~1x the closure for the image, ~2x transient in /nix.
+# ---------------------------------------------------------------------------
+
+closure=$(closure_mb)
+if [ -n "$closure" ]; then
+  need=$((closure * 2))
+  dim "The running system's closure is ${closure} MB; the build wants roughly"
+  dim "twice that in transient disk, and the image itself lands in /nix/store."
+  echo
+  check_disk /nix/store "$need" "building the image" || exit 1
+else
+  # Cannot measure, so no invented refusal -- but say so, because a silent
+  # skip reads as a check that passed.
+  dim "Could not read the running system's closure size, so free space was"
+  dim "not checked. The build needs 12 GB or more; ENOSPC mid-build fails"
+  dim "with errors that name none of this."
+  echo
+fi
+
+# ---------------------------------------------------------------------------
+# Preflight 2: a committed tree. The generated flake pins by commit and
+# installer/mkFlake.nix refuses a tree without self.rev.
+# ---------------------------------------------------------------------------
+
+case "$(committed_verdict "$FLAKE")" in
+  repo-missing)
+    red "$FLAKE is not a git repository."
+    echo "  The image embeds the configuration and pins it by commit, so it"
+    echo "  cannot be built from a tree with no history. Run:"
+    echo
+    bold "    nixarchy config repo"
+    echo
+    echo "  which sets the repository up (and pushes it somewhere that"
+    echo "  survives the disk, which you want anyway)."
+    exit 1
+    ;;
+  no-commit)
+    red "$FLAKE has no commit yet."
+    echo "  The installer leaves it staged but uncommitted, and the image"
+    echo "  pins the configuration by commit -- git add is not enough."
+    echo "  nixarchy config repo makes the first commit, or:"
+    echo
+    dim "    git -C $FLAKE commit -m 'This machine'"
+    exit 1
+    ;;
+  dirty)
+    red "$FLAKE has uncommitted changes."
+    echo "  The image pins the configuration by commit, so what you have"
+    echo "  edited would not be what it carries. Commit first:"
+    echo
+    dim "    git -C $FLAKE add -A && git -C $FLAKE commit -m 'Before the reinstall image'"
+    exit 1
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Preflight 3: drift. Warn and ask; never silently bake a system that
+# differs from the flake embedded beside it.
+# ---------------------------------------------------------------------------
+
+host=$(uname -n)
+running=$(readlink -f /run/current-system 2>/dev/null || :)
+evaluated=$(nix eval --raw \
+  "$FLAKE#nixosConfigurations.$host.config.system.build.toplevel.outPath" \
+  2>/dev/null || :)
+
+case "$(drift_verdict "$running" "$evaluated")" in
+  clean)
+    dim "The running system matches what $FLAKE evaluates to."
+    ;;
+  drift)
+    red "WARNING: the running system is not what $FLAKE evaluates to."
+    echo
+    echo "  running    $running"
+    echo "  configured $evaluated"
+    echo
+    echo "  Un-switched changes, or a rebuild since edits -- either way the"
+    echo "  image would carry what the CONFIGURATION says, not what is"
+    echo "  running right now. If that surprises you:"
+    echo
+    dim "    nh os switch    # make the machine match the config first"
+    echo
+    printf "Build from the configuration as committed anyway? [y/N] "
+    read -r reply
+    case "$reply" in [yY]*) ;; *) echo "Nothing built."; exit 0 ;; esac
+    ;;
+  unknown)
+    dim "Could not evaluate $FLAKE#nixosConfigurations.$host to compare it"
+    dim "with the running system. If the configuration is broken, the build"
+    dim "below will say exactly where."
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Confirm, build, report.
+# ---------------------------------------------------------------------------
+
+echo
+printf "Build the image? It takes tens of minutes. [y/N] "
+read -r reply
+case "$reply" in [yY]*) ;; *) echo "Nothing built."; exit 0 ;; esac
+
+outlink="$HOME/.local/share/nixarchy/reinstall-iso"
+mkdir -p "$(dirname "$outlink")"
+
+echo
+bold "Building. Compression is the long part; this is normal."
+if ! nix build "$REINSTALL_ATTR" -o "$outlink" --print-build-logs; then
+  echo
+  red "The build failed. Nothing was produced; the messages above say why."
+  echo "  Nothing on this machine was changed."
+  exit 1
+fi
+
+# find -L, because find does not follow the result symlink (AGENTS.md §5).
+iso=$(find -L "$outlink" -name '*.iso' | head -1 || :)
+if [ -z "$iso" ]; then
+  red "The build succeeded but produced no .iso under $outlink."
+  echo "  That is a bug in the image output, not in your configuration."
+  exit 1
+fi
+
+echo
+bold "Done: $(du -h "$iso" | cut -f1) at"
+echo "  $iso"
+echo
+echo "Write it to a USB stick (this ERASES the stick):"
+dim "  sudo dd if=$iso of=/dev/sdX bs=4M status=progress oflag=sync"
+echo
+echo "Keep it OFF this machine -- an image on the disk it exists to replace"
+echo "protects nothing. And keep it private: it contains your /etc/nixos and"
+echo "any unfree packages your system uses, which are yours to keep and not"
+echo "yours to publish."
+echo
+red "Remember what it is not: booting it erases the target disk and brings"
+red "back the system, not your files. Files come back from your backups."

--- a/tests/reinstall-iso.nix
+++ b/tests/reinstall-iso.nix
@@ -1,0 +1,163 @@
+{ pkgs, reinstallScript }:
+# nixarchy-reinstall-iso's preflights (#482), driven with an environment that
+# lies -- the manner of tests/installer-store-space.nix, because it is the
+# same failure being refused: this repo's ENOSPC deaths surface three levels
+# from the cause, and a 12 GB image build is the biggest single write a user
+# can ask this machine for.
+#
+# Three functions, extracted and driven on their own; then the assertions
+# that keep the extraction honest -- that main still calls each one before
+# `nix build`, because a probe tested here and wired nowhere would be #133
+# again -- and the honesty strings #478 makes non-negotiable: the image is
+# not a backup, and every screen that offers it must say what it does not
+# carry.
+pkgs.runCommand "nixarchy-reinstall-iso" { } ''
+  set -o pipefail
+
+  # ------------------------------------------------------------------------
+  # check_disk: refuse what will not fit, refuse a tmpfs, and never refuse
+  # on a df it could not read.
+  # ------------------------------------------------------------------------
+  sed -n '/^check_disk()/,/^}/p' ${reinstallScript} > cd.sh
+  test -s cd.sh || { echo "check_disk is not in nixarchy-reinstall-iso any more" >&2; exit 1; }
+
+  cat > cdt.sh <<'EOF'
+  red() { echo "$1"; }
+  . ./cd.sh
+  df() {
+    [ -n "$DF_LINE" ] || return 1
+    printf 'Type 1M-blocks\n%s\n' "$DF_LINE"
+  }
+  fails=0
+  t() {
+    want=$1 name=$2 line=$3
+    if DF_LINE=$line check_disk /somewhere 12000 "the image" >got 2>&1; then g=proceed; else g=refuse; fi
+    if [ "$g" = "$want" ]; then
+      echo "  ok      $name ($g)"
+    else
+      echo "  FAILED  $name: wanted $want, got $g"; sed 's/^/            /' got
+      fails=$((fails + 1))
+    fi
+  }
+  t refuse  "8 GB free, 12 GB needed"     "btrfs 8000M"
+  t proceed "40 GB free, 12 GB needed"    "btrfs 40000M"
+  # A live ISO's store: df's figure is RAM, and 12 GB of build into it takes
+  # the machine down. Refused whatever the number says.
+  t refuse  "tmpfs with a big number"     "tmpfs 64000M"
+  # Tolerance: a probe that cannot read must not invent a refusal.
+  t proceed "df answers nothing"          ""
+  exit $fails
+  EOF
+  bash cdt.sh
+
+  # ------------------------------------------------------------------------
+  # committed_verdict: the whole truth table, with a git that lies.
+  # ------------------------------------------------------------------------
+  sed -n '/^committed_verdict()/,/^}/p' ${reinstallScript} > cv.sh
+  test -s cv.sh || { echo "committed_verdict is not in nixarchy-reinstall-iso any more" >&2; exit 1; }
+
+  cat > cvt.sh <<'EOF'
+  . ./cv.sh
+  git() {
+    case "$*" in
+      *--git-dir*)   [ "$REPO" = 1 ] ;;
+      *"rev-parse HEAD"*) [ "$HEAD" = 1 ] ;;
+      *porcelain*)   [ "$DIRTY" = 1 ] && echo " M flake.nix"; return 0 ;;
+    esac
+  }
+  fails=0
+  t() {
+    want=$1 name=$2 repo=$3 head=$4 dirty=$5
+    g=$(REPO=$repo HEAD=$head DIRTY=$dirty committed_verdict /etc/nixos)
+    if [ "$g" = "$want" ]; then
+      echo "  ok      $name -> $g"
+    else
+      echo "  FAILED  $name: wanted $want, got '$g'"
+      fails=$((fails + 1))
+    fi
+  }
+  t repo-missing "no repository at all"        0 0 0
+  t no-commit    "repo, staged, never committed" 1 0 0
+  t dirty        "commits plus uncommitted edits" 1 1 1
+  t clean        "committed tree"                1 1 0
+  exit $fails
+  EOF
+  bash cvt.sh
+
+  # ------------------------------------------------------------------------
+  # drift_verdict: the comparison #478 calls the subtlety that must not be
+  # skipped -- and the tolerance arm, because an evaluation that failed is
+  # not evidence of drift.
+  # ------------------------------------------------------------------------
+  sed -n '/^drift_verdict()/,/^}/p' ${reinstallScript} > dv.sh
+  test -s dv.sh || { echo "drift_verdict is not in nixarchy-reinstall-iso any more" >&2; exit 1; }
+
+  cat > dvt.sh <<'EOF'
+  . ./dv.sh
+  fails=0
+  t() {
+    want=$1 name=$2 running=$3 evaluated=$4
+    g=$(drift_verdict "$running" "$evaluated")
+    if [ "$g" = "$want" ]; then
+      echo "  ok      $name -> $g"
+    else
+      echo "  FAILED  $name: wanted $want, got '$g'"
+      fails=$((fails + 1))
+    fi
+  }
+  t clean   "running matches the flake"    /nix/store/aaa-toplevel /nix/store/aaa-toplevel
+  t drift   "un-switched or edited config" /nix/store/aaa-toplevel /nix/store/bbb-toplevel
+  t unknown "the evaluation failed"        /nix/store/aaa-toplevel ""
+  exit $fails
+  EOF
+  bash dvt.sh
+
+  echo "the three preflights refuse what they must and only that"
+
+  # ------------------------------------------------------------------------
+  # The call sites. Function tests stay green with every call deleted, which
+  # is the #133 shape: each preflight must run, and run BEFORE `nix build`.
+  # `|| true` because stdenv sets pipefail and a no-match grep must reach
+  # the named refusal below.
+  # ------------------------------------------------------------------------
+  build_line=$(grep -n 'nix build "$REINSTALL_ATTR"' ${reinstallScript} | cut -d: -f1 | head -1 || true)
+  [ -n "$build_line" ] || { echo "the script no longer builds via REINSTALL_ATTR; retarget this check" >&2; exit 1; }
+  for probe in 'check_disk /nix/store' 'committed_verdict "$FLAKE"' 'drift_verdict "$running"'; do
+    line=$(grep -n "$probe" ${reinstallScript} | cut -d: -f1 | head -1 || true)
+    [ -n "$line" ] || { echo "main() never calls: $probe" >&2; exit 1; }
+    [ "$line" -lt "$build_line" ] || {
+      echo "$probe runs after the build starts; a preflight there refuses nothing" >&2
+      exit 1
+    }
+  done
+
+  # A drift verdict the user never sees is a warning that did not happen.
+  grep -q 'WARNING: the running system is not what' ${reinstallScript} || {
+    echo "the drift arm no longer warns in words; #478 says warn, never" >&2
+    echo "silently bake a system that differs from the flake beside it" >&2
+    exit 1
+  }
+
+  # ------------------------------------------------------------------------
+  # The honesty strings. #478: a menu row called "Backup" is a trap, and the
+  # same applies to the screen the row opens. Each pattern includes the
+  # printing call and its opening quote -- match the call, not the string
+  # (tests/AGENTS.md), because the script's own comments say all of this too,
+  # and a bare grep stayed green with the printed line deleted. Found by
+  # breaking it.
+  # ------------------------------------------------------------------------
+  for claim in \
+    'red "It is NOT a backup.' \
+    'echo "  It carries no /home, no service state, no secrets' \
+    'ERASES the disk it installs to.'; do
+    grep -qF "$claim" ${reinstallScript} || {
+      echo "the script no longer says: $claim" >&2
+      echo "#478 makes that honesty non-negotiable -- the image carries the" >&2
+      echo "system and /etc/nixos only, and booting it wipes the target" >&2
+      exit 1
+    }
+  done
+
+  echo "the preflights are wired ahead of the build, and the words are honest"
+  touch $out
+''


### PR DESCRIPTION
## What this changes, and why

Closes #481, closes #482 (children of #478). `nixarchy-reinstall-iso` is the front door for the reinstall image: a `nix-bin` command in the shape of `nixarchy-home-backup`, one `trigger.reinstall-iso` menu row beside the home-backup rows, a `data/bin-ledger.nix` row (class `new`), and `checks.reinstall-iso`. The script gates on `.nixarchy-url` ownership, then preflights before anything expensive: **space** (2× the running closure in `/nix/store`, with a tmpfs refused whatever number df prints, and a df that answers nothing refusing nothing — the tolerance rule from `tests/installer-store-space.nix`), **a committed tree** (`repo-missing | no-commit | dirty | clean`, each refusal saying what to do; `installer/mkFlake.nix` requires `self.rev` and `git add` is not enough), and **drift** (`/run/current-system` vs what `/etc/nixos` evaluates to — a warning and a question, never a silent proceed; a failed evaluation reads as `unknown`, not as drift). Every user-facing string says what #478 makes non-negotiable: it is NOT a backup, it carries no `/home` and no secrets, and booting it erases the target disk.

**The build step is deliberately unwired.** #480 (in flight, `installer/cd.nix` + `flake.nix` outside the checks block — not touched here) teaches the ISO module to carry a foreign flake's machines. Until its output exists, `REINSTALL_ATTR` (`$FLAKE#reinstall-iso`, overridable via `NIXARCHY_REINSTALL_ATTR`) fails with nix's own "does not provide attribute" — after every preflight has had its say. The variable and its comment at the top of the script mark the seam.

## How I proved the check fails

Three breaks, each restored after. Break 1 — delete the tmpfs arm from `check_disk`:

```
nixarchy-reinstall-iso>   ok      8 GB free, 12 GB needed (refuse)
nixarchy-reinstall-iso>   ok      40 GB free, 12 GB needed (proceed)
nixarchy-reinstall-iso>   FAILED  tmpfs with a big number: wanted refuse, got proceed
```

Break 2 — reword the printed `red "It is NOT a backup."` line. **The check passed** — the grep matched the script's own comment header, the exact match-the-call-not-the-string trap `tests/AGENTS.md` records. The assertions now include the printing call and its opening quote, and the same break then fails:

```
nixarchy-reinstall-iso> the script no longer says: red "It is NOT a backup.
nixarchy-reinstall-iso> #478 makes that honesty non-negotiable -- the image carries the
nixarchy-reinstall-iso> system and /etc/nixos only, and booting it wipes the target
```

Break 3 — delete the `check_disk /nix/store` call site (the #133 shape: tested, wired nowhere):

```
nixarchy-reinstall-iso> main() never calls: check_disk /nix/store
```

Restored, the check is green: `the three preflights refuse what they must and only that` / `the preflights are wired ahead of the build, and the words are honest`.

## Checks run locally

- `nix build .#checks.x86_64-linux.reinstall-iso` — green (and red under all three breaks above)
- `nix build .#checks.x86_64-linux.bin-ledger` — `457 commands: 13 new … 80 rows, all true` (builds the omarchy package, so the `# nixarchy:new` loop accepted the file too)
- `nix build .#checks.x86_64-linux.menu-verbs` — green
- `nix build .#checks.x86_64-linux.options` — green
- shellcheck on the script — clean
- [x] `nix fmt -- --ci` / statix are clean (deadnix not run separately; fmt and statix were)
- [x] New files are `git add`ed and the tree committed
- [x] No new option; no workflow edit needed — `reinstall-iso` is a cheap `runCommand`, which `build.yml`'s generated step enumerates via `nix eval` and builds on every PR

## What this cost, and where it is written down

- [x] Nothing general that is not already written down: the match-the-call-not-the-string trap I re-proved is already in `tests/AGENTS.md` ("A forbid-pattern matches prose too"), so the lesson lives as a comment at the assertion it protects rather than a duplicate paragraph.

## What I could not verify

The end-to-end path — preflights passing on a real machine and the build failing with "does not provide attribute" — was not run: this container is not a nixarchy-installed machine (no `/etc/nixos/.nixarchy-url`), and creating one is #478's VM-check child. The interactive flow past the preflights is exercised only by the extracted-function tests and the call-site ordering assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKxHykfWJNwHu5aCYUsLxS