### PR TITLE
The package picker: a miss opens it, rows say what they cost, and Remove means remove

### DIFF
--- a/docs/manual/other-packages.md
+++ b/docs/manual/other-packages.md
@@ -156,13 +156,18 @@ NixOS and `systemPackages` would be the wrong answer.
 
 ## Removing
 
-_Remove > App_ runs `nixarchy-app-remove`, a picker over whatever is
-currently enabled in `apps.nix`. It only ever deselects; then
-`nixarchy-apply` rebuilds without the app. Its files go away when the old
-generation is garbage-collected, and its config under `~/.config` stays, as on
-any system.
+_Remove > App / package_ runs `nixarchy-app-remove`, a picker over everything
+the Install picker has written into `apps.nix`: enabled apps, packages added
+with `nixarchy pkg add`, and options the Search picker set or scaffolded. It
+only ever deselects; then `nixarchy-apply` rebuilds without them. Files go
+away when the old generation is garbage-collected, and config under
+`~/.config` stays, as on any system.
+
+`nixarchy pkg remove <attr>` does the package half from a terminal, and with
+no argument opens the same fuzzy picker over just the added packages.
 
 Two things it deliberately will not do. It will not remove something you added
-in your own `systemPackages` — that is not this menu's to take away; delete the
-line yourself. And it will not run `omarchy pkg drop`, which still calls
-pacman and cannot work here.
+in your own `systemPackages` — the tools delete only lines carrying their own
+`#@pkg`/`#@opt` markers, so a line you wrote (or a marker you stripped) is not
+theirs to take away; delete it yourself. And it will not run
+`omarchy pkg drop`, which still calls pacman and cannot work here.

--- a/modules/AGENTS.md
+++ b/modules/AGENTS.md
@@ -1399,6 +1399,25 @@ which nixarchy does not own. ~/.config/nixarchy/apps.nix is already
 a full NixOS module, so a systemPackages list can sit beside the
 app selection with no new file and no new option.
 
+A name that does not resolve opens the picker on the query instead
+of printing a search URL (#492): a miss is a typo more often than a
+missing package, and the fuzzy index exists for typos. Two guards
+keep that sane. NIXARCHY_IN_PICKER stops the fallback when the
+caller IS the picker's own writer -- an index row that misses is an
+index bug, and recursing into a second picker would loop. And the
+picker is exec'd only after everything that DID resolve is
+committed and validated, because exec does not come back.
+
+When the chosen package is unfree and this generation sets
+allowUnfree = false, the script offers the narrow grant (#497): a
+commented nixpkgs.config.allowUnfreePredicate naming just that
+package's pname, in the user's own file, marked `#@unfree-allow`.
+Marked, because nixpkgs.config is a plain attrset whose keys do not
+merge -- a second add must grow the one list, never scaffold a
+second predicate. The policy itself is baked into the script as a
+constant at build time: script and system are the same generation,
+so the constant cannot go stale without the script being replaced.
+
 <a id="search-everything-this-machine-could-install-and-r"></a>
 ### Search everything this machine could install, and route the choice
 
@@ -1421,6 +1440,26 @@ options, not from search.nixos.org. It is slower to build and it
 cannot go stale against the machine, which is the trade that
 matters: an index that offers a package nixarchy-pkg-add will then
 refuse is worse than no index.
+
+The package rows come from our own walk (modules/pkg-index.nix),
+not `nix search`. That is not taste: `nix search --json` emits only
+pname, version and description -- verified on Nix 2.34, not read --
+so homepage, licence, unfree and broken (#493) had to come from an
+eval of our own. The walk follows the same recurseForDerivations
+rule nix search does and was verified to produce the identical row
+set (112,755 attrs, both ways) at the same ~30s cost, once per
+generation.
+
+Status -- [enabled], [queued], nothing -- is stamped at picker
+START, not into the cached index: the selection changes with every
+pick, the index once per generation. It is one sed over the user's
+apps.nix/services.nix (live `#@` marker lines only), one over the
+copies nixarchy-apply made into the flake, and one awk join over
+the index. No evaluation, and nothing per keystroke. "enabled"
+means the flake copy has the line too -- nixarchy-apply copies
+before rebuilding, so a selection absent there has not been built;
+an unreadable flake directory therefore reads as "queued", which is
+the honest claim for a machine that has never applied.
 
 <a id="ask-flathub-org-directly"></a>
 ### Ask flathub.org directly

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -1184,18 +1184,23 @@ in
               file="''${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/apps.nix"
               [ -f "$file" ] || { echo "no $file" >&2; exit 1; }
 
+              # `|| continue`, not `&&`: this script runs under set -e, and a
+              # failing AND-list on a blank line would end it mid-collect.
               entries=()
               while IFS= read -r name; do
-                [ -n "$name" ] && entries+=("app"$'\t'"$name")
+                [ -n "$name" ] || continue
+                entries+=("app"$'\t'"$name")
               done < <(
                 grep -oE "^[[:space:]]*[a-z0-9_-]+\.enable" "$file" \
                   | sed -E 's/[[:space:]]*//; s/\.enable//'
               )
               while IFS= read -r name; do
-                [ -n "$name" ] && entries+=("pkg"$'\t'"$name")
+                [ -n "$name" ] || continue
+                entries+=("pkg"$'\t'"$name")
               done < <(grep -oE '#@pkg [A-Za-z0-9_.-]+$' "$file" | sed 's/^#@pkg //')
               while IFS= read -r name; do
-                [ -n "$name" ] && entries+=("opt"$'\t'"$name")
+                [ -n "$name" ] || continue
+                entries+=("opt"$'\t'"$name")
               done < <(grep -o '#@opt .*' "$file" | sed 's/^#@opt //' | sort -u)
 
               if [ ''${#entries[@]} -eq 0 ]; then

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -390,12 +390,14 @@ let
         # Upstream wears the Arch logo here and runs `pacman -Rns` on the
         # selection. This picks over the app selection instead, and only ever
         # edits ~/.config/nixarchy/apps.nix -- never the user's own NixOS
-        # configuration, which nixarchy does not own.
+        # configuration, which nixarchy does not own. One picker for all
+        # three kinds the Install picker writes -- apps, extra packages,
+        # options -- so Remove covers what Install can add (#494, #522).
         "remove.package" = {
           icon = "󰭌";
-          label = "App";
+          label = "App / package";
           action = "omarchy-launch-floating-terminal-with-presentation nixarchy-app-remove";
-          description = "Deselect apps, then Apply changes to rebuild without them";
+          description = "Deselect apps, added packages and options, then Apply changes to rebuild without them";
         };
 
         # Upstream's label is "Omarchy" and its action pulls a git checkout and
@@ -1164,6 +1166,12 @@ in
           # An interactive picker over what is currently selected, for the
           # Remove > Package row. Upstream offers a fuzzy picker over installed
           # pacman packages; this is the same shape over the app selection.
+          #
+          # All three kinds the Install picker can write, because "Remove" that
+          # only sees one of them is a menu row that lies (#494, #522): curated
+          # apps (`id.enable` lines), extra packages (`#@pkg` markers from
+          # nixarchy-pkg-add) and options (`#@opt` markers from the Search
+          # picker's add_option).
           (pkgs.writeShellApplication {
             name = "nixarchy-app-remove";
             runtimeInputs = [
@@ -1176,26 +1184,260 @@ in
               file="''${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/apps.nix"
               [ -f "$file" ] || { echo "no $file" >&2; exit 1; }
 
-              mapfile -t enabled < <(
+              entries=()
+              while IFS= read -r name; do
+                [ -n "$name" ] && entries+=("app"$'\t'"$name")
+              done < <(
                 grep -oE "^[[:space:]]*[a-z0-9_-]+\.enable" "$file" \
                   | sed -E 's/[[:space:]]*//; s/\.enable//'
               )
-              if [ ''${#enabled[@]} -eq 0 ]; then
+              while IFS= read -r name; do
+                [ -n "$name" ] && entries+=("pkg"$'\t'"$name")
+              done < <(grep -oE '#@pkg [A-Za-z0-9_.-]+$' "$file" | sed 's/^#@pkg //')
+              while IFS= read -r name; do
+                [ -n "$name" ] && entries+=("opt"$'\t'"$name")
+              done < <(grep -o '#@opt .*' "$file" | sed 's/^#@opt //' | sort -u)
+
+              if [ ''${#entries[@]} -eq 0 ]; then
                 echo "Nothing is selected. Install > Package lists what is available."
                 exit 0
               fi
 
-              chosen=$(printf '%s\n' "''${enabled[@]}" | fzf --multi \
+              # The preview shows the line that would go, so what "remove"
+              # means for each entry is visible before it happens.
+              chosen=$(printf '%s\n' "''${entries[@]}" | fzf --multi \
+                --delimiter='\t' \
                 --prompt="remove > " \
-                --header="tab to select several, enter to confirm") || exit 0
+                --header="tab to select several, enter to confirm" \
+                --preview "grep -F -- {2} '$file' | grep -F -e '.enable' -e '#@'" \
+                --preview-window='down,3,wrap') || exit 0
               [ -n "$chosen" ] || exit 0
 
-              while IFS= read -r app; do
-                [ -n "$app" ] && nixarchy-app-disable "$app"
+              # Packages and options are batched: one backup, one parse check,
+              # one notification per kind rather than per line.
+              pkgsel=()
+              optsel=()
+              while IFS=$'\t' read -r kind name; do
+                [ -n "$name" ] || continue
+                case "$kind" in
+                  app) nixarchy-app-disable "$name" ;;
+                  pkg) pkgsel+=("$name") ;;
+                  opt) optsel+=("$name") ;;
+                esac
               done <<< "$chosen"
+              [ ''${#pkgsel[@]} -eq 0 ] || nixarchy-pkg-remove "''${pkgsel[@]}"
+              [ ''${#optsel[@]} -eq 0 ] || nixarchy-opt-remove "''${optsel[@]}"
 
               echo
               echo "Run 'nixarchy-apply' to rebuild without them."
+            '';
+          })
+
+          # The inverse of nixarchy-pkg-add. It deletes only lines carrying the
+          # `#@pkg` marker -- the marker is the writer's claim of ownership --
+          # and never reformats anything else: the file is the user's. The
+          # systemPackages block stays even when its last marked line goes,
+          # because the user may have put their own, unmarked lines in it, and
+          # an empty list evaluates fine.
+          (pkgs.writeShellApplication {
+            name = "nixarchy-pkg-remove";
+            runtimeInputs = [
+              pkgs.coreutils
+              pkgs.gnugrep
+              pkgs.gnused
+              pkgs.fzf
+              config.nix.package
+              cfg.package # omarchy-notification-send
+            ];
+            text = ''
+              file="''${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/apps.nix"
+              [ -f "$file" ] || { echo "no $file" >&2; exit 1; }
+
+              if [ $# -eq 0 ]; then
+                mapfile -t attrs < <(grep -oE '#@pkg [A-Za-z0-9_.-]+$' "$file" | sed 's/^#@pkg //')
+                if [ ''${#attrs[@]} -eq 0 ]; then
+                  echo "No extra packages are selected. 'nixarchy pkg add' or the Search picker adds one."
+                  exit 0
+                fi
+                chosen=$(printf '%s\n' "''${attrs[@]}" | fzf --multi \
+                  --prompt="remove pkg > " \
+                  --header="tab to select several, enter to confirm") || exit 0
+                [ -n "$chosen" ] || exit 0
+                mapfile -t picked <<< "$chosen"
+                set -- "''${picked[@]}"
+              fi
+
+              # Reverted as a unit if anything goes wrong, exactly as the
+              # writer's edits are: the file is the user's own NixOS module.
+              backup=$(mktemp)
+              cp "$file" "$backup"
+              trap 'rm -f "$backup"' EXIT
+              restore() { cp "$backup" "$file"; }
+
+              removed=()
+              for attr in "$@"; do
+                # Same alphabet nixarchy-pkg-add accepts. Anything else would
+                # reach the sed address below as a pattern, not a name.
+                case "$attr" in
+                  "" | -* | .* | *..* | *[!A-Za-z0-9_.-]*)
+                    restore
+                    echo "'$attr' is not a nixpkgs attribute name." >&2
+                    exit 1
+                    ;;
+                esac
+                if ! grep -qF -- "#@pkg $attr" "$file"; then
+                  restore
+                  echo "nixarchy: no package '$attr' in $file. Nothing was changed." >&2
+                  exit 1
+                fi
+                # Exactly the marked line nixarchy-pkg-add wrote, wherever the
+                # user has moved it to.
+                sed -i "/#@pkg $attr\$/d" "$file"
+                removed+=("$attr")
+              done
+
+              [ ''${#removed[@]} -gt 0 ] || exit 0
+
+              if ! nix-instantiate --parse "$file" >/dev/null 2>&1; then
+                restore
+                echo "nixarchy: that would have left $file unparseable. Nothing was changed." >&2
+                exit 1
+              fi
+
+              count=$(grep -c '#@pkg ' "$file" || true)
+              if command -v omarchy-notification-send >/dev/null 2>&1; then
+                omarchy-notification-send -r 8471 -t 8000 -u normal \
+                  "''${removed[*]} removed from your selection" \
+                  "$count extra package(s) still selected. Click here to run nixos-rebuild and apply it." \
+                  --exec omarchy-launch-floating-terminal-with-presentation nixarchy-apply || true
+              fi
+              for attr in "''${removed[@]}"; do
+                echo "removed $attr from $file"
+              done
+              echo "it stays installed until 'nixarchy-apply' rebuilds"
+            '';
+          })
+
+          # Removes an option the Search picker wrote (#522). What "remove"
+          # means here follows nixarchy-channel's rule -- only lines this
+          # project wrote get rewritten -- and the `#@opt` marker is the claim
+          # of authorship:
+          #
+          #   - a value the picker set, or a scaffold the user uncommented and
+          #     filled in while keeping the marker, is ONE marked line: that
+          #     line goes, and nothing around it. The picker's preview shows
+          #     the line first, so a filled-in scaffold is deleted with the
+          #     current value in view, not behind the user's back.
+          #   - an UNTOUCHED scaffold -- still commented, value never filled
+          #     in -- takes its doc-comment block with it: add_option wrote
+          #     blank line, comments and marker line as one unit, and the
+          #     comments mean nothing without the line they explain.
+          #   - a line the user stripped the marker from is invisible here,
+          #     which is the marker working as intended: removing it is how
+          #     an adopted line is kept out of this tool's reach.
+          #
+          # In both cases the one blank line add_option put above the unit
+          # goes too, so removing is byte-for-byte the inverse of adding --
+          # checks.options holds it to exactly that.
+          (pkgs.writeShellApplication {
+            name = "nixarchy-opt-remove";
+            runtimeInputs = [
+              pkgs.coreutils
+              pkgs.gnugrep
+              pkgs.gnused
+              pkgs.gawk
+              pkgs.fzf
+              config.nix.package
+            ];
+            text = ''
+              file="''${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/apps.nix"
+              [ -f "$file" ] || { echo "no $file" >&2; exit 1; }
+
+              if [ $# -eq 0 ]; then
+                mapfile -t paths < <(grep -o '#@opt .*' "$file" | sed 's/^#@opt //' | sort -u)
+                if [ ''${#paths[@]} -eq 0 ]; then
+                  echo "No options from the picker are in $file. The Search picker adds one."
+                  exit 0
+                fi
+                chosen=$(printf '%s\n' "''${paths[@]}" | fzf --multi \
+                  --prompt="remove opt > " \
+                  --header="tab to select several, enter to confirm" \
+                  --preview "grep -F -- '#@opt '{} '$file'" \
+                  --preview-window='down,3,wrap') || exit 0
+                [ -n "$chosen" ] || exit 0
+                mapfile -t picked <<< "$chosen"
+                set -- "''${picked[@]}"
+              fi
+
+              backup=$(mktemp)
+              cp "$file" "$backup"
+              trap 'rm -f "$backup"' EXIT
+              restore() { cp "$backup" "$file"; }
+
+              # String comparison throughout, never a regex: option paths
+              # carry dots, quotes and <name> placeholders, and a path read
+              # as a pattern would delete the wrong line quietly.
+              remove_one() {
+                path=$1
+                tmp=$(mktemp)
+                # `if !` rather than checking $? after: this script runs under
+                # set -e, and a bare failing awk would abort before the caller
+                # could restore the backup.
+                if ! awk -v path="$path" '
+                  { line[NR] = $0 }
+                  END {
+                    marker = "#@opt " path
+                    target = 0
+                    for (i = 1; i <= NR; i++) {
+                      l = line[i]
+                      if (length(l) >= length(marker) &&
+                          substr(l, length(l) - length(marker) + 1) == marker) {
+                        target = i; break
+                      }
+                    }
+                    if (target == 0) exit 3
+                    first = target
+                    stripped = line[target]
+                    sub(/^[ \t]*/, "", stripped)
+                    if (stripped == "# " path " = ;  " marker) {
+                      while (first > 1) {
+                        prev = line[first - 1]
+                        sub(/^[ \t]*/, "", prev)
+                        if (substr(prev, 1, 1) == "#") first -= 1; else break
+                      }
+                    }
+                    if (first > 1 && line[first - 1] == "") first -= 1
+                    for (i = 1; i <= NR; i++)
+                      if (i < first || i > target) print line[i]
+                  }' "$file" > "$tmp"; then
+                  rm -f "$tmp"
+                  return 1
+                fi
+                mv "$tmp" "$file"
+              }
+
+              removed=()
+              for path in "$@"; do
+                if ! remove_one "$path"; then
+                  restore
+                  echo "nixarchy: no option '$path' in $file. Nothing was changed." >&2
+                  exit 1
+                fi
+                removed+=("$path")
+              done
+
+              [ ''${#removed[@]} -gt 0 ] || exit 0
+
+              if ! nix-instantiate --parse "$file" >/dev/null 2>&1; then
+                restore
+                echo "nixarchy: that would have left $file unparseable. Nothing was changed." >&2
+                exit 1
+              fi
+
+              for path in "''${removed[@]}"; do
+                echo "removed $path from $file"
+              done
+              echo "a value that was live stays in effect until 'nixarchy-apply' rebuilds"
             '';
           })
 
@@ -1736,6 +1978,7 @@ in
                 pkg)
                   case "''${2:-}" in
                     add) shift 2; exec nixarchy-pkg-add "$@" ;;
+                    remove) shift 2; exec nixarchy-pkg-remove "$@" ;;
                   esac
                   ;;
                 app)
@@ -1771,9 +2014,10 @@ in
 
                 nixarchy search [query]     Every package, NixOS option and app, in one picker
                 nixarchy pkg add <attr>     Add a nixpkgs package to the app selection
+                nixarchy pkg remove [attr]  Take one out again (no argument picks interactively)
                 nixarchy app enable <id>    Select an app from the curated list
                 nixarchy app disable <id>   Deselect one
-                nixarchy app remove         Pick what to deselect, interactively
+                nixarchy app remove         Pick apps, packages and options to remove
                 nixarchy apply              Copy the selection into your flake and rebuild
                 nixarchy dev init <preset>  Scaffold a devenv project here (no argument lists them)
                 nixarchy try <app|attr>     Run something once without installing it

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -1462,10 +1462,30 @@ in
               file="''${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/apps.nix"
               table=${appAttrTable}
               nixpkgs=${pkgs.path}
+              # This generation's licence policy, baked in at build time: the
+              # script and the system it can queue packages for are the same
+              # generation, so this cannot go stale without the script itself
+              # being replaced.
+              allowunfree=${lib.boolToString (config.nixpkgs.config.allowUnfree or false)}
+
+              # The picker is reachable through the session PATH rather than
+              # runtimeInputs (same route nixarchy-apply takes to
+              # nixarchy-preview), so its absence must degrade to the usage
+              # text, not break the command.
+              can_pick() {
+                [ -z "''${NIXARCHY_IN_PICKER:-}" ] && [ -t 0 ] && [ -t 1 ] &&
+                  command -v nixarchy-search >/dev/null 2>&1
+              }
 
               if [ $# -eq 0 ]; then
+                # No arguments is not a mistake to scold, it is "show me what
+                # there is" -- which is exactly what the picker answers (#492).
+                if can_pick; then
+                  exec nixarchy-search
+                fi
                 echo "usage: nixarchy-pkg-add <nixpkgs-attribute>..." >&2
                 echo "  e.g. nixarchy-pkg-add ripgrep fd" >&2
+                echo "  or run 'nixarchy-search' to browse everything" >&2
                 exit 1
               fi
 
@@ -1525,6 +1545,8 @@ in
               }
 
               added=()
+              missed=()
+              unfree_hits=()
 
               for attr in "$@"; do
                 case "$attr" in
@@ -1567,15 +1589,25 @@ in
                          else [ ];
                   in {
                     inherit (q) name;
+                    pname = q.pname or \"\";
                     description = q.meta.description or \"\";
                     unfree = !(builtins.all (l: if builtins.isAttrs l then (l.free or true) else true) ls);
                     broken = q.meta.broken or false;
                   }" 2>/dev/null); then
+                  # A name that does not resolve is a typo more often than a
+                  # missing package, and the fuzzy index exists for typos: open
+                  # the picker on the query instead of handing back homework
+                  # (#492). Not when this run IS the picker's writer -- its rows
+                  # come from the index, so a miss there is an index bug and
+                  # recursing into a fresh picker would loop.
+                  if can_pick; then
+                    missed+=("$attr")
+                    continue
+                  fi
                   echo "nixpkgs has no package '$attr'." >&2
                   echo >&2
                   echo "Search for the right name:" >&2
-                  echo "  nix search nixpkgs $attr" >&2
-                  echo "  https://search.nixos.org/packages" >&2
+                  echo "  nixarchy-search $attr" >&2
                   exit 1
                 fi
 
@@ -1593,14 +1625,101 @@ in
 
                 echo "added $attr ($(jq -r .name <<<"$info")) -- $(jq -r '.description // ""' <<<"$info")"
                 if [ "$(jq -r .unfree <<<"$info")" = true ]; then
-                  echo "  unfree: needs nixpkgs.config.allowUnfree in your configuration, or the build fails."
+                  if [ "$allowunfree" = true ]; then
+                    echo "  unfree: fine here -- this machine allows unfree packages."
+                  else
+                    # The minority case (#497): allowUnfree defaults on, so
+                    # reaching this line means somebody turned it off on
+                    # purpose. Collect the pname (what allowUnfreePredicate
+                    # matches on), and offer the narrow grant after the loop.
+                    echo "  unfree, and this machine sets allowUnfree = false: the rebuild will refuse it."
+                    pn=$(jq -r '.pname // ""' <<<"$info")
+                    unfree_hits+=("''${pn:-$attr}")
+                  fi
                 fi
                 if [ "$(jq -r .broken <<<"$info")" = true ]; then
                   echo "  marked broken in nixpkgs: expect the build to fail."
                 fi
               done
 
-              [ ''${#added[@]} -gt 0 ] || exit 0
+              # Names that resolved nowhere, with a picker available: hand them
+              # to it, pre-filtered, so a typo becomes a fuzzy match. exec, so
+              # this only runs once everything above is committed or reverted.
+              open_missed() {
+                [ ''${#missed[@]} -gt 0 ] || return 0
+                echo "no exact match for ''${missed[*]} -- opening the picker on it"
+                exec nixarchy-search "''${missed[@]}"
+              }
+
+              if [ ''${#added[@]} -eq 0 ]; then
+                open_missed
+                exit 0
+              fi
+
+              # The narrow grant (#497): a commented allowUnfreePredicate
+              # naming just these packages, in the user's own file, rather
+              # than advice to flip the global flag. Commented, because
+              # changing licence policy is the user's line to uncomment.
+              # Runs before the parse check so one validation covers it.
+              offer_unfree_grant() {
+                [ ''${#unfree_hits[@]} -gt 0 ] || return 0
+
+                if grep -q '#@unfree-allow' "$file"; then
+                  # A grant already exists (ours, by its marker): grow its
+                  # list in place rather than scaffold a second predicate --
+                  # nixpkgs.config is a plain attrset, and two definitions of
+                  # one key do not merge.
+                  for pn in "''${unfree_hits[@]}"; do
+                    grep -q "\"$pn\"" "$file" ||
+                      sed -i "/#@unfree-allow/s/ \];/ \"$pn\" ];/" "$file"
+                    if ! grep -q "\"$pn\"" "$file"; then
+                      echo "  add \"$pn\" to the allowUnfreePredicate list already in $file"
+                    fi
+                  done
+                  return 0
+                fi
+
+                if [ -t 0 ]; then
+                  printf 'Scaffold a commented allowUnfreePredicate for %s into %s? [Y/n] ' \
+                    "''${unfree_hits[*]}" "$file"
+                  read -r reply || reply=n
+                  case "$reply" in
+                    [nN]*)
+                      echo "  then allow it yourself, or set programs.nixarchy.allowUnfree = true"
+                      return 0
+                      ;;
+                  esac
+                fi
+
+                names=""
+                for pn in "''${unfree_hits[@]}"; do names="$names\"$pn\" "; done
+                # printf rather than a multi-line literal: a raw
+                # newline-in-string here would lower the whole nix
+                # indented string's common indent and shift every
+                # line of the built script.
+                payload=$(printf '%s\n' \
+                  "" \
+                  "  # ''${unfree_hits[*]}: unfree, and this machine sets programs.nixarchy.allowUnfree" \
+                  "  # = false. Uncomment the line below to allow JUST the packages named -- the" \
+                  "  # narrow grant -- rather than flipping the global switch:" \
+                  "  # nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (pkgs.lib.getName pkg) [ $names];  #@unfree-allow")
+
+                tmp=$(mktemp)
+                awk -v payload="$payload" '
+                  { print }
+                  !done && /#@pkgs-end/ { print payload; done = 1 }
+                ' "$file" > "$tmp"
+                mv "$tmp" "$file"
+
+                if grep -q '#@unfree-allow' "$file"; then
+                  echo "  scaffolded a commented allowUnfreePredicate in $file -- uncomment it to allow just ''${unfree_hits[*]}"
+                else
+                  restore
+                  echo "nixarchy: failed to write the allowUnfreePredicate scaffold. Nothing was changed." >&2
+                  exit 1
+                fi
+              }
+              offer_unfree_grant
 
               if ! nix-instantiate --parse "$file" >/dev/null 2>&1; then
                 restore
@@ -1621,6 +1740,11 @@ in
 
               echo
               echo "run 'nixarchy-apply' when you have picked everything you want"
+
+              # Last, because exec does not come back: anything that
+              # resolved is committed above before a typo's picker
+              # takes over the terminal.
+              open_missed
             '';
           })
 
@@ -1644,18 +1768,32 @@ in
               stamp="$cache/stamp"
 
               appindex=${appIndexTable}
+              apptable=${appAttrTable}
               flatpakrows=${flatpakIndexRows}
               optionsjson=${optionsJsonPath}
               nixpkgs=${pkgs.path}
+              walk=${./pkg-index.nix}
+              flakedir="''${NIXARCHY_FLAKE:-${cfg.flake}}"
+              # This generation's licence policy, baked in like the index is:
+              # both are replaced together with the system generation.
+              allowunfree=${lib.boolToString (config.nixpkgs.config.allowUnfree or false)}
+
+              # The writers this picker calls fall back TO the picker on a miss
+              # (#492). A row that then misses would recurse into a second
+              # picker; this says "you are already inside one", so they error
+              # instead -- an index row that does not resolve is an index bug.
+              export NIXARCHY_IN_PICKER=1
 
               reindex=0
               [ "''${1:-}" = "--reindex" ] && { reindex=1; shift; }
 
-              # One index, four tab-separated fields: kind, name, one-line summary, option
-              # type, and the preview text with its newlines escaped. The preview is carried
-              # in the line rather than looked up on selection because fzf runs the preview
-              # command on every keystroke, and a jq pass over 19 MB of package metadata is
-              # not something to do sixty times a second.
+              # One index, five tab-separated fields: kind, name, one-line summary,
+              # a kind-specific fourth (an option's type; a package's flags, e.g.
+              # "unfree broken curated:firefox"; empty otherwise), and the preview
+              # text with its newlines escaped. The preview is carried in the line
+              # rather than looked up on selection because fzf runs the preview
+              # command on every keystroke, and a jq pass over 19 MB of package
+              # metadata is not something to do sixty times a second.
               build_index() {
                 mkdir -p "$cache"
                 tmp=$(mktemp)
@@ -1700,22 +1838,52 @@ in
                 # The system's own nixpkgs, not the flake registry: an index that offers a
                 # package this machine cannot build is worse than no index. Slow enough to
                 # be worth saying so -- about a minute, once per system generation.
+                #
+                # Our own walk (modules/pkg-index.nix) rather than `nix search`:
+                # verified to produce the identical row set, and it carries the
+                # meta `nix search --json` does not -- homepage, licence, unfree,
+                # broken (#493).
                 echo "  indexing nixpkgs (this takes about a minute)..." >&2
-                nix search --json --extra-experimental-features 'nix-command flakes' \
-                  "path:$nixpkgs" ^ 2>/dev/null |
+                nix-instantiate --eval --strict --json \
+                  --arg nixpkgs "$nixpkgs" "$walk" 2>/dev/null |
                   jq -r '
-                    to_entries[] | (.key | sub("^legacyPackages\\.[^.]+\\."; "")) as $a | .value as $v |
-                    [ "pkg", $a,
-                      (($v.description // "") | gsub("[\n\t ]+"; " ") | .[0:110]),
-                      "",
-                      ( "NIXPKGS PACKAGE  " + $a
-                        + "\n\nversion:  " + ($v.version // "?")
-                        + "\n\n" + ($v.description // "(no description)")
+                    .[] |
+                    [ "pkg", .attr,
+                      ( ((.description // "") | gsub("[\n\t ]+"; " ") | .[0:100])
+                        + (if .unfree then "  [unfree]" else "" end)
+                        + (if .broken then "  [broken]" else "" end)
+                      ),
+                      ( (if .unfree then "unfree " else "" end)
+                        + (if .broken then "broken" else "" end)
+                        | sub(" $"; "")
+                      ),
+                      ( "NIXPKGS PACKAGE  " + .attr
+                        + "\n\nversion:  " + (if .version == "" then "?" else .version end)
+                        + "\nlicence:  " + (if .license == "" then "unknown" else .license end)
+                        + (if .homepage == "" then "" else "\nhomepage: " + .homepage end)
+                        + (if .broken then "\n\nMarked BROKEN in nixpkgs: expect the build to fail." else "" end)
+                        + "\n\n" + (if .description == "" then "(no description)" else .description end)
                         + "\n\nAdding this writes it into your app selection:\n  "
-                        + "environment.systemPackages = with pkgs; [ " + $a + " ];"
+                        + "environment.systemPackages = with pkgs; [ " + .attr + " ];"
                         + "\n\nctrl-t tries it now, without installing."
                       )
                     ] | @tsv' >> "$tmp"
+
+                # A raw attribute that the curated list already covers deserves a
+                # warning on its row: picking the APP gets the module, policies
+                # and defaults; picking the package gets a bare binary. Baked in
+                # at build time -- the curated list is as per-generation as the
+                # index (#493).
+                tmp2=$(mktemp)
+                awk -F'\t' -v OFS='\t' '
+                  NR == FNR { curated[$1] = $2; next }
+                  $1 == "pkg" && ($2 in curated) {
+                    $4 = ($4 == "" ? "" : $4 " ") "curated:" curated[$2]
+                    $5 = $5 "\\n\\nCURATED: this name is on the app list as \047" curated[$2] "\047.\\nThe app row above sets programs." curated[$2] " -- the module, with policies\\nand defaults -- where this row would add only a bare package."
+                  }
+                  { print }
+                ' "$apptable" "$tmp" > "$tmp2"
+                mv "$tmp2" "$tmp"
 
                 # Curated flatpaks and the Flathub entry point. A plain cat:
                 # these rows are already in the index's five-field shape, and
@@ -1732,6 +1900,63 @@ in
                 build_index
               fi
 
+              # Status, at picker start rather than in the cached index (#493):
+              # what is selected changes with every pick, the index once per
+              # generation. Two greps and one awk pass over the index -- no
+              # evaluation, and nothing per keystroke.
+              #
+              # "enabled" vs "queued" comes from the copy nixarchy-apply makes
+              # into the flake before rebuilding: a selection that has not
+              # reached the copy has not been built. Same host-dir logic as
+              # nixarchy-apply. An unreadable flake dir marks everything
+              # selected as queued, which is the honest claim for a machine
+              # that has never applied.
+              appsbase="$flakedir"
+              [ -d "$flakedir/hosts/$(uname -n)" ] && appsbase="$flakedir/hosts/$(uname -n)"
+
+              # Live (uncommented) marked lines only: kind<TAB>name per line.
+              mark_live() {
+                [ -r "$1" ] || return 0
+                sed -nE "s/^[[:space:]]*[^#[:space:]].*#@pkg ([A-Za-z0-9_.-]+)[[:space:]]*$/pkg\t\1/p" "$1"
+                sed -nE "s/^[[:space:]]*[^#[:space:]].*#@ ([A-Za-z0-9_.-]+).*$/$2\t\1/p" "$1"
+              }
+
+              selected=$(mktemp)
+              applied=$(mktemp)
+              shown=$(mktemp)
+              trap 'rm -f "$selected" "$applied" "$shown"' EXIT
+
+              {
+                mark_live "$file" app
+                mark_live "''${file%/apps.nix}/services.nix" flatpak
+              } > "$selected" || true
+              {
+                mark_live "$appsbase/nixarchy/apps.nix" app
+                mark_live "$appsbase/nixarchy/services.nix" flatpak
+              } > "$applied" || true
+
+              awk -F'\t' -v OFS='\t' -v unfreeok="$allowunfree" '
+                FILENAME == ARGV[1] { sel[$0] = 1; next }
+                FILENAME == ARGV[2] { app[$0] = 1; next }
+                {
+                  key = $1 "\t" $2
+                  if (key in sel) {
+                    st = (key in app) ? "enabled" : "queued"
+                    note = (st == "enabled") \
+                      ? "enabled -- selected, and nixarchy-apply has copied it into the flake" \
+                      : "queued -- selected but not rebuilt; nixarchy-apply will install it"
+                    $3 = "[" st "] " $3
+                    $5 = $5 "\\n\\nstatus: " note
+                  }
+                  if ($1 == "pkg" && index($4, "unfree") && unfreeok != "true") {
+                    $3 = $3 "  [disallowed]"
+                    $5 = $5 "\\n\\nUNFREE, and this machine sets programs.nixarchy.allowUnfree = false:\\nthe rebuild will refuse it as it stands. nixarchy-pkg-add offers the\\nnarrow grant -- an allowUnfreePredicate naming just this package."
+                  }
+                  print
+                }
+              ' "$selected" "$applied" "$index" > "$shown"
+
+
               # --expect makes fzf accept on ctrl-t as well as enter, and say which
               # was pressed on the first output line. The previews on pkg and app
               # rows document the key; the other two kinds have nothing to run.
@@ -1742,7 +1967,7 @@ in
                 --preview-window='right,58%,wrap' \
                 --prompt='nixarchy > ' \
                 --header='enter to select · ctrl-t to try · tab for several · esc to cancel' \
-                --query="''${*:-}" < "$index") || exit 0
+                --query="''${*:-}" < "$shown") || exit 0
               key=$(printf '%s\n' "$picked" | head -n 1)
               selection=$(printf '%s\n' "$picked" | tail -n +2)
               [ -n "$selection" ] || exit 0
@@ -1768,7 +1993,7 @@ in
 
               backup=$(mktemp)
               cp "$file" "$backup"
-              trap 'rm -f "$backup"' EXIT
+              trap 'rm -f "$backup" "$selected" "$applied" "$shown"' EXIT
 
               changed=0
               scaffolded=0

--- a/modules/pkg-index.nix
+++ b/modules/pkg-index.nix
@@ -1,0 +1,89 @@
+# The package half of nixarchy-search's index: every derivation `nix search`
+# would show, plus the meta that `nix search --json` does not carry --
+# homepage, licence, unfree, broken (#493). Verified against Nix 2.34: its
+# JSON is pname/version/description and nothing else, so the walk has to be
+# ours. It follows the same rule nix search does -- descend into attrsets
+# only where recurseForDerivations says to -- and produces the identical row
+# set (112,755 attrs on the nixpkgs it was written against, both ways).
+#
+# Evaluated by the built nixarchy-search script, once per system generation,
+# via `nix-instantiate --eval --strict --json --arg nixpkgs <path>`. Never
+# per keystroke: the picker inlines everything in the row for that reason.
+#
+# Every meta access sits under tryEval because a broken meta on one package
+# must cost that one row, not the index.
+{
+  nixpkgs,
+}:
+let
+  pkgs = import nixpkgs {
+    # Show everything and say what it is, rather than hide it: the picker
+    # marks unfree and broken instead of pretending they do not exist.
+    # Nothing here decides licence policy; that stays with the rebuild.
+    config = {
+      allowUnfree = true;
+      allowBroken = true;
+      allowInsecurePredicate = _: true;
+      allowUnsupportedSystem = true;
+    };
+  };
+  inherit (pkgs) lib;
+
+  try =
+    v: d:
+    let
+      r = builtins.tryEval v;
+    in
+    if r.success then r.value else d;
+
+  asList = l: if builtins.isList l then l else [ l ];
+
+  licNames =
+    m:
+    let
+      one = l: if builtins.isAttrs l then (l.shortName or l.spdxId or "?") else builtins.toString l;
+    in
+    if m ? license then builtins.concatStringsSep ", " (map one (asList m.license)) else "";
+
+  # The same question nixarchy-pkg-add asks: any licence that is not
+  # `free = true` makes the package unfree.
+  isUnfree =
+    m:
+    m ? license
+    && !(builtins.all (l: if builtins.isAttrs l then (l.free or true) else true) (asList m.license));
+
+  row = path: v: {
+    attr = path;
+    version = try (v.version or "") "";
+    description = try (v.meta.description or "") "";
+    homepage =
+      let
+        h = try (v.meta.homepage or "") "";
+      in
+      if builtins.isList h then (if h == [ ] then "" else builtins.head h) else builtins.toString h;
+    license = try (licNames (try v.meta { })) "";
+    unfree = try (isUnfree (try v.meta { })) false;
+    broken = try (v.meta.broken or false) false;
+  };
+
+  go =
+    prefix: set:
+    builtins.concatLists (
+      map (
+        n:
+        let
+          r = builtins.tryEval (builtins.getAttr n set);
+          v = r.value;
+        in
+        if !r.success then
+          [ ]
+        else if try (lib.isDerivation v) false then
+          [ (builtins.tryEval (row (prefix + n) v)) ]
+        else if try (builtins.isAttrs v && (v.recurseForDerivations or false)) false then
+          go (prefix + n + ".") v
+        else
+          [ ]
+      ) (builtins.attrNames set)
+    );
+in
+map (r: r.value) (builtins.filter (r: r.success) (go "" pkgs))

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -1094,6 +1094,22 @@ let
     ) services
   );
 
+  # #497 both ways: nixarchy-pkg-add bakes this generation's licence policy
+  # in as a constant (`allowunfree=...`), because the script and the system
+  # it queues packages for are the same generation. The on state (the
+  # default) is asserted against $vm's built script below; this is the off
+  # half, which no built VM covers -- exactly the half a refactor breaks
+  # quietly.
+  pkgAddTextWith =
+    settings:
+    (pkgs.lib.findFirst (
+      p: (p.name or "") == "nixarchy-pkg-add"
+    ) (throw "no nixarchy-pkg-add in systemPackages") (configWith settings).environment.systemPackages)
+    .text;
+  pkgAddUnfreeOffBaked = pkgs.lib.hasInfix "allowunfree=false" (pkgAddTextWith {
+    allowUnfree = false;
+  });
+
   broken = pkgs.lib.filterAttrs (_: c: !(c.on && !c.off)) cases;
 
   report = pkgs.lib.concatStringsSep "\n" (
@@ -1121,6 +1137,7 @@ pkgs.runCommand "nixarchy-options"
     microvmProblems = pkgs.lib.concatStringsSep "\n" microvmProblems;
     flatpakCount = builtins.toString (builtins.length (builtins.attrNames flatpaks));
     flatpakRemotes = pkgs.lib.concatStringsSep " " flatpakRemotes;
+    pkgAddUnfreeOff = pkgs.lib.boolToString pkgAddUnfreeOffBaked;
     fleetOff = pkgs.lib.boolToString fleet.offByDefault;
     fleetOn = pkgs.lib.boolToString fleet.onWhenAsked;
     fleetUrl = fleet.url;
@@ -1940,6 +1957,77 @@ pkgs.runCommand "nixarchy-options"
           }
         done
         echo "every advertised nixarchy subcommand has a route"
+
+        # ---- a package miss opens the picker, not a URL (#492) --------------
+        #
+        # Grepped from the built script text, like the flatpak rows above:
+        # these names are load-bearing, and renaming one is a deliberate CI
+        # trip-wire rather than an accident.
+        pkgadd="$vm/sw/bin/nixarchy-pkg-add"
+        search="$vm/sw/bin/nixarchy-search"
+        grep -q 'nixarchy-search' "$pkgadd" || {
+          echo "nixarchy-pkg-add never reaches for the picker: a miss is a dead end again" >&2
+          exit 1
+        }
+        if grep -q 'search\.nixos\.org' "$pkgadd"; then
+          echo "nixarchy-pkg-add answers a miss with a URL again -- that is the homework #492 removed" >&2
+          exit 1
+        fi
+        # Both halves of the recursion guard: the picker declares itself, and
+        # the writer checks. Lose either and a bad index row opens pickers
+        # inside pickers forever.
+        grep -q 'NIXARCHY_IN_PICKER' "$pkgadd" || {
+          echo "nixarchy-pkg-add lost the in-picker guard: a miss inside the picker recurses" >&2
+          exit 1
+        }
+        grep -q 'export NIXARCHY_IN_PICKER=1' "$search" || {
+          echo "nixarchy-search no longer declares itself to its writers (NIXARCHY_IN_PICKER)" >&2
+          exit 1
+        }
+        echo "a package miss opens the picker, with the recursion guard in place"
+
+        # ---- the index carries meta, and the picker carries status (#493) ---
+        walkfile=$(sed -n 's/.*walk=\(\/nix\/store[^ ]*\).*/\1/p' "$search" | head -1)
+        test -n "$walkfile" || {
+          echo "nixarchy-search names no meta-walk file: the indexer lost its package source" >&2
+          exit 1
+        }
+        for field in homepage license unfree broken recurseForDerivations; do
+          grep -q "$field" "$walkfile" || {
+            echo "the index walk ($walkfile) no longer carries '$field'" >&2
+            echo "  nix search --json has only pname/version/description; the walk exists" >&2
+            echo "  precisely to carry the rest (#493)" >&2
+            exit 1
+          }
+        done
+        grep -q 'mark_live' "$search" || {
+          echo "nixarchy-search lost its status pass: rows no longer say enabled/queued" >&2
+          exit 1
+        }
+        # The baked licence-policy constant, in its default (allow) state.
+        grep -q 'allowunfree=true' "$search" || {
+          echo "nixarchy-search does not carry allowunfree=true on a default config" >&2
+          exit 1
+        }
+        echo "the picker's index carries meta and its rows carry status"
+
+        # ---- unfree help is the narrow grant (#497) --------------------------
+        grep -q 'allowUnfreePredicate' "$pkgadd" || {
+          echo "nixarchy-pkg-add no longer offers allowUnfreePredicate for a disallowed unfree package" >&2
+          exit 1
+        }
+        grep -q '#@unfree-allow' "$pkgadd" || {
+          echo "the unfree grant lost its #@unfree-allow marker, so a second add would scaffold a" >&2
+          echo "  second predicate -- and nixpkgs.config keys do not merge" >&2
+          exit 1
+        }
+        test "$pkgAddUnfreeOff" = true || {
+          echo "with allowUnfree = false the built nixarchy-pkg-add does not carry allowunfree=false:" >&2
+          echo "  the baked policy constant no longer follows the option, so the unfree help" >&2
+          echo "  fires never or always" >&2
+          exit 1
+        }
+        echo "unfree help scaffolds the narrow grant, and the baked policy follows the option"
 
         # ---- machines pull only when asked ---------------------------------
         test "$fleetOff" = false || {

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -2330,6 +2330,154 @@ pkgs.runCommand "nixarchy-options"
         }
         echo "gsr-kms-server has its cap_sys_admin wrapper, so recording can start"
 
+        # ---- Remove can un-write everything Install writes (#494, #522) ----
+        #
+        # The Install picker writes three kinds of thing: `id.enable` lines
+        # (nixarchy-app-enable), `#@pkg` markers (nixarchy-pkg-add) and
+        # `#@opt` markers (add_option in nixarchy-search). For months only the
+        # first could be un-written -- nixarchy-app-remove greps `.enable`
+        # lines, so the other two were invisible to it, not merely unrouted.
+        #
+        # SYMMETRY, not existence: each kind is added by the real writer and
+        # removed by the real remover, and the file must come back
+        # byte-for-byte. A check that only asserts "remove deleted a line"
+        # passes while the other two kinds stay stuck, which was exactly the
+        # shipped state.
+        export NIX_STATE_DIR=$PWD/nix-state NIX_LOG_DIR=$PWD/nix-state
+        mkdir -p nix-state
+        rmhome=$PWD/remove-home
+        mkdir -p "$rmhome/.config/nixarchy"
+        cp "$vm/etc/nixarchy/apps-template.nix" "$rmhome/.config/nixarchy/apps.nix"
+        appfile=$rmhome/.config/nixarchy/apps.nix
+        chmod u+w "$appfile"
+        run() { HOME=$rmhome XDG_CONFIG_HOME=$rmhome/.config PATH="$vm/sw/bin:$PATH" "$@"; }
+
+        # An app: enable uncomments the marked row, disable re-comments it.
+        appid=$(grep -oE '#@ [a-z0-9_-]+$' "$appfile" | head -1 | cut -d' ' -f2)
+        test -n "$appid" || { echo "the apps template has no plain #@ marker to test with" >&2; exit 1; }
+        before=$(cksum < "$appfile")
+        run nixarchy-app-enable "$appid" >/dev/null
+        grep -q "^[[:space:]]*$appid\.enable" "$appfile" || {
+          echo "nixarchy-app-enable $appid wrote no .enable line" >&2; exit 1; }
+        run nixarchy-app-disable "$appid" >/dev/null
+        [ "$before" = "$(cksum < "$appfile")" ] || {
+          echo "app add/remove is not symmetric: enable then disable changed the file" >&2
+          exit 1
+        }
+        echo "an enabled app can be un-enabled, byte for byte"
+
+        # A package. The first add also creates the systemPackages block,
+        # which remove deliberately leaves in place (the user may keep their
+        # own unmarked lines in it) -- so the baseline is taken after the
+        # block exists, and remove must be the exact inverse of add from
+        # there.
+        run nixarchy-pkg-add hello >/dev/null
+        grep -q '#@pkg hello$' "$appfile" || {
+          echo "nixarchy-pkg-add hello wrote no marked line" >&2; exit 1; }
+        withblock=$(cksum < "$appfile")
+        run nixarchy-pkg-add cowsay >/dev/null
+        grep -q '#@pkg cowsay$' "$appfile" || {
+          echo "nixarchy-pkg-add cowsay wrote no marked line" >&2; exit 1; }
+        run nixarchy-pkg-remove cowsay >/dev/null
+        [ "$withblock" = "$(cksum < "$appfile")" ] || {
+          echo "pkg add/remove is not symmetric: adding then removing cowsay changed the file" >&2
+          exit 1
+        }
+        run nixarchy-pkg-remove hello >/dev/null
+        if grep -q '#@pkg ' "$appfile"; then
+          echo "removing the last package left a #@pkg marker behind" >&2; exit 1
+        fi
+        echo "an added package can be removed, byte for byte"
+
+        # An option. add_option lives inside nixarchy-search's fzf loop and
+        # cannot be driven without a tty, so the add is simulated with the
+        # writer's own byte shapes -- and those two greps below pin the
+        # WRITER's format strings, so if add_option changes what it writes,
+        # this goes red here rather than drifting apart silently. Match the
+        # call, not prose: these are the printf/insert_line arguments.
+        grep -qF ' = $value;  #@opt $path' "$vm/sw/bin/nixarchy-search" || {
+          echo "add_option no longer writes '\$path = \$value;  #@opt \$path'" >&2
+          echo "  update the simulated add below to the new shape" >&2
+          exit 1
+        }
+        grep -qF "printf '  # %s = ;  #@opt %s" "$vm/sw/bin/nixarchy-search" || {
+          echo "add_option no longer scaffolds '  # <path> = ;  #@opt <path>'" >&2
+          echo "  update the simulated scaffold below to the new shape" >&2
+          exit 1
+        }
+        # insert_line, byte for byte: payload before the closing brace, with
+        # awk -v doing the \n expansion, exactly as nixarchy-search does it.
+        simulate_add() {
+          tmp2=$(mktemp)
+          awk -v payload="$1" '
+            !ins && /^}[[:space:]]*$/ { printf "%s", payload; ins = 1 }
+            { print }
+          ' "$appfile" > "$tmp2"
+          mv "$tmp2" "$appfile"
+        }
+
+        optbase=$(cksum < "$appfile")
+        simulate_add '\n  services.demo.enable = true;  #@opt services.demo.enable\n'
+        run nixarchy-opt-remove services.demo.enable >/dev/null
+        [ "$optbase" = "$(cksum < "$appfile")" ] || {
+          echo "opt add/remove is not symmetric for a value the picker set" >&2
+          exit 1
+        }
+        # And the scaffold shape: blank line, doc comments, marked line --
+        # one unit in, one unit out.
+        simulate_add '\n  # NIXOS OPTION  services.demo.port\n  # \n  # type:     int\n  # services.demo.port = ;  #@opt services.demo.port\n'
+        run nixarchy-opt-remove services.demo.port >/dev/null
+        [ "$optbase" = "$(cksum < "$appfile")" ] || {
+          echo "opt add/remove is not symmetric for a commented scaffold" >&2
+          exit 1
+        }
+        # A path that is not there must change nothing and say so.
+        if run nixarchy-opt-remove no.such.option >/dev/null 2>&1; then
+          echo "nixarchy-opt-remove succeeded on an option that is not in the file" >&2
+          exit 1
+        fi
+        [ "$optbase" = "$(cksum < "$appfile")" ] || {
+          echo "a refused opt removal still changed the file" >&2; exit 1; }
+        echo "a picker-written option can be removed, byte for byte, scaffold included"
+
+        # The Remove picker must SEE all three kinds -- being removable from
+        # the command line while invisible in the menu is the bug in a
+        # different coat. Comments stripped first; match the greps and the
+        # dispatch, not prose.
+        appremove=$(grep -v '^[[:space:]]*#' "$vm/sw/bin/nixarchy-app-remove")
+        for needle in '#@pkg ' '#@opt ' nixarchy-pkg-remove nixarchy-opt-remove; do
+          printf '%s' "$appremove" | grep -qF -- "$needle" || {
+            echo "nixarchy-app-remove does not handle $needle:" >&2
+            echo "  the Remove menu is then blind to a kind the Install picker writes" >&2
+            exit 1
+          }
+        done
+        echo "the Remove picker lists apps, packages and options"
+
+        # And the ROUTE, not just the call site: #498 shipped `nixarchy try`
+        # advertised and unreachable, because nothing asserted the dispatcher
+        # had a row for it. Run the dispatcher itself; a missing route falls
+        # through to `exec omarchy ...` and dies as an unknown Omarchy
+        # command instead of reaching nixarchy-pkg-remove's own refusal.
+        grep -q 'nixarchy pkg remove' "$vm/sw/bin/nixarchy" || {
+          echo "the dispatcher's usage does not advertise 'nixarchy pkg remove'" >&2
+          exit 1
+        }
+        if r=$(run "$vm/sw/bin/nixarchy" pkg remove nosuchattr 2>&1); then
+          echo "nixarchy pkg remove succeeded on a package that is not in the file:" >&2
+          printf '%s\n' "$r" >&2
+          exit 1
+        fi
+        case "$r" in
+          *"no package 'nosuchattr'"*) ;;
+          *)
+            echo "nixarchy pkg remove did not reach nixarchy-pkg-remove; it said:" >&2
+            printf '%s\n' "$r" >&2
+            exit 1
+            ;;
+        esac
+        echo "nixarchy pkg remove routes to nixarchy-pkg-remove"
+
           touch $out
       ''
     else


### PR DESCRIPTION
**Epic #491, as one pull request.** Closes #492, closes #493, closes #494, closes #497, closes #522.

*(A keyword each — `Closes #a, #b` closes only the first, which cost four issues an hour ago.)*

## Remove now means remove

The picker could write three kinds of thing and un-write **one**:

| written as | removable before | now |
|---|---|---|
| `firefox.enable = true;` | yes | yes |
| `vscode  #@pkg vscode` | **no** | `nixarchy-pkg-remove` |
| `services.foo.enable = …  #@opt` | **no** | `nixarchy-opt-remove` |

`nixarchy-app-remove` greps `.enable` lines, so the other two were **invisible** to it rather than merely unrouted.

**#522 is in scope, not excused.** The `#@opt` marker is the claim of authorship, per `nixarchy-channel`'s rule: a set value or a filled-in scaffold that kept its marker loses one line; an untouched scaffold loses the whole unit; **a line whose marker the user stripped is invisible** — that is how an adopted line stays out of reach.

## A miss opens the picker

No args → the picker. An unresolvable name → the picker **pre-filtered on the query**, so a typo becomes a fuzzy match instead of a URL. Exact matches keep the fast path.

## One of my issue premises was wrong

I wrote #493 saying to pull licence/homepage/unfree/broken *"out of the `nix search --json` output it already parses"*. **It does not carry them** — Nix 2.34 gives `pname`, `version`, `description` only, verified live.

So `modules/pkg-index.nix` walks `recurseForDerivations` instead, proven to produce an **identical row set** — 112,755 attrs both ways, same nixpkgs, same ~30s, every `meta` access under `tryEval`.

Status (`[enabled]`/`[queued]`) is stamped at **picker start**, not baked into the per-generation index — what is selected changes with every pick. No evaluation, nothing per keystroke, preview stays inlined.

## The check asserts symmetry, and the route by executing it

**Add each kind, remove it, assert the file returns byte-for-byte.** A check asserting "remove deleted a line" passes while the other two kinds stay stuck — which was the state.

And it **runs** `nixarchy pkg remove`. That matters: #521's route loop matches `^ *$verb\)` and **cannot see a two-word subcommand**, so `remove)` under `pkg)` is invisible to it. Worse, the red output shows what unrouted actually does:

```
nixarchy pkg remove → omarchy-pkg-remove: line 18: yay: command not found
```

It falls through to upstream's **Arch** package manager. A better argument for asserting routes than the one I wrote.

## The rebase

#521's ctrl-t key and this branch's richer index both rewrite the same fzf invocation — not an additive conflict. Resolved semantically: the status pass builds `$shown`, and `--expect=ctrl-t` now reads from it. Taking either side alone would have silently dropped a feature.

## Verified

`checks.options` (both epics' assertions, **proven red twice**: opt-remove's blank-line deletion, and the dispatcher arm deleted — reproducing #498's exact bug) · `bin-ledger` · `doc-options` · `readme-counts --check` · fmt, statix, `deadnix --fail` all rc=0.

Two commits carry `wip:` subjects. This is a multi-commit PR so the squash uses this title, but do not squash on one of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5