### PR TITLE
What a network install would have to build, before it formats anything

### DIFF
--- a/docs/internals/onboarding.md
+++ b/docs/internals/onboarding.md
@@ -64,9 +64,15 @@ module surface and catches most mistakes in a minute or two.
 ```bash
 nix fmt -- --ci
 nix run --inputs-from . nixpkgs#statix -- check .
+nix run --inputs-from . nixpkgs#deadnix -- --fail .
 nix run --inputs-from . nixpkgs#shellcheck -- <script>
 nix run --inputs-from . nixpkgs#actionlint -- .github/workflows/<file>.yml
 ```
+
+**Copy those invocations exactly, flags included.** `deadnix` without
+`--fail` prints the same warning and exits **0** -- so the obvious form says
+clean while CI says otherwise. `build.yml:132-138` is the authority, and this
+list was missing `deadnix` altogether until it cost a red pipeline.
 
 They catch different things and CI runs all of them. `statix` in particular
 finds repeated keys and useless parens that `nix fmt` is happy with — it has

--- a/flake.nix
+++ b/flake.nix
@@ -1296,6 +1296,12 @@
             omarchy = self.packages.${system}.omarchy;
           };
 
+          # What a network install would have to build, before it formats
+          # anything. See tests/substitutable.nix.
+          substitutable = import ./tests/substitutable.nix {
+            pkgs = pkgsFor.${system};
+          };
+
           # Every configuration this repository ships evaluates without
           # warnings. See tests/config-warnings.nix for why that is a check
           # and not a preference.

--- a/installer/substitutable.sh
+++ b/installer/substitutable.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# What a network install would have to BUILD, answered before anything is
+# formatted.
+#
+# The network image (#483) is ~1.5 GB instead of 6-10 because it fetches the
+# closure instead of carrying it. That is only honest for a closure the caches
+# actually hold, and a user's is not the reference's:
+#
+#   - cache.nixos.org does not build UNFREE packages at all. vscode, zoom,
+#     cursor, discord and every IDE with a licence are absent from it by
+#     policy, not by accident.
+#   - nixarchy.cachix.org holds this project's closure, not a user's app
+#     selection beyond what nixpkgs already covers.
+#   - anything built on the machine -- an overlay, a patched package, a local
+#     flake -- is in no cache anywhere by definition.
+#
+# Discovering that after the disk is wiped is the failure this exists to
+# prevent: an installer that has partitioned a disk and then cannot fill it.
+#
+# ---------------------------------------------------------------------------
+# Why this asks the local store rather than the caches
+#
+# The obvious implementation is to ask each cache whether it has each path. It
+# does not work, and both reasons are worth writing down.
+#
+# `nix path-info --store https://cache.nixos.org a b c` returns NOTHING when
+# any one of the paths is missing -- measured, not assumed. So the batch form
+# cannot report which are absent, which is the only question being asked.
+#
+# One HTTP request per path degrades gracefully and is unusable: a desktop
+# closure here is 5,463 paths.
+#
+# The local store already knows. A path substituted from a cache carries that
+# cache's SIGNATURE; a path built here has none and is marked `ultimate`. So
+# "no cache can supply this" is a local query over the closure -- 5,463 paths
+# in 0.6 seconds, no network, and correct while offline.
+#
+# ---------------------------------------------------------------------------
+# Three classes, because "unsigned" alone would cry wolf
+#
+# Of 1,186 unsigned paths in a real desktop closure, most are text: unit files,
+# udev rules, /etc fragments. NixOS assembles those locally on every machine
+# and they cost seconds. Reporting them as "must build" would bury the six
+# entries that matter under a thousand that do not.
+#
+#   fixed-output   has `ca`, so its hash is known: re-downloadable from
+#                  upstream. Costs bandwidth, not a compiler.
+#   small          under the size floor: text derivations, assembled locally
+#                  on any machine in seconds.
+#   must build     everything else. This is the answer.
+#
+# On the machine this was written on: 145 paths over 1 MB, 6 of them
+# fixed-output, leaving 139 paths and 19.1 GB that a target would have to
+# compile -- lmstudio, vscode, zoom, cursor. Every one of them unfree.
+
+set -euo pipefail
+
+# 1 MB. Chosen because it is the gap in the measured distribution rather than a
+# round number that felt right: unit files and /etc fragments are kilobytes,
+# real packages are tens of megabytes and up. A path between the two is rare
+# and cheap either way.
+# Exported, not just assigned: the python below reads it from the environment,
+# and a plain shell variable is invisible there -- it would raise KeyError
+# rather than fall back. shellcheck caught this as "FLOOR appears unused".
+export FLOOR=${NIXARCHY_SUBSTITUTABLE_FLOOR:-1000000}
+
+usage() {
+  echo "Usage: nixarchy-substitutable <store-path>"
+  echo "  Reports what a machine without this store would have to build."
+  echo
+  echo "  Exit 0: everything can be fetched."
+  echo "  Exit 1: something would have to be built -- listed, largest first."
+  echo "  Exit 2: the question could not be answered."
+}
+
+case "${1:-}" in
+  "" | -h | --help) usage; [ -z "${1:-}" ] && exit 2 || exit 0 ;;
+esac
+
+target=$1
+
+# The tolerance rule: a probe that cannot read must not invent a verdict.
+# Refusing to answer is exit 2, which the caller shows as "unknown" -- never as
+# "nothing to build", which is the answer that gets a disk wiped.
+if ! info=$(nix path-info --json --recursive "$target" 2>/dev/null); then
+  echo "nixarchy-substitutable: cannot read the closure of $target" >&2
+  echo "  Nothing was concluded. Do not read this as 'it can all be fetched'." >&2
+  exit 2
+fi
+
+printf '%s' "$info" | python3 -c '
+import json, sys, os
+
+floor = int(os.environ["FLOOR"])
+raw = json.load(sys.stdin)
+# nix has printed both shapes across versions: an object keyed by path, and a
+# list of records carrying "path". Accept either rather than pinning a version.
+items = raw.items() if isinstance(raw, dict) else [(r["path"], r) for r in raw]
+
+total = 0
+build = []
+for path, meta in items:
+    total += 1
+    if meta.get("signatures"):
+        continue                      # some cache vouched for it
+    if meta.get("ca"):
+        continue                      # fixed output: re-downloadable
+    size = meta.get("narSize") or 0
+    if size < floor:
+        continue                      # assembled locally on any machine
+    build.append((size, path))
+
+# A closure this small is not a desktop, and answering "nothing to build" from
+# it would be answering a question that was never asked.
+if total < 100:
+    print(f"only {total} paths in that closure, which cannot be a system.", file=sys.stderr)
+    print("Refusing rather than reporting on it.", file=sys.stderr)
+    sys.exit(2)
+
+build.sort(reverse=True)
+gb = sum(s for s, _ in build) / 1e9
+print(f"{total} paths in the closure")
+
+if not build:
+    print("every one of them can be fetched from a cache")
+    sys.exit(0)
+
+print()
+print(f"{len(build)} would have to be BUILT on the target ({gb:.1f} GB):")
+for size, path in build[:12]:
+    print(f"  {size/1e6:8.0f} MB  {path.split("-", 1)[-1]}")
+if len(build) > 12:
+    print(f"  ... and {len(build) - 12} more")
+sys.exit(1)
+'

--- a/tests/substitutable.nix
+++ b/tests/substitutable.nix
@@ -1,0 +1,171 @@
+{ pkgs }:
+# installer/substitutable.sh answers "what would a machine without this store
+# have to build?", and the answer decides whether a network reinstall image
+# (#483) is honest for a given closure.
+#
+# The classification is the whole thing, so the fixtures are the three classes
+# and the two refusals. Real `nix path-info --json` output, reshaped: the
+# fields are the ones nix actually emits (ultimate, signatures, ca, narSize),
+# because a fixture invented from the man page proves the script agrees with a
+# document rather than with nix.
+let
+  inherit (pkgs) lib;
+
+  # A closure the script will accept: over the 100-path floor, and carrying one
+  # of each class. Padded with signed text derivations, which is what a real
+  # closure mostly is.
+  padding = lib.listToAttrs (
+    lib.genList (i: {
+      name = "/nix/store/${toString i}pad000000000000000000000000000-unit-${toString i}.service";
+      value = {
+        narSize = 4096;
+        signatures = [ "cache.nixos.org-1:fake" ];
+        ca = null;
+        ultimate = false;
+        references = [ ];
+      };
+    }) 120
+  );
+
+  closure = padding // {
+    # Signed by a cache: free, whatever its size.
+    "/nix/store/aaa00000000000000000000000000000-firefox-140.0" = {
+      narSize = 300000000;
+      signatures = [ "cache.nixos.org-1:fake" ];
+      ca = null;
+      ultimate = false;
+      references = [ ];
+    };
+    # Built here, big: THE answer. Nothing can supply it.
+    "/nix/store/bbb00000000000000000000000000000-vscode-1.136.1" = {
+      narSize = 1073000000;
+      signatures = [ ];
+      ca = null;
+      ultimate = true;
+      references = [ ];
+    };
+    # Built here, fixed-output: re-downloadable from upstream, so it costs
+    # bandwidth rather than a compiler. Must NOT be reported as a build.
+    "/nix/store/ccc00000000000000000000000000000-lmstudio-extracted" = {
+      narSize = 2326000000;
+      signatures = [ ];
+      ca = "fixed:r:sha256:deadbeef";
+      ultimate = true;
+      references = [ ];
+    };
+    # Built here and tiny: a unit file. NixOS assembles these on every machine
+    # in seconds, and reporting 1,186 of them would bury the entries that
+    # matter under a thousand that do not.
+    "/nix/store/ddd00000000000000000000000000000-etc-updatedb.conf" = {
+      narSize = 200;
+      signatures = [ ];
+      ca = null;
+      ultimate = true;
+      references = [ ];
+    };
+  };
+
+  # Same shape, one path: trips the "that cannot be a system" floor.
+  tiny = {
+    "/nix/store/eee00000000000000000000000000000-nothing" = {
+      narSize = 10;
+      signatures = [ ];
+      ca = null;
+      ultimate = true;
+      references = [ ];
+    };
+  };
+in
+pkgs.runCommand "nixarchy-substitutable"
+  {
+    nativeBuildInputs = [
+      pkgs.python3
+      pkgs.gnugrep
+      pkgs.coreutils
+    ];
+    closureJson = builtins.toJSON closure;
+    tinyJson = builtins.toJSON tiny;
+    script = ../installer/substitutable.sh;
+  }
+  ''
+    export HOME=$PWD
+    mkdir -p bin
+    printf '%s' "$closureJson" > closure.json
+    printf '%s' "$tinyJson" > tiny.json
+
+    # `nix` is not in this sandbox and must not be: the point is to drive the
+    # CLASSIFICATION, not nix. The stub answers with the fixture named by
+    # $FIXTURE, and fails the way nix does when asked for a path it has no
+    # record of -- which is the refusal path.
+    cat > bin/nix <<'STUB'
+    #!/bin/sh
+    case "$*" in
+      *missing-closure*) exit 1 ;;
+    esac
+    cat "$FIXTURE"
+    STUB
+    sed -i 's/^    //' bin/nix
+    chmod +x bin/nix
+    export PATH=$PWD/bin:$PATH
+
+    fails=0
+    want() {
+      if printf '%s' "$2" | grep -q -- "$3"; then echo "  ok      $1"
+      else
+        echo "  FAILED  $1: no /$3/ in:"; printf '%s\n' "$2" | sed 's/^/            /'
+        fails=$((fails + 1))
+      fi
+    }
+    reject() {
+      if printf '%s' "$2" | grep -q -- "$3"; then
+        echo "  FAILED  $1: /$3/ is present and should not be"
+        printf '%s\n' "$2" | sed 's/^/            /'
+        fails=$((fails + 1))
+      else echo "  ok      $1"
+      fi
+    }
+    code() {
+      if [ "$2" = "$3" ]; then echo "  ok      $1 (exit $3)"
+      else echo "  FAILED  $1: wanted exit $3, got $2"; fails=$((fails + 1)); fi
+    }
+
+    echo "classification:"
+    FIXTURE=$PWD/closure.json
+    export FIXTURE
+    got=$(sh $script /nix/store/xxx-system 2>&1) || rc=$?
+    rc=''${rc:-0}
+
+    want "counts the whole closure"          "$got" "124 paths"
+    want "reports the locally built package" "$got" "vscode-1.136.1"
+    reject "does not report the signed one"  "$got" "firefox"
+    reject "does not report the fixed-output one" "$got" "lmstudio"
+    reject "does not report the text derivation" "$got" "etc-updatedb"
+    code "says something must be built"      "$rc" 1
+
+    # Size is the only thing separating "a package" from "a unit file", so the
+    # floor is a knob and the knob is asserted.
+    echo "the floor:"
+    rc=0
+    got=$(NIXARCHY_SUBSTITUTABLE_FLOOR=1 sh $script /nix/store/xxx-system 2>&1) || rc=$?
+    want "a floor of 1 catches the text derivation" "$got" "etc-updatedb"
+    reject "and still not the fixed-output one"     "$got" "lmstudio"
+
+    echo "refusals:"
+    rc=0
+    FIXTURE=$PWD/tiny.json
+    got=$(sh $script /nix/store/xxx-system 2>&1) || rc=$?
+    want "a one-path closure is refused" "$got" "cannot be a system"
+    code "and says so with exit 2"       "$rc" 2
+
+    rc=0
+    got=$(sh $script /nix/store/missing-closure 2>&1) || rc=$?
+    want "an unreadable closure refuses"          "$got" "cannot read the closure"
+    # The tolerance rule: a probe that cannot read must not answer "nothing to
+    # build", because that is the answer that gets a disk wiped.
+    want "and says what it must not be read as"   "$got" "can all be fetched"
+    code "with exit 2, not 0"                     "$rc" 2
+
+    [ "$fails" -eq 0 ] || { echo "$fails failed"; exit 1; }
+    echo "all ok"
+    touch $out
+  ''


### PR DESCRIPTION
Most of #483. The image variant is a one-line `offline = false` through `mkUserIso` and follows #514; **the prediction is what the issue calls the whole scope**, and it is the part that stops a disk being wiped by an installer that then cannot fill it.

## Why a user's closure is not the reference's

`cache.nixos.org` **does not build unfree packages at all** — vscode, zoom, cursor, discord, every IDE with a licence, absent by policy. `nixarchy.cachix.org` holds this project's closure, not a user's app selection. Anything built on the machine is in no cache by definition.

Measured on a real desktop rather than argued: **5,463 paths, of which 139 and 19.1 GB would have to be BUILT on a target** — lmstudio, vscode, zoom, cursor, 1password, claude-desktop. Every one unfree.

## Asking the local store, not the caches

The obvious implementation does not work, and both reasons are in the script because the next person will try it:

```
nix path-info --store https://cache.nixos.org a b c
```

returns **nothing** when any one path is missing — measured, not assumed. So the batch form cannot report which are absent, which is the only question being asked. One request per path degrades gracefully and is unusable at 5,463 paths.

**The local store already knows.** A substituted path carries the cache's signature; one built here has none and is marked `ultimate`. So it is a local query: 5,463 paths in **0.6 s**, no network — which matters, because this runs on a machine that may be about to lose its disk.

## Three classes, because "unsigned" alone cries wolf

1,186 unsigned paths, and most are text — unit files, udev rules, `/etc` fragments NixOS assembles on every machine in seconds. Reporting them would bury the six that matter under a thousand that do not.

| | |
|---|---|
| **fixed-output** | has `ca`: re-downloadable. Bandwidth, not a compiler. 6 of the 145 over 1 MB |
| **small** | under the floor: assembled locally anywhere |
| **must build** | everything else. The answer |

The 1 MB floor sits at the gap in the measured distribution, not at a round number, and the test asserts it as a knob.

## Refusals

A probe that cannot read must not invent a verdict. An unreadable closure and one too small to be a system both exit 2, and the message says what the output must **not** be read as — *"nothing to build"* is the answer that gets a disk wiped.

## Two bugs the tools caught

**shellcheck**: `FLOOR` was assigned and not exported, so the python would have raised `KeyError` rather than falling back. Reported as *"FLOOR appears unused"* — the same defect from outside.

**Running it**: `path.split('-', 1)` sat inside a single-quoted shell string and closed it early, so python saw `split(-, 1)`.

## Verified

**Proven able to fail** (§1): making the script stop treating fixed-output paths as fetchable turns two assertions red naming lmstudio; restoring turns them green. 14 assertions, fixtures shaped from real `nix path-info --json` output rather than from the man page. All four linters clean with real exit codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)