### PR TITLE
A nested AGENTS.md stops running the install VM, and here is the first one

### DIFF
--- a/.github/scripts/pr-touches-build.sh
+++ b/.github/scripts/pr-touches-build.sh
@@ -90,7 +90,16 @@ while IFS= read -r f; do
     # greps README.md for them, so a README-only edit can legitimately fail
     # the omarchy job -- it did on #424. Excluding it would turn a working
     # guard into one that only runs when something else changed too.
-    docs/*|AGENTS.md|CONTRIBUTING.md|.envrc|.gitignore|.github/*)
+    # `AGENTS.md` matched only at the root, so installer/AGENTS.md and
+    # modules/AGENTS.md fell through to `*` and ran the whole build -- and,
+    # once install-check grew its own narrower list, a 26-46 minute VM install
+    # for a markdown file. Every AGENTS.md in this repository is documentation
+    # for agents; verified that nothing reads one into a derivation, and the
+    # only mentions in .nix files and scripts are comments citing it.
+    #
+    # `*/AGENTS.md` covers any depth, because `case` globs are not path-aware
+    # and `*` crosses `/` -- the same property the `docs/*` arm relies on.
+    docs/*|AGENTS.md|*/AGENTS.md|CONTRIBUTING.md|.envrc|.gitignore|.github/*)
       continue ;;
 
     # Only for the install question, and only files the install job cannot

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,6 +291,27 @@ to your branch cancels and restarts your own run (that is deliberate — a PR
 only needs an answer about its current head), but the queue is shared:
 batching your pushes is a courtesy to everyone else's merge latency.
 
+**Do not build a VM check locally while CI has an install job in flight.**
+The concurrency group in `install-check.yml` serialises GitHub *jobs*; it
+knows nothing about a `nix build .#checks.x86_64-linux.session` you start by
+hand on the same machine. The runners are on p620 and so is your shell.
+
+What it looks like when you do is not "your build was slow" — it is somebody
+else's check failing, on a line that has nothing to do with their change:
+
+    installer # Startup finished in ... 6min 34.738s (userspace)
+    installer # systemd-udevd: Worker [441] ... is taking a long time
+    installer # systemd-udevd: Worker [441] ... killed
+    installer # dhcpcd.service: start operation timed out
+    RequestedAssertionFailed: command `udevadm settle` failed (exit code 1)
+
+Six and a half minutes for a userspace boot that normally takes seconds.
+`udevadm settle` did not break; it was starved. This is §6's own lesson from
+the other side — **a guest-side timeout is a hidden concurrency limit**, and
+host-side timeouts scale with the box while guest-side ones do not.
+
+Check first: `gh run list --limit 8 --json status -q '[.[]|select(.status!="completed")]|length'`.
+
 ## 7. Code rules the repo has already written down
 
 Do not restate these in new comments; read them where they live, because the

--- a/installer/AGENTS.md
+++ b/installer/AGENTS.md
@@ -52,6 +52,47 @@ before that resolves against the ISO's passwd, not the target's.
   stages everything and deliberately makes no commit: git needs an identity, and
   choosing the user's is not the installer's business.
 
+## An offline install COPIES a system; it does not evaluate one
+
+This changed in #436 and the file described the old model until #507. If you
+are reading `installer/` to understand how an install works, this is the part
+that surprises people.
+
+The image bakes the reference toplevel through **`isoImage.storeContents`**
+(`cd.nix:657`) — outputs, not a build graph — and writes
+`/etc/nixarchy-reference-$encrypt` naming it (`cd.nix:897`). `install.sh:2501`
+reads that marker, validates the path with `nix path-info`, and hands it to
+`nixos-install --system`, which **copies and never evaluates**
+(`nixos-install.sh:266` skips the build entirely).
+
+And it is asserted rather than hoped: when the system was copied rather than
+built, `install.sh:2569` adds `--max-jobs 0`, so a single attempted build
+fails loudly instead of quietly reaching for a compiler.
+
+**`system.extraDependencies` cannot do this job**, and the file used to imply
+it could. Its type is `listOf pathInStore` — it carries runtime OUTPUT paths
+and cannot carry a build graph, which is why every probe said "present" while
+nix still rebuilt the world.
+
+Three things follow, and each is load-bearing:
+
+- **The toplevel must be identical across machines**, or the copy has nothing
+  to copy. `networking.hostName = ""` and a pinned `system.name`
+  (`host.nix:209`) are what make that true — `systemd/initrd.nix:597` writes
+  the hostname into the initrd unconditionally, so two machines differing only
+  in name have two different initrds, and offline a different initrd is a
+  build that ends in the stage0 source bootstrap.
+- **The installed machine boots the REFERENCE's initrd**, so a storage driver
+  the reference lacks is a machine that cannot find its root.
+  `checks.reference-initrd` compares the two lists and fails on a gap.
+- **The detected `hardware-configuration.nix` is still written** to
+  `/etc/nixos` for the first ONLINE rebuild to pick up. It simply stops being
+  an install-time input.
+
+The password follows the same rule for the same reason: it is a **file**
+(`/var/lib/nixarchy/password.hash`, `host.nix:181`), not an evaluation input,
+so two machines with different passwords are still the same closure.
+
 ## Tests
 
 | check | covers |

--- a/tests/install-gate.nix
+++ b/tests/install-gate.nix
@@ -49,10 +49,18 @@ pkgs.runCommand "nixarchy-install-gate"
     # and greps README for them, so a README-only edit can legitimately fail.
     t "README does"                            --install "README.md" true
 
+    # `AGENTS.md` matched at the ROOT only, so installer/AGENTS.md ran a
+    # 26-46 minute VM install for a markdown file. Every depth, because
+    # `case` globs cross `/` and the fix relies on that.
+    t "a nested AGENTS.md does not run the VM"  --install "installer/AGENTS.md" false
+    t "nor a deeper one"                        --install "a/b/AGENTS.md" false
+    t "nor the root one"                        --install "AGENTS.md" false
+
     echo "the build question, unchanged:"
     t "an unrelated check still builds"        "" "tests/substitutable.nix" true
     t "docs still do not"                      "" "docs/manual/android.md" false
     t "the gate itself always does"            "" ".github/scripts/pr-touches-build.sh" true
+    t "a nested AGENTS.md builds nothing"      "" "modules/AGENTS.md" false
     t "install-check.yml always does"          "" ".github/workflows/install-check.yml" true
 
     echo "fails safe:"


### PR DESCRIPTION
Two commits: the gate fix, and the docs edit it makes free. Closes #507.

## The gap

`AGENTS.md` matched only at the **root**, so `installer/AGENTS.md` and `modules/AGENTS.md` fell through to `*` and counted as build-relevant. Once the install question got its own narrower list this morning, that meant a **26–46 minute VM install for a markdown file** — and #507 is exactly that edit.

Safe because nothing reads one into a derivation: checked every `.nix` file and every script under `pkgs/` and `installer/`, where the only mentions are comments citing a section number.

`*/AGENTS.md` covers any depth — `case` globs are not path-aware and `*` crosses `/`, the same property the existing `docs/*` arm relies on.

**Proven able to fail** (§1): removing the pattern turns three assertions red naming the paths.

## And the first beneficiary

`installer/AGENTS.md` is what somebody reads to understand the installer, and it **predates #436** — so it described the model that was replaced, which is worse than describing nothing.

The new section says what an offline install now is: `isoImage.storeContents` (`cd.nix:657`) bakes **outputs, not a build graph**; a marker names it (`cd.nix:897`); `install.sh:2501` hands that path to `nixos-install --system`, which copies and never evaluates; and `install.sh:2569` adds `--max-jobs 0` so an attempted build fails loudly.

It also says why `system.extraDependencies` **cannot** do that job — `listOf pathInStore` carries runtime outputs, which is why every probe said "present" while nix rebuilt the world.

Plus the three consequences, each load-bearing: the toplevel must be identical across machines (hence `hostName = ""`, because systemd writes it into the initrd and a different initrd is a build); the installed machine boots the **reference's** initrd; and `hardware-configuration.nix` is still written, for the first *online* rebuild.

## Verified

Every `file:line` checked against the tree. **Two were wrong on the first pass** — `cd.nix` moved when #514 added the `source` argument, so 636 and 867 pointed at unrelated lines. A pointer that is confidently wrong costs more than no pointer.

`checks.install-gate` passes and is proven red · shellcheck rc=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)