### PR TITLE
Stable is checked in twenty-three seconds, and it found something on its first run

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -567,6 +567,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1789009968,
+        "narHash": "sha256-GB16oaxpsrnGNnGIE+0uYBqMRzB9X6FYDUvjvnJAYew=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d58a46e3bc02d91ebe04667f8397752a749c0024",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1788881743,
@@ -634,6 +650,7 @@
         "nixi": "nixi",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_2",
+        "nixpkgs-stable": "nixpkgs-stable",
         "omarchy": "omarchy",
         "sops-nix": "sops-nix",
         "systems": "systems_2",

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,25 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # Stable nixpkgs, carried so CI can prove this flake still evaluates
+    # against it (#527).
+    #
+    # PINNED in the lock rather than resolved fresh, and the split is
+    # deliberate. A moving ref would turn every open pull request red the
+    # moment upstream moved, for a reason none of their authors could fix --
+    # which is the failure that took the roadmap check off pull requests
+    # earlier in this file's history. nightly.yml's canary already owns
+    # upstream drift: it runs a bare `nix flake update` and its failure has
+    # its own identity, "a canary failure means UPSTREAM moved under us".
+    #
+    # So: pull requests get a fixed answer, and the canary is what notices
+    # 26.05 moving. Two questions, two places, neither pretending to be the
+    # other.
+    #
+    # Nothing on a user's machine reads this. It is a check input, and the
+    # only thing that evaluates it is tests/stable-eval.nix.
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-26.05";
+
     # The same, on the release branch, for a machine whose nixpkgs is a
     # release rather than unstable (#525).
     #
@@ -145,6 +164,7 @@
       systems,
       home-manager,
       home-manager-stable,
+      nixpkgs-stable,
       hyprland,
       omarchy,
       zen-browser,
@@ -188,11 +208,46 @@
       # warning. That is honest -- this project carries one release branch,
       # not every one -- and the warning names the real situation.
       stableRelease = "26.05";
-      homeManagerModule =
-        if lib.trivial.release == stableRelease then
+      homeManagerFor =
+        release:
+        if release == stableRelease then
           home-manager-stable.nixosModules.home-manager
         else
           home-manager.nixosModules.home-manager;
+      homeManagerModule = homeManagerFor lib.trivial.release;
+
+      # The smoke VM's module list, shared by the real configuration and by
+      # the stable evaluation in tests/stable-eval.nix (#527).
+      #
+      # Shared rather than copied, because a check that proves "this
+      # evaluates on stable" while evaluating a DIFFERENT set of modules
+      # proves nothing about the thing it names -- and a copied list is one
+      # somebody extends in exactly one of the two places. Same failure mode
+      # config-warnings.nix avoids by deriving its configuration list instead
+      # of writing one down.
+      #
+      # A function of the home-manager module rather than a plain list: the
+      # two systems need different ones, and the ORDER has to stay exactly as
+      # it was. environment.systemPackages order reaches buildEnv, so moving
+      # a module is not free even when the resulting set is identical.
+      vmModulesWith = hm: [
+        self.nixosModules.nixarchy
+        hm
+        ./vm/configuration.nix
+      ];
+
+      # This flake, evaluated against stable nixpkgs. NOT a
+      # nixosConfigurations entry, deliberately: config-warnings.nix maps over
+      # every entry there, so adding one would pull a full stable evaluation
+      # into an unrelated check -- and that check asserts on warnings, while
+      # this configuration emits one on purpose (the screen-sharing note in
+      # modules/nixos.nix). It would have gone red on arrival, for a reason
+      # that is correct behaviour.
+      stableVm = nixpkgs-stable.lib.nixosSystem {
+        system = "x86_64-linux";
+        specialArgs = { inherit inputs; };
+        modules = vmModulesWith (homeManagerFor nixpkgs-stable.lib.trivial.release);
+      };
 
       # Why: docs/internals/flake.md#which-nixarchy-built-this-machine-208-for-nixarchy
       nixarchyRev = self.shortRev or self.dirtyShortRev or "unknown";
@@ -1055,11 +1110,7 @@
             vm = nixpkgs.lib.nixosSystem {
               system = "x86_64-linux";
               specialArgs = { inherit inputs; };
-              modules = [
-                self.nixosModules.nixarchy
-                homeManagerModule
-                ./vm/configuration.nix
-              ];
+              modules = vmModulesWith homeManagerModule;
             };
 
             # Why: docs/internals/flake.md#the-same-vm-with-room-to-run-a-model
@@ -1485,6 +1536,14 @@
           # and not a preference.
           config-warnings = import ./tests/config-warnings.nix {
             inherit inputs;
+            pkgs = pkgsFor.${system};
+          };
+
+          # Evaluation against stable, ~20s and no VM (#527). `stableVm` is
+          # passed in rather than reached through `inputs.self`, because it is
+          # deliberately not a nixosConfigurations entry -- see its definition.
+          stable-eval = import ./tests/stable-eval.nix {
+            inherit inputs stableVm;
             pkgs = pkgsFor.${system};
           };
 

--- a/installer/host.nix
+++ b/installer/host.nix
@@ -123,7 +123,25 @@
   # unreproducible from the flake it was installed from, which is Invariant 1,
   # and it is why checks.install went red the moment this was added. nixpkgs is
   # safe because both sides resolve the same lock entry to the same store path.
-  nix.registry.nixpkgs.flake = inputs.nixpkgs;
+  #
+  # NOT set here any more (#527). NixOS's own
+  # nixos/modules/misc/nixpkgs-flake.nix already pins the registry, to
+  # `nixpkgs.flake.source` -- the nixpkgs actually being evaluated -- which is
+  # the same store path this line used to name whenever the machine follows
+  # this flake's nixpkgs, and the RIGHT one when it does not.
+  #
+  # Evaluating against nixos-26.05 is what showed the difference:
+  #
+  #   error: The option `nix.registry.nixpkgs.to.path' has conflicting
+  #   definition values:
+  #   - In `nixos/modules/config/nix-flakes.nix':  <this flake's nixpkgs>
+  #   - In `nixos/modules/misc/nixpkgs-flake.nix': <the machine's nixpkgs>
+  #
+  # A tie, because both sides are mkDefault -- so it could not be resolved by
+  # lowering ours, and lowering it would have been wrong anyway: on a stable
+  # machine, `nixpkgs#foo` pointed at this flake's UNSTABLE nixpkgs is exactly
+  # the "binary built against a different glibc" the paragraph above exists to
+  # prevent. The requirement stands; NixOS is now what meets it.
   nix.settings.flake-registry = "";
 
   # `nh os switch` is the loop the user lives in, and it only works with no

--- a/pkgs/omarchy/default.nix
+++ b/pkgs/omarchy/default.nix
@@ -1841,6 +1841,19 @@ stdenvNoCC.mkDerivation {
 
   passthru = {
     inherit runtimeDeps;
+
+    # The desktop shell this build actually uses, so it can be asserted on
+    # (#528). flake.nix pins it to a FLOOR: on a nixpkgs shipping quickshell
+    # below 0.3.1 the argument is overridden, because 0.3.0's session lock
+    # reaches qFatal when screens sleep while locked and leaves the machine
+    # with nowhere to type a password.
+    #
+    # Exposed because `pkgs.quickshell` is the wrong place to look and would
+    # give the wrong answer: the floor is deliberately scoped to this package
+    # rather than applied as an overlay, so that a user's own quickshell is
+    # left exactly as their nixpkgs has it. The version the SESSION launches
+    # is this one, and until now nothing could see it.
+    inherit quickshell;
   };
 
   meta = {

--- a/tests/stable-eval.nix
+++ b/tests/stable-eval.nix
@@ -1,0 +1,135 @@
+{
+  inputs,
+  pkgs,
+  stableVm,
+}:
+# This flake still evaluates against stable nixpkgs (#527).
+#
+# ## What this proves, and what it does not
+#
+# It proves EVALUATION. The expression is valid against nixos-26.05: every
+# attribute it names exists, every option it sets is an option, and the
+# system's derivation can be computed.
+#
+# It does NOT prove the machine boots, that the desktop comes up, or that
+# anything on it works. Nothing here starts a VM. Read a green tick on this
+# check as "the expression is valid on stable" and nothing more -- the
+# temptation is to read it as "stable works", and it does not say that.
+#
+# That limit is a budget decision, not an oversight. The install job is 55 of
+# 58 minutes on a single self-hosted runner and gates every pull request; a
+# second install slot for stable would roughly double merge latency on the
+# hardware that is already the bottleneck. Evaluation is what is affordable,
+# so evaluation is what is claimed.
+#
+# ## Why it exists
+#
+# Stable stopped evaluating and nobody noticed, because nothing looked:
+#
+#   error: undefined variable 'hyprland-preview-share-picker'
+#   at modules/nixos.nix:758
+#
+# The cheapest class of failure there is, found by hand months later. This
+# costs about twenty seconds and no VM.
+#
+# ## Why the assertions below, and not just the evaluation
+#
+# Forcing the toplevel would catch an `undefined variable`. It would not
+# catch the thing that made stable DANGEROUS rather than merely broken:
+# nixos-26.05 ships quickshell 0.3.0, whose session lock reaches qFatal when
+# screens sleep and wake while locked, leaving the machine blank with nowhere
+# to type a password (#35, #528). That was fixed by a floor in flake.nix, and
+# a floor with nothing watching it is one somebody removes as dead code.
+let
+  inherit (pkgs) lib;
+
+  cfg = stableVm.config;
+
+  # The evaluation itself. `unsafeDiscardStringContext` on purpose: the point
+  # is to force the system's derivation to be COMPUTED, not to build it. With
+  # the context left on, this check would depend on the stable toplevel and a
+  # twenty-second evaluation would become a full system build of a package set
+  # nothing here has cached -- which is precisely the install-slot cost this
+  # check exists to avoid.
+  toplevel = builtins.unsafeDiscardStringContext cfg.system.build.toplevel.drvPath;
+
+  release = stableVm.pkgs.lib.trivial.release;
+
+  # #528, watched. Read off the built system's own package set rather than
+  # from nixpkgs, because what matters is the version the SESSION launches
+  # after the floor in flake.nix has been applied -- asking nixpkgs directly
+  # would ask a question whose answer is 0.3.0 and always was.
+  quickshellVersion = cfg.programs.nixarchy.package.passthru.quickshell.version;
+in
+pkgs.runCommand "nixarchy-stable-eval"
+  {
+    inherit toplevel release;
+
+    # Named so the log says which stable this was, not merely "stable".
+    stableRev = inputs.nixpkgs-stable.rev or "unlocked";
+
+    # #526, watched from the other side. The picker is absent on 26.05, and
+    # modules/nixos.nix guards it -- so the guard is doing its job when this
+    # is false, and the guard has become dead code when it is true. Either is
+    # worth knowing; only one of them is worth failing on, below.
+    pickerPresent = lib.boolToString (stableVm.pkgs ? hyprland-preview-share-picker);
+
+    inherit quickshellVersion;
+
+    # The version below which 0.3.0's lockscreen bug is present. Named so the
+    # failure message can quote it rather than restate it.
+    quickshellFloor = "0.3.1";
+
+    # Decided in Nix, not in shell: a shell string comparison orders 0.3.10
+    # before 0.3.9, and this is the assertion that is load-bearing for whether
+    # somebody can get back into their laptop.
+    quickshellOk = lib.boolToString (lib.versionAtLeast quickshellVersion "0.3.1");
+  }
+  ''
+    echo "nixpkgs-stable: $release @ $stableRev"
+    echo "the system evaluates: $toplevel"
+
+    # A floor, in the shape this repository keeps arriving at: a check whose
+    # inputs came back empty satisfies every comparison below while proving
+    # nothing. tests/reference-initrd.nix refuses for the same reason.
+    case "$toplevel" in
+      /nix/store/*-nixos-system-*.drv) ;;
+      *)
+        echo "::error::the stable toplevel is not a system derivation path:" >&2
+        echo "  '$toplevel'" >&2
+        echo "  This check cannot answer anything and is refusing rather" >&2
+        echo "  than passing." >&2
+        exit 1
+        ;;
+    esac
+
+    if [ "$release" != "${cfg.system.nixos.release}" ]; then
+      echo "::error::the evaluated release ($release) is not the one the" >&2
+      echo "  system reports (${cfg.system.nixos.release})." >&2
+      exit 1
+    fi
+
+    echo "the share picker is present on this nixpkgs: $pickerPresent"
+
+    echo "the session's quickshell: $quickshellVersion (floor $quickshellFloor)"
+    if [ "$quickshellOk" != "true" ]; then
+      echo "::error::this stable machine would run quickshell" >&2
+      echo "  $quickshellVersion, below the $quickshellFloor floor." >&2
+      echo >&2
+      echo "  quickshell 0.3.0's session lock reaches qFatal when screens" >&2
+      echo "  sleep and wake while locked, and the Wayland protocol keeps the" >&2
+      echo "  compositor locked when its lock client dies -- so the machine" >&2
+      echo "  is left blank with nowhere to type a password (#35, #528)." >&2
+      echo >&2
+      echo "  The floor is on the quickshell argument to pkgs/omarchy in" >&2
+      echo "  flake.nix. If it was removed as a no-op, this is why it was" >&2
+      echo "  not one." >&2
+      exit 1
+    fi
+
+    echo
+    echo "PROVEN: nixarchy evaluates against nixpkgs $release."
+    echo "NOT PROVEN: that it boots, or that the desktop comes up. Nothing"
+    echo "here starts a VM. A green tick on this check is not 'stable works'."
+    touch $out
+  ''


### PR DESCRIPTION
Stable is checked in twenty-three seconds, and it found something on its first run

Closes #527. Part of #525.

#526 was an `undefined variable` -- the cheapest class of failure there is --
and it went unnoticed for months because nothing looked. This looks, on every
pull request, for **23.6 seconds** and no VM.

## What it proves, and what it refuses to claim

    nixpkgs-stable: 26.05 @ d58a46e3bc02d91ebe04667f8397752a749c0024
    the system evaluates: /nix/store/...-nixos-system-nixarchy-26.05...drv
    the share picker is present on this nixpkgs: false
    the session's quickshell: 0.3.1 (floor 0.3.1)

    PROVEN: nixarchy evaluates against nixpkgs 26.05.
    NOT PROVEN: that it boots, or that the desktop comes up. Nothing
    here starts a VM. A green tick on this check is not 'stable works'.

The check says the second half itself, in its own output, because the whole
risk of a cheap check is that a green tick gets read as a guarantee it never
made. The install job is 55 of 58 minutes on a single self-hosted runner and
gates every pull request; a second slot for stable would roughly double merge
latency on the hardware that is already the bottleneck. Evaluation is what is
affordable, so evaluation is what is claimed.

## It found a real bug immediately

Not in the wiring. On stable:

    error: The option `nix.registry.nixpkgs.to.path' has conflicting
    definition values:
    - In `nixos/modules/config/nix-flakes.nix':  <this flake's nixpkgs>
    - In `nixos/modules/misc/nixpkgs-flake.nix': <the machine's nixpkgs>

`installer/host.nix` pinned the registry to **this flake's** nixpkgs. Its own
comment states the assumption that makes that safe -- *"both sides resolve the
same lock entry to the same store path"* -- which holds only while the machine
follows this flake's nixpkgs. On stable they are two different package sets,
and the line was pointing `nixpkgs#foo` at an unstable tree: precisely the
"binary built against a different glibc" the paragraph above it exists to
prevent.

Both definitions are `mkDefault`, so it could not be resolved by lowering ours
-- and lowering it would have been the wrong fix anyway. NixOS's own
`nixpkgs-flake.nix` derives the registry from the nixpkgs actually being
evaluated, which is the right answer in both cases, so the line is removed and
its reasoning kept.

**Verified this changes nothing on unstable**, since it touches every installed
machine's `/etc/nix/registry.json`:

| | `nix.registry.nixpkgs.to.path` on `reference` |
|---|---|
| before | `/nix/store/j0xsrr9a6dx6b4rf3lnzmak43ff82cs6-source` |
| after | `/nix/store/j0xsrr9a6dx6b4rf3lnzmak43ff82cs6-source` |

Worth noting this is a stronger reproduction than `--override-input nixpkgs`,
which I used while writing #526 and which never hit this: overriding makes the
flake's nixpkgs and the machine's the same tree, so the two definitions agree
and the conflict cannot appear. A separate input is a truer stable.

## Pinned, not tracking

`nixpkgs-stable` is an input in the lock rather than a moving ref. A moving one
would turn every open pull request red the moment upstream moved, for a reason
none of their authors could fix -- the failure that took the roadmap check off
pull requests earlier. `nightly.yml`'s canary already owns upstream drift: it
runs a bare `nix flake update`, and its failure has its own identity, *"a
canary failure means UPSTREAM moved under us"*. Two questions, two places.

## It watches the fixes, not just the evaluation

Forcing the toplevel catches an `undefined variable`. It would not catch the
thing that made stable *dangerous* rather than merely broken. So the check also
asserts #528's quickshell floor, which needed one line of `passthru` to become
observable at all -- `pkgs.quickshell` is the wrong place to look, because the
floor is deliberately scoped to what nixarchy builds and leaves a user's own
quickshell alone.

## Proven red, not just green

| regression simulated | check says | time |
|---|---|---|
| the quickshell floor removed as "dead code" | `0.3.0, below the 0.3.1 floor` + why a user gets locked out | 23s |
| the #526 picker guard removed | `attribute 'hyprland-preview-share-picker' missing` | 13s |

Both restored afterwards; the working tree is the fixed one.

## No workflow change

The check list is generated by asking Nix, not by a hand-maintained list, so a
new check that is not in `claimed`/`exempt`/`nightly_only` joins the light job
on its own. `stable-eval` is one of 70 and in none of those lists. That also
means this pull request touches no workflow file.

## Verification

| | |
|---|---|
| the check builds | pass, **23.6s**, no VM |
| red when the quickshell floor goes | pass |
| red when the picker guard goes | pass |
| refuses rather than passes on an empty/implausible toplevel | floor in the script |
| registry path on unstable | **unchanged**, table above |
| **unstable package list** | **byte-identical, order included** |
| statix / deadnix --fail / nix fmt --ci | clean |

The stable system is deliberately NOT a `nixosConfigurations` entry:
`tests/config-warnings.nix` maps over every entry there and asserts on
warnings, and this configuration emits one on purpose (the screen-sharing note
from #526). Adding it would have turned an unrelated check red for correct
behaviour.

The smoke VM's module list is now shared between the two systems rather than
copied -- a check proving "this evaluates on stable" while evaluating a
different set of modules proves nothing about the thing it names.
