### PR TITLE
The install VM stops running on changes that cannot affect an install

### DIFF
--- a/.github/scripts/pr-touches-build.sh
+++ b/.github/scripts/pr-touches-build.sh
@@ -18,11 +18,31 @@
 # allowlist silently stops covering the next directory somebody adds. A
 # denylist can only be wrong about the few paths it names.
 #
+# TWO questions, one denylist, plus a narrower second list.
+#
+# build.yml asks "can this change anything Nix builds?" -- a new tests/foo.nix
+# is a new derivation, so yes. install-check.yml asks the narrower "can this
+# change an INSTALL?", and for that a new check that the install job does not
+# build is a 30-minute VM for nothing. Measured: 26 to 46 minutes per run,
+# serialised behind one slot.
+#
+# `--install` adds the second list. It stays a denylist for the reason the
+# header gives, and every entry names why that path cannot reach the install
+# closure -- an entry without one is a guess, and a wrong guess here merges a
+# broken installer.
+#
 # Usage:  pr-touches-build.sh            # reads $EVENT_NAME/$GH_REPO/$PR_NUMBER
+#         pr-touches-build.sh --install  # the narrower question
 #         echo "$files" | pr-touches-build.sh -   # a file list on stdin
 #
 # Prints `true` or `false` on stdout. Nothing else goes to stdout.
 set -euo pipefail
+
+install_only=false
+if [ "${1:-}" = "--install" ]; then
+  install_only=true
+  shift
+fi
 
 if [ "${1:-}" = "-" ]; then
   files=$(cat)
@@ -72,6 +92,25 @@ while IFS= read -r f; do
     # guard into one that only runs when something else changed too.
     docs/*|AGENTS.md|CONTRIBUTING.md|.envrc|.gitignore|.github/*)
       continue ;;
+
+    # Only for the install question, and only files the install job cannot
+    # reach. install-check.yml builds exactly three checks -- install,
+    # free-space and installer-refusal -- and those three import only
+    # ./hardware-configuration.nix and ./test-instrumentation.nix from this
+    # directory. Verified by reading them, not assumed; the five names below
+    # are re-included above this arm so they keep triggering it.
+    #
+    # Everything else under tests/ is a SEPARATE derivation that build.yml
+    # builds and this job never touches. tests/substitutable.nix cost a
+    # 37-minute VM install on the day it was added, and could not have
+    # changed one byte of an install.
+    tests/install.nix|tests/free-space.nix|tests/installer-refusal.nix)
+      relevant=true; break ;;
+    tests/hardware-configuration.nix|tests/test-instrumentation.nix)
+      relevant=true; break ;;
+    tests/*)
+      if [ "$install_only" = true ]; then continue; fi
+      relevant=true; break ;;
 
     *) relevant=true; break ;;
   esac

--- a/.github/workflows/install-check.yml
+++ b/.github/workflows/install-check.yml
@@ -117,7 +117,7 @@ jobs:
           # build.yml now asks the same question and two copies of a filter is
           # how one of them goes stale while both are still trusted. The
           # reasoning that was here is there, next to the list.
-          relevant=$(.github/scripts/pr-touches-build.sh)
+          relevant=$(.github/scripts/pr-touches-build.sh --install)
 
           echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
 

--- a/flake.nix
+++ b/flake.nix
@@ -1304,6 +1304,10 @@
             pkgs = pkgsFor.${system};
           };
 
+          # The gate that decides whether a PR runs the install VM. Both
+          # questions it answers, and both directions. See tests/install-gate.nix.
+          install-gate = import ./tests/install-gate.nix { pkgs = pkgsFor.${system}; };
+
           # The shipped images carry the reference machines, and the network
           # image carries none of them. Guards the `source` argument #479
           # added to installer/cd.nix. See tests/iso-source.nix.

--- a/tests/install-gate.nix
+++ b/tests/install-gate.nix
@@ -1,0 +1,67 @@
+{ pkgs }:
+# The gate that decides whether a pull request runs the install VM.
+#
+# It is worth a check because the two directions cost very differently. A false
+# RUN wastes 26-46 minutes on one serialised slot. A false SKIP merges a
+# broken installer with nothing having looked at it -- and that is exactly
+# what #123 was: hosts/<name>/ layout changed module ORDER, which changed the
+# system path hash, and the installer then tried to build 517 derivations
+# offline. No file anyone would have called "installer" was touched.
+#
+# So the script stays a denylist, and this asserts both questions it answers:
+# build.yml's "can this change anything Nix builds?" and install-check.yml's
+# narrower "can this change an INSTALL?".
+pkgs.runCommand "nixarchy-install-gate"
+  {
+    nativeBuildInputs = [
+      pkgs.bash
+      pkgs.coreutils
+    ];
+    gate = ../.github/scripts/pr-touches-build.sh;
+  }
+  ''
+    fails=0
+    # $2 is the mode: empty for the build question, --install for the narrow
+    # one. Passing the file list on stdin is the script's own test seam.
+    t() {
+      got=$(printf '%s\n' "$3" | bash $gate $2 - 2>/dev/null || true)
+      if [ "$got" = "$4" ]; then echo "  ok      $1"
+      else echo "  FAILED  $1: got '$got', wanted '$4'"; fails=$((fails + 1)); fi
+    }
+
+    echo "the install question:"
+    # The saving. A check the install job does not build cannot change an
+    # install, and this one cost a 37-minute VM on the day it was added.
+    t "an unrelated check does not run the VM" --install "tests/substitutable.nix" false
+    t "docs do not"                            --install "docs/manual/android.md" false
+    # The three the job actually builds, and the two files they import. These
+    # are the entries whose absence would make the saving unsafe.
+    t "tests/install.nix does"                 --install "tests/install.nix" true
+    t "tests/free-space.nix does"              --install "tests/free-space.nix" true
+    t "tests/installer-refusal.nix does"       --install "tests/installer-refusal.nix" true
+    t "the shared hardware fixture does"       --install "tests/hardware-configuration.nix" true
+    t "the shared instrumentation does"        --install "tests/test-instrumentation.nix" true
+    # #123's lesson: relevance is not a directory name.
+    t "a module does"                          --install "modules/nixos.nix" true
+    t "installer code does"                    --install "installer/install.sh" true
+    t "a data row does"                        --install "data/apps.nix" true
+    # README is deliberately NOT excluded: build.yml derives counts from data/
+    # and greps README for them, so a README-only edit can legitimately fail.
+    t "README does"                            --install "README.md" true
+
+    echo "the build question, unchanged:"
+    t "an unrelated check still builds"        "" "tests/substitutable.nix" true
+    t "docs still do not"                      "" "docs/manual/android.md" false
+    t "the gate itself always does"            "" ".github/scripts/pr-touches-build.sh" true
+    t "install-check.yml always does"          "" ".github/workflows/install-check.yml" true
+
+    echo "fails safe:"
+    # An empty list means the question could not be answered -- a paginated API
+    # call that returned nothing, a renamed field. Unknown must mean run
+    # everything, because the cheap answer skips every build.
+    t "an empty file list runs everything"     --install "" true
+
+    [ "$fails" -eq 0 ] || { echo "$fails failed"; exit 1; }
+    echo "all ok"
+    touch $out
+  ''


### PR DESCRIPTION
Measured today: **26 to 46 minutes** per run, serialised behind one slot. A PR adding `tests/substitutable.nix` — a check the install job does not build, and cannot — paid **37 minutes** of it.

## The cause: one denylist answering two questions

`build.yml` asks *"can this change anything Nix builds?"* — a new `tests/foo.nix` is a new derivation, so **yes**. `install-check.yml` asks the narrower *"can this change an INSTALL?"* — where the same file is 37 minutes for nothing.

`--install` adds a second, narrower list. **It stays a denylist**, and the header's argument for that is why rather than taste: #123 changed `hosts/<name>/` layout → module **order** → the system path hash, and the installer then tried to build 517 derivations offline, with no file anyone would have called "installer" touched. An allowlist stops covering the next directory somebody adds; a denylist can only be wrong about the paths it names.

**Why the skip is safe:** `install-check.yml` builds exactly three checks, and those three import only `./hardware-configuration.nix` and `./test-instrumentation.nix` from `tests/`. Verified by reading them. Those five names are re-included **above** the `tests/*` arm so they keep triggering it.

**README stays relevant, deliberately** — `build.yml` derives counts from `data/` and greps README for them, so a README-only edit can legitimately fail the omarchy job (#424).

## `checks.install-gate`

Nothing guarded this script, and the directions cost very differently: a false **run** wastes half an hour; a false **skip** merges a broken installer with nothing having looked at it.

17 assertions — both questions, both directions, and the fails-safe path where an unanswerable question must mean *run everything*.

**Proven able to fail** (§1): making the three re-include names match nothing turns it red naming all three.

## Also

`tests/substitutable.nix` took `inputs` and never used it. **Caught by CI, not by me:** I ran `deadnix -- .` where `build.yml:138` runs `deadnix -- --fail .`, and without the flag it prints the same warning and **exits 0**. `AGENTS.md:265` has the right invocation; `docs/internals/onboarding.md` omitted deadnix from its linter list entirely — which is the list I was working from. Both now say to copy the flags exactly.

## Verified

statix, deadnix `--fail`, actionlint, fmt all clean · `checks.install-gate` passes and proven red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)