### PR TITLE
A Roadmap row stops costing a 55-minute install, and home-manager follows the channel

### DIFF
--- a/.github/scripts/pr-touches-build.sh
+++ b/.github/scripts/pr-touches-build.sh
@@ -85,11 +85,13 @@ while IFS= read -r f; do
     .github/workflows/build.yml) relevant=true; break ;;
     .github/scripts/pr-touches-build.sh) relevant=true; break ;;
 
-    # README.md is NOT in this list, and that is deliberate rather than an
+    # README.md is NOT in this arm, and that is deliberate rather than an
     # oversight. build.yml derives the app and command counts from data/ and
     # greps README.md for them, so a README-only edit can legitimately fail
-    # the omarchy job -- it did on #424. Excluding it would turn a working
-    # guard into one that only runs when something else changed too.
+    # the omarchy job -- it did on #424. Excluding it HERE would turn a
+    # working guard into one that only runs when something else changed too.
+    # It is excluded from the INSTALL question further down instead, which
+    # is a different question and does not touch that guard.
     # `AGENTS.md` matched only at the root, so installer/AGENTS.md and
     # modules/AGENTS.md fell through to `*` and ran the whole build -- and,
     # once install-check grew its own narrower list, a 26-46 minute VM install
@@ -118,6 +120,27 @@ while IFS= read -r f; do
     tests/hardware-configuration.nix|tests/test-instrumentation.nix)
       relevant=true; break ;;
     tests/*)
+      if [ "$install_only" = true ]; then continue; fi
+      relevant=true; break ;;
+
+    # README.md, for the install question only -- and the split is the whole
+    # point of it being here rather than in the arm above.
+    #
+    # The guard that makes README relevant is the omarchy job's: build.yml
+    # derives the app and command counts from data/ and greps README for
+    # them, and it caught a real mismatch on #424. That job runs in build.yml
+    # and is not gated by the install question at all -- install-check.yml's
+    # own header says its cap covers "the one job that boots a VM, not the
+    # build, system, box or omarchy jobs that run beside it". So the counts
+    # are still checked on every README edit, exactly as before.
+    #
+    # What a README edit cannot do is change an install. The three checks the
+    # install job builds -- install, free-space, installer-refusal -- reach
+    # ./hardware-configuration.nix and ./test-instrumentation.nix and nothing
+    # else; no derivation reads README.md. Measured cost of not saying so: a
+    # one-line Roadmap row took a 55-minute VM install, serialised behind the
+    # single slot every other pull request is also waiting for.
+    README.md)
       if [ "$install_only" = true ]; then continue; fi
       relevant=true; break ;;
 

--- a/flake.lock
+++ b/flake.lock
@@ -90,6 +90,27 @@
         "type": "github"
       }
     },
+    "home-manager-stable": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788642154,
+        "narHash": "sha256-sPpQFVaFTDqO/4vvCAhuAhqTgqN/ygu+9eJcs5eB0js=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "fd0956c99c41ae3c13a73a638f1f7e963aebc4ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-26.05",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "home-manager_2": {
       "inputs": {
         "nixpkgs": [
@@ -605,6 +626,7 @@
       "inputs": {
         "disko": "disko",
         "home-manager": "home-manager",
+        "home-manager-stable": "home-manager-stable",
         "hypr-rdp": "hypr-rdp",
         "hyprland": "hyprland",
         "microvm": "microvm",

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,29 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # The same, on the release branch, for a machine whose nixpkgs is a
+    # release rather than unstable (#525).
+    #
+    # home-manager and nixpkgs are developed as a pair, and home-manager says
+    # so itself: point this flake's nixpkgs at nixos-26.05 and every
+    # evaluation carries its warning that "using mismatched versions is
+    # likely to cause errors and unexpected behavior" -- version 26.11
+    # against nixpkgs 26.05. That is upstream's judgement, not ours.
+    #
+    # installer/template/flake.nix has told users to move the two together
+    # since it was written. This is that advice applied to this flake, so the
+    # advice is something the project follows rather than only prints.
+    #
+    # Worth being plain about the cost of NOT doing it, because it is not the
+    # warning itself: modules/nixos.nix now emits a real warning on stable,
+    # about screen sharing being gone. A second warning that every stable
+    # evaluation prints and nobody can act on is what teaches a reader to
+    # skip both.
+    home-manager-stable = {
+      url = "github:nix-community/home-manager/release-26.05";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # Why: docs/internals/flake.md#hyprland-from-hyprwm-tracking-their-branch-not-a
     hyprland.url = "github:hyprwm/Hyprland";
 
@@ -121,6 +144,7 @@
       nixpkgs,
       systems,
       home-manager,
+      home-manager-stable,
       hyprland,
       omarchy,
       zen-browser,
@@ -138,6 +162,37 @@
       );
 
       omarchyVersion = "4.0.3";
+
+      # home-manager, matched to whichever nixpkgs this is being evaluated
+      # against (#525).
+      #
+      # The two are developed as a pair, and home-manager warns when they are
+      # not: "Home Manager version 26.11 and Nixpkgs version 26.05 ... likely
+      # to cause errors and unexpected behavior". Nothing here overrides a
+      # user's choice -- it FOLLOWS it. Whatever nixpkgs the machine is on
+      # picks the home-manager built for it.
+      #
+      # `lib.trivial.release` is nixpkgs' own release string ("26.05",
+      # "26.11"), so this reads the package set actually in use rather than
+      # any flag or option someone has to remember to set.
+      #
+      # The accepted weakness, stated rather than hidden: `stableRelease`
+      # must name the same release as the home-manager-stable input's URL,
+      # and nothing here can check that -- a flake input URL is not readable
+      # from inside the flake. The two move together when NixOS cuts a
+      # release. What makes that survivable is that being wrong is LOUD: if
+      # they disagree, home-manager's own mismatch warning is exactly what
+      # comes back, which is the thing this exists to remove.
+      #
+      # A machine on some third release (25.11, say) gets master and its
+      # warning. That is honest -- this project carries one release branch,
+      # not every one -- and the warning names the real situation.
+      stableRelease = "26.05";
+      homeManagerModule =
+        if lib.trivial.release == stableRelease then
+          home-manager-stable.nixosModules.home-manager
+        else
+          home-manager.nixosModules.home-manager;
 
       # Why: docs/internals/flake.md#which-nixarchy-built-this-machine-208-for-nixarchy
       nixarchyRev = self.shortRev or self.dirtyShortRev or "unknown";
@@ -975,7 +1030,7 @@
               specialArgs = { inherit inputs; };
               modules = [
                 self.nixosModules.nixarchy
-                home-manager.nixosModules.home-manager
+                homeManagerModule
                 ./vm/configuration.nix
               ];
             };
@@ -986,7 +1041,7 @@
               specialArgs = { inherit inputs; };
               modules = [
                 self.nixosModules.nixarchy
-                home-manager.nixosModules.home-manager
+                homeManagerModule
                 ./vm/configuration.nix
                 (
                   { lib, ... }:
@@ -1090,7 +1145,7 @@
             specialArgs = { inherit inputs; };
             modules = [
               self.nixosModules.nixarchy
-              home-manager.nixosModules.home-manager
+              homeManagerModule
               inputs.disko.nixosModules.disko
 
               # Why: docs/internals/flake.md#one-module-that-imports-the-machines-own-two-rathe

--- a/installer/template/flake.nix
+++ b/installer/template/flake.nix
@@ -26,12 +26,12 @@
     # `omarchy update`) moves it forward when you decide to.
     #
     # To follow STABLE nixpkgs instead, point this at the release branch (e.g.
-    # "github:NixOS/nixpkgs/nixos-25.05") -- and move home-manager with it, as
+    # "github:NixOS/nixpkgs/nixos-26.05") -- and move home-manager with it, as
     # the two are developed as a pair. Add this inside the `nixarchy` block
     # below, beside the `follows`:
     #
     #   inputs.home-manager.url =
-    #     "github:nix-community/home-manager/release-25.05";
+    #     "github:nix-community/home-manager/release-26.05";
     #
     # then `nix flake update nixpkgs` and `nh os switch` (the changed
     # home-manager override is re-locked in the same pass).

--- a/tests/install-gate.nix
+++ b/tests/install-gate.nix
@@ -45,9 +45,12 @@ pkgs.runCommand "nixarchy-install-gate"
     t "a module does"                          --install "modules/nixos.nix" true
     t "installer code does"                    --install "installer/install.sh" true
     t "a data row does"                        --install "data/apps.nix" true
-    # README is deliberately NOT excluded: build.yml derives counts from data/
-    # and greps README for them, so a README-only edit can legitimately fail.
-    t "README does"                            --install "README.md" true
+    # README does not run the VM, and the pair below is the claim: exempt
+    # from the INSTALL question, still relevant to the BUILD one. The guard
+    # that matters -- build.yml deriving the app and command counts from
+    # data/ and grepping README for them, which caught #424 -- lives in the
+    # omarchy job, which the install gate never covered.
+    t "README does not run the VM"             --install "README.md" false
 
     # `AGENTS.md` matched at the ROOT only, so installer/AGENTS.md ran a
     # 26-46 minute VM install for a markdown file. Every depth, because
@@ -58,6 +61,10 @@ pkgs.runCommand "nixarchy-install-gate"
 
     echo "the build question, unchanged:"
     t "an unrelated check still builds"        "" "tests/substitutable.nix" true
+    # The half of the README pair that keeps #424's guard honest. If this
+    # ever flips to false, a README whose counts disagree with data/ merges
+    # without the omarchy job ever looking at it.
+    t "README still builds"                    "" "README.md" true
     t "docs still do not"                      "" "docs/manual/android.md" false
     t "the gate itself always does"            "" ".github/scripts/pr-touches-build.sh" true
     t "a nested AGENTS.md builds nothing"      "" "modules/AGENTS.md" false


### PR DESCRIPTION
A Roadmap row stops costing a 55-minute install, and home-manager follows the channel

Two things, both of which came out of filing #525 rather than out of the epic
itself.

## The install gate: README is exempt from the INSTALL question only

Adding an epic to the README's Roadmap table took a **55-minute VM install**,
serialised behind the single slot every other pull request is also queued on.
It happened twice today.

`pr-touches-build.sh` carries a comment explaining that README is deliberately
NOT excluded, and that comment is right -- about the question it was written
for. build.yml derives the app and command counts from `data/` and greps
README for them, and that guard caught a real mismatch on #424. Excluding
README outright would turn a working guard into one that only runs when
something else changed too.

But that argument is entirely about the **omarchy job**, and the install gate
never covered the omarchy job. install-check.yml's own header says so:

> this caps the one job that boots a VM, not the build, system, box or
> omarchy jobs that run beside it

So README moves into the `--install`-only arm, beside `tests/*`. The counts
are still checked on every README edit, by the same job as before. What goes
away is a VM install for a file no derivation reads -- the three checks that
job builds reach `./hardware-configuration.nix` and
`./test-instrumentation.nix` and nothing else.

The gate's own check now asserts **both halves**, because one without the
other is the bug:

    t "README does not run the VM"   --install "README.md" false
    t "README still builds"          ""        "README.md" true

Verified through the script directly:

| file | install | build |
|---|---|---|
| `README.md` | false | **true** |
| `tests/install.nix` | true | true |
| `modules/nixos.nix` | true | true |
| `docs/manual/android.md` | false | false |

## home-manager follows the machine's nixpkgs

Evaluating against nixos-26.05 printed, on every evaluation:

    You are using Home Manager version 26.11 and Nixpkgs version 26.05.
    Using mismatched versions is likely to cause errors and unexpected
    behavior.

That is home-manager's own judgement, not this project's. The two are
developed as a pair, and `installer/template/flake.nix` has told users to
move them together since it was written -- while this flake did not. This is
that advice being something the project follows rather than only prints.

A second input on the release branch, selected by nixpkgs' own
`lib.trivial.release`. It does not override anyone's choice, it FOLLOWS it:
whatever nixpkgs the machine is on picks the home-manager built for it.

The reason it was worth fixing now rather than with the rest of #525 is not
the warning itself. modules/nixos.nix now emits a REAL warning on stable,
about screen sharing being gone. A second warning that every stable
evaluation prints and nobody can act on is what teaches a reader to skip
both.

The template's worked example moved from 25.05 to 26.05 in passing -- a stale
example is a documentation bug, and it now names the branch this flake
actually carries.

## Verification

| | |
|---|---|
| stable: home-manager mismatch warning | **gone** -- measured with #534 applied |
| stable: remaining warnings | one, the picker/screen-sharing one, which is actionable |
| unstable: which home-manager | master, unchanged (release 26.11 != 26.05) |
| **unstable: package list** | **byte-identical, order included** |
| statix / deadnix --fail / nix fmt --ci x2 | clean |
| gate behaviour | table above, run through the script itself |

Accepted weakness, stated rather than hidden: `stableRelease` must name the
same release as the `home-manager-stable` input's URL, and nothing can check
that -- a flake input URL is not readable from inside the flake. What makes
it survivable is that being wrong is loud: the two disagreeing produces
exactly the mismatch warning this removes. A machine on some third release
gets master and that warning, which is honest -- this project carries one
release branch, not every one.

The home-manager row is measured on the combined tree with #534, not on this
branch alone: without #534's picker guard, evaluation against stable aborts
at `undefined variable 'hyprland-preview-share-picker'` before home-manager
would warn at all. Said explicitly because a table row that cannot be
reproduced from the branch it sits on is the kind of claim that rots.

actionlint reports five pre-existing info/style findings in build.yml and
omarchy.yml, neither of which this touches.

Part of #525.
