### PR TITLE
The channel choice, unfreeze, and a front page that stops calling shipped work in flight

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -179,16 +179,25 @@ supported by this version of adb"*.
 firewall hole, and authentication that does not quietly fall back to a shared
 secret.
 
+**Stable or unstable, your choice.** *Update ▸ Channel* offers it the way
+Omarchy does, and moves nixpkgs and home-manager together — the two are
+developed as a pair and a mismatch is a combination neither project supports.
+You can also take a single package from the other channel without moving the
+machine.
+
+It was sequenced deliberately, and the reason is worth stating: nixos-26.05
+ships a version of the desktop shell whose lockscreen can leave a machine blank
+with nowhere to type a password. That is fixed *before* anyone is offered the
+choice that would hand it to them. And the page says the uncomfortable part
+plainly — "stable" sounds safer and here it is **less tested**, because nixarchy
+is developed against unstable.
+
+See **[stable or unstable](manual/channels)**.
+
 ### What is being worked on now
 
-A **choice of channel** — stable or unstable — offered the way Omarchy offers
-it, plus a way to take a single package from the other one. It is sequenced
-deliberately: nixos-26.05 ships a version of the desktop shell whose lockscreen
-can leave a machine blank with nowhere to type a password, so that is fixed
-*before* anyone is offered the choice that would hand it to them. Also in
-flight: the package picker remade, running an application once without
-installing it, and building a reinstall image from a machine's own
-configuration.
+The package picker remade, running an application once without installing it,
+and a network variant of the reinstall image.
 
 The [board](https://github.com/users/olafkfreund/projects/9) is public, and its
 *Shipped* view is the honest answer to "is this thing alive".

--- a/docs/manual/channels.md
+++ b/docs/manual/channels.md
@@ -1,0 +1,106 @@
+---
+title: Stable or unstable
+---
+
+# Stable or unstable
+
+Omarchy lets you pick a release channel. So does nixarchy — **Update ▸ Channel**
+in the menu, or:
+
+```
+nixarchy channel              # which one this machine follows
+nixarchy channel stable       # nixos-26.05, and the matching home-manager
+nixarchy channel unstable     # nixos-unstable
+```
+
+## The uncomfortable part, first
+
+**"Stable" sounds safer, and here it is less tested.**
+
+nixarchy is developed against unstable. The flake pins `nixos-unstable` and
+every check runs against whatever that locks to. Stable is a real answer, not a
+supported one.
+
+What CI proves about stable is narrow and worth knowing exactly: a check
+evaluates this flake against `nixos-26.05` on every change, in about twenty
+seconds. That proves the configuration is **valid** on stable — every attribute
+exists, every option is an option. It does **not** prove the machine boots or
+that the desktop comes up. Nothing starts a VM on stable, because the install
+job is already the slowest thing in the project and doubling it would slow every
+change for everyone.
+
+So: fewer people run stable here, and the automated evidence behind it is
+thinner. If you want the combination that is actually exercised, that is
+unstable.
+
+## What each one means
+
+| | stable | unstable |
+|---|---|---|
+| nixpkgs | `nixos-26.05` | `nixos-unstable` |
+| home-manager | `release-26.05` | tracks master |
+| package versions | frozen until the next release | move continuously |
+| tested by nixarchy | evaluation only | everything |
+
+Switching moves **both** nixpkgs and home-manager, and that is not a
+convenience. The two are developed as a pair, and a machine on stable nixpkgs
+with a master home-manager is a combination neither project supports —
+home-manager itself warns about it. `nixarchy channel` does both edits or
+neither.
+
+## What it does not change
+
+**Hyprland comes from upstream either way.** The compositor is pinned to
+`github:hyprwm/Hyprland`, not taken from nixpkgs, so choosing stable does not
+give you a stable compositor. Same for Omarchy itself, which is pinned to a
+release.
+
+So the choice is about your *package set* — your browser, your editor, your
+libraries — and not about the desktop.
+
+## Your flake stays yours
+
+`nixarchy channel` edits `/etc/nixos/flake.nix`, and it does that under one
+rule: **only lines this project wrote get rewritten.** If you have reshaped
+your flake, it refuses and prints the edit for you to make, rather than
+guessing. It backs up first and re-locks only what moved.
+
+## One package from the other channel
+
+You do not have to move the whole machine to get one newer package.
+
+```
+nixarchy pkg add --unstable helix     # on a stable machine
+nixarchy pkg add --stable   vlc       # on an unstable one
+```
+
+**This is expensive, and the number is not intuitive.** The two channels share
+**nothing** in the nix store — not "less", nothing — even where the version is
+identical. Measured: `btop` at the same version on both is **0 shared paths and
+51 MB duplicated**; `vlc 3.0.23-2` is **1.5 GB**.
+
+So it is a deliberate per-package decision, never a default. The command tells
+you what channel the machine is on, refuses if you asked for the one you are
+already using, and prints the two lines you need to add to your own `flake.nix`
+— it does not edit that file for you, because adding an input is your decision.
+
+**Packages only.** A NixOS *option* comes from the package set the system is
+evaluated with, so `services.foo.enable` cannot be taken from the other
+channel. Only packages cross.
+
+## Checking where you are
+
+```
+nixarchy doctor
+```
+
+reports which channel the machine follows, says plainly that nixarchy is tested
+against unstable if you are on stable, and counts any packages you have taken
+from the other channel — because a duplicated closure is invisible until a disk
+fills.
+
+## Related
+
+- [Updates](updates) — what moves when, and what does not
+- [Updating NixOS](updating-nixos) — the rebuild loop underneath all of this
+- [Other packages](other-packages) — adding packages in the ordinary way

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -65,6 +65,7 @@ the documentation as much as the code.
 | **Preview changes** | **nixarchy only** — [read here](preview) |
 | **Try it first** | **nixarchy only** — [read here](try-it-first) |
 | **Updates** | **differs on NixOS** — [read here](updates) |
+| **Stable or unstable** | **nixarchy only** — [read here](channels) |
 | **Dotfiles** | **differs on NixOS** — [read here](dotfiles) |
 | Shell plugins | same as Omarchy — [read there](https://omarchy.org/manual/shell-plugins/) |
 | Monitors | same as Omarchy — [read there](https://omarchy.org/manual/monitors/) |

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -48,6 +48,31 @@ Always pass both flags to `omarchy debug`: `--no-sudo` skips `dmesg`, and
 `--print` writes to the terminal instead of trying to upload. The pacman
 lines in its output read `unknown`, which is expected.
 
+### `omarchy update` says it updated, but nothing ever moves
+
+If this machine was installed before the fix, its flake **can never move**, and
+the update said so is the worst part of it: inputs were reported as going
+forward while nothing did. No nixpkgs updates, no security fixes.
+
+The cause is exact. The old installer wrote a *commit* into both the nixarchy
+URL in `flake.nix` and the lock's `original` field — and `nix flake update`
+re-resolves `original`. Re-resolving a commit returns that commit, forever.
+
+```
+nixarchy unfreeze
+```
+
+rewrites the two things the installer got wrong, in place: the nixarchy input
+moves from a commit to the release branch, and nixpkgs becomes an input of your
+own that nixarchy follows.
+
+It only ever rewrites the installer's own line. If you have edited that URL
+into some other shape, the flake has an owner with opinions and the command
+refuses rather than editing around you.
+
+Nothing to do if you installed recently — new machines are not written this
+way. `nixarchy doctor` is the quick way to tell.
+
 ### My change rebuilt fine but the keybinding still runs the old thing
 
 `OMARCHY_PATH` and `PATH` are set at login. A rebuild produces a new store


### PR DESCRIPTION
An audit of every nixarchy command against the manual and the README, prompted
by the reinstall image turning out to be documented nowhere. Two more were:

| command | documented before |
|---|---|
| `nixarchy channel` | **nowhere** |
| `nixarchy unfreeze` | **nowhere** |

Everything else was covered.

## `docs/manual/channels.md`

The whole of #525, which shipped this week and which a user had no way to learn
about.

It leads with the uncomfortable part rather than burying it: **"stable" sounds
safer and here it is less tested.** nixarchy is developed against unstable, and
what CI proves about stable is narrow and stated exactly -- it evaluates in
about twenty seconds, which proves the configuration is valid and does not
prove the machine boots.

Also: that switching moves nixpkgs and home-manager together because neither
project supports the mismatch; that Hyprland comes from upstream either way, so
stable does not give you a stable compositor; that the tool rewrites only lines
this project wrote; and the per-package escape with the measurement that makes
it a deliberate choice -- 0 shared paths and 51 MB for btop at the SAME version,
1.5 GB for vlc.

## `unfreeze`, in troubleshooting

Not a feature page: it is a one-off repair for machines the old installer wrote
with a commit in the lock's `original`, where `nix flake update` re-resolved
that commit forever. Filed under the symptom somebody would actually search
for -- "omarchy update says it updated, but nothing ever moves" -- because
nobody looks up a command whose name they have never seen.

## The front page

It still described the channel choice under **"What is being worked on now"**.
That is the stale direction that matters on a public page: work that shipped,
advertised as pending. It moves up beside the other finished features, and the
in-flight list is now what is actually in flight.

Docs only; the gate returns false for both questions. Every internal link in
both new sections was checked to resolve.