### PR TITLE
How to get this machine back on new hardware, written down for the first time

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -128,6 +128,25 @@ skills, and the NixOS philosophy underneath all of it.
 New to NixOS? Start with
 **[the philosophy](manual/philosophy)** and **[updating NixOS](manual/updating-nixos)**.
 
+## Get this machine back on new hardware
+
+`nixarchy reinstall iso` builds a bootable image **from this machine's own
+configuration**. Boot it on a new laptop and you get this system back --
+packages, desktop, services, settings -- with nothing downloaded and nothing
+compiled, because the closure is on the medium.
+
+It is the only one of the five ways back that survives losing the disk: a
+generation covers a bad change, a snapshot covers a deleted file, and two git
+repos cover your dotfiles and your configuration.
+
+**It is not a backup, and the name says so on purpose.** It carries your
+system, not your files -- no `/home`, no browser profiles, no service state --
+and booting it erases the target disk. The trap that names avoids is somebody
+losing a disk, booting the thing they called a backup, and getting a clean
+machine with none of their photographs.
+
+See **[a reinstall image of this machine](manual/reinstall-image)**.
+
 ## Where this has got to
 
 Four features finished recently, and each is here because it is *checked*, not

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -88,6 +88,7 @@ the documentation as much as the code.
 | Omarchy on | same as Omarchy — [read there](https://omarchy.org/manual/omarchy-on/) |
 | **Dual boot install** | **differs on NixOS** — [read here](dual-boot-install) |
 | **Many machines, one repo** | **nixarchy only** — [read here](many-machines) |
+| **A reinstall image of this machine** | **nixarchy only** — [read here](reinstall-image) |
 | **Unattended installs** | **differs on NixOS** — [read here](unattended-installs) |
 
 ## The short version of the difference

--- a/docs/manual/reinstall-image.md
+++ b/docs/manual/reinstall-image.md
@@ -1,0 +1,133 @@
+---
+title: A reinstall image of this machine
+---
+
+# A reinstall image of this machine
+
+`nixarchy reinstall iso` builds a bootable image **from this machine's own
+configuration**. Boot it on new hardware and you get this system back: the same
+packages, the same desktop, the same services, the same settings.
+
+It is the last of the five ways back, and the only one that survives losing the
+disk:
+
+| what went wrong | what gets you back |
+|---|---|
+| a bad change | a previous [generation](system-snapshots) |
+| a deleted file, same disk | a [snapshot](system-snapshots#snapshots-of-your-home-directory) |
+| your dotfiles | [the home backup](dotfiles) |
+| your configuration | [the config repo](many-machines) |
+| **the disk itself, or the whole machine** | **this image** |
+
+## It is not a backup, and that distinction is the whole page
+
+**The image carries your system. It does not carry your files.**
+
+No `/home`. No browser profiles. No service state, no databases, no
+photographs. And **booting it erases the target disk**.
+
+That is why the menu row is called *Build reinstall image* and not *Backup*.
+The trap it avoids is a specific one: somebody loses a disk, boots the thing
+they were calling a backup, and ends up with a clean machine and none of their
+files. Your files come back from your backups. This brings back the machine
+they go on.
+
+## Making one
+
+From the menu: **Trigger ▸ Build reinstall image**. Or in a terminal:
+
+```
+nixarchy reinstall iso
+```
+
+It checks three things before it starts, and each refusal says what to do:
+
+- **Disk space.** The image is 6–10 GB and the build wants roughly twice the
+  closure in transient space. Checked first, because running out of disk
+  mid-build fails several levels away from the cause.
+- **Committed.** The flake embedded in the image pins by commit, so an
+  uncommitted tree cannot be baked. `git add` is not enough — it has to be
+  committed.
+- **Drift.** If what is running differs from what `/etc/nixos` evaluates to —
+  edits you have not switched to yet — it says so and asks. It does not refuse:
+  building an image of what the configuration *says*, rather than what happens
+  to be running, is a legitimate thing to want. It just should not happen
+  without being told.
+
+Then it asks before building, because the build takes tens of minutes —
+compression is most of it.
+
+The image lands at `~/.local/share/nixarchy/reinstall-iso/`, and the command
+prints the exact path and size.
+
+## Writing it to a USB stick
+
+```
+sudo dd if=<the path it printed> of=/dev/sdX bs=4M status=progress oflag=sync
+```
+
+`/dev/sdX` is the stick, not a partition on it, and **this erases the stick**.
+Check the device name with `lsblk` first.
+
+Two things to do with the image once you have it:
+
+**Keep it off this machine.** An image stored on the disk it exists to replace
+protects nothing.
+
+**Keep it private.** It contains your `/etc/nixos` — hostnames, options, the
+shape of your network — and the unfree packages your system uses. Those are
+yours to keep and not yours to publish.
+
+## Using it: a new machine
+
+Boot the stick. There is no boot menu and no login prompt — the installer is
+what comes up, the same one the [normal ISO](getting-started) runs, and it asks
+the same questions.
+
+The difference is what it installs. A normal ISO installs a fresh nixarchy. This
+one installs **the system that built it** — the closure is on the medium, so
+nothing is downloaded and nothing is compiled. That means it works on a machine
+with no network at all: no wifi driver loaded, no cable to hand.
+
+After it finishes, the machine has your system and `/etc/nixos` is your
+repository. What it does not have is your files — bring those back with
+[`nixarchy home backup restore`](dotfiles) and your own backups.
+
+## Using it: a machine that already has something on it
+
+**The installer erases the disk you point it at.** There is no in-place upgrade
+here and no merge with what is already there.
+
+If the target has something you want, you have two honest options:
+
+1. **Move the data off first**, then install and bring it back.
+2. **Install beside it** rather than over it — that is a different flow, and
+   [dual boot](dual-boot-install) covers installing into free space next to an
+   existing system.
+
+If what you actually want is *this configuration on a machine that already runs
+NixOS*, do not use the image at all. Add the nixarchy module to the
+configuration that machine already has — it touches neither the partitions nor
+the bootloader, and a bad result is one `nixos-rebuild --rollback` away.
+[Many machines, one repo](many-machines) is the page for that.
+
+## What is checked, and what is not
+
+The image is built and reinstalled from, in a VM, on a machine that is
+deliberately *not* this project's reference system — and the assertion is not
+"the install worked" but that **nothing was built and nothing was fetched**:
+every path came off the medium. That check runs nightly rather than on every
+change, because it builds a second full image and installs from it.
+
+What no check covers is your particular hardware. A green check says the image
+reinstalls correctly in a VM; it says nothing about whether your new laptop's
+wifi chip has a driver in the closure you baked. If the new machine's hardware
+differs from the old one, expect to edit `hosts/<name>/hardware-configuration.nix`
+after the first boot, and to rebuild — which needs a network.
+
+## Related
+
+- [Getting started](getting-started) — the normal installer
+- [Many machines, one repo](many-machines) — one configuration, several machines
+- [Your dotfiles](dotfiles) — the half this image does not carry
+- [System snapshots](system-snapshots) — generations, and undoing a bad change


### PR DESCRIPTION
How to get this machine back on new hardware, written down for the first time

The reinstall image was shipped and documented nowhere. `nixarchy-reinstall-iso`
appeared in **no** manual page, **not** in the README, and **not** on the
website -- only in the menu row and its own source comments.

Four of #478's six children are closed: the image builds (#479), carries the
user's repository and autostarts the installer (#480), has a command and a menu
row (#481), and refuses on space, an uncommitted tree and configuration drift
(#482). A user had no way to learn any of that existed.

## `docs/manual/reinstall-image.md`

The page a person needs, in the order they need it.

**What it is**, as the fifth way back, positioned against the other four rather
than described in isolation:

| what went wrong | what gets you back |
|---|---|
| a bad change | a previous generation |
| a deleted file, same disk | a snapshot |
| your dotfiles | the home backup |
| your configuration | the config repo |
| **the disk itself, or the whole machine** | **this image** |

**What it is not**, given its own section because it is the whole point: the
image carries the system and not the files, and booting it ERASES the target
disk. That is why the row is called *Build reinstall image* and not *Backup* --
the trap the name avoids is somebody losing a disk, booting the thing they
called a backup, and getting a clean machine with none of their photographs.

**Making one**: the menu row, the command, and what each of the three
preflights means. Including why drift WARNS rather than refuses -- building an
image of what the configuration says, rather than what happens to be running,
is a legitimate thing to want and just must not happen silently.

**Writing it to a stick**, with the `dd` line, `lsblk` first, and two things to
do afterwards that nobody would guess:

- keep it OFF this machine -- an image on the disk it exists to replace
  protects nothing
- keep it PRIVATE -- it contains your `/etc/nixos` and the unfree packages your
  system uses

**Using it on a new machine**: it boots straight into the installer like the
normal ISO, and the difference is what it installs -- the system that built it,
copied from the medium, so it works with no network at all.

**Using it on a machine that already has something on it**, which the user
asked about specifically and which has an uncomfortable answer: **the installer
erases the disk you point it at.** There is no in-place upgrade and no merge.
Two honest options are given (move the data first, or install beside it via
dual boot) plus the answer that is usually what was actually wanted -- if the
target already runs NixOS, do not use the image at all, add the module to the
configuration it already has, where a bad result is one rollback away.

**What is checked and what is not.** `checks.reinstall-vm` builds a user image
and reinstalls from it in a VM, asserting not "the install worked" but that
nothing was built and nothing was fetched. It runs nightly, because it builds a
second full image. What no check covers is the reader's hardware: a green check
says nothing about whether the new laptop's wifi chip has a driver in the
closure they baked, so the page says to expect a
`hardware-configuration.nix` edit and a rebuild.

## The front page

A section above *Where this has got to*, because "get this machine back on new
hardware" is a reason to try this and was invisible.

## Verified rather than assumed

- every internal link in the new page resolves, including the
  `system-snapshots#snapshots-of-your-home-directory` anchor
- the markers really do come from `source.installed`
  (`installer/cd.nix:897`), so a user's image installs THEIR machine and not
  this project's reference -- the half-refactor that comment warns about is
  fixed, and the page can honestly say "the system that built it"
- `checks.reinstall-vm` is in `nightly_only`, so "runs nightly" is accurate
- the gate returns `false` for both questions: no build, no install

**Depends on #539**, which routes `nixarchy reinstall iso` and `nixarchy home
backup restore`. Both are written as verbs in this page because that is how
they will read once it merges; #539 is CLEAN as I write this.

Part of #478. Does not close it -- #483 (a network variant) and #484 (the VM
check) remain, and the page states the limits rather than papering over them.
