### PR TITLE
Try an application once, without installing it

### DIFF
--- a/data/bin-ledger.nix
+++ b/data/bin-ledger.nix
@@ -74,6 +74,10 @@
     class = "new";
     reason = "Not in upstream, whose recovery story is snapper snapshots on the same disk. Builds a bootable image from this machine's own configuration -- the system closure and /etc/nixos, never /home or secrets -- after refusing on low disk, an uncommitted tree, or a running system that drifted from the flake.";
   };
+  "nixarchy-try" = {
+    class = "new";
+    reason = "Not in upstream, where trying an app IS installing it (pacman, then remove). Runs a catalogue app or nixpkgs attribute once from the machine's own pinned nixpkgs -- nix shell -f with the catalogue's binary field, never nix run's mainProgram guess -- and prints the app-enable/pkg-add hand-off when it exits.";
+  };
   "nixarchy-rollback" = {
     class = "new";
     reason = "Not in upstream, whose undo is omarchy-snapshot via snapper and limine. Lists and switches NixOS system generations, which are the bootable snapshot every rebuild already leaves behind.";

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -41,6 +41,7 @@ nav:
   - { path: /manual/updating-nixos,           title: Updating NixOS }
   - { path: /manual/updates,                  title: Updates }
   - { path: /manual/other-packages,           title: Packages }
+  - { path: /manual/try-it-first,             title: Try It First }
   - { path: /manual/dotfiles,                 title: Dotfiles }
   - { path: /manual/making-your-own-theme,    title: Making Your Own Theme }
   - { path: /manual/development-tools,        title: Development Tools }

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -106,6 +106,7 @@ Key facts an assistant should know before answering questions about nixarchy:
 - [Updates](https://olafkfreund.github.io/nixarchy/manual/updates): what Update ▸ Nixarchy does here, why release channels do not exist, firmware updates, rolling back
 - [Preview changes](https://olafkfreund.github.io/nixarchy/manual/preview): booting a config change in a VM before switching to it — the disk lifecycle, and what a green preview does not prove
 - [Packages](https://olafkfreund.github.io/nixarchy/manual/other-packages): the app selection, apps.nix and nixarchy-apply, Install ▸ Search, services.nix, unfree software, removing apps
+- [Try It First](https://olafkfreund.github.io/nixarchy/manual/try-it-first): nixarchy try runs an app once, from the pinned nixpkgs, without installing — no isolation, no launcher entry, and it stays in /nix/store until garbage collection nobody schedules
 - [Dotfiles](https://olafkfreund.github.io/nixarchy/manual/dotfiles): which config files are yours, which are seeded, and how the menu is extended
 - [Making Your Own Theme](https://olafkfreund.github.io/nixarchy/manual/making-your-own-theme): overlaying or forking a stock theme out of the read-only store
 - [Development Tools](https://olafkfreund.github.io/nixarchy/manual/development-tools): editors, and the 13 language toolchains from nixpkgs instead of mise

--- a/docs/manual/boxes.md
+++ b/docs/manual/boxes.md
@@ -39,6 +39,7 @@ leave the directory. A box is a whole userland; devenv is a version of `node`.
 | you have | reach for |
 |---|---|
 | anything in nixpkgs | nixpkgs -- always first |
+| a package you are not sure you want yet | [`nixarchy try`](try-it-first) -- runs it once, installs nothing, isolates nothing |
 | a GUI app that is not, and you want it contained | Flatpak |
 | a loose prebuilt binary | `nix-ld`, already on |
 | a toolchain this project needs | [devenv](per-project-environments) |

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -63,6 +63,7 @@ the documentation as much as the code.
 | Windows vm | same as Omarchy — [read there](https://omarchy.org/manual/windows-vm/) |
 | **Other packages** | **differs on NixOS** — [read here](other-packages) |
 | **Preview changes** | **nixarchy only** — [read here](preview) |
+| **Try it first** | **nixarchy only** — [read here](try-it-first) |
 | **Updates** | **differs on NixOS** — [read here](updates) |
 | **Dotfiles** | **differs on NixOS** — [read here](dotfiles) |
 | Shell plugins | same as Omarchy — [read there](https://omarchy.org/manual/shell-plugins/) |

--- a/docs/manual/try-it-first.md
+++ b/docs/manual/try-it-first.md
@@ -1,0 +1,66 @@
+---
+title: Try It First
+---
+
+# Try It First
+
+`nixarchy try <name>` runs an application once, to see whether you want it,
+without adding it to your configuration. Nothing is written to
+`~/.config/nixarchy/apps.nix`, nothing is rebuilt, and when the app exits
+your system is configured exactly as it was.
+
+It runs from the system's own pinned nixpkgs -- the same tree
+`nixarchy-apply` installs from -- so what you try is exactly what installing
+would deliver. A bare `nix run nixpkgs#name` does not give you that: it
+resolves the global flake registry to whatever nixpkgs-unstable is today,
+a version this machine has never seen.
+
+There are two ways in:
+
+- **`nixarchy try <name>`** in a terminal.
+- **Install ▸ Search**, then `ctrl-t` on a package or app row. Enter still
+  queues the selection for install; `ctrl-t` runs it now instead, in the
+  same terminal the picker is in. The rows that can be tried say so in
+  their preview.
+
+## What it is not
+
+**Not a sandbox.** This is the thing to be clearest about: `try` runs the
+same code installing would, with your full user privileges -- your home
+directory, your network, your session. The only thing it spares you is the
+commitment. For code you do not *trust*, the answer is a
+[sandbox](sandboxes): `nixarchy vm` boots a disposable NixOS with real
+isolation. `try` is for an app you would happily install and are just not
+sure you want.
+
+**Not gone when it exits.** The package is downloaded into `/nix/store`
+and stays there until garbage collection -- and nixarchy schedules none,
+so tried apps accumulate until you clear them yourself:
+
+```sh
+sudo nix-collect-garbage
+```
+
+A tried package has no garbage-collection root, so that one command
+reclaims it (along with anything else nothing references).
+
+**Not installed.** No launcher entry is created -- nothing writes a
+`.desktop` file -- and the app runs in the terminal you launched it from.
+Close the terminal and it goes with it. If it should survive that, that
+is what installing is for.
+
+## What can be tried
+
+nixpkgs packages, and the apps in the catalogue that are a package
+underneath. An app that is really a NixOS module -- firefox, docker --
+has no single program to run; enabling it configures the system, which
+only a rebuild can do. Flatpaks likewise have no package attribute to
+run. `nixarchy try` says so rather than guessing at something to
+execute, and the picker's `ctrl-t` gives the same answer.
+
+## Keeping it
+
+Install it the way you always would: pick it with enter in
+**Install ▸ Search**, or `nixarchy-pkg-add <name>`, then
+`nixarchy-apply`. Because `try` ran the pinned tree, the version you
+tried is the version that installs.

--- a/flake.nix
+++ b/flake.nix
@@ -1345,6 +1345,15 @@
             reinstallScript = ./pkgs/omarchy/nix-bin/nixarchy-reinstall-iso;
           };
 
+          # nixarchy-try's lookup and probe expressions run against the REAL
+          # data/apps.nix and nixpkgs, plus the binary fallback ladder, the
+          # unfree seasoning, the honest footer and the try-to-keep hand-off
+          # (#499, #503). See tests/try.nix.
+          try = import ./tests/try.nix {
+            pkgs = pkgsFor.${system};
+            tryScript = ./pkgs/omarchy/nix-bin/nixarchy-try;
+          };
+
           installer-store-space = import ./tests/installer-store-space.nix {
             pkgs = pkgsFor.${system};
             installScript = ./installer/install.sh;

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -172,7 +172,13 @@ let
         let
           flat = lib.replaceStrings [ "\n" "\t" ] [ " " " " ];
         in
-        "${name}\t${app.label}\t${app.category}\t${flat (app.note or "")}\n"
+        # The fifth field marks the rows `nixarchy try` can run: only an app
+        # backed by a package attribute is runnable. A module app (firefox,
+        # docker) has nothing to execute, so its preview must not sell a key
+        # that would only print a refusal.
+        "${name}\t${app.label}\t${app.category}\t${flat (app.note or "")}\t${
+          if app ? attr then "try" else ""
+        }\n"
       ) available
     )
   );
@@ -1412,10 +1418,11 @@ in
                 # it as a package does not.
                 awk -F'\t' -v OFS='\t' '{
                   note = ($4 == "" ? "" : "\\n\\n" $4)
+                  foot = ($5 == "try" ? "\\n\\nctrl-t tries it now, without installing." : "")
                   print "app", $1, $2 " (" $3 ")", "",
                     "OMARCHY APP  " $1 "\\n\\n" $2 "\\n" $3 \
                     note "\\n\\nEnabling this writes a line in your app selection:\\n  " \
-                    $1 ".enable = true;"
+                    $1 ".enable = true;" foot
                 }' "$appindex" > "$tmp"
 
                 # Empty when this system builds no manual, in which case the
@@ -1459,6 +1466,7 @@ in
                         + "\n\n" + ($v.description // "(no description)")
                         + "\n\nAdding this writes it into your app selection:\n  "
                         + "environment.systemPackages = with pkgs; [ " + $a + " ];"
+                        + "\n\nctrl-t tries it now, without installing."
                       )
                     ] | @tsv' >> "$tmp"
 
@@ -1477,14 +1485,37 @@ in
                 build_index
               fi
 
-              selection=$(fzf --multi \
+              # --expect makes fzf accept on ctrl-t as well as enter, and say which
+              # was pressed on the first output line. The previews on pkg and app
+              # rows document the key; the other two kinds have nothing to run.
+              picked=$(fzf --multi \
                 --delimiter='\t' --with-nth=1,2,3 --nth=2,3 \
+                --expect=ctrl-t \
                 --preview 'printf "%b\n" {5}' \
                 --preview-window='right,58%,wrap' \
                 --prompt='nixarchy > ' \
-                --header='enter to select · tab for several · esc to cancel' \
+                --header='enter to select · ctrl-t to try · tab for several · esc to cancel' \
                 --query="''${*:-}" < "$index") || exit 0
+              key=$(printf '%s\n' "$picked" | head -n 1)
+              selection=$(printf '%s\n' "$picked" | tail -n +2)
               [ -n "$selection" ] || exit 0
+
+              # Try, not queue: run it now, in this terminal, and write nothing.
+              # `nixarchy try` owns the how -- the pinned tree, the catalogue's
+              # binary field, unfree -- and refuses with a reason on an app that
+              # is really a NixOS module. Options and flatpaks have no package
+              # attribute to run, so the picker says so itself.
+              if [ "$key" = "ctrl-t" ]; then
+                while IFS=$'\t' read -r kind name _ _ _; do
+                  [ -n "$kind" ] || continue
+                  case "$kind" in
+                    app | pkg) nixarchy try "$name" || true ;;
+                    opt) echo "$name is a NixOS option -- there is nothing to run, so nothing to try" ;;
+                    flatpak) echo "$name is a flatpak -- nothing to try; enable it and apply instead" ;;
+                  esac
+                done <<< "$selection"
+                exit 0
+              fi
 
               [ -f "$file" ] || { echo "no $file -- log in again to have it created" >&2; exit 1; }
 

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -1750,6 +1750,17 @@ in
                     init) shift 2; exec nixarchy-dev-init "$@" ;;
                   esac
                   ;;
+                # Without this row `nixarchy try foo` falls through to
+                # `exec omarchy try ...` and dies as "Unknown Omarchy command"
+                # -- omarchy's own dispatcher discovers only omarchy-*
+                # siblings, and nixarchy-try is not one.
+                #
+                # It is the Search picker's ctrl-t path too, so the whole
+                # feature is unreachable without it. Both halves shipped
+                # green: the picker's check greps that nixarchy-search SAYS
+                # `nixarchy try `, which is the call site, not the route.
+                # checks.options now asserts the route.
+                try) shift; exec nixarchy-try "$@" ;;
                 vm) shift; exec nixarchy-vm "$@" ;;
                 box) shift; exec nixarchy-box "$@" ;;
                 ""|--help|-h|help)
@@ -1765,6 +1776,7 @@ in
                 nixarchy app remove         Pick what to deselect, interactively
                 nixarchy apply              Copy the selection into your flake and rebuild
                 nixarchy dev init <preset>  Scaffold a devenv project here (no argument lists them)
+                nixarchy try <app|attr>     Run something once without installing it
                 nixarchy vm <subcommand>    Disposable NixOS MicroVMs -- 'nixarchy vm help'
                 nixarchy box <subcommand>   distrobox, for software NixOS will not run -- 'nixarchy box help'
                 nixarchy doctor             What this machine needs to run nixarchy

--- a/pkgs/omarchy/nix-bin/nixarchy-try
+++ b/pkgs/omarchy/nix-bin/nixarchy-try
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+
+# nixarchy:new
+# omarchy:summary=Run an app once, without installing it. No isolation; it stays in the store until collected.
+# omarchy:args=<app-or-attr> [-- args...]
+# omarchy:examples=nixarchy try helix
+# omarchy:examples=nixarchy try chrome
+# omarchy:examples=nixarchy try ripgrep -- --version
+
+# Run an application once, to see whether you want it, without adding it to
+# the configuration (#499). The repo already recommends exactly this --
+# skills/nixos/SKILL.md's "Try out helix quickly" row -- and offered no
+# command for it.
+#
+# ## The three findings that shaped the invocation (#498)
+#
+# `nix shell -f <pinned nixpkgs> <attr> -c <binary>`, never `nix run
+# nixpkgs#<attr>`, because each half of the obvious spelling is wrong:
+#
+# - `nix run` guesses the binary from the attribute name when a package
+#   declares no mainProgram, and the guess fails outright on android-tools
+#   (ships adb, not android-tools). data/apps.nix grew a `binary` field for
+#   precisely this (#468); the catalogue names the command, so use it.
+# - A bare `nixpkgs#` resolves the global registry to unstable HEAD -- a
+#   nixpkgs this machine has never seen, and a DIFFERENT version than
+#   `nixarchy-apply` would install. `-f` on the system's own nixpkgs makes a
+#   try preview what an install would deliver, which is the entire point.
+#   (Pinning the registry globally is #502, a separate decision.)
+# - Unfree is backwards from installing: nixarchy defaults allowUnfree on
+#   for the system, but that never reaches an ad-hoc evaluation -- so Chrome
+#   installs fine and refuses to be tried unless this sets
+#   NIXPKGS_ALLOW_UNFREE itself. Classic `-f` evaluation reads the variable
+#   without --impure.
+#
+# `option`-only rows (firefox, docker) are NixOS modules with no package
+# attribute to run; they are refused with the enable path, not guessed at.
+#
+# ## What this is not, said out loud every time
+#
+# No isolation: the app runs the same code installing would, with your full
+# user privileges. For code you do not trust, that is `nixarchy vm`. And
+# nothing is installed, which cuts both ways: no launcher entry, and the
+# store paths stay until garbage-collected -- nixarchy schedules no GC.
+#
+# When the try exits, the next step is printed (#503): the same app, kept,
+# is one command -- nixarchy-app-enable for a catalogue row, nixarchy-pkg-add
+# for a raw attribute. tests/try.nix drives the lookup against the real
+# catalogue, the fallback ladder, and the hand-off table, and asserts main
+# still calls each piece before `nix shell` runs.
+
+set -euo pipefail
+
+FLAKE="${NIXARCHY_FLAKE:-/etc/nixos}"
+
+red() { printf "\033[0;31m%s\033[0m\n" "$1"; }
+dim() { printf "\033[0;90m%s\033[0m\n" "$1"; }
+bold() { printf "\033[1m%s\033[0m\n" "$1"; }
+
+usage() {
+  echo "Usage: nixarchy-try <app-or-attr> [-- args...]"
+  echo "  <app-or-attr>  a curated app id (chrome) or a nixpkgs attribute (ripgrep)"
+  echo "  -- args...     handed to the program"
+}
+
+# ---------------------------------------------------------------------------
+# The two nix expressions, in quoted heredocs so tests/try.nix can extract
+# each verbatim (splitting on the delimiter) and run it at evaluation time
+# against the real data/apps.nix and the real nixpkgs. Change one and the
+# check re-runs the truth table on the changed code, not on a copy.
+# ---------------------------------------------------------------------------
+
+# apps -> name -> one line:
+#   raw                                   not in the catalogue
+#   unavailable<TAB><why>                 catalogued as not installable here
+#   module<TAB><option.path>              a NixOS module; nothing to run
+#   app<TAB><attr><TAB><binary><TAB>0|1   a package row (binary may be empty)
+read -r -d '' LOOKUP_EXPR <<'NIX_LOOKUP_EOF' || :
+apps: name:
+if !(builtins.hasAttr name apps) then
+  "raw"
+else
+  let
+    a = apps.${name};
+  in
+  if a ? unavailable then
+    "unavailable\t" + a.unavailable
+  else if a ? option then
+    "module\t" + builtins.concatStringsSep "." a.option
+  else
+    "app\t" + (a.attr or name) + "\t" + (a.binary or "") + "\t" + (if a.unfree or false then "1" else "0")
+NIX_LOOKUP_EOF
+
+# imported pkgs -> attr -> one line:
+#   missing                               no such attribute in that tree
+#   found<TAB><mainProgram><TAB>0|1       mainProgram may be empty; 1 = unfree
+# Takes pkgs already imported (the import sits at the call site) so
+# tests/try.nix can apply it to its own pkgs under pure evaluation, where
+# `import nixpkgs { }` cannot read currentSystem. tryEval, because a package
+# marked broken or unfree can throw on meta access, and a throw here would
+# be an unreadable refusal for a question the run itself answers better.
+read -r -d '' PROBE_EXPR <<'NIX_PROBE_EOF' || :
+pkgs: attr:
+let
+  v = pkgs.lib.attrByPath (pkgs.lib.splitString "." attr) null pkgs;
+  main =
+    let
+      t = builtins.tryEval (v.meta.mainProgram or "");
+    in
+    if t.success then t.value else "";
+  unfree =
+    let
+      t = builtins.tryEval (v.meta.unfree or false);
+    in
+    if t.success && t.value then "1" else "0";
+in
+if v == null then "missing" else "found\t" + main + "\t" + unfree
+NIX_PROBE_EOF
+
+# ---------------------------------------------------------------------------
+# Pure helpers. Each takes plain arguments and touches nothing, so
+# tests/try.nix drives the truth tables directly.
+# ---------------------------------------------------------------------------
+
+# The fallback ladder for the command to exec: the catalogue's `binary`
+# field (the human answer, #468), else nixpkgs' own mainProgram, else the
+# last dot-segment of the attribute -- the same guess `nix run` would make,
+# kept only as the final rung because for most single-binary packages it is
+# right, and when it is wrong the error names the command it tried.
+resolve_binary() {
+  local row_binary=$1 main=$2 attr=$3
+  if [ -n "$row_binary" ]; then
+    echo "$row_binary"
+  elif [ -n "$main" ]; then
+    echo "$main"
+  else
+    echo "${attr##*.}"
+  fi
+}
+
+# The #503 hand-off: someone who has just decided they like the thing must
+# not have to look up how to keep it. A catalogue row is kept as the app
+# (the route that knows about modules and settings); a raw attribute as a
+# package line.
+next_step() {
+  local kind=$1 id=$2
+  echo
+  bold "To keep it:"
+  case "$kind" in
+    app)
+      echo "  nixarchy-app-enable $id    # then: nixarchy-apply"
+      ;;
+    raw)
+      echo "  nixarchy-pkg-add $id    # then: nixarchy-apply"
+      ;;
+  esac
+}
+
+# Every word of the uncomfortable part, before anything runs. Asserted by
+# tests/try.nix, so the honesty cannot be edited away quietly.
+print_footer() {
+  dim "Nothing is installed: no launcher entry, no configuration change."
+  dim "The download stays in /nix/store until it is garbage-collected, and"
+  dim "nixarchy schedules no GC -- nix-collect-garbage clears it by hand."
+  red "It runs with your full user privileges. This is NOT a sandbox --"
+  red "for code you do not trust, that is 'nixarchy vm'."
+}
+
+# The launch, isolated so the unfree seasoning is testable: NIXPKGS_ALLOW_UNFREE
+# only on the runs that need it, because exporting it unconditionally would
+# teach every child process that unfree is fine.
+run_try() {
+  local nixpkgs=$1 attr=$2 binary=$3 unfree=$4
+  shift 4
+  if [ "$unfree" = 1 ]; then
+    NIXPKGS_ALLOW_UNFREE=1 nix shell -f "$nixpkgs" "$attr" -c "$binary" "$@"
+  else
+    nix shell -f "$nixpkgs" "$attr" -c "$binary" "$@"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Arguments
+# ---------------------------------------------------------------------------
+
+if [ $# -eq 0 ]; then
+  usage >&2
+  exit 1
+fi
+case "$1" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+esac
+
+name=$1
+shift
+if [ "${1:-}" = "--" ]; then shift; fi
+
+# The same charset gate nixarchy-pkg-add applies, and here it also keeps the
+# name safe to splice into the nix expressions below.
+case "$name" in
+  -* | .* | *..* | *[!A-Za-z0-9_.-]*)
+    red "'$name' is not an app id or a nixpkgs attribute name."
+    exit 1
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# The pinned tree. pkgs.path of this machine's own configuration -- the
+# nixpkgs an install would come from -- with a seam for the tests and for a
+# machine whose flake this cannot read.
+# ---------------------------------------------------------------------------
+
+host=$(uname -n)
+nixpkgs="${NIXARCHY_TRY_NIXPKGS:-}"
+if [ -z "$nixpkgs" ]; then
+  nixpkgs=$(nix eval --raw \
+    "$FLAKE#nixosConfigurations.$host.pkgs.path" 2>/dev/null || :)
+fi
+if [ -z "$nixpkgs" ]; then
+  red "Could not read this machine's pinned nixpkgs from $FLAKE."
+  echo "  A try must run the version an install would deliver; falling back"
+  echo "  to whatever 'nixpkgs' resolves to today would try a DIFFERENT one."
+  echo "  Set NIXARCHY_FLAKE at the machine's flake, or NIXARCHY_TRY_NIXPKGS"
+  echo "  at a nixpkgs tree."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# The catalogue. data/apps.nix from the nixarchy this flake pins -- the
+# generated flake hands the module `inputs` with nixarchy standing in as
+# self (installer/template/flake.nix), so specialArgs is where its source
+# is reachable. A flake where that path does not answer (Mode A, hand-rolled
+# specialArgs) degrades to raw-attribute mode rather than refusing: the
+# catalogue improves a try, it is not a precondition for one.
+# ---------------------------------------------------------------------------
+
+catalogue="${NIXARCHY_TRY_CATALOGUE:-}"
+if [ -z "$catalogue" ]; then
+  src=$(nix eval --raw \
+    "$FLAKE#nixosConfigurations.$host._module.specialArgs.inputs.self.outPath" \
+    2>/dev/null || :)
+  [ -n "$src" ] && [ -f "$src/data/apps.nix" ] && catalogue="$src/data/apps.nix"
+fi
+
+row="raw"
+if [ -n "$catalogue" ]; then
+  row=$(nix eval --raw --impure \
+    --expr "($LOOKUP_EXPR) (import $catalogue) \"$name\"" 2>/dev/null || echo raw)
+else
+  dim "No app catalogue readable through $FLAKE; treating '$name' as a raw"
+  dim "nixpkgs attribute."
+fi
+
+kind=${row%%$'\t'*}
+case "$kind" in
+  unavailable)
+    red "'$name' is in the catalogue as not installable here:"
+    echo "  ${row#*$'\t'}"
+    exit 1
+    ;;
+  module)
+    optpath=${row#*$'\t'}
+    red "'$name' is a NixOS module ($optpath), not a package -- there is no"
+    echo "  binary to run without enabling it. A module brings its"
+    echo "  configuration with it, which is why it is not a bare package:"
+    echo
+    bold "    nixarchy-app-enable $name    # then: nixarchy-apply"
+    exit 1
+    ;;
+  app)
+    rest=${row#*$'\t'}
+    attr=${rest%%$'\t'*}
+    rest=${rest#*$'\t'}
+    row_binary=${rest%%$'\t'*}
+    row_unfree=${rest##*$'\t'}
+    ;;
+  *)
+    kind=raw
+    attr=$name
+    row_binary=""
+    row_unfree=0
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Probe the pinned tree: does the attribute exist, what does it call its
+# program, and is it unfree. Metadata only; nothing is built yet.
+# ---------------------------------------------------------------------------
+
+# allowUnfree at the import: reading metadata is not running anything, and
+# without it the probe could throw on the exact rows the unfree handling
+# below exists for.
+probe=$(nix eval --raw --impure \
+  --expr "($PROBE_EXPR) (import $nixpkgs { config.allowUnfree = true; }) \"$attr\"" \
+  2>/dev/null || :)
+
+if [ "${probe%%$'\t'*}" != found ]; then
+  red "'$attr' is not in this machine's pinned nixpkgs."
+  if [ "$kind" = raw ]; then
+    echo "  nixarchy-search finds the attribute if the name is close;"
+    echo "  the tree probed was $nixpkgs"
+  else
+    echo "  The catalogue row names an attribute the pinned tree does not"
+    echo "  carry -- that is a nixarchy bug worth reporting, not a typo."
+  fi
+  exit 1
+fi
+
+rest=${probe#*$'\t'}
+main=${rest%%$'\t'*}
+probe_unfree=${rest##*$'\t'}
+
+# The row's word OR the tree's word: the catalogue marks what a human
+# curated, the probe catches a raw attribute nobody curated. Either alone
+# would refuse a try that installing would have allowed.
+unfree=0
+if [ "$row_unfree" = 1 ] || [ "$probe_unfree" = 1 ]; then
+  unfree=1
+fi
+
+binary=$(resolve_binary "$row_binary" "$main" "$attr")
+
+# ---------------------------------------------------------------------------
+# Say what is about to happen and what it is not, then run.
+# ---------------------------------------------------------------------------
+
+bold "Trying $name ($attr from this machine's own nixpkgs, running '$binary')"
+print_footer
+echo
+
+rc=0
+run_try "$nixpkgs" "$attr" "$binary" "$unfree" "$@" || rc=$?
+
+# ---------------------------------------------------------------------------
+# From try to keep (#503). Printed whatever the program exited with: a tool
+# that returns nonzero on --help was still worth keeping.
+# ---------------------------------------------------------------------------
+
+next_step "$kind" "$name"
+exit "$rc"

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -1898,6 +1898,26 @@ pkgs.runCommand "nixarchy-options"
         }
         echo "the picker's flatpak rows are $(wc -l < "$rows") well-formed lines"
 
+        # ---- the picker's try key is real, and routed -----------------------
+        #
+        # The pkg and app previews advertise ctrl-t. A footer that names a key
+        # fzf does not intercept is a promise the picker cannot keep, and a key
+        # fzf intercepts but nothing routes is a silent no-op -- both read as
+        # "try is broken" to the person in the picker. So the built script must
+        # carry both halves: the --expect that intercepts the key, and the
+        # `nixarchy try` call the footer is selling.
+        grep -q -- '--expect=ctrl-t' "$vm/sw/bin/nixarchy-search" || {
+          echo "nixarchy-search advertises ctrl-t but fzf does not intercept it" >&2
+          echo "  the preview footers promise a try key; --expect=ctrl-t is what honours it" >&2
+          exit 1
+        }
+        grep -q 'nixarchy try ' "$vm/sw/bin/nixarchy-search" || {
+          echo "nixarchy-search intercepts ctrl-t but routes it to nothing:" >&2
+          echo "  no 'nixarchy try' call in the built script" >&2
+          exit 1
+        }
+        echo "the picker's try key is intercepted and routes to nixarchy try"
+
         # ---- machines pull only when asked ---------------------------------
         test "$fleetOff" = false || {
           echo "system.autoUpgrade is on without programs.nixarchy.fleet.enable" >&2

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -1918,6 +1918,29 @@ pkgs.runCommand "nixarchy-options"
         }
         echo "the picker's try key is intercepted and routes to nixarchy try"
 
+        # And that `nixarchy try` REACHES something. The assertion above is
+        # about the call site; this is about the route, and the difference is
+        # not academic -- both halves of #498 shipped green with no `try` row
+        # in the dispatcher, so ctrl-t ran `nixarchy try foo`, fell through to
+        # `exec omarchy try foo`, and died as "Unknown Omarchy command".
+        # omarchy's dispatcher discovers only omarchy-* siblings, and
+        # nixarchy-try is not one.
+        #
+        # Every subcommand the dispatcher advertises, checked the same way: a
+        # usage line promising a command that routes nowhere is the same
+        # defect, and this is the file that would otherwise let the next one
+        # through.
+        for verb in try search apply vm box; do
+          grep -qE "^ *$verb\)" "$vm/sw/bin/nixarchy" || {
+            echo "the nixarchy dispatcher has no route for '$verb':" >&2
+            echo "  it falls through to \`exec omarchy $verb\`, which knows only" >&2
+            echo "  omarchy-* siblings, so the command dies as 'Unknown Omarchy" >&2
+            echo "  command' -- with nothing naming the real cause." >&2
+            exit 1
+          }
+        done
+        echo "every advertised nixarchy subcommand has a route"
+
         # ---- machines pull only when asked ---------------------------------
         test "$fleetOff" = false || {
           echo "system.autoUpgrade is on without programs.nixarchy.fleet.enable" >&2

--- a/tests/try.nix
+++ b/tests/try.nix
@@ -1,0 +1,248 @@
+{ pkgs, tryScript }:
+# nixarchy-try's resolution, refusals and hand-off (#499, #503), run on the
+# REAL code against the REAL data. The command exists because three guesses
+# go wrong -- `nix run`'s mainProgram fallback, the registry's unstable HEAD,
+# and unfree refusing to be tried while installing fine -- so the check's job
+# is to prove the code that avoids each guess is still the code that runs.
+#
+# The two nix expressions are extracted verbatim from the script's heredocs
+# and applied AT EVALUATION TIME to the repo's own data/apps.nix and the
+# check's own nixpkgs -- not to fixtures shaped like them. android-tools is
+# in the table because it is the receipt: the package `nix run` fails on
+# outright, and the row the `binary` field (#468) exists for.
+#
+# The shell halves -- the fallback ladder, the unfree seasoning, the #503
+# hand-off -- are sed-extracted and driven with a stubbed `nix`, in the
+# manner of tests/preview.nix. Then the wiring assertions: main still calls
+# each piece, in the order the honesty requires (footer BEFORE the program
+# runs, hand-off after), and no call site anywhere says `nix run` -- matched
+# on non-comment lines, because a forbid-pattern that reads prose fails
+# against correctly-gated code (tests/AGENTS.md).
+let
+  inherit (pkgs) lib;
+  text = builtins.readFile tryScript;
+
+  # A heredoc body, verbatim. Splitting on the delimiter yields exactly
+  # three parts (before, body, after); the body starts with the `' || :`
+  # tail of the `read` line. Anything else means the script was reshaped and
+  # this extraction is reading garbage -- throw, loudly, rather than test it.
+  extract =
+    delim:
+    let
+      parts = lib.splitString delim text;
+      raw = builtins.elemAt parts 1;
+    in
+    if builtins.length parts != 3 then
+      throw "tests/try.nix: expected exactly one ${delim} heredoc in nixarchy-try"
+    else if !(lib.hasPrefix "' || :\n" raw) then
+      throw "tests/try.nix: the ${delim} heredoc is not shaped as expected"
+    else
+      lib.removePrefix "' || :\n" raw;
+
+  lookup = import (builtins.toFile "try-lookup.nix" (extract "NIX_LOOKUP_EOF"));
+  probe = import (builtins.toFile "try-probe.nix" (extract "NIX_PROBE_EOF"));
+
+  apps = import ../data/apps.nix;
+
+  # kind / attr / binary / unfree, against the real catalogue. The rows are
+  # chosen for what they exercise, not for convenience: firefox is the
+  # module refusal (#499's "name the enable path"), chrome the unfree flag,
+  # android-tools the binary field, sublime the unavailable note, and a name
+  # not in the catalogue must come back `raw` -- never a guess.
+  lookupCases = [
+    {
+      name = "firefox";
+      want = "module\tprograms.firefox";
+    }
+    {
+      name = "chrome";
+      want = "app\tgoogle-chrome\t\t1";
+    }
+    {
+      name = "android-tools";
+      want = "app\tandroid-tools\tadb\t0";
+    }
+    {
+      name = "alacritty";
+      want = "app\talacritty\t\t0";
+    }
+    {
+      name = "not-a-catalogue-row";
+      want = "raw";
+    }
+  ];
+
+  # The probe against this check's own nixpkgs: mainProgram read out where
+  # one exists, EMPTY where none does (android-tools -- the fallback ladder's
+  # reason to exist), the unfree bit for chrome, and `missing` for an
+  # attribute the tree does not carry.
+  probeCases = [
+    {
+      attr = "hello";
+      want = "found\thello\t0";
+    }
+    {
+      attr = "android-tools";
+      want = "found\t\t0";
+    }
+    {
+      attr = "google-chrome";
+      want = "found\tgoogle-chrome-stable\t1";
+    }
+    {
+      attr = "no-such-attribute-anywhere";
+      want = "missing";
+    }
+  ];
+
+  renderCases =
+    label: f: cases:
+    lib.concatMapStrings (
+      c:
+      let
+        id = f c;
+        got = if label == "lookup" then lookup apps c.name else probe pkgs c.attr;
+      in
+      if got == c.want then
+        "echo ${lib.escapeShellArg "  ok      ${label} ${id} -> ${got}"}\n"
+      else
+        "echo ${lib.escapeShellArg "  FAILED  ${label} ${id}: wanted '${c.want}', got '${got}'"}; fails=1\n"
+    ) cases;
+
+  lookupAsserts = renderCases "lookup" (c: c.name) lookupCases;
+  probeAsserts = renderCases "probe" (c: c.attr) probeCases;
+in
+pkgs.runCommand "nixarchy-try" { } ''
+    set -o pipefail
+    fails=0
+
+    # ------------------------------------------------------------------------
+    # The two expressions, already applied at evaluation time (see the let
+    # above); here only the verdicts land.
+    # ------------------------------------------------------------------------
+    echo "lookup expression, against the real data/apps.nix:"
+    ${lookupAsserts}
+    echo "probe expression, against this check's nixpkgs:"
+    ${probeAsserts}
+
+    # ------------------------------------------------------------------------
+    # resolve_binary: the fallback ladder. The catalogue's word beats
+    # mainProgram beats the attribute's last segment -- in that order, because
+    # the first two are answers and the last is the guess nix run makes.
+    # ------------------------------------------------------------------------
+    sed -n '/^resolve_binary()/,/^}/p' ${tryScript} > rb.sh
+    test -s rb.sh || { echo "resolve_binary is not in nixarchy-try any more" >&2; exit 1; }
+    . ./rb.sh
+    t_rb() {
+      want=$1 name=$2 row=$3 main=$4 attr=$5
+      g=$(resolve_binary "$row" "$main" "$attr")
+      if [ "$g" = "$want" ]; then
+        echo "  ok      $name -> $g"
+      else
+        echo "  FAILED  $name: wanted $want, got '$g'"
+        fails=1
+      fi
+    }
+    t_rb adb                  "catalogue binary wins"        adb "" android-tools
+    t_rb adb                  "catalogue beats mainProgram"  adb wrong android-tools
+    t_rb google-chrome-stable "mainProgram next"             "" google-chrome-stable google-chrome
+    t_rb ripgrep              "last resort: the attr"        "" "" ripgrep
+    t_rb hello                "dotted attr: last segment"    "" "" python3Packages.hello
+
+    # ------------------------------------------------------------------------
+    # run_try, with a stubbed nix: the launch is `nix shell -f <tree> <attr>
+    # -c <binary>`, and NIXPKGS_ALLOW_UNFREE reaches ONLY the unfree runs.
+    # ------------------------------------------------------------------------
+    sed -n '/^run_try()/,/^}/p' ${tryScript} > rt.sh
+    test -s rt.sh || { echo "run_try is not in nixarchy-try any more" >&2; exit 1; }
+    . ./rt.sh
+    nix() {
+      printf 'call:%s\n' "$*"
+      printf 'env:%s\n' "''${NIXPKGS_ALLOW_UNFREE:-unset}"
+    }
+    t_run() {
+      name=$1 unfree=$2 wantenv=$3
+      got=$(run_try /some/nixpkgs some-attr some-bin "$unfree" --flag)
+      case "$got" in
+        "call:shell -f /some/nixpkgs some-attr -c some-bin --flag
+  env:$wantenv")
+          echo "  ok      $name"
+          ;;
+        *)
+          echo "  FAILED  $name:"
+          printf '%s\n' "$got" | sed 's/^/            /'
+          fails=1
+          ;;
+      esac
+    }
+    t_run "free run: no unfree leak"  0 unset
+    t_run "unfree run: env is set"    1 1
+
+    # ------------------------------------------------------------------------
+    # The honesty and the hand-off live in named functions; assert the words
+    # are still in them, then that main still says them, in the right order.
+    # ------------------------------------------------------------------------
+    sed -n '/^print_footer()/,/^}/p' ${tryScript} > pf.sh
+    test -s pf.sh || { echo "print_footer is not in nixarchy-try any more" >&2; exit 1; }
+    for phrase in "NOT a sandbox" "full user privileges" "garbage-collected" \
+                  "Nothing is installed" "nixarchy vm"; do
+      if grep -qF "$phrase" pf.sh; then
+        echo "  ok      footer says: $phrase"
+      else
+        echo "  FAILED  footer no longer says: $phrase"
+        fails=1
+      fi
+    done
+
+    sed -n '/^next_step()/,/^}/p' ${tryScript} > ns.sh
+    test -s ns.sh || { echo "next_step is not in nixarchy-try any more" >&2; exit 1; }
+    bold() { echo "$1"; }
+    . ./ns.sh
+    if next_step app helix | grep -q 'nixarchy-app-enable helix'; then
+      echo "  ok      hand-off: catalogue row -> nixarchy-app-enable"
+    else
+      echo "  FAILED  hand-off for a catalogue row does not name nixarchy-app-enable"
+      fails=1
+    fi
+    if next_step raw ripgrep | grep -q 'nixarchy-pkg-add ripgrep'; then
+      echo "  ok      hand-off: raw attr -> nixarchy-pkg-add"
+    else
+      echo "  FAILED  hand-off for a raw attribute does not name nixarchy-pkg-add"
+      fails=1
+    fi
+
+    # ------------------------------------------------------------------------
+    # Wiring: extracted-and-green is not called-and-green (#133). Match the
+    # CALLS, by line number, so the order is the one a user experiences:
+    # footer before the program runs, hand-off after.
+    # ------------------------------------------------------------------------
+    footer_line=$(grep -n '^print_footer$' ${tryScript} | cut -d: -f1 | head -1)
+    run_line=$(grep -n '^run_try "' ${tryScript} | cut -d: -f1 | head -1)
+    step_line=$(grep -n '^next_step "' ${tryScript} | cut -d: -f1 | head -1)
+    for pair in "print_footer:$footer_line" "run_try:$run_line" "next_step:$step_line"; do
+      if [ -z "''${pair#*:}" ]; then
+        echo "  FAILED  main no longer calls ''${pair%%:*}"
+        fails=1
+      fi
+    done
+    if [ -n "$footer_line" ] && [ -n "$run_line" ] && [ -n "$step_line" ] \
+      && [ "$footer_line" -lt "$run_line" ] && [ "$run_line" -lt "$step_line" ]; then
+      echo "  ok      order: footer ($footer_line) < run ($run_line) < hand-off ($step_line)"
+    else
+      echo "  FAILED  call order is not footer < run < hand-off ($footer_line/$run_line/$step_line)"
+      fails=1
+    fi
+
+    # No call site says `nix run`: strip comment lines first, because the
+    # script's own comments discuss `nix run` at length and a pattern that
+    # reads prose would pass or fail on the wrong thing entirely.
+    if grep -vE '^[[:space:]]*#' ${tryScript} | grep -q 'nix run '; then
+      echo "  FAILED  a call site invokes 'nix run' -- the mainProgram guess is back"
+      fails=1
+    else
+      echo "  ok      no call site invokes nix run"
+    fi
+
+    [ "$fails" = 0 ] || { echo "nixarchy-try assertions failed" >&2; exit 1; }
+    echo ok > $out
+''


### PR DESCRIPTION
**Epic #498, as one pull request.** Closes #499, closes #500, closes #501, closes #503.

*(Each with its own keyword — `Closes #a, #b, #c` only closes the first, which is why four of #485's children needed closing by hand.)*

The repo already recommended this and offered no way to do it: `skills/nixos/SKILL.md:288` tells users *"Try out helix quickly → `nix shell nixpkgs#helix`"*. Now there is a command, a key in the picker, and a page.

## Three findings decided the design

**`nix run` guesses the binary and gets it wrong.** Verified live: `nix run nixpkgs#android-tools` fails with *"unable to execute …/bin/android-tools"* — the package ships `adb` and correctly declares no `mainProgram`, so nix fell back to the attribute name. That is why `data/apps.nix` grew a `binary` field (#468). So: **`nix shell -c <binary>`**, with a ladder of catalogue `binary` → `meta.mainProgram` → last attr segment.

**A bare `nixpkgs#` downloads a nixpkgs this machine has never seen** — we pin no registry, so it resolves to unstable HEAD, a *different version than `nixarchy-apply` would install*. `-f <pkgs.path>` from the machine's own config makes **try preview what install delivers**. If that path is unreadable it **refuses** rather than silently falling back to registry HEAD.

**Unfree is backwards from installing.** `allowUnfree` is on for the system but does not reach an ad-hoc evaluation — so Chrome installs fine and refuses to be *tried*. Handled per-run, only where needed.

## The bug that would have shipped

**Both halves were green with the feature unreachable.** The picker's ctrl-t runs `nixarchy try`; the dispatcher had no `try` row, so it fell through to `exec omarchy try` and died as *"Unknown Omarchy command"*.

Found by the agent that wrote `nixarchy-try`, reading across into territory it had been told not to edit. **Neither check caught it**: the picker asserted that `nixarchy-search` *says* `nixarchy try ` — the **call site**, not the **route**.

I ran a cross-agent interface check before this — positional args, the module-app refusal, pinned tree, `binary`, unfree — and all five held. I never checked the command could be reached.

`checks.options` now asserts the route for **every** advertised subcommand, not just this one. Proven red by deleting the row.

## Honest limits, printed before every run

Nothing was installed · it stays in the store until garbage collection, and **nixarchy schedules none** · it ran with your full privileges — **this is not a sandbox**; for code you do not trust that is `nixarchy vm`.

## Verified

`checks.try` (25 assertions, **proven red twice**: the module branch deleted, and `run_try` rewritten to `nix run`) · `checks.options` · `bin-ledger` · `doc-options` · fmt, statix, `deadnix --fail`, shellcheck, `readme-counts` all rc=0.

Live smoke: `try android-tools -- version` runs **adb** — the exact invocation `nix run` fails on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5