### PR TITLE
Preview a config change in a VM before switching to it

### DIFF
--- a/data/bin-ledger.nix
+++ b/data/bin-ledger.nix
@@ -66,6 +66,10 @@
     class = "new";
     reason = "Not in upstream. programs.nixarchy.localAi enables the service but deliberately downloads no weights; this pulls a model at runtime and sizes it against VRAM, which Nix cannot read.";
   };
+  "nixarchy-preview" = {
+    class = "new";
+    reason = "Not in upstream, where a config change is a pacman transaction with no dry run to look at. Builds nixosConfigurations.<host>.config.system.build.vm -- the same configuration re-evaluated under qemu-vm.nix -- and boots it in a window, on a managed disk that is refused when stale rather than silently reused.";
+  };
   "nixarchy-reinstall-iso" = {
     class = "new";
     reason = "Not in upstream, whose recovery story is snapper snapshots on the same disk. Builds a bootable image from this machine's own configuration -- the system closure and /etc/nixos, never /home or secrets -- after refusing on low disk, an uncommitted tree, or a running system that drifted from the flake.";

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -104,6 +104,7 @@ Key facts an assistant should know before answering questions about nixarchy:
 - [Getting Started](https://olafkfreund.github.io/nixarchy/manual/getting-started): building and booting the installer ISO, the seven install questions, and the first hour on the desktop
 - [Updating NixOS](https://olafkfreund.github.io/nixarchy/manual/updating-nixos): flake updates, the rebuild modes, generations, rollback, and the stale-session trap
 - [Updates](https://olafkfreund.github.io/nixarchy/manual/updates): what Update ▸ Nixarchy does here, why release channels do not exist, firmware updates, rolling back
+- [Preview changes](https://olafkfreund.github.io/nixarchy/manual/preview): booting a config change in a VM before switching to it — the disk lifecycle, and what a green preview does not prove
 - [Packages](https://olafkfreund.github.io/nixarchy/manual/other-packages): the app selection, apps.nix and nixarchy-apply, Install ▸ Search, services.nix, unfree software, removing apps
 - [Dotfiles](https://olafkfreund.github.io/nixarchy/manual/dotfiles): which config files are yours, which are seeded, and how the menu is extended
 - [Making Your Own Theme](https://olafkfreund.github.io/nixarchy/manual/making-your-own-theme): overlaying or forking a stock theme out of the read-only store

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -62,6 +62,7 @@ the documentation as much as the code.
 | Filling out pdfs | same as Omarchy — [read there](https://omarchy.org/manual/filling-out-pdfs/) |
 | Windows vm | same as Omarchy — [read there](https://omarchy.org/manual/windows-vm/) |
 | **Other packages** | **differs on NixOS** — [read here](other-packages) |
+| **Preview changes** | **nixarchy only** — [read here](preview) |
 | **Updates** | **differs on NixOS** — [read here](updates) |
 | **Dotfiles** | **differs on NixOS** — [read here](dotfiles) |
 | Shell plugins | same as Omarchy — [read there](https://omarchy.org/manual/shell-plugins/) |

--- a/docs/manual/preview.md
+++ b/docs/manual/preview.md
@@ -1,0 +1,60 @@
+---
+title: Preview changes
+---
+
+# Preview changes
+
+`nixarchy preview` (or Omarchy menu → Install → **Preview changes**) builds
+what your `/etc/nixos` evaluates to *right now* and boots it in a VM window
+— so you can look at a configuration change before switching the machine to
+it. Apply changes offers the same thing as a question, at the moment you are
+about to switch.
+
+Underneath it is `nixosConfigurations.<host>.config.system.build.vm`: your
+own configuration re-evaluated with nixpkgs' `qemu-vm.nix` layered on — the
+same thing `nixos-rebuild build-vm` builds. The guest shares your machine's
+`/nix/store` read-only, so the first preview builds the *delta* of your
+change, not a second copy of the desktop, and the disk image carries state
+rather than a system.
+
+## What a green preview proves, and what it does not
+
+A preview is **strong evidence, not proof**. The VM re-evaluates your
+configuration with VM filesystems and a VM bootloader, so its toplevel is
+not the one `nixos-rebuild switch` would activate. What it verifies: your
+options evaluate, your services start, your session comes up. What it does
+not verify: your bootloader, your real GPU, your real disks. A change that
+touches any of those still meets its first real test at the switch — which
+is one `nixarchy rollback` away from undone.
+
+## The disk, and why the command sometimes refuses
+
+Each preview gets a disk image in `~/.local/share/nixarchy/preview/`. Left
+to its own devices, qemu's runner would reuse that disk forever — and a
+reused disk replays the *previous* preview's state (logins, notification
+history, anything written in the guest) into the one you are looking at,
+which quietly turns "what does my change do?" into "what did my last
+preview do?".
+
+So when a previous preview's disk is there, the command refuses to guess:
+
+- `nixarchy preview --fresh` — delete it and preview on a clean disk
+- `nixarchy preview --keep` — boot on it, previous state and all
+
+`--keep` is for looking at something that needs state to exist — a second
+boot, a service that migrates data. Everything else wants `--fresh`.
+
+## Speed
+
+Without `/dev/kvm` (no hardware virtualisation, or you are not in the
+`kvm` group) the preview runs under software emulation, several times
+slower — near-unusable for a graphical desktop. The command warns loudly;
+the lag is the emulation, not your configuration. The guest gets 8192 MB
+by default; `--memory 4096` runs a smaller one, and 4096 is the floor.
+
+## Not Sandboxes
+
+[Sandboxes](sandboxes) (`nixarchy vm`) are disposable *generic* NixOS
+MicroVMs — a clean room for software you do not trust. A preview is the
+opposite: **your own configuration**, booted to be looked at. The sandbox
+page says "Not nixarchy's own test VM" about itself; this is that VM.

--- a/flake.nix
+++ b/flake.nix
@@ -1330,6 +1330,14 @@
             installScript = ./installer/install.sh;
           };
 
+          # nixarchy-preview's preflights and its disk lifecycle, with a df,
+          # meminfo and /dev/kvm that lie -- plus the #485 honesty strings.
+          # See tests/preview.nix.
+          preview = import ./tests/preview.nix {
+            pkgs = pkgsFor.${system};
+            previewScript = ./pkgs/omarchy/nix-bin/nixarchy-preview;
+          };
+
           # nixarchy-reinstall-iso's preflights, with a df, git and eval that
           # lie -- plus the #478 honesty strings. See tests/reinstall-iso.nix.
           reinstall-iso = import ./tests/reinstall-iso.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -1577,6 +1577,15 @@
             pkgs = pkgsFor.${system};
           };
 
+          # A previewed config's desktop actually renders: the vmVariant
+          # gains the software-GL fallbacks and sizing, only when nixarchy
+          # is on, all of it overridable. See tests/preview-variant.nix
+          # and #487.
+          preview-variant = import ./tests/preview-variant.nix {
+            inherit inputs;
+            pkgs = pkgsFor.${system};
+          };
+
           # Two machines differing only by name must build the same parts, or
           # an offline install has to build the difference. See #404.
           machine-name-free = import ./tests/machine-name-free.nix {

--- a/modules/AGENTS.md
+++ b/modules/AGENTS.md
@@ -21,6 +21,7 @@ working:
 | `home.nix` | the Home Manager side: the seed, plugins, per-user state |
 | `apps.nix` | the app catalogue and the selection model (`nixarchy-apply`) |
 | `flatpaks.nix` | the software nixpkgs genuinely does not carry |
+| `preview.nix` | the `virtualisation.vmVariant` defaults that make a previewed desktop render |
 | `fleet.nix` | pull-based `system.autoUpgrade` from a remote flake, opt-in |
 
 ## Tests

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -448,6 +448,17 @@ let
           action = "omarchy-launch-webapp 'https://search.nixos.org/options'";
           description = "Search NixOS configuration options";
         };
+        # Beside Apply, because it answers the question Apply raises: what
+        # does this change look like, before the machine switches to it?
+        # NOT "nixarchy vm" -- that name is taken by MicroVM sandboxes, and
+        # docs/manual/sandboxes.md says outright "Not nixarchy's own test
+        # VM". #485 settles the name.
+        "install.preview" = {
+          icon = "󰍹";
+          label = "Preview changes";
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-preview";
+          description = "Build this configuration and boot it in a VM window, before switching the machine to it";
+        };
         "install.apply" = {
           icon = "";
           label = "Apply changes";
@@ -1860,6 +1871,26 @@ in
                 echo "  host under hosts/<name>/ needs ../../nixarchy-apps.nix"
                 echo "  or however many levels up the flake root is."
                 echo
+              fi
+
+              # The offer, at the one moment somebody actually wants it
+              # (#488): the selection is copied, the switch is the next
+              # keypress, and a look before leaping costs a question.
+              #
+              # `command -v`, because nixarchy-preview ships in the omarchy
+              # package rather than in this script's runtimeInputs -- it is
+              # reached through the session PATH writeShellApplication
+              # prepends to, and on a machine without the package the offer
+              # must vanish rather than break the apply.
+              #
+              # `|| true`: a refused preflight (or a preview closed with a
+              # nonzero status) must land back at the switch question, not
+              # kill the apply under set -e.
+              if command -v nixarchy-preview >/dev/null 2>&1; then
+                read -r -p "Preview in a VM first? [y/N] " reply
+                case "$reply" in
+                  [yY]*) nixarchy-preview || true ;;
+                esac
               fi
 
               read -r -p "Build and switch now? [y/N] " reply

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -1886,14 +1886,26 @@ in
               # `|| true`: a refused preflight (or a preview closed with a
               # nonzero status) must land back at the switch question, not
               # kill the apply under set -e.
+              # `|| reply=""` on every prompt, because EOF is not a crash.
+              #
+              # `read` returns non-zero at end of input, and under
+              # writeShellApplication's `set -e` that KILLS the script. So the
+              # moment this file grew a second prompt, `echo n | nixarchy-apply`
+              # -- one line, two reads -- started exiting 1: the first read took
+              # the "n", the second hit EOF. checks.session drives exactly that
+              # and went red on it.
+              #
+              # Treating EOF as an empty answer is also the right behaviour
+              # rather than a test accommodation: a piped or non-interactive
+              # apply should decline to switch, not die halfway through.
               if command -v nixarchy-preview >/dev/null 2>&1; then
-                read -r -p "Preview in a VM first? [y/N] " reply
+                read -r -p "Preview in a VM first? [y/N] " reply || reply=""
                 case "$reply" in
                   [yY]*) nixarchy-preview || true ;;
                 esac
               fi
 
-              read -r -p "Build and switch now? [y/N] " reply
+              read -r -p "Build and switch now? [y/N] " reply || reply=""
               case "$reply" in
                 # No sudo: nh elevates itself, and wrapping it means the
                 # elevation happens before nh can decide how to do it.

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -137,6 +137,7 @@ in
     ./fleet.nix
     ./auto-update.nix
     (import ./services inputs)
+    ./preview.nix
     ./flatpaks.nix
     inputs.nix-flatpak.nixosModules.nix-flatpak
 

--- a/modules/preview.nix
+++ b/modules/preview.nix
@@ -32,16 +32,32 @@
         memorySize = lib.mkDefault 8192;
         cores = lib.mkDefault 4;
 
-        # ssh -p 2222 <user>@localhost, IF the previewed config runs sshd --
-        # nothing here enables it, because the preview should show the
-        # user's config, not a doctored one. A list, so a plain assignment
-        # that merges with the user's own forwards (modules/services/
-        # default.nix header: mkDefault on a merging type drops the whole
-        # contribution the moment they add an element).
+        # ssh -p 2223 <user>@localhost, IF the previewed config runs sshd --
+        # nothing here enables it, because the preview should show the user's
+        # config, not a doctored one. A list, so a plain assignment that
+        # merges with the user's own forwards (modules/services/default.nix
+        # header: mkDefault on a merging type drops the whole contribution the
+        # moment they add an element).
+        #
+        # 2223, and the number is not free choice. qemu cannot bind a host
+        # port twice, so a forward that collides fails the SECOND VM to start
+        # -- with an error about binding, not about ports being a shared
+        # resource. Every guest this repository can run, in one place, because
+        # the next person adding one will look for exactly this list:
+        #
+        #   2222  vm/configuration.nix   `nix run .#vm`, the smoke VM
+        #   2223  here                   a user previewing their own config
+        #   2224  flake.nix              `nix run .#vm-big`
+        #   set   modules/services/microvm.nix  per machine, `sshPort`
+        #
+        # The collision this avoids is specifically a nixarchy DEVELOPER's:
+        # a user previewing their own machine has no smoke VM running. It is
+        # still worth avoiding, because the person who hits it is whoever is
+        # working on this feature.
         forwardPorts = [
           {
             from = "host";
-            host.port = 2222;
+            host.port = 2223;
             guest.port = 22;
           }
         ];

--- a/modules/preview.nix
+++ b/modules/preview.nix
@@ -1,0 +1,56 @@
+{ config, lib, ... }:
+{
+  # What `nixos-rebuild build-vm` needs so a nixarchy desktop actually
+  # renders in the preview VM, instead of a black screen. #487, child of
+  # #485 -- `nixarchy-preview` runs the resulting VM.
+  #
+  # `virtualisation.vmVariant` is this configuration re-evaluated with
+  # qemu-vm.nix layered on, so everything set below reaches ONLY the VM;
+  # the host these defaults would be wrong for never sees them.
+  config = lib.mkIf config.programs.nixarchy.enable {
+    virtualisation.vmVariant = {
+      # Software rendering. qemu's virgl path hands out no usable EGLConfig
+      # -- "EGL: No EGLConfigs returned" -- so without these, wlroots
+      # refuses to start and every GL app dies on launch. Diagnosed for the
+      # smoke VM in vm/configuration.nix:67-86; a user's config booted
+      # verbatim has none of them and shows a black screen.
+      #
+      # VM-only by construction, which matters for LIBGL_ALWAYS_SOFTWARE:
+      # on a machine with a real GPU it would force every GL app onto the
+      # CPU. mkDefault throughout, so a vmVariant of the user's own wins.
+      environment.sessionVariables = {
+        WLR_RENDERER_ALLOW_SOFTWARE = lib.mkDefault "1";
+        WLR_NO_HARDWARE_CURSORS = lib.mkDefault "1";
+        LIBGL_ALWAYS_SOFTWARE = lib.mkDefault "1";
+      };
+
+      virtualisation = {
+        # qemu-vm.nix's defaults are 1024 MB and one core, which a
+        # software-rendered Hyprland session cannot live on. 8192/4 is the
+        # house standard for a desktop guest (vm/configuration.nix:102-104);
+        # 4096 is the stated floor.
+        memorySize = lib.mkDefault 8192;
+        cores = lib.mkDefault 4;
+
+        # ssh -p 2222 <user>@localhost, IF the previewed config runs sshd --
+        # nothing here enables it, because the preview should show the
+        # user's config, not a doctored one. A list, so a plain assignment
+        # that merges with the user's own forwards (modules/services/
+        # default.nix header: mkDefault on a merging type drops the whole
+        # contribution the moment they add an element).
+        forwardPorts = [
+          {
+            from = "host";
+            host.port = 2222;
+            guest.port = 22;
+          }
+        ];
+
+        # The display backend is deliberately NOT pinned here. Hardcoding
+        # `-device virtio-vga-gl -display gtk,gl=on` makes the VM refuse to
+        # start anywhere without a GL-capable display; leave it to
+        # QEMU_OPTS at runtime -- vm/configuration.nix:128-135.
+      };
+    };
+  };
+}

--- a/pkgs/omarchy/nix-bin/nixarchy-preview
+++ b/pkgs/omarchy/nix-bin/nixarchy-preview
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+
+# nixarchy:new
+# omarchy:summary=Build this machine's configuration and boot it in a VM window, before switching to it
+# omarchy:args=[--fresh | --keep] [--memory MB]
+# omarchy:examples=nixarchy preview
+# omarchy:examples=nixarchy preview --fresh
+# omarchy:examples=nixarchy preview --memory 4096
+
+# Look at a configuration change before the machine switches to it (#486).
+# `nix build` of nixosConfigurations.<host>.config.system.build.vm is the
+# same configuration re-evaluated with nixpkgs' qemu-vm.nix layered on --
+# what `nixos-rebuild build-vm` builds -- and the result is a script that
+# boots it in a window. The guest shares this machine's /nix/store
+# read-only, so the disk image carries state, not a copy of the system.
+#
+# ## The disk trap this exists to refuse (#489)
+#
+# qemu-vm.nix's runner creates its qcow2 only if missing and keeps it
+# forever, defaulting to the CURRENT DIRECTORY -- so previewing change N+1
+# silently boots on change N's disk, and the receipt is real:
+# vm/configuration.nix:98-109 records stale notification history replayed
+# from a reused disk. So the disk lives in a managed state dir under an
+# explicit name, and when one is already there this refuses to guess
+# (installer/try.sh:400-410 is the precedent): --fresh deletes it, --keep
+# boots on it, no flag gets a sentence instead of a coin toss.
+#
+# ## What a green preview does NOT verify
+#
+# The vmVariant re-evaluates with VM filesystems and a VM bootloader, so
+# the toplevel differs from the one the real machine would switch to. It is
+# strong evidence -- your services, your session, your options, evaluated
+# and booted -- and it is not proof: not your bootloader, not your real
+# GPU, not your real disks. The script says so out loud before booting,
+# and tests/preview.nix asserts it keeps saying so.
+
+set -euo pipefail
+
+FLAKE="${NIXARCHY_FLAKE:-/etc/nixos}"
+STATE_DIR="${NIXARCHY_PREVIEW_DIR:-$HOME/.local/share/nixarchy/preview}"
+
+# 8192 MB is the house standard for a graphical guest and 4096 the floor
+# (vm/configuration.nix:102-105, installer/try.sh:50-52): below the floor a
+# desktop guest dies partway up with errors that name none of this.
+MEM_MB=8192
+MEM_MIN=4096
+
+red() { printf "\033[0;31m%s\033[0m\n" "$1"; }
+dim() { printf "\033[0;90m%s\033[0m\n" "$1"; }
+bold() { printf "\033[1m%s\033[0m\n" "$1"; }
+
+usage() {
+  echo "Usage: nixarchy-preview [--fresh | --keep] [--memory MB]"
+  echo "  (no flag)      boot a preview on a new disk; refuse if an old one is there"
+  echo "  --fresh        delete the previous preview's disk and start clean"
+  echo "  --keep         boot on the previous preview's disk, state and all"
+  echo "  --memory MB    give the guest this much RAM (default $MEM_MB, floor $MEM_MIN)"
+}
+
+# ---------------------------------------------------------------------------
+# Probes. Each returns a word or a verdict, reads its inputs from stubbable
+# paths or plain arguments, and touches neither qemu nor nix --
+# tests/preview.nix drives every one with an environment that lies.
+# ---------------------------------------------------------------------------
+
+# kvm | nogroup | none -- installer/try.sh:63-72, for the same reason:
+# existence alone is not the answer, because on most setups /dev/kvm exists
+# and the user is simply not in the kvm group, and qemu's accel fallback
+# would then run several times slower without a word.
+detect_kvm() {
+  local dev="${PREVIEW_KVM_DEV:-/dev/kvm}"
+  if [ ! -e "$dev" ]; then
+    echo none
+  elif [ ! -r "$dev" ] || [ ! -w "$dev" ]; then
+    echo nogroup
+  else
+    echo kvm
+  fi
+}
+
+# Loud, not fatal: a preview under software emulation is still a preview,
+# but a graphical desktop under TCG is near-unusable and somebody who was
+# not told will read the lag as their configuration being broken.
+explain_kvm() {
+  case "$1" in
+    kvm) dim "hardware virtualisation: yes (/dev/kvm)" ;;
+    none)
+      red "WARNING: no /dev/kvm -- this machine offers no hardware virtualisation."
+      echo "  The preview will run under software emulation, SEVERAL TIMES SLOWER,"
+      echo "  and a graphical desktop under it is near-unusable. The lag is the"
+      echo "  emulation, not your configuration. If the CPU has VT-x/AMD-V,"
+      echo "  enable it in the firmware setup."
+      ;;
+    nogroup)
+      red "WARNING: /dev/kvm exists but you may not open it -- you are probably"
+      echo "  not in the 'kvm' group. The preview will run under software"
+      echo "  emulation, SEVERAL TIMES SLOWER; the lag is the emulation, not"
+      echo "  your configuration. To fix it:"
+      # shellcheck disable=SC2016  # $USER is theirs to expand, not ours
+      echo '    sudo usermod -aG kvm $USER    # then log out and back in'
+      ;;
+  esac
+}
+
+# Refuse rather than OOM -- installer/try.sh:96-113: a guest that outgrows
+# the host dies mid-boot under errors that name neither RAM nor the guest.
+# A meminfo with no MemAvailable line proceeds: a probe that cannot read
+# must not invent a refusal (the tolerance rule
+# tests/installer-store-space.nix states).
+check_ram() {
+  local need=$1 meminfo="${PREVIEW_MEMINFO:-/proc/meminfo}" avail_kb avail
+  avail_kb=$(awk '/^MemAvailable:/ { print $2 }' "$meminfo" 2>/dev/null || :)
+  [ -n "$avail_kb" ] || return 0
+  avail=$((avail_kb / 1024))
+  if [ "$avail" -lt $((need + 512)) ]; then
+    red "Not enough free memory: the preview VM wants ${need} MB and this"
+    echo "  machine has ${avail} MB available. Close something, or run a"
+    echo "  smaller preview:"
+    echo "    nixarchy-preview --memory $MEM_MIN"
+    echo "  ($MEM_MIN MB is the floor: below it a graphical desktop is not a"
+    echo "  preview of anything.)"
+    return 1
+  fi
+}
+
+# The same probe installer/try.sh:118-135 runs, for the same reason: on a
+# tmpfs the number df prints is RAM, not disk -- /tmp here is exactly that
+# -- and running out of either mid-build dies several levels from the
+# cause. This repo has the ENOSPC scars.
+check_disk() {
+  local dir=$1 need_mb=$2 what=$3 fstype avail
+  read -r fstype avail < <(df --output=fstype,avail -BM "$dir" 2>/dev/null | tail -n1) || :
+  # No df answer, no verdict (the tolerance rule again).
+  [ -n "${avail:-}" ] || return 0
+  avail=${avail%M}
+  case "$fstype" in
+    tmpfs | ramfs)
+      red "$dir is on $fstype -- RAM, not disk."
+      echo "  $what would be written there, competing with the memory the VM"
+      echo "  itself needs. df calls it free space; it is not. Point"
+      echo "  NIXARCHY_PREVIEW_DIR at a real filesystem."
+      return 1
+      ;;
+  esac
+  if [ "$avail" -lt "$need_mb" ]; then
+    red "Not enough disk space for $what."
+    echo "  It needs roughly ${need_mb} MB and $dir has ${avail} MB free."
+    echo "  Free some space (nix-collect-garbage reclaims old generations)"
+    echo "  and run this again. Nothing was started."
+    return 1
+  fi
+}
+
+# contradict | keep-missing | stale | fresh | keep | none. A word, not a
+# refusal, so the caller owns the sentences and a test owns the truth
+# table. `stale` is the row that matters: a disk exists and no flag chose
+# what to do with it, and guessing either way is the #489 trap.
+disk_verdict() {
+  local exists=$1 fresh=$2 keep=$3
+  if [ "$fresh" = 1 ] && [ "$keep" = 1 ]; then
+    echo contradict
+  elif [ "$keep" = 1 ] && [ "$exists" = 0 ]; then
+    echo keep-missing
+  elif [ "$keep" = 1 ]; then
+    echo keep
+  elif [ "$fresh" = 1 ]; then
+    echo fresh
+  elif [ "$exists" = 1 ]; then
+    echo stale
+  else
+    echo none
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Flags
+# ---------------------------------------------------------------------------
+
+fresh=0
+keep=0
+mem=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --fresh) fresh=1 ;;
+    --keep) keep=1 ;;
+    --memory)
+      mem="${2:-}"
+      case "$mem" in
+        '' | *[!0-9]*)
+          red "--memory takes a number of megabytes, like: --memory $MEM_MIN"
+          exit 1
+          ;;
+      esac
+      if [ "$mem" -lt "$MEM_MIN" ]; then
+        red "--memory $mem is below the $MEM_MIN MB floor."
+        echo "  Below it a graphical desktop guest dies partway up, with errors"
+        echo "  that name none of this. $MEM_MIN is the least that previews anything."
+        exit 1
+      fi
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+[ -f "$FLAKE/flake.nix" ] || {
+  red "No flake at $FLAKE."
+  echo "  The preview builds this machine's own configuration, and there is"
+  echo "  none there to build. Set NIXARCHY_FLAKE, or programs.nixarchy.flake."
+  exit 1
+}
+
+host=$(uname -n)
+
+# The seam, like nixarchy-reinstall-iso's REINSTALL_ATTR: overridable for
+# the day the output moves, and for the tests.
+PREVIEW_ATTR="${NIXARCHY_PREVIEW_ATTR:-$FLAKE#nixosConfigurations.$host.config.system.build.vm}"
+
+# One explicit name, not qemu-vm.nix's cwd default. The runner reads
+# NIX_DISK_IMAGE, which is its documented seam for exactly this.
+disk="$STATE_DIR/preview-$host.qcow2"
+
+# ---------------------------------------------------------------------------
+# What this is, and is not, before anything builds.
+# ---------------------------------------------------------------------------
+
+bold "Preview this machine's configuration in a VM"
+echo
+echo "What $FLAKE evaluates to right now, built and booted in a window --"
+echo "so you can look at a change before switching the machine to it."
+echo "The machine itself is not touched."
+echo
+
+# ---------------------------------------------------------------------------
+# The disk lifecycle (#489). Decided before any preflight spends time.
+# ---------------------------------------------------------------------------
+
+mkdir -p "$STATE_DIR"
+
+exists=0
+[ -e "$disk" ] && exists=1
+
+case "$(disk_verdict "$exists" "$fresh" "$keep")" in
+  contradict)
+    red "--fresh deletes the previous preview's disk and --keep boots on it;"
+    echo "  they contradict. Pick one."
+    exit 1
+    ;;
+  keep-missing)
+    red "--keep: there is no previous preview disk at $disk."
+    echo "  Run without --keep and this preview makes one."
+    exit 1
+    ;;
+  keep)
+    dim "Booting on the previous preview's disk ($disk)."
+    dim "It carries that preview's state -- logins, notification history,"
+    dim "anything written in the guest -- replayed into this one."
+    ;;
+  fresh)
+    if [ "$exists" = 1 ]; then
+      rm -f "$disk"
+      dim "Deleted the previous preview's disk. This one starts clean."
+    fi
+    ;;
+  stale)
+    red "$disk already exists -- a previous preview made it, and booting the"
+    echo "  new configuration on the old disk replays the old preview's state"
+    echo "  into it (stale notification history is the receipt this repo"
+    echo "  holds). Refusing to guess:"
+    echo "    --fresh    delete it and preview on a clean disk"
+    echo "    --keep     boot on it, previous state and all"
+    exit 1
+    ;;
+  none) ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Preflights, each refusing in a sentence, all before the build.
+# ---------------------------------------------------------------------------
+
+explain_kvm "$(detect_kvm)"
+check_ram "${mem:-$MEM_MB}" || exit 1
+# The build lands in /nix/store; the qcow2 lands in the state dir. The
+# store figure is a floor, not the worst case: the guest shares this
+# machine's store over 9p/virtiofs, so a preview builds the delta of the
+# change, not a second copy of the desktop. The disk figure is small for
+# the same reason -- the image is sparse and holds state, not the system.
+check_disk /nix/store 8192 "building the preview system" || exit 1
+check_disk "$STATE_DIR" 4096 "the preview VM's disk" || exit 1
+
+# ---------------------------------------------------------------------------
+# Build, then say what a green boot means before showing one.
+# ---------------------------------------------------------------------------
+
+echo
+bold "Building the preview of $FLAKE#$host. The first one is the long one."
+if ! nix build "$PREVIEW_ATTR" -o "$STATE_DIR/result" --print-build-logs; then
+  echo
+  red "The build failed. The messages above say why; the same failure would"
+  echo "  have met 'Apply changes'. Nothing on this machine was changed, and"
+  echo "  no VM was started."
+  exit 1
+fi
+
+# find -L, because find does not follow the result symlink (AGENTS.md §5).
+runner=$(find -L "$STATE_DIR/result/bin" -name 'run-*-vm' 2>/dev/null | head -1 || :)
+if [ -z "$runner" ]; then
+  red "The build succeeded but produced no run-*-vm script."
+  echo "  That is a bug in the VM output, not in your configuration."
+  exit 1
+fi
+
+echo
+red "A green preview is strong evidence, not proof."
+echo "  The VM re-evaluates your configuration with VM filesystems and a VM"
+echo "  bootloader, so it does not verify your bootloader, your real GPU,"
+echo "  or your real disks. What it does verify: your options evaluate,"
+echo "  your services start, your session comes up."
+echo
+dim "Close the VM window (or poweroff inside it) to end the preview."
+echo
+
+# NIX_DISK_IMAGE pins the disk to the managed name above; the cd is the
+# belt for any qemu-vm.nix that derives a second path from the cwd.
+# QEMU_OPTS is appended after the baked -m, and qemu takes the last one.
+export NIX_DISK_IMAGE="$disk"
+[ -n "$mem" ] && export QEMU_OPTS="${QEMU_OPTS:-} -m $mem"
+cd "$STATE_DIR"
+exec "$runner"

--- a/tests/preview-variant.nix
+++ b/tests/preview-variant.nix
@@ -1,0 +1,141 @@
+{ inputs, pkgs }:
+# The previewVariant module (#487): a nixarchy config previewed with
+# `nixos-rebuild build-vm` gets the software-GL fallbacks and the VM sizing
+# that make its desktop actually render, and gets them ONLY there.
+#
+# `virtualisation.vmVariant` is the same config re-evaluated with qemu-vm.nix
+# layered on, so it can be asked at evaluation time -- no VM boots here.
+# Three machines, because the module makes three claims:
+#
+#   on        enabling nixarchy fills the vmVariant in;
+#   off       Mode A -- an inert import leaves the vmVariant exactly as
+#             nixpkgs would have it, measured against a baseline WITHOUT the
+#             module rather than against remembered nixpkgs defaults, which
+#             would go stale the day nixpkgs changes one;
+#   override  everything scalar is mkDefault, so a user's plain assignment
+#             in their own vmVariant wins without mkForce -- and the
+#             forwardPorts list MERGES with their addition rather than
+#             being dropped by it.
+let
+  inherit (pkgs) lib;
+  system = pkgs.stdenv.hostPlatform.system;
+
+  hardware = {
+    boot.loader.grub.device = "/dev/sda";
+    fileSystems."/" = {
+      device = "/dev/sda1";
+      fsType = "ext4";
+    };
+    system.stateVersion = "25.05";
+  };
+
+  machine =
+    modules:
+    (inputs.nixpkgs.lib.nixosSystem {
+      inherit system;
+      modules = modules ++ [ hardware ];
+    }).config.virtualisation.vmVariant;
+
+  on = machine [
+    inputs.self.nixosModules.nixarchy
+    { programs.nixarchy.enable = true; }
+  ];
+
+  off = machine [
+    inputs.self.nixosModules.nixarchy
+    { programs.nixarchy.enable = false; }
+  ];
+
+  # No nixarchy module at all: what nixpkgs gives a vmVariant on its own.
+  # The off machine must be indistinguishable from this one in everything
+  # the preview module touches.
+  baseline = machine [ ];
+
+  overridden = machine [
+    inputs.self.nixosModules.nixarchy
+    {
+      programs.nixarchy.enable = true;
+      virtualisation.vmVariant = {
+        environment.sessionVariables.LIBGL_ALWAYS_SOFTWARE = "0";
+        virtualisation = {
+          memorySize = 4096;
+          cores = 2;
+          forwardPorts = [
+            {
+              from = "host";
+              host.port = 8080;
+              guest.port = 80;
+            }
+          ];
+        };
+      };
+    }
+  ];
+
+  glVars = [
+    "WLR_RENDERER_ALLOW_SOFTWARE"
+    "WLR_NO_HARDWARE_CURSORS"
+    "LIBGL_ALWAYS_SOFTWARE"
+  ];
+
+  hostPorts = cfg: map (p: p.host.port) cfg.virtualisation.forwardPorts;
+
+  cases = {
+    # ---- on: the black-screen fix is present in the VM ----
+    on-sets-software-gl = builtins.all (
+      v: (on.environment.sessionVariables.${v} or null) == "1"
+    ) glVars;
+    on-sizes-the-guest = on.virtualisation.memorySize == 8192 && on.virtualisation.cores == 4;
+    on-forwards-ssh = builtins.elem 2222 (hostPorts on);
+
+    # ---- off: Mode A, indistinguishable from no module at all ----
+    off-adds-no-variables = builtins.all (
+      v: (off.environment.sessionVariables ? ${v}) == (baseline.environment.sessionVariables ? ${v})
+    ) glVars;
+    off-leaves-sizing-alone =
+      off.virtualisation.memorySize == baseline.virtualisation.memorySize
+      && off.virtualisation.cores == baseline.virtualisation.cores;
+    off-forwards-nothing = hostPorts off == hostPorts baseline;
+
+    # ---- override: a plain assignment beats every default here ----
+    override-wins-variables = overridden.environment.sessionVariables.LIBGL_ALWAYS_SOFTWARE == "0";
+    override-wins-sizing =
+      overridden.virtualisation.memorySize == 4096 && overridden.virtualisation.cores == 2;
+    # And the list is the other way round on purpose: their port arrives
+    # AND ours survives. If ours vanished, forwardPorts was mkDefault'd and
+    # the module has the merging-type trap the services header warns about.
+    override-merges-forwards =
+      builtins.elem 8080 (hostPorts overridden) && builtins.elem 2222 (hostPorts overridden);
+  };
+
+  broken = lib.filterAttrs (_: ok: !ok) cases;
+in
+pkgs.runCommand "nixarchy-preview-variant"
+  {
+    report = lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (name: ok: "  ${name}: ${if ok then "ok" else "BROKEN"}") cases
+    );
+    checked = toString (builtins.length (builtins.attrNames cases));
+    bad = lib.concatStringsSep " " (builtins.attrNames broken);
+  }
+  (
+    if broken == { } then
+      ''
+        echo "the preview vmVariant, in three states:"
+        printf '%s\n' "$report"
+
+        # A floor, so an emptied cases set cannot pass having asked nothing.
+        test "$checked" -ge 9
+
+        echo "on fills it in, off leaves nixpkgs' own, a plain assignment wins"
+        touch $out
+      ''
+    else
+      ''
+        printf '%s\n' "$report"
+        echo "these preview-variant claims do not hold: $bad" >&2
+        echo "a preview whose desktop cannot render is a VM that boots to a" >&2
+        echo "black screen -- see modules/preview.nix and #487." >&2
+        exit 1
+      ''
+  )

--- a/tests/preview-variant.nix
+++ b/tests/preview-variant.nix
@@ -86,7 +86,11 @@ let
       v: (on.environment.sessionVariables.${v} or null) == "1"
     ) glVars;
     on-sizes-the-guest = on.virtualisation.memorySize == 8192 && on.virtualisation.cores == 4;
-    on-forwards-ssh = builtins.elem 2222 (hostPorts on);
+    # 2223, not 2222: qemu cannot bind a host port twice, and 2222 belongs to
+    # `nix run .#vm`. The map of every guest's port is in modules/preview.nix
+    # beside the forward. Asserting the NUMBER rather than "some forward exists"
+    # is the point -- a collision is a wrong number, not a missing one.
+    on-forwards-ssh = builtins.elem 2223 (hostPorts on);
 
     # ---- off: Mode A, indistinguishable from no module at all ----
     off-adds-no-variables = builtins.all (
@@ -105,7 +109,7 @@ let
     # AND ours survives. If ours vanished, forwardPorts was mkDefault'd and
     # the module has the merging-type trap the services header warns about.
     override-merges-forwards =
-      builtins.elem 8080 (hostPorts overridden) && builtins.elem 2222 (hostPorts overridden);
+      builtins.elem 8080 (hostPorts overridden) && builtins.elem 2223 (hostPorts overridden);
   };
 
   broken = lib.filterAttrs (_: ok: !ok) cases;

--- a/tests/preview.nix
+++ b/tests/preview.nix
@@ -1,0 +1,195 @@
+{ pkgs, previewScript }:
+# nixarchy-preview's preflights and its disk lifecycle (#486, #489), driven
+# with an environment that lies -- the manner of tests/reinstall-iso.nix,
+# because they are the same refusals: ENOSPC and OOM deaths surface levels
+# from the cause, and the stale-qcow2 trap has a receipt in this repo
+# (vm/configuration.nix:98-109, stale notification history replayed from a
+# reused disk).
+#
+# Three probe truth tables, extracted and driven on their own; then the
+# assertions that keep the extraction honest -- that main still calls each
+# probe, and calls it BEFORE `nix build`, because a probe tested here and
+# wired nowhere would be #133 again -- and the honesty strings #485 makes
+# non-negotiable: a green preview is evidence, not proof.
+pkgs.runCommand "nixarchy-preview" { } ''
+  set -o pipefail
+
+  # ------------------------------------------------------------------------
+  # disk_verdict: the whole #489 truth table. `stale` is the row the
+  # feature exists for -- a disk and no flag must be a refusal, never a
+  # guess in either direction.
+  # ------------------------------------------------------------------------
+  sed -n '/^disk_verdict()/,/^}/p' ${previewScript} > dv.sh
+  test -s dv.sh || { echo "disk_verdict is not in nixarchy-preview any more" >&2; exit 1; }
+
+  cat > dvt.sh <<'EOF'
+  . ./dv.sh
+  fails=0
+  t() {
+    want=$1 name=$2 exists=$3 fresh=$4 keep=$5
+    g=$(disk_verdict "$exists" "$fresh" "$keep")
+    if [ "$g" = "$want" ]; then
+      echo "  ok      $name -> $g"
+    else
+      echo "  FAILED  $name: wanted $want, got '$g'"
+      fails=$((fails + 1))
+    fi
+  }
+  t none        "first preview, no flags"        0 0 0
+  t stale       "old disk, no flags: refuse"     1 0 0
+  t fresh       "old disk, --fresh"              1 1 0
+  t fresh       "no disk, --fresh (harmless)"    0 1 0
+  t keep        "old disk, --keep"               1 0 1
+  t keep-missing "--keep with nothing to keep"   0 0 1
+  t contradict  "--fresh --keep together"        1 1 1
+  t contradict  "--fresh --keep, even diskless"  0 1 1
+  exit $fails
+  EOF
+  bash dvt.sh
+
+  # ------------------------------------------------------------------------
+  # check_ram: refuse what will not fit, and never refuse on a meminfo it
+  # could not read.
+  # ------------------------------------------------------------------------
+  sed -n '/^check_ram()/,/^}/p' ${previewScript} > cr.sh
+  test -s cr.sh || { echo "check_ram is not in nixarchy-preview any more" >&2; exit 1; }
+
+  cat > crt.sh <<'EOF'
+  red() { echo "$1"; }
+  MEM_MIN=4096
+  . ./cr.sh
+  fails=0
+  t() {
+    want=$1 name=$2 avail_kb=$3
+    m=$(mktemp)
+    [ -z "$avail_kb" ] || printf 'MemAvailable: %s kB\n' "$avail_kb" > "$m"
+    if PREVIEW_MEMINFO=$m check_ram 8192 >got 2>&1; then g=proceed; else g=refuse; fi
+    if [ "$g" = "$want" ]; then
+      echo "  ok      $name ($g)"
+    else
+      echo "  FAILED  $name: wanted $want, got $g"; sed 's/^/            /' got
+      fails=$((fails + 1))
+    fi
+  }
+  t refuse  "4 GB available, 8 GB wanted"   4194304
+  t proceed "32 GB available, 8 GB wanted"  33554432
+  # Tolerance: a probe that cannot read must not invent a refusal.
+  t proceed "meminfo answers nothing"       ""
+  exit $fails
+  EOF
+  bash crt.sh
+
+  # ------------------------------------------------------------------------
+  # check_disk: refuse what will not fit, refuse a tmpfs whatever its
+  # number says (df's figure there is RAM), and tolerate a silent df.
+  # ------------------------------------------------------------------------
+  sed -n '/^check_disk()/,/^}/p' ${previewScript} > cd.sh
+  test -s cd.sh || { echo "check_disk is not in nixarchy-preview any more" >&2; exit 1; }
+
+  cat > cdt.sh <<'EOF'
+  red() { echo "$1"; }
+  . ./cd.sh
+  df() {
+    [ -n "$DF_LINE" ] || return 1
+    printf 'Type 1M-blocks\n%s\n' "$DF_LINE"
+  }
+  fails=0
+  t() {
+    want=$1 name=$2 line=$3
+    if DF_LINE=$line check_disk /somewhere 8192 "the preview" >got 2>&1; then g=proceed; else g=refuse; fi
+    if [ "$g" = "$want" ]; then
+      echo "  ok      $name ($g)"
+    else
+      echo "  FAILED  $name: wanted $want, got $g"; sed 's/^/            /' got
+      fails=$((fails + 1))
+    fi
+  }
+  t refuse  "4 GB free, 8 GB needed"    "btrfs 4000M"
+  t proceed "40 GB free, 8 GB needed"   "btrfs 40000M"
+  t refuse  "tmpfs with a big number"   "tmpfs 64000M"
+  t proceed "df answers nothing"        ""
+  exit $fails
+  EOF
+  bash cdt.sh
+
+  # ------------------------------------------------------------------------
+  # detect_kvm: the three-way answer, because existence alone is not it --
+  # a /dev/kvm the user cannot open falls back to TCG just as silently.
+  # ------------------------------------------------------------------------
+  sed -n '/^detect_kvm()/,/^}/p' ${previewScript} > dk.sh
+  test -s dk.sh || { echo "detect_kvm is not in nixarchy-preview any more" >&2; exit 1; }
+
+  cat > dkt.sh <<'EOF'
+  . ./dk.sh
+  fails=0
+  t() {
+    want=$1 name=$2 dev=$3
+    g=$(PREVIEW_KVM_DEV=$dev detect_kvm)
+    if [ "$g" = "$want" ]; then
+      echo "  ok      $name -> $g"
+    else
+      echo "  FAILED  $name: wanted $want, got '$g'"
+      fails=$((fails + 1))
+    fi
+  }
+  touch openable; chmod 600 openable
+  touch locked;   chmod 000 locked
+  t kvm     "an openable device"       ./openable
+  t nogroup "a device with no access"  ./locked
+  t none    "no device at all"         ./absent
+  exit $fails
+  EOF
+  bash dkt.sh
+
+  echo "the probes refuse what they must and only that"
+
+  # ------------------------------------------------------------------------
+  # The call sites. Function tests stay green with every call deleted,
+  # which is the #133 shape: each probe must run, and run BEFORE the
+  # `nix build` -- a preflight after the build starts refuses nothing,
+  # and a disk verdict after it wastes the build it refuses.
+  # `|| true` because stdenv sets pipefail and a no-match grep must reach
+  # the named refusal below.
+  # ------------------------------------------------------------------------
+  build_line=$(grep -n 'nix build "$PREVIEW_ATTR"' ${previewScript} | cut -d: -f1 | head -1 || true)
+  [ -n "$build_line" ] || { echo "the script no longer builds via PREVIEW_ATTR; retarget this check" >&2; exit 1; }
+  for probe in 'disk_verdict "$exists"' 'explain_kvm "$(detect_kvm)"' 'check_ram "''${mem:-$MEM_MB}"' 'check_disk /nix/store' 'check_disk "$STATE_DIR"'; do
+    line=$(grep -n "$probe" ${previewScript} | cut -d: -f1 | head -1 || true)
+    [ -n "$line" ] || { echo "main() never calls: $probe" >&2; exit 1; }
+    [ "$line" -lt "$build_line" ] || {
+      echo "$probe runs after the build starts; a preflight there refuses nothing" >&2
+      exit 1
+    }
+  done
+
+  # The runner must be pinned to the managed disk name, or qemu-vm.nix's
+  # cwd default quietly comes back and #489 reopens.
+  grep -q 'export NIX_DISK_IMAGE="$disk"' ${previewScript} || {
+    echo "the runner is no longer pinned via NIX_DISK_IMAGE; the qcow2" >&2
+    echo "falls back to the cwd default, which is the #489 trap itself" >&2
+    exit 1
+  }
+
+  # ------------------------------------------------------------------------
+  # The honesty strings. #485: a preview that reads as proof is a trap.
+  # Each pattern includes the printing call and its opening quote -- match
+  # the call, not the string (tests/AGENTS.md), because the script's own
+  # comments say all of this too and a bare grep stays green with the
+  # printed line deleted. Found by breaking it, per §1.
+  # ------------------------------------------------------------------------
+  for claim in \
+    'red "A green preview is strong evidence, not proof."' \
+    'echo "  bootloader, so it does not verify your bootloader, your real GPU,"' \
+    'red "$disk already exists -- a previous preview made it, and booting the"'; do
+    grep -qF "$claim" ${previewScript} || {
+      echo "the script no longer says: $claim" >&2
+      echo "#485 makes that honesty non-negotiable -- the vmVariant boots VM" >&2
+      echo "filesystems and a VM bootloader, and a stale disk replays the" >&2
+      echo "previous preview's state" >&2
+      exit 1
+    }
+  done
+
+  echo "the preflights are wired ahead of the build, and the words are honest"
+  touch $out
+''


### PR DESCRIPTION
**Epic #485, as one pull request** rather than four. Closes #486, #487, #488, #489.

The last epic went out as four PRs and cost 4 install runs, 3 evictions, 2 conflicts and a hand-written conflict resolver. This one is one branch, two agents, separate files — and the `flake.nix` checks entries did not even collide.

## The work is not `build-vm`, it is making the desktop render

`nixos-rebuild build-vm` is one command. **A user's config booted verbatim shows a black screen** — `vm/configuration.nix:67-86` records why: qemu's virgl path hands out no usable EGLConfig, so nixarchy's own smoke VM sets `WLR_RENDERER_ALLOW_SOFTWARE`, `WLR_NO_HARDWARE_CURSORS` and `LIBGL_ALWAYS_SOFTWARE`. A user's config has none of them.

`modules/preview.nix` ships those through `virtualisation.vmVariant`, so they apply **only** in the preview and never to the real machine.

One detail worth naming: `forwardPorts` is a **plain assignment, not `mkDefault`**. On a merging list type `mkDefault` drops the whole contribution the moment a user adds an element — so the check asserts the user's 8080 *and* our forward both survive.

## The name, decided rather than defaulted

`nixarchy vm` is **already taken** — `docs/manual/sandboxes.md` says outright *"Not nixarchy's own test VM."* So: `nixarchy-preview`, menu row **"Preview changes"**, beside Apply and Roll back. `nixarchy-apply` now offers *"Preview in a VM first?"* before *"build and switch"*, which is the moment anyone actually wants it.

## The traps, each with a receipt in this repo

**Stale disk.** `virtualisation.diskImage` defaults to `./<host>.qcow2` **in the cwd at run time** and is created only if missing — so previewing change N+1 silently runs on change N's disk. We have the receipt: `vm/configuration.nix:98-109`, stale notification history replayed from a reused disk. Fixed with a managed state dir, `NIX_DISK_IMAGE` pinning, and a refusal that names `--fresh`/`--keep` rather than guessing.

**Port collision.** The module first forwarded 2222, which `nix run .#vm` already binds — and **qemu cannot bind a host port twice**, so the second VM fails with an error about binding rather than about ports. Moved to 2223, and the map of every guest's port is now written beside the forward, because there was no such list and that is why the collision happened.

## Honest limits, printed before it boots

*"A green preview is strong evidence, not proof"* — `vmVariant` re-evaluates with VM filesystems and bootloader, so it does not verify your bootloader, your real GPU, or your real disks.

## Verified

- `checks.preview` and `checks.preview-variant` — **both proven able to fail**: reintroducing the stale-disk bug, deleting the honesty line, moving a preflight after the build, and pointing the forward back at 2222 each turn them red
- `checks.bin-ledger`, `checks.doc-options` pass
- fmt · statix · **deadnix `--fail`** · shellcheck · `readme-counts --check` — all rc=0
- No workflow edit needed: both checks are cheap and unclaimed, so `build.yml`'s generated step builds them

## Not verified

An end-to-end preview boot of a real host. The software-GL trio's sufficiency rests on the smoke VM's diagnosis rather than on watching pixels here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5