### PR TITLE
Stable evaluates, and does not ship the lock that strands you (#526, #528)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -375,14 +375,41 @@
           # The compositor the Lua config is written against, not nixpkgs'.
           inherit (hyprland.packages.${final.stdenv.hostPlatform.system}) hyprland;
 
-          # The desktop shell. nixpkgs' own, since #35: it was overridden to
-          # 0.3.1 while nixpkgs sat on 0.3.0, whose session lock reaches
-          # qFatal when screens sleep and wake while locked -- and the
-          # Wayland protocol keeps the compositor locked when its lock client
-          # dies, so the machine is left blank with nowhere to type a
-          # password. nixpkgs now ships 0.3.1 from the same tag and the same
-          # URL the override fetched, so the override had become a no-op.
-          inherit (final) quickshell;
+          # The desktop shell, and the one package here pinned to a FLOOR
+          # rather than left to the machine's own nixpkgs (#528).
+          #
+          # quickshell 0.3.0's session lock reaches qFatal when screens sleep
+          # and wake while locked, and the Wayland session-lock protocol
+          # deliberately keeps the compositor locked when its lock client
+          # disappears -- so the machine is left blank with nowhere to type a
+          # password, and power-cycling is the only way back in. #35 records
+          # it happening three times in one night on a real machine.
+          #
+          # The override that fixed it was dropped in #380 because nixpkgs
+          # had reached 0.3.1 "from the same tag and the same URL the
+          # override fetched", which made it a no-op. That was true of the
+          # nixpkgs this repo is developed against and of no other: measured
+          # 2026-09-10, nixos-26.05 ships 0.3.0 and unstable ships 0.3.1. So
+          # a user following stable -- the channel that SOUNDS safer -- would
+          # get the session lock that can strand them out of their laptop,
+          # and would not find out until their screens next slept.
+          #
+          # Hence a floor rather than a no-op or a warning. A warning is the
+          # wrong instrument for this one: what it costs to ignore is access
+          # to your own machine, and it would be read months before it is
+          # paid. On unstable the branch is not taken and nothing about the
+          # package changes.
+          quickshell =
+            if lib.versionAtLeast final.quickshell.version "0.3.1" then
+              final.quickshell
+            else
+              final.quickshell.overrideAttrs (_: rec {
+                version = "0.3.1";
+                src = final.fetchzip {
+                  url = "https://git.outfoxxed.me/quickshell/quickshell/archive/refs/tags/v${version}.tar.gz";
+                  hash = "sha256-CLX2Zp5i5BuLbOxNOkwRd9YY84IOrACNxBV79o9/F9Y=";
+                };
+              });
           # The screensaver's text-effects engine, packaged in this repo rather
           # than nixpkgs. Passed explicitly for the same reason hyprland is: it
           # lives under nixarchy-apps, which callPackage does not search.

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -753,10 +753,36 @@ in
         yaru-theme
         # Yaru inherits from Adwaita for anything it does not draw itself.
         adwaita-icon-theme
-
+      ])
+      ++ (
         # Why: modules/AGENTS.md#config-hypr-xdph-conf-which-the-package-seeds-into
-        hyprland-preview-share-picker
-
+        #
+        # Conditional, and loud when it is absent. nixos-26.05 carries no
+        # such attribute at all -- not an older one, none -- so on stable
+        # this was an `undefined variable` that stopped the whole
+        # configuration from evaluating (#526). Guarding it is what lets
+        # stable evaluate.
+        #
+        # Not a bare `optional`, which would trade a loud eval error for
+        # precisely the failure #202 took a day to find: the portal execs a
+        # name that is not there, reads selection -1 and destroys the
+        # session, so screen sharing dies in every application with no dialog
+        # and no error anywhere a user would look. A missing package that
+        # announces itself is a different thing from one that does not.
+        #
+        # Spliced in here rather than appended to the end of the list because
+        # `environment.systemPackages` order reaches buildEnv: keeping the
+        # position keeps the package list byte-identical, in order as well as
+        # in content, for every user whose nixpkgs has the picker -- which is
+        # everyone on unstable. A fix for stable should cost them nothing,
+        # and "nothing" is checkable rather than asserted.
+        lib.warnIf (!(pkgs ? hyprland-preview-share-picker)) ''
+          nixarchy: this nixpkgs has no hyprland-preview-share-picker, so
+          screen sharing will fail in every application -- silently, with no
+          dialog (#202). nixos-26.05 is the known case; unstable has it.
+        '' (lib.optional (pkgs ? hyprland-preview-share-picker) pkgs.hyprland-preview-share-picker)
+      )
+      ++ (with pkgs; [
         # Omarchy sets a cursor size but never a cursor theme -- on Arch one
         # comes with the desktop packages. NixOS ships none, so Hyprland used
         # its own built-in pointer. Bibata is here rather than Yaru or Adwaita


### PR DESCRIPTION
Stable evaluates, and does not ship the lock that strands you (#526, #528)

Two children of #525, together because they are one surface: what nixarchy
does when the machine's nixpkgs is not the one it is developed against.

## The rule these follow

nixarchy pins what *nixarchy* needs. It does not move what the user has.

Both changes are scoped to what this project builds -- the `quickshell`
argument to `pkgs/omarchy`, and nixarchy's own contribution to
`environment.systemPackages`. Neither is an overlay on the user's `pkgs`.
So `pkgs.quickshell` stays whatever that machine's nixpkgs says it is, and
a user who overrides either one keeps their value. Hyprland has always
worked this way (it comes from hyprwm, on both channels); this is the same
principle applied to the two packages that needed it.

## #526 -- stable did not evaluate

    nix eval --override-input nixpkgs github:NixOS/nixpkgs/nixos-26.05 \
      .#nixosConfigurations.vm.config.system.build.toplevel.drvPath
    error: undefined variable 'hyprland-preview-share-picker'
    at modules/nixos.nix:758

nixos-26.05 carries no such attribute at all -- not an older version, none.
Guarded, so stable evaluates.

But guarded *loudly*. A bare `lib.optional` would have traded a loud
evaluation error for exactly the failure #202 took a day to find: the portal
execs a name that is not there, reads selection -1 and destroys the session,
so screen sharing dies in every application with no dialog and no error
anywhere a user would look. The guard warns by name instead, so the
degradation is something a user can act on.

Spliced in at its original position rather than appended, because
`environment.systemPackages` order reaches buildEnv -- see the measurement
below.

## #528 -- stable ships the quickshell that can lock you out

quickshell 0.3.0's session lock reaches qFatal when screens sleep and wake
while locked, and the Wayland session-lock protocol deliberately keeps the
compositor locked when its lock client disappears. The machine is left blank
with nowhere to type a password. #35 records it happening three times in one
night on a real machine.

The override that fixed it was dropped in #380 because nixpkgs had reached
0.3.1 "from the same tag and the same URL the override fetched", making it a
no-op. That was true of the nixpkgs this repo is developed against and of no
other. Measured today:

    nixos-26.05   quickshell 0.3.0
    unstable      quickshell 0.3.1

So a user choosing "stable" -- the channel that sounds safer -- would have
got the lockscreen that can strand them out of their laptop, and would not
have found out until their screens next slept.

Now a floor rather than a no-op: below 0.3.1 the override is reinstated,
fetching the same tag from the same URL it fetched before. A warning was the
wrong instrument here -- what it costs to ignore is access to your own
machine, and it would be read months before it is paid.

## Verification

| | |
|---|---|
| stable evaluates | yes, toplevel drvPath |
| quickshell in the stable system's dependency graph | **0.3.1** |
| the picker warning fires on stable, naming #202 | yes |
| unstable package list | **byte-identical, order included** |
| statix / deadnix --fail / nix fmt --ci | clean |

The unstable row is the one that took the most work and matters most: 288
packages before, 288 after, identical as a set *and* in order. A fix for a
channel nobody is on yet should cost the people who are on this one nothing,
and "nothing" is checkable rather than asserted. Compared as package lists
rather than closure hashes on purpose -- `inputSources` carries
`flake.outPath`, so a dirty tree changes every derivation regardless
(AGENTS.md section 5).

The quickshell row is checked on the system closure, not on an intermediate
expression, for the reason #380 gave: it is the property #35 exists to
protect.

## Also found, not fixed here

On stable, home-manager warns that it is version 26.11 against nixpkgs
26.05, and says mismatched versions cause errors. home-manager follows
unstable in this flake regardless of the machine's channel. That is a real
gap in #525's plan and is recorded on the epic; it belongs to the child that
offers the choice, not to this one.

No check guards either fix yet -- that is #527, deliberately next in the
epic's order.

Part of #525.
Closes #526
Closes #528
