### PR TITLE
The image can carry somebody else's machine

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -924,6 +924,21 @@
                 # those packages are on the medium; nobody installs it.
                 reference-hardware
               ];
+
+              # What an install actually WRITES, keyed on the encryption
+              # answer -- the two markers installer/cd.nix puts on the image
+              # and install.sh reads. Separate from `configs` because the
+              # image carries more than it installs: reference-hardware is
+              # seeded so its packages are on the medium (#382) and is not a
+              # machine anyone installs.
+              #
+              # A user's image (#478) points both at their one machine; this
+              # repository ships two because the reference exists in both
+              # encryption shapes.
+              installed = {
+                encrypted = reference;
+                unencrypted = reference-unencrypted;
+              };
             };
 
             # The live image. See installer/cd.nix.
@@ -1058,112 +1073,169 @@
       devShells = eachSystem (system: {
         default = pkgsFor.${system}.callPackage ./shell.nix { };
       });
+      # One attrset, not three `lib.x =` assignments: statix's repeated-keys
+      # lint fails the build at three, and adding mkUserIso was the third.
+      lib = {
 
-      # The installed machine, as the installer would produce it. Both disk
-      # modes come from here so they cannot drift apart, and so installer/cd.nix
-      # can bake each one onto the image without restating the host.
-      lib.mkReference =
-        {
-          encrypt,
-          hardware ? false,
-        }:
-        nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
-          specialArgs = { inherit inputs; };
-          modules = [
-            self.nixosModules.nixarchy
-            home-manager.nixosModules.home-manager
-            inputs.disko.nixosModules.disko
+        # The installed machine, as the installer would produce it. Both disk
+        # modes come from here so they cannot drift apart, and so installer/cd.nix
+        # can bake each one onto the image without restating the host.
+        mkReference =
+          {
+            encrypt,
+            hardware ? false,
+          }:
+          nixpkgs.lib.nixosSystem {
+            system = "x86_64-linux";
+            specialArgs = { inherit inputs; };
+            modules = [
+              self.nixosModules.nixarchy
+              home-manager.nixosModules.home-manager
+              inputs.disko.nixosModules.disko
 
-            # Why: docs/internals/flake.md#one-module-that-imports-the-machines-own-two-rathe
-            {
-              imports = [
-                (import ./installer/host.nix {
-                  hostname = "nixarchy";
-                  username = "omarchy";
-                })
-                (import ./installer/disk-config.nix {
-                  device = "/dev/vda";
-                  inherit encrypt;
-                })
+              # Why: docs/internals/flake.md#one-module-that-imports-the-machines-own-two-rathe
+              {
+                imports = [
+                  (import ./installer/host.nix {
+                    hostname = "nixarchy";
+                    username = "omarchy";
+                  })
+                  (import ./installer/disk-config.nix {
+                    device = "/dev/vda";
+                    inherit encrypt;
+                  })
+                ];
+              }
+            ]
+            ++ nixpkgs.lib.optional hardware {
+              # Kept in step with tests/generate-config-surface.nix, which fails
+              # if this list stops covering what nixos-generate-config emits.
+              # Two of the tool's package-adding attributes are deliberately NOT
+              # here, and the check states why: hardware.parallels.enable pulls
+              # a proprietary Parallels disk image that cannot be redistributed
+              # on an ISO, and boot.isNspawnContainer is emitted only when the
+              # tool runs INSIDE an nspawn container, which an installer that
+              # partitions a physical disk never is.
+              hardware.cpu.intel.npu.enable = true;
+              boot.swraid.enable = true;
+
+              # Answered, not muted. swraid.nix:16 accepts any mdadm.conf
+              # matching MAILADDR|PROGRAM, and without one it warns that mdmon
+              # will crash -- on every evaluation of this configuration, which
+              # is every ISO build and every run of checks.iso-source.
+              #
+              # #472 answered the same question for the `iso` configuration and
+              # verified ITS warnings were empty; this one was never checked and
+              # went on warning. Hence checks.config-warnings below, so the next
+              # one fails instead of accumulating.
+              #
+              # root is where NixOS mail goes with no MTA configured, which on a
+              # configuration that exists only to put mdadm's packages on an
+              # image is exactly right: the point is that mdmon starts, not that
+              # anyone reads it.
+              boot.swraid.mdadmConf = "MAILADDR root";
+              virtualisation.hypervGuest.enable = true;
+              virtualisation.virtualbox.guest.enable = true;
+
+              # Every nixos-hardware module installer/hardware-modules.sh can
+              # select, so the packages behind them are on the offline image.
+              #
+              # This is the same argument as the attributes above, and the same
+              # one #382 made the hard way: a real machine's generated config is
+              # not the reference's, and where the difference is a PACKAGE, an
+              # offline install has to build it from parts with no compiler.
+              # common-gpu-intel alone pulls intel-media-driver, the compute
+              # runtime and vpl-gpu-rt.
+              #
+              # The UNION, not a machine: no real machine has an Intel and an
+              # AMD GPU and both microcode sets. Every entry is mkDefault config
+              # and this host is never installed -- it exists so the medium
+              # carries the parts, which is exactly what the header above says.
+              #
+              # checks.hardware-modules asserts these names exist; the ISO budget
+              # check is what says whether they FIT.
+              imports = with inputs.nixos-hardware.nixosModules; [
+                common-cpu-intel-cpu-only
+                common-cpu-amd
+                common-gpu-intel
+                common-gpu-amd
+                # Imports common-pc and common-pc-laptop too, so it covers all
+                # four of the chassis/disk outcomes.
+                common-pc-laptop-ssd
               ];
-            }
-          ]
-          ++ nixpkgs.lib.optional hardware {
-            # Kept in step with tests/generate-config-surface.nix, which fails
-            # if this list stops covering what nixos-generate-config emits.
-            # Two of the tool's package-adding attributes are deliberately NOT
-            # here, and the check states why: hardware.parallels.enable pulls
-            # a proprietary Parallels disk image that cannot be redistributed
-            # on an ISO, and boot.isNspawnContainer is emitted only when the
-            # tool runs INSIDE an nspawn container, which an installer that
-            # partitions a physical disk never is.
-            hardware.cpu.intel.npu.enable = true;
-            boot.swraid.enable = true;
-
-            # Answered, not muted. swraid.nix:16 accepts any mdadm.conf
-            # matching MAILADDR|PROGRAM, and without one it warns that mdmon
-            # will crash -- on every evaluation of this configuration, which
-            # is every ISO build and every run of checks.iso-source.
-            #
-            # #472 answered the same question for the `iso` configuration and
-            # verified ITS warnings were empty; this one was never checked and
-            # went on warning. Hence checks.config-warnings below, so the next
-            # one fails instead of accumulating.
-            #
-            # root is where NixOS mail goes with no MTA configured, which on a
-            # configuration that exists only to put mdadm's packages on an
-            # image is exactly right: the point is that mdmon starts, not that
-            # anyone reads it.
-            boot.swraid.mdadmConf = "MAILADDR root";
-            virtualisation.hypervGuest.enable = true;
-            virtualisation.virtualbox.guest.enable = true;
-
-            # Every nixos-hardware module installer/hardware-modules.sh can
-            # select, so the packages behind them are on the offline image.
-            #
-            # This is the same argument as the attributes above, and the same
-            # one #382 made the hard way: a real machine's generated config is
-            # not the reference's, and where the difference is a PACKAGE, an
-            # offline install has to build it from parts with no compiler.
-            # common-gpu-intel alone pulls intel-media-driver, the compute
-            # runtime and vpl-gpu-rt.
-            #
-            # The UNION, not a machine: no real machine has an Intel and an
-            # AMD GPU and both microcode sets. Every entry is mkDefault config
-            # and this host is never installed -- it exists so the medium
-            # carries the parts, which is exactly what the header above says.
-            #
-            # checks.hardware-modules asserts these names exist; the ISO budget
-            # check is what says whether they FIT.
-            imports = with inputs.nixos-hardware.nixosModules; [
-              common-cpu-intel-cpu-only
-              common-cpu-amd
-              common-gpu-intel
-              common-gpu-amd
-              # Imports common-pc and common-pc-laptop too, so it covers all
-              # four of the chassis/disk outcomes.
-              common-pc-laptop-ssd
-            ];
+            };
           };
-        };
 
-      # Why: docs/internals/flake.md#one-closure-per-template-shared-by-every-vm-a-user
-      lib.mkMicrovm =
-        {
-          template,
-          system,
-          modules ? [ ],
-        }:
-        (nixpkgs.lib.nixosSystem {
-          inherit system;
-          modules = [
-            inputs.microvm.nixosModules.microvm
-            ./modules/microvm/guest.nix
-            template
-          ]
-          ++ modules;
-        }).config.microvm.declaredRunner;
+        # Why: docs/internals/flake.md#one-closure-per-template-shared-by-every-vm-a-user
+        # An installable image carrying somebody else's machine (#478).
+        #
+        # The same installer/cd.nix the reference images use, with `source`
+        # pointing at the caller's flake instead of this one -- so a user's
+        # reinstall image is one function call rather than a copy of a
+        # 900-line module that goes stale on the next bump.
+        #
+        # Called from the generated flake (installer/template/flake.nix), which
+        # is why it takes `flake` and `host` rather than reading anything here:
+        # at that point `self` is the USER's repository and this repository is
+        # one of its inputs.
+        #
+        # It is a reinstaller, not a backup. What it carries is the system
+        # closure and the configuration; what it does not carry is /home,
+        # service state or secrets, and booting it erases the target disk. The
+        # command that builds it says so; this is the machinery underneath.
+        mkUserIso =
+          {
+            flake,
+            host,
+            # Offline by default, because the whole point is a machine that can
+            # be rebuilt when there is nothing to fetch from. The network
+            # variant is #483.
+            offline ? true,
+          }:
+          let
+            machine =
+              flake.nixosConfigurations.${host} or (throw ''
+                mkUserIso: this flake has no machine called "${host}".
+                It has: ${lib.concatStringsSep ", " (lib.attrNames flake.nixosConfigurations)}
+              '');
+          in
+          (nixpkgs.lib.nixosSystem {
+            system = "x86_64-linux";
+            specialArgs = {
+              inherit inputs offline;
+              source = {
+                inherit flake;
+                # One machine, seeded and installed. The reference images carry
+                # three because the reference exists in two encryption shapes
+                # plus a hardware superset; a user has the machine they have,
+                # and its own configuration already decided whether it is
+                # encrypted.
+                configs = [ machine ];
+                installed = {
+                  encrypted = machine;
+                  unencrypted = machine;
+                };
+              };
+            };
+            modules = [ ./installer/cd.nix ];
+          }).config.system.build.isoImage;
+
+        mkMicrovm =
+          {
+            template,
+            system,
+            modules ? [ ],
+          }:
+          (nixpkgs.lib.nixosSystem {
+            inherit system;
+            modules = [
+              inputs.microvm.nixosModules.microvm
+              ./modules/microvm/guest.nix
+              template
+            ]
+            ++ modules;
+          }).config.microvm.declaredRunner;
+      };
 
       formatter = eachSystem (system: pkgsFor.${system}.nixfmt-tree);
 

--- a/installer/cd.nix
+++ b/installer/cd.nix
@@ -20,6 +20,13 @@
   # user's machines are called whatever they called them; the reference set is
   # three configurations that happen to have fixed names, which is a fact
   # about this repository and not about the shape of an image.
+  #
+  # `installed` is which of them the installer actually writes, keyed by
+  # whether the user asked for encryption -- the two markers install.sh reads.
+  # Separate from `configs` because the image carries more than it installs:
+  # reference-hardware is seeded so its PACKAGES are on the medium and is not
+  # a machine anyone installs (#382). Both must be in `configs`, and
+  # checks.iso-source fails if they are not.
   # Passed through specialArgs, NOT defaulted here with `?`. A module argument
   # missing from specialArgs is resolved through `_module.args` rather than by
   # the function default, so `source ? {...}` evaluates to
@@ -878,11 +885,20 @@ in
         # These are the SAME configurations seeded into the store above --
         # referenceConfigs -- so naming their toplevels here adds no closure.
         # It records a path the image already contains.
+        #
+        # From `source`, not from inputs.self. #479 parameterised what gets
+        # SEEDED and left these naming nixarchy's own machines, which is a
+        # half-refactor that reads fine and is fatal: a user's image would
+        # carry their closures and then tell the installer to install the
+        # reference system, which is not on the medium at all. Harmless for
+        # this repository's own images, where the two are the same
+        # configurations, and checks.iso-source now asserts the pairing rather
+        # than trusting it.
         "nixarchy-reference-true".text = ''
-          ${inputs.self.nixosConfigurations.reference.config.system.build.toplevel}
+          ${source.installed.encrypted.config.system.build.toplevel}
         '';
         "nixarchy-reference-false".text = ''
-          ${inputs.self.nixosConfigurations.reference-unencrypted.config.system.build.toplevel}
+          ${source.installed.unencrypted.config.system.build.toplevel}
         '';
       }
     else

--- a/installer/template/flake.nix
+++ b/installer/template/flake.nix
@@ -47,7 +47,7 @@
   };
 
   outputs =
-    { nixarchy, ... }:
+    { self, nixarchy, ... }:
     let
       inherit (nixarchy.inputs.nixpkgs) lib;
 
@@ -77,5 +77,42 @@
           ];
         }
       );
+
+      # `nixarchy reinstall-iso` builds this: a bootable image carrying THIS
+      # machine, so it can be rebuilt on new hardware after a disk is lost.
+      #
+      # Read the honesty in the command before you rely on it. The image
+      # carries the system closure and this repository; it carries no /home,
+      # no service state and no secrets, and booting it ERASES the target
+      # disk. Files come back from your backups, not from here.
+      #
+      # One per machine, named for it, because `hosts/` can hold several and
+      # an image is of one of them. `self` rather than a path so the image
+      # embeds the flake as git sees it -- which is also why the command
+      # refuses on an uncommitted tree.
+      packages.x86_64-linux =
+        lib.genAttrs hosts (
+          name:
+          nixarchy.lib.mkUserIso {
+            flake = self;
+            host = name;
+          }
+        )
+        // {
+          # The bare name, for the common case of one machine. With several,
+          # the command names the one it means.
+          reinstall-iso =
+            if lib.length hosts == 1 then
+              nixarchy.lib.mkUserIso {
+                flake = self;
+                host = lib.head hosts;
+              }
+            else
+              throw ''
+                This repository has ${toString (lib.length hosts)} machines, so
+                "reinstall-iso" does not say which one. Name it:
+                ${lib.concatStringsSep "\n" (map (h: "  nix build .#${h}") hosts)}
+              '';
+        };
     };
 }

--- a/tests/iso-source.nix
+++ b/tests/iso-source.nix
@@ -40,6 +40,37 @@ let
   ];
 
   missingFrom = sc: builtins.filter (t: !(builtins.elem t sc)) expected;
+
+  # What the markers name, which is what an offline install actually WRITES.
+  #
+  # This is the half of the parameter that a storeContents check cannot see,
+  # and #479 shipped it wrong: `source` changed what was seeded and the
+  # markers still read `inputs.self.nixosConfigurations.reference`. On this
+  # repository's own images the two coincide, so nothing was visibly broken --
+  # a user's image would have carried their closures and then installed a
+  # system that was not on the medium.
+  #
+  # install.sh:2513 validates the marker with `nix path-info` and falls back
+  # to BUILDING when it does not resolve, which offline is the source
+  # bootstrap. So "the marker names something the image carries" is exactly
+  # the invariant, checked here at evaluation instead of discovered there.
+  markers = {
+    "nixarchy-reference-true" = iso.environment.etc."nixarchy-reference-true".text;
+    "nixarchy-reference-false" = iso.environment.etc."nixarchy-reference-false".text;
+  };
+
+  # The file has a trailing newline; the store path does not.
+  marked = lib.mapAttrs (_: t: lib.head (lib.splitString "\n" (lib.removeSuffix "\n" t))) markers;
+
+  # toString on both sides. storeContents holds DERIVATIONS and the marker is
+  # the plain string that was written into a file, so `builtins.elem` compares
+  # a string against a list of attrsets and is false for every entry -- the
+  # check reported all markers stray while both were demonstrably present.
+  # A comparison that cannot succeed is the same failure as one that cannot
+  # fail, seen from the other side (AGENTS.md 1).
+  carried = map toString iso.isoImage.storeContents;
+
+  strayMarkers = lib.filterAttrs (_: t: !(builtins.elem t carried)) marked;
 in
 pkgs.runCommand "nixarchy-iso-source"
   {
@@ -51,6 +82,8 @@ pkgs.runCommand "nixarchy-iso-source"
     # silently emptied the offline image and a `source` that silently filled
     # the network one are the same mistake seen from two sides.
     netCount = toString (builtins.length isoNet.isoImage.storeContents);
+    strayMarkers = lib.concatStringsSep " " (lib.mapAttrsToList (n: t: "${n} -> ${t}") strayMarkers);
+
     netHasToplevels = lib.concatStringsSep " " (
       builtins.filter (t: builtins.elem t isoNet.isoImage.storeContents) expected
     );
@@ -89,7 +122,19 @@ pkgs.runCommand "nixarchy-iso-source"
       exit 1
     fi
 
+    if [ -n "$strayMarkers" ]; then
+      echo "::error::a marker names a system the image does not carry:" >&2
+      for m in $strayMarkers; do echo "  $m" >&2; done
+      echo >&2
+      echo "  installer/cd.nix writes these, install.sh reads them and hands" >&2
+      echo "  the path to nixos-install --system. A path the image does not" >&2
+      echo "  have makes the installer fall back to BUILDING it, and with no" >&2
+      echo "  network that is the source bootstrap -- #436, three days." >&2
+      exit 1
+    fi
+
     echo "the offline image carries all three reference machines"
+    echo "both markers name systems it carries"
     echo "the network image carries none of them"
     touch $out
   ''


### PR DESCRIPTION
Second of #478. Closes #480.

## The half-refactor #479 left

`installer/cd.nix` writes `/etc/nixarchy-reference-{true,false}`, which `install.sh:2513` reads and hands to `nixos-install --system`. #479 parameterised what gets **seeded** and left those two naming `inputs.self.nixosConfigurations.reference`.

That reads fine and is fatal for the feature: a user's image would carry their closures and then tell the installer to install nixarchy's reference system, **which is not on the medium at all** — so `path-info` fails, the installer falls back to building, and offline that is the source bootstrap. #436, three days.

Invisible on this repo's own images, where the two coincide. **Found by the agent writing #484's check, not by me.**

## `lib.mkUserIso`, and the output the command builds

`nixarchy reinstall-iso` (#511) runs `nix build /etc/nixos#reinstall-iso`, so the **user's** flake must expose it. `installer/template/flake.nix` now does: one package per machine under `hosts/`, plus a bare `reinstall-iso` when there is exactly one — and a throw naming the machines when there are several, because an image is of one machine and guessing which is how the wrong disk gets rebuilt.

A user's `source` names one machine for all three slots. The reference carries three because it exists in two encryption shapes plus a hardware superset; a user has the machine they have, and its own config already decided whether it is encrypted.

## The check could not have failed

`checks.iso-source`'s new marker assertion reported **every** marker stray while both were demonstrably in `storeContents`. `storeContents` holds derivations; the marker is the string written into a file; `builtins.elem` compared a string against a list of attrsets and was false for all of them.

**A comparison that cannot succeed is the same defect as one that cannot fail, seen from the other side.** `toString` on both sides now, and proven both ways: pointing `installed.encrypted` at a machine the image does not carry turns it red naming the marker; restoring turns it green.

## And statix caught the third key

Adding `lib.mkUserIso` made three `lib.*` assignments, which trips the repeated-keys lint — `statix` exits 1, and CI's lint job would have failed. Collapsed into one `lib = { … }`. Third time this session that statix has caught this class.

## Verified

`checks.iso-source` green · marker assertion proven red and green · the template parses with placeholders intact · `nix fmt -- --ci` and `statix` clean · all three `lib` functions still exported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)