### PR TITLE
Ten commands that said they were verbs become verbs, and the channel is a menu row

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ layout: home
 [Omarchy](https://omarchy.org) — the Hyprland desktop — vendored for NixOS, with
 its menus rewired to Nix instead of pacman.
 
-Omarchy 4.x is not a dotfiles repo, it is an application: 429 shell commands, a
+Omarchy 4.x is not a dotfiles repo, it is an application: 444 shell commands, a
 QuickShell desktop shell, 22 themes, and Hyprland configured through the Lua API
 introduced in 0.55. nixarchy packages that tree as a derivation and replaces the
 parts that assume Arch, rather than reimplementing it in Nix.
@@ -48,14 +48,16 @@ holding the disk layout, the configuration and your app selection. A rebuild
 straight after installing builds nothing, because everything the installer did
 is written there rather than done behind it.
 
-The ISO still downloads rather than carrying its own closure, so an install
-needs a network — [see the manual](manual/getting-started) for that and the
-other limits. Already running NixOS? Then you want the flake, not the ISO, and
-that is on the same page.
+**The ISO carries its own closure, so an install needs no network.** It is
+checked with no network device present at all: 2,221 store paths copied from
+the medium, zero fetched, nothing built. A machine with no wifi driver yet, or
+no cable to hand, still installs — [see the manual](manual/getting-started) for
+the remaining limits. Already running NixOS? Then you want the flake, not the
+ISO, and that is on the same page.
 
 ## Search everything, install declaratively
 
-Omarchy's Install menu offers 56 applications. **Install ▸ Search** offers the
+Omarchy's Install menu offers 64 applications. **Install ▸ Search** offers the
 rest of NixOS — one fuzzy picker over **137,599 rows**: every nixpkgs package,
 every NixOS option, and the app selection, with each entry's type, default and
 documentation in a preview pane.
@@ -91,9 +93,9 @@ See **[other packages](manual/other-packages)** for the whole flow.
 ## An agent that knows this machine
 
 Omarchy symlinks its agent skills into every harness's skill directory. Upstream
-ships one, written for Arch; nixarchy ships ten, written for NixOS — the desktop,
-packages, GPUs, services, secrets, performance, security, log triage, and getting
-the configuration into git.
+ships one, written for Arch; nixarchy ships thirteen, written for NixOS — the
+desktop, packages, GPUs, services, secrets, performance, security, log triage,
+Android, and getting the configuration into git.
 
 That matters more than it sounds. A model asked how to install a package on NixOS
 will confidently invent an answer; the same model handed the `nixos` skill routes
@@ -126,10 +128,56 @@ skills, and the NixOS philosophy underneath all of it.
 New to NixOS? Start with
 **[the philosophy](manual/philosophy)** and **[updating NixOS](manual/updating-nixos)**.
 
+## Where this has got to
+
+Four features finished recently, and each is here because it is *checked*, not
+because it was written:
+
+**An install that needs no network.** The ISO carries its own closure instead
+of downloading one. Proven with no network device present at all — 2,221 store
+paths copied from the medium, zero fetched, nothing built. This was the last
+thing standing between the installer and a machine whose wifi driver is not
+loaded yet.
+
+**See a change before you live in it.** `nixarchy-preview` boots your edited
+configuration in a VM and shows it to you, and the machine you are sitting at
+is untouched until you decide. It is not `build-vm`, which is one command and
+gives you a black screen — qemu's virgl path hands out no usable EGLConfig, so
+the feature is a VM-only module carrying software-GL fallbacks that never reach
+your real machine. It says plainly that a green preview is strong evidence and
+not proof: it does not verify your bootloader, your real GPU, or your real
+disks.
+
+**Your phone, on the desktop.** scrcpy and Waydroid in the catalogues, and a
+pairing helper for the part that actually defeats people — pairing over Wi-Fi,
+where Android wants two different ports, regenerates one of them every time you
+open the dialog, and gives you a code that expires in seconds.
+Discovery goes through avahi, because nixpkgs builds `android-tools` without an
+mDNS backend and the command every tutorial names answers *"mdns is not
+supported by this version of adb"*.
+
+**The session, from somewhere else.** A headless output, an RDP service and its
+firewall hole, and authentication that does not quietly fall back to a shared
+secret.
+
+### What is being worked on now
+
+A **choice of channel** — stable or unstable — offered the way Omarchy offers
+it, plus a way to take a single package from the other one. It is sequenced
+deliberately: nixos-26.05 ships a version of the desktop shell whose lockscreen
+can leave a machine blank with nowhere to type a password, so that is fixed
+*before* anyone is offered the choice that would hand it to them. Also in
+flight: the package picker remade, running an application once without
+installing it, and building a reinstall image from a machine's own
+configuration.
+
+The [board](https://github.com/users/olafkfreund/projects/9) is public, and its
+*Shipped* view is the honest answer to "is this thing alive".
+
 ## Elsewhere
 
 | Where | What is there |
 |---|---|
 | [Source and README](https://github.com/olafkfreund/nixarchy) | installation, module options, design notes, what is left |
 | [Omarchy's own manual](https://omarchy.org/manual/) | the desktop itself — 38 of its 51 pages are true here unchanged |
-| [Issues](https://github.com/olafkfreund/nixarchy/issues) | including the epic for a bare-metal installer, which does not exist yet |
+| [Issues](https://github.com/olafkfreund/nixarchy/issues) and the [board](https://github.com/users/olafkfreund/projects/9) | what is in flight, what is waiting, and what each feature has left — public |

--- a/docs/internals/workflows.md
+++ b/docs/internals/workflows.md
@@ -48,6 +48,30 @@ Computes whether the diff can possibly change a build output. A
 documentation-only change skips the expensive jobs, and each skipped job still
 reports success so required checks are satisfied.
 
+It is a **denylist**, never an allowlist, and
+`.github/scripts/pr-touches-build.sh` states why: Nix closures are computed by
+evaluation, not by directory, so an allowlist silently stops covering the next
+directory somebody adds. A denylist can only be wrong about the paths it names.
+
+**It answers two questions, not one.** `build.yml` asks *"can this change
+anything Nix builds?"* — a new `tests/foo.nix` is a new derivation, so yes.
+`install-check.yml` asks the narrower *"can this change an INSTALL?"*, and
+`--install` adds a second, tighter list for it.
+
+`README.md` is the case worth knowing, because it sits on opposite sides of
+those two questions:
+
+| | `README.md` |
+|---|---|
+| can it change a build? | **yes** — `build.yml` derives the app and command counts from `data/` and greps README for them, and that guard caught a real mismatch |
+| can it change an install? | **no** — nothing an install builds reads it |
+
+So a one-line edit to the README's roadmap table runs the count guard and
+**skips the 55-minute install**. Before that split it did both, twice in one
+day, queued behind every other pull request on the single slot.
+`tests/install-gate.nix` asserts both halves, because one without the other is
+the bug.
+
 ### `lint` — four linters, because they catch different things
 1. **Check formatting** — `nix fmt -- --ci`
 2. **statix** — repeated keys, useless parens; things `nix fmt` is happy with
@@ -106,6 +130,23 @@ contention. Two concurrent jobs is what demonstrably passes.
 
 **If your install check sits queued for twenty minutes, the cap is working.**
 
+### What that cap costs, and what is done instead
+
+One slot for the whole repository means every minute spent there is a minute
+every other pull request waits. Two rules follow from it, and both are visible
+in the checks:
+
+- **A check that does not need a VM must not take one.** `stable-eval` proves
+  this flake still evaluates against stable nixpkgs in about **twenty
+  seconds**, by forcing the system's derivation to be computed rather than
+  built. It exists because stable stopped evaluating on an `undefined
+  variable` — the cheapest class of failure there is — and nothing looked for
+  months.
+- **A cheap check must say what it does not prove.** `stable-eval` prints it
+  in its own output: *"NOT PROVEN: that it boots, or that the desktop comes
+  up. Nothing here starts a VM."* A green tick that gets read as a guarantee
+  it never made is worse than no check.
+
 ---
 
 ## `nightly.yml` — 03:00 UTC, the expensive checks
@@ -125,6 +166,24 @@ contention. Two concurrent jobs is what demonstrably passes.
 `install-iso` is the one that proves the offline image: it installs with **no
 network device at all** and asserts not that the install succeeded but that
 **nothing was built and nothing was fetched**.
+
+---
+
+### Pinned inputs on pull requests, moving ones only here
+
+`nixpkgs-stable` is an input in `flake.lock`, not a ref resolved fresh. A
+moving ref would turn **every open pull request red** the moment upstream
+moved, for a reason none of their authors could fix — the same failure that
+took the roadmap check off pull requests (see `omarchy` above).
+
+Upstream drift is this workflow's `canary` job instead: it runs a bare `nix
+flake update` and resolves every input the repository leaves mobile. Its
+failure has its own identity — *a canary failure means UPSTREAM moved under
+us* — and it files an issue saying so.
+
+**Two questions, two places, neither pretending to be the other.** If you are
+adding a check that depends on something outside the lock, this is the split
+to follow.
 
 ---
 
@@ -279,3 +338,27 @@ The second works while other jobs in the run are still going, when
 - README's Roadmap — the shape, CI-enforced
 
 `AGENTS.md` §12 has the filing rules.
+
+### File the Roadmap row *before* the epic, not after
+
+The roadmap check reads the **live issue list**, not the diff. So an epic that
+exists without a Roadmap row turns `main` red on **whatever commit pushes
+next** — someone else's merge, with nothing in it about your epic and nothing
+its author can do.
+
+It does not run on pull requests, deliberately: closing an epic correctly once
+turned every open pull request red at the same time, none of which had touched
+the README. So it runs on pushes to `main` and weekly, and the red always
+lands somewhere other than the change that caused it.
+
+The order that avoids it:
+
+1. open the pull request that adds the Roadmap row
+2. **let it merge**
+3. then file the epic
+
+Doing it the other way round costs a red `main` and a re-run. Getting the row
+merged first is not always possible — if another pull request is already armed
+with auto-merge it will land ahead of yours — in which case the red is
+expected, harmless, and clears on a re-run once the row exists. No new commit
+is needed, because the check reads live state.

--- a/flake.lock
+++ b/flake.lock
@@ -567,6 +567,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1789009968,
+        "narHash": "sha256-GB16oaxpsrnGNnGIE+0uYBqMRzB9X6FYDUvjvnJAYew=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d58a46e3bc02d91ebe04667f8397752a749c0024",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1788881743,
@@ -634,6 +650,7 @@
         "nixi": "nixi",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_2",
+        "nixpkgs-stable": "nixpkgs-stable",
         "omarchy": "omarchy",
         "sops-nix": "sops-nix",
         "systems": "systems_2",

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,25 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # Stable nixpkgs, carried so CI can prove this flake still evaluates
+    # against it (#527).
+    #
+    # PINNED in the lock rather than resolved fresh, and the split is
+    # deliberate. A moving ref would turn every open pull request red the
+    # moment upstream moved, for a reason none of their authors could fix --
+    # which is the failure that took the roadmap check off pull requests
+    # earlier in this file's history. nightly.yml's canary already owns
+    # upstream drift: it runs a bare `nix flake update` and its failure has
+    # its own identity, "a canary failure means UPSTREAM moved under us".
+    #
+    # So: pull requests get a fixed answer, and the canary is what notices
+    # 26.05 moving. Two questions, two places, neither pretending to be the
+    # other.
+    #
+    # Nothing on a user's machine reads this. It is a check input, and the
+    # only thing that evaluates it is tests/stable-eval.nix.
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-26.05";
+
     # The same, on the release branch, for a machine whose nixpkgs is a
     # release rather than unstable (#525).
     #
@@ -145,6 +164,7 @@
       systems,
       home-manager,
       home-manager-stable,
+      nixpkgs-stable,
       hyprland,
       omarchy,
       zen-browser,
@@ -188,11 +208,46 @@
       # warning. That is honest -- this project carries one release branch,
       # not every one -- and the warning names the real situation.
       stableRelease = "26.05";
-      homeManagerModule =
-        if lib.trivial.release == stableRelease then
+      homeManagerFor =
+        release:
+        if release == stableRelease then
           home-manager-stable.nixosModules.home-manager
         else
           home-manager.nixosModules.home-manager;
+      homeManagerModule = homeManagerFor lib.trivial.release;
+
+      # The smoke VM's module list, shared by the real configuration and by
+      # the stable evaluation in tests/stable-eval.nix (#527).
+      #
+      # Shared rather than copied, because a check that proves "this
+      # evaluates on stable" while evaluating a DIFFERENT set of modules
+      # proves nothing about the thing it names -- and a copied list is one
+      # somebody extends in exactly one of the two places. Same failure mode
+      # config-warnings.nix avoids by deriving its configuration list instead
+      # of writing one down.
+      #
+      # A function of the home-manager module rather than a plain list: the
+      # two systems need different ones, and the ORDER has to stay exactly as
+      # it was. environment.systemPackages order reaches buildEnv, so moving
+      # a module is not free even when the resulting set is identical.
+      vmModulesWith = hm: [
+        self.nixosModules.nixarchy
+        hm
+        ./vm/configuration.nix
+      ];
+
+      # This flake, evaluated against stable nixpkgs. NOT a
+      # nixosConfigurations entry, deliberately: config-warnings.nix maps over
+      # every entry there, so adding one would pull a full stable evaluation
+      # into an unrelated check -- and that check asserts on warnings, while
+      # this configuration emits one on purpose (the screen-sharing note in
+      # modules/nixos.nix). It would have gone red on arrival, for a reason
+      # that is correct behaviour.
+      stableVm = nixpkgs-stable.lib.nixosSystem {
+        system = "x86_64-linux";
+        specialArgs = { inherit inputs; };
+        modules = vmModulesWith (homeManagerFor nixpkgs-stable.lib.trivial.release);
+      };
 
       # Why: docs/internals/flake.md#which-nixarchy-built-this-machine-208-for-nixarchy
       nixarchyRev = self.shortRev or self.dirtyShortRev or "unknown";
@@ -1055,11 +1110,7 @@
             vm = nixpkgs.lib.nixosSystem {
               system = "x86_64-linux";
               specialArgs = { inherit inputs; };
-              modules = [
-                self.nixosModules.nixarchy
-                homeManagerModule
-                ./vm/configuration.nix
-              ];
+              modules = vmModulesWith homeManagerModule;
             };
 
             # Why: docs/internals/flake.md#the-same-vm-with-room-to-run-a-model
@@ -1485,6 +1536,14 @@
           # and not a preference.
           config-warnings = import ./tests/config-warnings.nix {
             inherit inputs;
+            pkgs = pkgsFor.${system};
+          };
+
+          # Evaluation against stable, ~20s and no VM (#527). `stableVm` is
+          # passed in rather than reached through `inputs.self`, because it is
+          # deliberately not a nixosConfigurations entry -- see its definition.
+          stable-eval = import ./tests/stable-eval.nix {
+            inherit inputs stableVm;
             pkgs = pkgsFor.${system};
           };
 

--- a/installer/host.nix
+++ b/installer/host.nix
@@ -123,7 +123,25 @@
   # unreproducible from the flake it was installed from, which is Invariant 1,
   # and it is why checks.install went red the moment this was added. nixpkgs is
   # safe because both sides resolve the same lock entry to the same store path.
-  nix.registry.nixpkgs.flake = inputs.nixpkgs;
+  #
+  # NOT set here any more (#527). NixOS's own
+  # nixos/modules/misc/nixpkgs-flake.nix already pins the registry, to
+  # `nixpkgs.flake.source` -- the nixpkgs actually being evaluated -- which is
+  # the same store path this line used to name whenever the machine follows
+  # this flake's nixpkgs, and the RIGHT one when it does not.
+  #
+  # Evaluating against nixos-26.05 is what showed the difference:
+  #
+  #   error: The option `nix.registry.nixpkgs.to.path' has conflicting
+  #   definition values:
+  #   - In `nixos/modules/config/nix-flakes.nix':  <this flake's nixpkgs>
+  #   - In `nixos/modules/misc/nixpkgs-flake.nix': <the machine's nixpkgs>
+  #
+  # A tie, because both sides are mkDefault -- so it could not be resolved by
+  # lowering ours, and lowering it would have been wrong anyway: on a stable
+  # machine, `nixpkgs#foo` pointed at this flake's UNSTABLE nixpkgs is exactly
+  # the "binary built against a different glibc" the paragraph above exists to
+  # prevent. The requirement stands; NixOS is now what meets it.
   nix.settings.flake-registry = "";
 
   # `nh os switch` is the loop the user lives in, and it only works with no

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -409,25 +409,46 @@ let
           description = "nh os switch --update: move every flake input forward, then rebuild";
         };
 
-        # Omarchy's release channels are a pacman repository choice. Here the
-        # version is whatever the flake's omarchy input is pinned to, so there
-        # is nothing to switch. Switching nixpkgs between stable and unstable
-        # would mean editing the user's own system flake, which nixarchy does
-        # not own -- it owns the Omarchy installation and its applications.
+        # Omarchy's release channels are a pacman repository choice, and two
+        # of its four have a meaning here (#529).
         #
-        # The children are hidden individually: hiding a parent keeps its rows
-        # out of the menu tree, but they stay reachable through search and
-        # `omarchy menu summon`.
+        # This block used to hide all five rows, with a reason that has since
+        # stopped being true in both halves: "there is nothing to switch", and
+        # "switching nixpkgs would mean editing the user's own system flake,
+        # which nixarchy does not own". There is something to switch --
+        # nixos-26.05 or unstable -- and `nixarchy-channel` does that edit
+        # consensually, under the rule nixarchy-unfreeze set: only lines this
+        # project wrote get rewritten, a flake somebody has reshaped is theirs
+        # and gets the edit printed instead of guessed at, and nixpkgs and
+        # home-manager move together because neither project supports the
+        # mismatch.
+        #
+        # `rc` and `dev` stay hidden. They are pacman repositories with no
+        # NixOS equivalent, and inventing a meaning for them would be worse
+        # than leaving them out -- a row that does something other than what
+        # its name says is the failure this menu has the most guards against.
+        #
+        # The children are still hidden individually: hiding a parent keeps
+        # its rows out of the menu tree, but they stay reachable through
+        # search and `omarchy menu summon`.
         "update.channel" = {
-          when = "false";
+          icon = "󰓾";
+          label = "Channel";
+          description = "Follow stable or unstable nixpkgs. Nixarchy is developed against unstable";
         };
         "update.channel.stable" = {
-          when = "false";
-        };
-        "update.channel.rc" = {
-          when = "false";
+          icon = "󰋼";
+          label = "Stable";
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-channel stable";
+          description = "nixos-26.05 and the matching home-manager. Less tested here, not more";
         };
         "update.channel.edge" = {
+          icon = "󰇾";
+          label = "Unstable";
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-channel unstable";
+          description = "nixos-unstable, what nixarchy is developed and tested against";
+        };
+        "update.channel.rc" = {
           when = "false";
         };
         "update.channel.dev" = {
@@ -2236,6 +2257,54 @@ in
                 try) shift; exec nixarchy-try "$@" ;;
                 vm) shift; exec nixarchy-vm "$@" ;;
                 box) shift; exec nixarchy-box "$@" ;;
+
+                # The rest of them (#538). Every one of these was shipped,
+                # documented, and unreachable: without a row here the command
+                # reaches `exec omarchy "$@"`, and Omarchy's own dispatcher
+                # builds `omarchy-$(join_words ...)` and globs `omarchy-*`
+                # only -- so `nixarchy channel stable` died as "Unknown
+                # Omarchy command: omarchy channel stable".
+                #
+                # `try` was found by hand and fixed alone. Nothing generalised
+                # it, and the same bug was sitting in ten siblings. What makes
+                # that not happen again is not this list -- it is
+                # checks.options deriving the list from the commands' own
+                # `# omarchy:examples=nixarchy <verb>` headers and asserting
+                # every one of them routes. A command declares the verb it
+                # answers to; the check makes the dispatcher agree.
+                android) shift; exec nixarchy-android "$@" ;;
+                ask) shift; exec nixarchy-ask "$@" ;;
+                channel) shift; exec nixarchy-channel "$@" ;;
+                local-ai) shift; exec nixarchy-local-ai "$@" ;;
+                preview) shift; exec nixarchy-preview "$@" ;;
+                rollback) shift; exec nixarchy-rollback "$@" ;;
+                unfreeze) shift; exec nixarchy-unfreeze "$@" ;;
+
+                # Two-word verbs, in the shape `pkg`, `app` and `dev` already
+                # use. These are the ones a route check that matches
+                # `^ *<verb>)` cannot see, which is why the first version of
+                # that check passed over them.
+                #
+                # No bare fallthrough on the inner case: `nixarchy config`
+                # with no second word drops out of the inner `case` and
+                # reaches `exec omarchy "$@"`, which is the right answer --
+                # Omarchy has its own `config` and this port does not take the
+                # word from it.
+                config)
+                  case "''${2:-}" in
+                    repo) shift 2; exec nixarchy-config-repo "$@" ;;
+                  esac
+                  ;;
+                home)
+                  case "''${2:-}" in
+                    backup) shift 2; exec nixarchy-home-backup "$@" ;;
+                  esac
+                  ;;
+                reinstall)
+                  case "''${2:-}" in
+                    iso) shift 2; exec nixarchy-reinstall-iso "$@" ;;
+                  esac
+                  ;;
                 ""|--help|-h|help)
                   cat <<'USAGE'
               nixarchy -- the Omarchy desktop, vendored for NixOS.
@@ -2254,6 +2323,19 @@ in
                 nixarchy vm <subcommand>    Disposable NixOS MicroVMs -- 'nixarchy vm help'
                 nixarchy box <subcommand>   distrobox, for software NixOS will not run -- 'nixarchy box help'
                 nixarchy doctor             What this machine needs to run nixarchy
+
+              This machine:
+
+                nixarchy channel [stable|unstable]  Which nixpkgs this machine follows
+                nixarchy preview            Boot this configuration in a VM before switching
+                nixarchy rollback           Go back to an earlier system generation
+                nixarchy unfreeze           Let this machine receive updates again
+                nixarchy config repo        Put /etc/nixos in git, with a remote and CI
+                nixarchy home backup        Back up the desktop configuration in your home
+                nixarchy reinstall iso      Build an image that reinstalls this machine
+                nixarchy android            Connect an Android phone over Wi-Fi, for scrcpy
+                nixarchy ask                Ask the default agent, with the right skill chosen
+                nixarchy local-ai           Set up the local language model
 
               Everything else is Omarchy's own, and reaches it unchanged:
 

--- a/pkgs/omarchy/default.nix
+++ b/pkgs/omarchy/default.nix
@@ -1841,6 +1841,19 @@ stdenvNoCC.mkDerivation {
 
   passthru = {
     inherit runtimeDeps;
+
+    # The desktop shell this build actually uses, so it can be asserted on
+    # (#528). flake.nix pins it to a FLOOR: on a nixpkgs shipping quickshell
+    # below 0.3.1 the argument is overridden, because 0.3.0's session lock
+    # reaches qFatal when screens sleep while locked and leaves the machine
+    # with nowhere to type a password.
+    #
+    # Exposed because `pkgs.quickshell` is the wrong place to look and would
+    # give the wrong answer: the floor is deliberately scoped to this package
+    # rather than applied as an overlay, so that a user's own quickshell is
+    # left exactly as their nixpkgs has it. The version the SESSION launches
+    # is this one, and until now nothing could see it.
+    inherit quickshell;
   };
 
   meta = {

--- a/tests/menu-verbs.nix
+++ b/tests/menu-verbs.nix
@@ -35,6 +35,10 @@ let
 
   vmcli = inputs.self.packages.${system}.nixarchy-vm;
   boxcli = inputs.self.packages.${system}.nixarchy-box;
+
+  # nixarchy-channel ships in the omarchy tree rather than as its own package,
+  # so it is reached through the built tree the same way the menu reaches it.
+  omarchyPkg = (pkgs.extend inputs.self.overlays.default).omarchy;
 in
 pkgs.runCommand "nixarchy-menu-verbs"
   {
@@ -49,9 +53,19 @@ pkgs.runCommand "nixarchy-menu-verbs"
     # The verbs each CLI accepts, read out of the shipped script's own case
     # block -- the built artifact, not the repo source, so a build that mangles
     # the dispatch is caught too.
+    # Two `case` shapes, because both are in use: most of these scripts
+    # dispatch on "$1" directly, and nixarchy-channel assigns it to $target
+    # first. Verified that adding the second address leaves nixarchy-vm and
+    # nixarchy-box's verb lists byte-identical (10 each) -- a helper that
+    # claims to read "the shipped script's own case block" should not be
+    # silently blind to a script that writes it the other way.
+    #
+    # The character class allows spaces so `"" | stable | unstable)` parses;
+    # the `tr -d ' '` below already removes them.
     verbs_of() {
-      sed -n '/case "''${1:-}" in/,/^ *esac/p' "$1" \
-        | grep -oE '^[[:space:]]*[-a-z|"]+\)' \
+      sed -n -e '/case "''${1:-}" in/,/^ *esac/p' \
+             -e '/case "$target" in/,/^ *esac/p' "$1" \
+        | grep -oE '^[[:space:]]*[-a-z|"[:space:]]+\)' \
         | tr -d ' )"' \
         | tr '|' '\n' \
         | grep -vE '^\*?$' \
@@ -60,15 +74,20 @@ pkgs.runCommand "nixarchy-menu-verbs"
 
     verbs_of ${vmcli}/bin/nixarchy-vm   > vm-verbs
     verbs_of ${boxcli}/bin/nixarchy-box > box-verbs
+    verbs_of ${omarchyPkg}/share/omarchy/bin/nixarchy-channel > channel-verbs
 
     echo "nixarchy-vm accepts:  $(tr '\n' ' ' < vm-verbs)"
     echo "nixarchy-box accepts: $(tr '\n' ' ' < box-verbs)"
+    echo "nixarchy-channel accepts: $(tr '\n' ' ' < channel-verbs)"
 
     # A floor. An empty verb list makes every row below pass, turning "the
     # dispatch stopped parsing" into a green check -- the exact shape of failure
     # this file exists to reject.
     test "$(wc -l < vm-verbs)"  -ge 5
     test "$(wc -l < box-verbs)" -ge 5
+    # Two: stable and unstable. `rc` and `dev` are pacman repositories with no
+    # NixOS meaning and stay out of the menu, so this floor is 2 and not 4.
+    test "$(wc -l < channel-verbs)" -ge 2
 
     fail=0
     checked=0
@@ -92,6 +111,13 @@ pkgs.runCommand "nixarchy-menu-verbs"
     scan '\bnixarchy +vm +[-a-z]+'     3 nixarchy-vm  vm-verbs
     scan '\bnixarchy-box +[-a-z]+'     2 nixarchy-box box-verbs
     scan '\bnixarchy +box +[-a-z]+'    3 nixarchy-box box-verbs
+
+    # The channel rows (#529). Added with the rows themselves rather than
+    # after the first one breaks, because the row this file was written about
+    # -- `nixarchy-vm new`, a verb that does not exist -- shipped and was
+    # found by a tester.
+    scan '\bnixarchy-channel +[-a-z]+'  2 nixarchy-channel channel-verbs
+    scan '\bnixarchy +channel +[-a-z]+' 3 nixarchy-channel channel-verbs
 
     # The second floor: if the menu stopped carrying these rows, every scan
     # above would run zero times and the check would pass having read nothing.

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -1947,6 +1947,11 @@ pkgs.runCommand "nixarchy-options"
         # usage line promising a command that routes nowhere is the same
         # defect, and this is the file that would otherwise let the next one
         # through.
+        #
+        # These five have no file of their own -- nixarchy-search and
+        # nixarchy-apply are built by writeShellApplication in
+        # modules/apps.nix rather than shipped in nix-bin -- so they cannot be
+        # derived below and are named here.
         for verb in try search apply vm box; do
           grep -qE "^ *$verb\)" "$vm/sw/bin/nixarchy" || {
             echo "the nixarchy dispatcher has no route for '$verb':" >&2
@@ -1956,7 +1961,91 @@ pkgs.runCommand "nixarchy-options"
             exit 1
           }
         done
-        echo "every advertised nixarchy subcommand has a route"
+
+        # ---- and every command that SAYS it is a verb (#538) ---------------
+        #
+        # The list above is hand-written, under a comment promising it was
+        # "the file that would otherwise let the next one through". It let ten
+        # through: `try` was found by hand and fixed alone, nothing
+        # generalised the fix, and android, ask, channel, config repo, home
+        # backup, local-ai, preview, reinstall iso, rollback and unfreeze were
+        # all shipped, documented, and dead on arrival.
+        #
+        # So this half is DERIVED. Each command's header names the verb it
+        # answers to:
+        #
+        #   # omarchy:examples=nixarchy channel stable
+        #
+        # and the FILE NAME says where the verb ends: the shortest run of
+        # leading words whose `-`-join equals the file's stem is the verb
+        # path, and whatever follows is arguments. `nixarchy config repo` is
+        # two words because the file is nixarchy-config-repo; `nixarchy
+        # channel stable` is one because the file is nixarchy-channel.
+        #
+        # That distinction is precisely what a `^ *$verb\)` grep cannot make,
+        # and why the two-word commands were invisible to the loop above.
+        binDir=$omarchyPath/bin
+        derived=0
+        for f in "$binDir"/nixarchy-*; do
+          [ -f "$f" ] || continue
+          stem=$(basename "$f"); stem=''${stem#nixarchy-}
+
+          ex=$(grep -m1 '^# omarchy:examples=nixarchy ' "$f" || true)
+          # A command that never claims to be a verb is not one. Several are
+          # reached only from the menu or by another script, and this check
+          # has no opinion about those -- it checks the promise, not the file.
+          [ -n "$ex" ] || continue
+
+          joined=""; verbpath=""
+          for w in ''${ex#\# omarchy:examples=nixarchy }; do
+            if [ -z "$joined" ]; then joined="$w"; verbpath="$w";
+            else joined="$joined-$w"; verbpath="$verbpath $w"; fi
+            [ "$joined" = "$stem" ] && break
+          done
+
+          [ "$joined" = "$stem" ] || {
+            echo "::error::nixarchy-$stem's example does not name a verb path" >&2
+            echo "  matching its file name:" >&2
+            echo "    $ex" >&2
+            echo "  Either the example or the file name is wrong; this check" >&2
+            echo "  cannot tell which and will not guess." >&2
+            exit 1
+          }
+          derived=$((derived + 1))
+
+          first=''${verbpath%% *}
+          second=""
+          case "$verbpath" in *" "*) second=''${verbpath#* } ;; esac
+
+          grep -qE "^ *$first\)" "$vm/sw/bin/nixarchy" || {
+            echo "::error::nixarchy-$stem says it answers to '$verbpath'," >&2
+            echo "  and the dispatcher has no '$first)' row. It falls through" >&2
+            echo "  to \`exec omarchy $verbpath\`, and omarchy builds" >&2
+            echo "  omarchy-<words> and globs omarchy-* only -- so it dies as" >&2
+            echo "  'Unknown Omarchy command'. Shipped, documented, dead." >&2
+            exit 1
+          }
+
+          if [ -n "$second" ]; then
+            grep -qE "^ *$second\) *shift 2; exec nixarchy-$stem" "$vm/sw/bin/nixarchy" || {
+              echo "::error::nixarchy-$stem says it answers to '$verbpath'." >&2
+              echo "  The outer '$first)' row exists and nothing inside it" >&2
+              echo "  routes '$second' to nixarchy-$stem." >&2
+              exit 1
+            }
+          fi
+        done
+
+        # The floor this repository keeps arriving at: a loop that iterated
+        # nothing satisfies every assertion above while proving nothing -- and
+        # this check exists because that exact silence shipped ten broken
+        # commands.
+        if [ "$derived" -lt 8 ]; then
+          echo "::error::only $derived commands declared a verb, which is too" >&2
+          echo "  few to be real -- this check is not reading the headers." >&2
+          exit 1
+        fi
+        echo "every advertised nixarchy subcommand has a route ($derived derived)"
 
         # ---- a package miss opens the picker, not a URL (#492) --------------
         #

--- a/tests/stable-eval.nix
+++ b/tests/stable-eval.nix
@@ -1,0 +1,135 @@
+{
+  inputs,
+  pkgs,
+  stableVm,
+}:
+# This flake still evaluates against stable nixpkgs (#527).
+#
+# ## What this proves, and what it does not
+#
+# It proves EVALUATION. The expression is valid against nixos-26.05: every
+# attribute it names exists, every option it sets is an option, and the
+# system's derivation can be computed.
+#
+# It does NOT prove the machine boots, that the desktop comes up, or that
+# anything on it works. Nothing here starts a VM. Read a green tick on this
+# check as "the expression is valid on stable" and nothing more -- the
+# temptation is to read it as "stable works", and it does not say that.
+#
+# That limit is a budget decision, not an oversight. The install job is 55 of
+# 58 minutes on a single self-hosted runner and gates every pull request; a
+# second install slot for stable would roughly double merge latency on the
+# hardware that is already the bottleneck. Evaluation is what is affordable,
+# so evaluation is what is claimed.
+#
+# ## Why it exists
+#
+# Stable stopped evaluating and nobody noticed, because nothing looked:
+#
+#   error: undefined variable 'hyprland-preview-share-picker'
+#   at modules/nixos.nix:758
+#
+# The cheapest class of failure there is, found by hand months later. This
+# costs about twenty seconds and no VM.
+#
+# ## Why the assertions below, and not just the evaluation
+#
+# Forcing the toplevel would catch an `undefined variable`. It would not
+# catch the thing that made stable DANGEROUS rather than merely broken:
+# nixos-26.05 ships quickshell 0.3.0, whose session lock reaches qFatal when
+# screens sleep and wake while locked, leaving the machine blank with nowhere
+# to type a password (#35, #528). That was fixed by a floor in flake.nix, and
+# a floor with nothing watching it is one somebody removes as dead code.
+let
+  inherit (pkgs) lib;
+
+  cfg = stableVm.config;
+
+  # The evaluation itself. `unsafeDiscardStringContext` on purpose: the point
+  # is to force the system's derivation to be COMPUTED, not to build it. With
+  # the context left on, this check would depend on the stable toplevel and a
+  # twenty-second evaluation would become a full system build of a package set
+  # nothing here has cached -- which is precisely the install-slot cost this
+  # check exists to avoid.
+  toplevel = builtins.unsafeDiscardStringContext cfg.system.build.toplevel.drvPath;
+
+  release = stableVm.pkgs.lib.trivial.release;
+
+  # #528, watched. Read off the built system's own package set rather than
+  # from nixpkgs, because what matters is the version the SESSION launches
+  # after the floor in flake.nix has been applied -- asking nixpkgs directly
+  # would ask a question whose answer is 0.3.0 and always was.
+  quickshellVersion = cfg.programs.nixarchy.package.passthru.quickshell.version;
+in
+pkgs.runCommand "nixarchy-stable-eval"
+  {
+    inherit toplevel release;
+
+    # Named so the log says which stable this was, not merely "stable".
+    stableRev = inputs.nixpkgs-stable.rev or "unlocked";
+
+    # #526, watched from the other side. The picker is absent on 26.05, and
+    # modules/nixos.nix guards it -- so the guard is doing its job when this
+    # is false, and the guard has become dead code when it is true. Either is
+    # worth knowing; only one of them is worth failing on, below.
+    pickerPresent = lib.boolToString (stableVm.pkgs ? hyprland-preview-share-picker);
+
+    inherit quickshellVersion;
+
+    # The version below which 0.3.0's lockscreen bug is present. Named so the
+    # failure message can quote it rather than restate it.
+    quickshellFloor = "0.3.1";
+
+    # Decided in Nix, not in shell: a shell string comparison orders 0.3.10
+    # before 0.3.9, and this is the assertion that is load-bearing for whether
+    # somebody can get back into their laptop.
+    quickshellOk = lib.boolToString (lib.versionAtLeast quickshellVersion "0.3.1");
+  }
+  ''
+    echo "nixpkgs-stable: $release @ $stableRev"
+    echo "the system evaluates: $toplevel"
+
+    # A floor, in the shape this repository keeps arriving at: a check whose
+    # inputs came back empty satisfies every comparison below while proving
+    # nothing. tests/reference-initrd.nix refuses for the same reason.
+    case "$toplevel" in
+      /nix/store/*-nixos-system-*.drv) ;;
+      *)
+        echo "::error::the stable toplevel is not a system derivation path:" >&2
+        echo "  '$toplevel'" >&2
+        echo "  This check cannot answer anything and is refusing rather" >&2
+        echo "  than passing." >&2
+        exit 1
+        ;;
+    esac
+
+    if [ "$release" != "${cfg.system.nixos.release}" ]; then
+      echo "::error::the evaluated release ($release) is not the one the" >&2
+      echo "  system reports (${cfg.system.nixos.release})." >&2
+      exit 1
+    fi
+
+    echo "the share picker is present on this nixpkgs: $pickerPresent"
+
+    echo "the session's quickshell: $quickshellVersion (floor $quickshellFloor)"
+    if [ "$quickshellOk" != "true" ]; then
+      echo "::error::this stable machine would run quickshell" >&2
+      echo "  $quickshellVersion, below the $quickshellFloor floor." >&2
+      echo >&2
+      echo "  quickshell 0.3.0's session lock reaches qFatal when screens" >&2
+      echo "  sleep and wake while locked, and the Wayland protocol keeps the" >&2
+      echo "  compositor locked when its lock client dies -- so the machine" >&2
+      echo "  is left blank with nowhere to type a password (#35, #528)." >&2
+      echo >&2
+      echo "  The floor is on the quickshell argument to pkgs/omarchy in" >&2
+      echo "  flake.nix. If it was removed as a no-op, this is why it was" >&2
+      echo "  not one." >&2
+      exit 1
+    fi
+
+    echo
+    echo "PROVEN: nixarchy evaluates against nixpkgs $release."
+    echo "NOT PROVEN: that it boots, or that the desktop comes up. Nothing"
+    echo "here starts a VM. A green tick on this check is not 'stable works'."
+    touch $out
+  ''


### PR DESCRIPTION
Ten commands that said they were verbs become verbs, and the channel is a menu row

Closes #538. Closes #529. Part of #525.

I set out to do #529 -- the channel row in the menu -- and found its command
could not be typed.

## Ten shipped commands were unreachable, not one

#538 reported `nixarchy android`. Deriving the list rather than reading it, it
was ten of eleven:

| command | says it answers to | routed before |
|---|---|---|
| `nixarchy-android` | `nixarchy android` | no |
| `nixarchy-ask` | `nixarchy ask` | no |
| `nixarchy-channel` | `nixarchy channel` | no |
| `nixarchy-config-repo` | `nixarchy config repo` | no |
| `nixarchy-home-backup` | `nixarchy home backup` | no |
| `nixarchy-local-ai` | `nixarchy local-ai` | no |
| `nixarchy-preview` | `nixarchy preview` | no |
| `nixarchy-reinstall-iso` | `nixarchy reinstall iso` | no |
| `nixarchy-rollback` | `nixarchy rollback` | no |
| `nixarchy-unfreeze` | `nixarchy unfreeze` | no |
| `nixarchy-try` | `nixarchy try` | **yes** |

Each declares its own verb in its header (`# omarchy:examples=nixarchy
channel stable`). Without a dispatcher row the command reaches `exec omarchy
"$@"`, and Omarchy's dispatcher builds `omarchy-$(join_words ...)` and globs
`omarchy-*` only -- so every one of them died as *"Unknown Omarchy command"*.

`try` is routed because it was found by hand and fixed alone. Nothing
generalised the fix.

## The check that was supposed to prevent exactly this

`checks.options` already had a route check, under a comment promising it was
*"the file that would otherwise let the next one through"*. It let ten
through, because its list was hand-written:

```
for verb in try search apply vm box; do
```

**So the list is derived now.** Each command's header names its verb; the FILE
NAME says where the verb ends -- the shortest run of leading words whose
`-`-join equals the file's stem. `nixarchy config repo` is two words because
the file is `nixarchy-config-repo`; `nixarchy channel stable` is one because
the file is `nixarchy-channel`.

That distinction is precisely what the old `^ *$verb\)` grep could not make,
which is why the three two-word commands were invisible to it -- the blind
spot that was already known and had never been closed.

Proven in both directions against the real tree:

| | |
|---|---|
| all 11 verbs derived and routed | pass |
| remove the `channel)` row | `NO ROUTE channel -> 'channel'` |
| remove the inner `repo)` row | `NO INNER config-repo (outer ok, 'repo' unrouted)` |
| `nixarchy-version`, which claims no verb | correctly ignored |
| floor when fewer than 8 declare a verb | refuses rather than passes |

The five with no file of their own (`search`, `apply` are built by
`writeShellApplication`) stay named explicitly, with the reason written down.

## #529: Update > Channel

`modules/apps.nix` hid all five of upstream's channel rows behind a rationale
that had stopped being true in both halves -- *"there is nothing to switch"*
and *"editing the user's own system flake, which nixarchy does not own"*.
There is something to switch, and `nixarchy-channel` does that edit
consensually, under the rule `nixarchy-unfreeze` set: only lines this project
wrote get rewritten, and a flake somebody has reshaped is theirs.

Two rows now exist:

- **Stable** -- `nixos-26.05` and the matching home-manager
- **Unstable** -- what nixarchy is developed and tested against

`rc` and `dev` stay hidden. They are pacman repositories with no NixOS
equivalent, and a row that does something other than what its name says is the
failure this menu has the most guards against.

The descriptions say the uncomfortable part, because the command already does:
*"Less tested here, not more."*

## The row is checked, before a tester finds it

`tests/menu-verbs.nix` exists because `trigger.vm.new` shipped calling a verb
that did not exist and closed the terminal on a tester. It scanned only
`nixarchy-vm` and `nixarchy-box` rows -- the same hand-written-scope gap -- so
the channel rows are added to it with the rows themselves.

That needed `verbs_of` to grow a second `case` address: most of these scripts
dispatch on `"$1"`, and `nixarchy-channel` assigns it to `$target` first, so
the helper read **zero** verbs from it and the floor would have failed the
build. **Verified the change leaves `nixarchy-vm` and `nixarchy-box`'s verb
lists byte-identical (10 each)** before relying on it.

## Verification

| | |
|---|---|
| route derivation, all 11 | pass, rehearsed against the source tree |
| red when a route is removed (both shapes) | pass |
| `nixarchy-channel` accepts `stable`/`unstable` | read from its own `case` |
| `verbs_of` on vm and box | **byte-identical**, 10 verbs each |
| statix / deadnix --fail / nix fmt --ci | clean |

`checks.options` and `checks.menu-verbs` were not built locally: two CI install
jobs were in flight on the shared host, and AGENTS.md section 6 exists because
a local build of mine starved CI once already and surfaced as an unrelated
`free-space` timeout. The shell logic was rehearsed standalone against the real
files instead; CI builds the derivations.
