### PR TITLE
Two evaluation warnings were pointing at real defects

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -890,161 +890,170 @@
       # Smoke-test VM. Not a daily driver -- it exists to prove the QuickShell
       # bar comes up against Hyprland's Lua config before any packaging effort
       # is spent on the long tail.
-      nixosConfigurations = rec {
-        # Whose machines the images below carry.
-        #
-        # Named here rather than inside installer/cd.nix so that a user's own
-        # image (#478) is the same module with a different `source` -- their
-        # flake, their machines, their rev -- instead of a second copy of a
-        # 900-line file. What stays nixarchy's either way is the installer
-        # itself: the script, the version and the branding come from
-        # `inputs.self` inside cd.nix, whoever is being installed.
-        #
-        # `rec` so the three configurations below can be named without
-        # repeating `self.nixosConfigurations`. They are defined further down
-        # this attrset.
-        isoSource = {
-          flake = inputs.self;
-          configs = [
-            reference
-            reference-unencrypted
+      # isoSource is a helper, not a machine, so it is removed after the `rec`
+      # has used it. Left in, `nix flake show` lists it as a configuration and
+      # anything iterating nixosConfigurations -- checks.config-warnings does
+      # exactly that -- gets an attrset with no `config` and has to guess what
+      # it is looking at.
+      nixosConfigurations =
+        let
+          withHelpers = rec {
+            # Whose machines the images below carry.
+            #
+            # Named here rather than inside installer/cd.nix so that a user's own
+            # image (#478) is the same module with a different `source` -- their
+            # flake, their machines, their rev -- instead of a second copy of a
+            # 900-line file. What stays nixarchy's either way is the installer
+            # itself: the script, the version and the branding come from
+            # `inputs.self` inside cd.nix, whoever is being installed.
+            #
+            # `rec` so the three configurations below can be named without
+            # repeating `self.nixosConfigurations`. They are defined further down
+            # this attrset.
+            isoSource = {
+              flake = inputs.self;
+              configs = [
+                reference
+                reference-unencrypted
 
-            # The hardware the reference machine does not have. #382: a real
-            # laptop's hardware-configuration.nix is not the reference's, and
-            # where the difference is a PACKAGE the "a few dozen text
-            # derivations" argument stops holding -- building a package with
-            # no compiler on the image is the source bootstrap. This exists so
-            # those packages are on the medium; nobody installs it.
-            reference-hardware
-          ];
-        };
+                # The hardware the reference machine does not have. #382: a real
+                # laptop's hardware-configuration.nix is not the reference's, and
+                # where the difference is a PACKAGE the "a few dozen text
+                # derivations" argument stops holding -- building a package with
+                # no compiler on the image is the source bootstrap. This exists so
+                # those packages are on the medium; nobody installs it.
+                reference-hardware
+              ];
+            };
 
-        # The live image. See installer/cd.nix.
-        iso = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
-          specialArgs = {
-            inherit inputs;
-            offline = true;
-            source = isoSource;
+            # The live image. See installer/cd.nix.
+            iso = nixpkgs.lib.nixosSystem {
+              system = "x86_64-linux";
+              specialArgs = {
+                inherit inputs;
+                offline = true;
+                source = isoSource;
+              };
+              modules = [ ./installer/cd.nix ];
+            };
+
+            # Same module, one argument different. See the `offline` parameter in
+            # installer/cd.nix for what it turns off.
+            iso-net = nixpkgs.lib.nixosSystem {
+              system = "x86_64-linux";
+              specialArgs = {
+                inherit inputs;
+                offline = false;
+                source = isoSource;
+              };
+              modules = [ ./installer/cd.nix ];
+            };
+
+            installer-vm = nixpkgs.lib.nixosSystem {
+              system = "x86_64-linux";
+              specialArgs = { inherit inputs; };
+              modules = [ ./installer/vm.nix ];
+            };
+
+            vm = nixpkgs.lib.nixosSystem {
+              system = "x86_64-linux";
+              specialArgs = { inherit inputs; };
+              modules = [
+                self.nixosModules.nixarchy
+                home-manager.nixosModules.home-manager
+                ./vm/configuration.nix
+              ];
+            };
+
+            # Why: docs/internals/flake.md#the-same-vm-with-room-to-run-a-model
+            vm-big = nixpkgs.lib.nixosSystem {
+              system = "x86_64-linux";
+              specialArgs = { inherit inputs; };
+              modules = [
+                self.nixosModules.nixarchy
+                home-manager.nixosModules.home-manager
+                ./vm/configuration.nix
+                (
+                  { lib, ... }:
+                  {
+                    virtualisation = {
+                      memorySize = lib.mkForce 32768;
+                      cores = lib.mkForce 8;
+                      diskSize = lib.mkForce 131072; # 128GB: several models, comfortably
+                      diskImage = lib.mkForce "./nixarchy-vm-big.qcow2";
+                      # A different port, so this and .#vm can run side by side.
+                      forwardPorts = lib.mkForce [
+                        {
+                          from = "host";
+                          host.port = 2224;
+                          guest.port = 22;
+                        }
+                      ];
+                    };
+
+                    # Sized for the machine rather than inherited from the smoke
+                    # test: with 32GB the 8b tier is comfortable, and 8b is the
+                    # smallest size shown to follow the skills rather than answer
+                    # from memory while claiming to have read them.
+                    programs.nixarchy.localAi = {
+                      enable = lib.mkDefault true;
+                      model = lib.mkDefault "qwen3:8b";
+                      # A VM has no GPU, and localAi refuses to build without one
+                      # unless told. This is the case the option exists for: a rig
+                      # for exercising the wiring, where a slow answer is still an
+                      # answer and nobody is trying to work.
+                      allowCpu = lib.mkDefault true;
+                    };
+                  }
+                )
+              ];
+            };
+
+            # The machine the installer produces, with the installer's own defaults.
+            # Built in CI so the install path cannot rot between releases, and baked
+            # into the ISO's store later so that installing copies rather than
+            # downloads -- which only works if this closure is a closure of something
+            # a real install actually produces.
+            #
+            # `device` is a placeholder: nothing here formats a disk. What matters is
+            # that the expensive derivations in this toplevel are the same ones a real
+            # install needs, and the device string is not one of them.
+            reference = self.lib.mkReference { encrypt = true; };
+
+            # The same machine on an unencrypted disk.
+            #
+            # Not a variant anybody installs -- it exists so the ISO can carry
+            # both. The installer offers encryption on or off, and the two produce
+            # different systems: 51 derivations differ, all of them unit files and
+            # etc fragments, 180 MiB of content. Small, but not present is not
+            # present, and on an image with no network the difference between
+            # having them and not is a source bootstrap.
+            reference-unencrypted = self.lib.mkReference { encrypt = false; };
+
+            # The same machine again, with every hardware attribute
+            # nixos-generate-config can emit that ADDS A PACKAGE turned on. It is
+            # not a machine anyone installs; it exists so installer/cd.nix can put
+            # those packages on the image.
+            #
+            # #382: an Intel NPU made the tool write hardware.cpu.intel.npu.enable
+            # into hardware-configuration.nix, which put intel-npu-driver into
+            # environment.systemPackages, which no baked closure carried, so the
+            # target had to BUILD it -- and building a cmake package with no
+            # compiler on the image is the stdenv source bootstrap, which is where
+            # two users' installs died, after the disk was partitioned.
+            #
+            # boot.swraid.enable is the one that matters most and was found by
+            # tests/generate-config-surface.nix rather than by a user: a machine
+            # whose root is on mdraid gets it written, and it pulls mdadm. That
+            # one cannot be worked around by commenting it out either -- without
+            # it the installed machine does not boot at all.
+            reference-hardware = self.lib.mkReference {
+              encrypt = false;
+              hardware = true;
+            };
           };
-          modules = [ ./installer/cd.nix ];
-        };
-
-        # Same module, one argument different. See the `offline` parameter in
-        # installer/cd.nix for what it turns off.
-        iso-net = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
-          specialArgs = {
-            inherit inputs;
-            offline = false;
-            source = isoSource;
-          };
-          modules = [ ./installer/cd.nix ];
-        };
-
-        installer-vm = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
-          specialArgs = { inherit inputs; };
-          modules = [ ./installer/vm.nix ];
-        };
-
-        vm = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
-          specialArgs = { inherit inputs; };
-          modules = [
-            self.nixosModules.nixarchy
-            home-manager.nixosModules.home-manager
-            ./vm/configuration.nix
-          ];
-        };
-
-        # Why: docs/internals/flake.md#the-same-vm-with-room-to-run-a-model
-        vm-big = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
-          specialArgs = { inherit inputs; };
-          modules = [
-            self.nixosModules.nixarchy
-            home-manager.nixosModules.home-manager
-            ./vm/configuration.nix
-            (
-              { lib, ... }:
-              {
-                virtualisation = {
-                  memorySize = lib.mkForce 32768;
-                  cores = lib.mkForce 8;
-                  diskSize = lib.mkForce 131072; # 128GB: several models, comfortably
-                  diskImage = lib.mkForce "./nixarchy-vm-big.qcow2";
-                  # A different port, so this and .#vm can run side by side.
-                  forwardPorts = lib.mkForce [
-                    {
-                      from = "host";
-                      host.port = 2224;
-                      guest.port = 22;
-                    }
-                  ];
-                };
-
-                # Sized for the machine rather than inherited from the smoke
-                # test: with 32GB the 8b tier is comfortable, and 8b is the
-                # smallest size shown to follow the skills rather than answer
-                # from memory while claiming to have read them.
-                programs.nixarchy.localAi = {
-                  enable = lib.mkDefault true;
-                  model = lib.mkDefault "qwen3:8b";
-                  # A VM has no GPU, and localAi refuses to build without one
-                  # unless told. This is the case the option exists for: a rig
-                  # for exercising the wiring, where a slow answer is still an
-                  # answer and nobody is trying to work.
-                  allowCpu = lib.mkDefault true;
-                };
-              }
-            )
-          ];
-        };
-
-        # The machine the installer produces, with the installer's own defaults.
-        # Built in CI so the install path cannot rot between releases, and baked
-        # into the ISO's store later so that installing copies rather than
-        # downloads -- which only works if this closure is a closure of something
-        # a real install actually produces.
-        #
-        # `device` is a placeholder: nothing here formats a disk. What matters is
-        # that the expensive derivations in this toplevel are the same ones a real
-        # install needs, and the device string is not one of them.
-        reference = self.lib.mkReference { encrypt = true; };
-
-        # The same machine on an unencrypted disk.
-        #
-        # Not a variant anybody installs -- it exists so the ISO can carry
-        # both. The installer offers encryption on or off, and the two produce
-        # different systems: 51 derivations differ, all of them unit files and
-        # etc fragments, 180 MiB of content. Small, but not present is not
-        # present, and on an image with no network the difference between
-        # having them and not is a source bootstrap.
-        reference-unencrypted = self.lib.mkReference { encrypt = false; };
-
-        # The same machine again, with every hardware attribute
-        # nixos-generate-config can emit that ADDS A PACKAGE turned on. It is
-        # not a machine anyone installs; it exists so installer/cd.nix can put
-        # those packages on the image.
-        #
-        # #382: an Intel NPU made the tool write hardware.cpu.intel.npu.enable
-        # into hardware-configuration.nix, which put intel-npu-driver into
-        # environment.systemPackages, which no baked closure carried, so the
-        # target had to BUILD it -- and building a cmake package with no
-        # compiler on the image is the stdenv source bootstrap, which is where
-        # two users' installs died, after the disk was partitioned.
-        #
-        # boot.swraid.enable is the one that matters most and was found by
-        # tests/generate-config-surface.nix rather than by a user: a machine
-        # whose root is on mdraid gets it written, and it pulls mdadm. That
-        # one cannot be worked around by commenting it out either -- without
-        # it the installed machine does not boot at all.
-        reference-hardware = self.lib.mkReference {
-          encrypt = false;
-          hardware = true;
-        };
-      };
+        in
+        builtins.removeAttrs withHelpers [ "isoSource" ];
 
       devShells = eachSystem (system: {
         default = pkgsFor.${system}.callPackage ./shell.nix { };
@@ -1091,6 +1100,22 @@
             # partitions a physical disk never is.
             hardware.cpu.intel.npu.enable = true;
             boot.swraid.enable = true;
+
+            # Answered, not muted. swraid.nix:16 accepts any mdadm.conf
+            # matching MAILADDR|PROGRAM, and without one it warns that mdmon
+            # will crash -- on every evaluation of this configuration, which
+            # is every ISO build and every run of checks.iso-source.
+            #
+            # #472 answered the same question for the `iso` configuration and
+            # verified ITS warnings were empty; this one was never checked and
+            # went on warning. Hence checks.config-warnings below, so the next
+            # one fails instead of accumulating.
+            #
+            # root is where NixOS mail goes with no MTA configured, which on a
+            # configuration that exists only to put mdadm's packages on an
+            # image is exactly right: the point is that mdmon starts, not that
+            # anyone reads it.
+            boot.swraid.mdadmConf = "MAILADDR root";
             virtualisation.hypervGuest.enable = true;
             virtualisation.virtualbox.guest.enable = true;
 
@@ -1269,6 +1294,14 @@
           channel = import ./tests/channel.nix {
             pkgs = pkgsFor.${system};
             omarchy = self.packages.${system}.omarchy;
+          };
+
+          # Every configuration this repository ships evaluates without
+          # warnings. See tests/config-warnings.nix for why that is a check
+          # and not a preference.
+          config-warnings = import ./tests/config-warnings.nix {
+            inherit inputs;
+            pkgs = pkgsFor.${system};
           };
 
           # The shipped images carry the reference machines, and the network

--- a/tests/config-warnings.nix
+++ b/tests/config-warnings.nix
@@ -1,0 +1,122 @@
+{ inputs, pkgs }:
+# Every configuration this repository ships evaluates without warnings.
+#
+# Not tidiness. Both warnings this check was written after were pointing at
+# real defects, and both had been printing for weeks with nobody acting:
+#
+#   vm: "The user 'omarchy' has multiple of the options ... set to a non-null
+#   value" -- installer/host.nix sets hashedPasswordFile, which is load-bearing
+#   for #436, and vm/configuration.nix sets `password`. With mutableUsers the
+#   FILE wins, and the smoke VM never runs the installer that writes it, so the
+#   account had NO usable password. autoLogin walked past it; `sudo` would not
+#   have.
+#
+#   reference-hardware: "mdadm: Neither MAILADDR nor PROGRAM has been set. This
+#   will cause the `mdmon` service to crash." #472 answered that for the `iso`
+#   configuration and verified its warnings were empty; this one was never
+#   checked and went on warning on every ISO build.
+#
+# A warning nobody acts on trains everyone to read past warnings, which is how
+# the next real one is missed. So they are answered, and this fails if a new
+# one appears.
+#
+# Answered, never muted: `lib.mkForce null` on the password file above is a
+# statement that the VM has no installer to write it. Silencing a warning we
+# do not understand would be worse than the warning.
+let
+  inherit (pkgs) lib;
+
+  # Everything with a nixosConfigurations entry, derived rather than listed --
+  # a hand-written list is one somebody forgets to extend, which is the failure
+  # this check exists to prevent, one level up.
+  configs = lib.mapAttrs (_: c: c.config.warnings or [ ]) inputs.self.nixosConfigurations;
+
+  # Exemptions, by configuration and with the reason stated. Deliberately not
+  # a list of strings to grep for: an exemption that matches by substring
+  # silently covers the next warning that happens to share a word.
+  #
+  # The bar is "this warning is correct, and the thing it warns about is a
+  # decision this configuration has already made". Not "it is noisy".
+  exempt = {
+    vm-big = ''
+      A rig for exercising the local-AI wiring, and both warnings are advice it
+      has already taken. It sets allowCpu = true -- the option that exists to
+      say "I know there is no GPU here" -- and runs qwen3:8b on purpose,
+      because 8b is the smallest size shown to follow the skills rather than
+      answer from memory while claiming to have read them. The context-window
+      warning is the same shape: correct for somebody configuring a machine to
+      work on, irrelevant to a VM that exists to prove the wiring.
+
+      Worth revisiting separately: the no-GPU warning fires even when allowCpu
+      is explicitly true, which is a user saying "I know" and being told
+      anyway.
+    '';
+  };
+
+  offenders = lib.filterAttrs (n: w: w != [ ] && !(exempt ? ${n})) configs;
+
+  # An exemption for a configuration that no longer warns is a stale entry, and
+  # stale entries are how a list stops describing anything -- the same rule
+  # tests/reference-initrd.nix applies to its excluded modules.
+  stale = lib.filter (n: (configs.${n} or [ ]) == [ ]) (builtins.attrNames exempt);
+
+  report = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (
+      name: warns:
+      "  ${name}:\n"
+      + lib.concatStringsSep "\n" (map (w: "    ${lib.head (lib.splitString "\n" w)}") warns)
+    ) offenders
+  );
+in
+pkgs.runCommand "nixarchy-config-warnings"
+  {
+    inherit report;
+    count = toString (builtins.length (builtins.attrNames configs));
+    bad = toString (builtins.length (builtins.attrNames offenders));
+
+    # Warnings from NIXPKGS' own code are not ours to answer and must not be
+    # silenced here. There are none today; if one appears, exempt it BY NAME
+    # with the reason, the way tests/reference-initrd.nix exempts modules --
+    # an exclusion without a reason is where a real one hides.
+    names = lib.concatStringsSep " " (builtins.attrNames configs);
+    exemptNames = lib.concatStringsSep " " (builtins.attrNames exempt);
+    staleExempt = lib.concatStringsSep " " stale;
+  }
+  ''
+    echo "configurations checked: $count"
+    echo "  $names"
+
+    # A floor. An empty attrset satisfies "no offenders" while proving
+    # nothing, and this repository has been bitten by a check that passed on
+    # an answer it never got.
+    if [ "$count" -lt 5 ]; then
+      echo "::error::only $count configurations were found, which cannot be" >&2
+      echo "  right -- this repository ships iso, iso-net, the references and" >&2
+      echo "  the VMs. Refusing rather than passing on nothing." >&2
+      exit 1
+    fi
+
+    if [ "$bad" != 0 ]; then
+      echo "::error::$bad configuration(s) evaluate with warnings:" >&2
+      printf '%s\n' "$report" >&2
+      echo >&2
+      echo "  Answer it, do not mute it. Both warnings this check was written" >&2
+      echo "  after were real defects: a VM account with no usable password," >&2
+      echo "  and an mdadm service that would crash. If the warning comes from" >&2
+      echo "  nixpkgs rather than from us, exempt it by name in this file with" >&2
+      echo "  the reason." >&2
+      exit 1
+    fi
+
+    if [ -n "$staleExempt" ]; then
+      echo "::error::these exemptions name configurations that no longer warn:" >&2
+      for e in $staleExempt; do echo "  $e" >&2; done
+      echo "  Remove them -- an exemption that exempts nothing hides the next" >&2
+      echo "  real warning behind a list that looks considered." >&2
+      exit 1
+    fi
+
+    [ -n "$exemptNames" ] && echo "exempt, with a reason on each: $exemptNames"
+    echo "every other configuration evaluates without warnings"
+    touch $out
+  ''

--- a/vm/configuration.nix
+++ b/vm/configuration.nix
@@ -38,6 +38,24 @@
   users.users.omarchy = {
     description = "Nixarchy smoke test";
     password = "omarchy"; # VM-only; never reachable off the host.
+
+    # And the line above is INERT without this, which is why it is here.
+    #
+    # installer/host.nix:181 sets hashedPasswordFile = /var/lib/nixarchy/
+    # password.hash -- load-bearing for #436, because a machine installed
+    # offline gets its password from a file rather than from an evaluation.
+    # The installer writes that file. This VM never runs the installer, so the
+    # file does not exist; and with mutableUsers the FILE outranks `password`,
+    # so the account had no usable password at all.
+    #
+    # Nobody noticed because autoLogin below walks straight past it. It shows
+    # up the moment anything in the VM asks for a password -- `sudo` at a
+    # prompt that cannot be satisfied.
+    #
+    # Found by the evaluation warning about multiple password options, which
+    # is the case for reading warnings rather than living with them: it was
+    # pointing at a real defect, not at untidiness.
+    hashedPasswordFile = lib.mkForce null;
   };
 
   # Straight to a session -- a login prompt adds nothing to the smoke test.


### PR DESCRIPTION
*"Correct all warnings so they do not bite us later"* turned out right in a stronger sense than tidiness: **both warnings this repo was emitting were defects**, and both had been printing for weeks.

## The VM account had no usable password

`installer/host.nix:181` sets `hashedPasswordFile` — load-bearing for #436, so an offline-installed machine reads its password from a file and the value never enters a derivation. `vm/configuration.nix:40` sets `password = "omarchy"` and calls it VM-only.

**With `mutableUsers` the file wins, and the smoke VM never runs the installer that writes it.** So the account had no usable password at all, and the comment describing one was wrong. `autoLogin` walks straight past it; `sudo` would not have.

Fixed by clearing the file on that configuration, and verified: `users.users.omarchy.password` now evaluates to `omarchy`.

## reference-hardware would have crashed mdmon

`flake.nix` sets `boot.swraid.enable = true` there so mdadm's packages reach the offline image (#382). #472 answered this for the `iso` configuration and verified *its* warnings were empty; this one was never checked.

Answered with `MAILADDR root`, not by disabling swraid — turning it off strips the md/raid initrd modules, and `tests/reference-initrd.nix` excludes those **by name**, so it would fail on exclusions that exclude nothing.

## `checks.config-warnings`

A paragraph would let the third one accumulate. Every configuration in `nixosConfigurations` must evaluate with no warnings — derived from the attrset, not a hand-written list, because a list somebody forgets to extend is the failure one level up.

Exemptions are **by name with the reason written out**; `vm-big` is the only one, and stale exemptions fail too.

**Proven able to fail** (§1): reverting the password fix turns it red naming `vm` and quoting the warning.

## Also: `isoSource` was pretending to be a machine

The check found it. #479 put a helper attrset inside `nixosConfigurations`, where `nix flake show` lists it as a configuration and anything iterating that attrset gets something with no `config`. Removed after the `rec` has used it.

## Not fixed, and not ours

```
Using 'builtins.derivation' to create a derivation named 'options.json'
that references the store path '...-source' without a proper context.
```

`nixos/lib/make-options-doc/default.nix:217` calls `unsafeDiscardStringContext` **deliberately**, so the manual does not depend on nixpkgs' own store location — there is a `grep /nixpkgs/nixos/modules` guard three lines below enforcing exactly that. Newer Nix warns about the pattern. Upstream's to fix, and silencing a warning we do not own would hide the day it becomes an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)