### PR TITLE
Backup and recovery in one menu, and a diff before your file is touched

### DIFF
--- a/docs/manual/reinstall-image.md
+++ b/docs/manual/reinstall-image.md
@@ -34,7 +34,8 @@ they go on.
 
 ## Making one
 
-From the menu: **Trigger ▸ Build reinstall image**. Or in a terminal:
+From the menu: **System ▸ Backup and recovery ▸ Build reinstall image**. Or in
+a terminal:
 
 ```
 nixarchy reinstall iso

--- a/modules/AGENTS.md
+++ b/modules/AGENTS.md
@@ -1203,16 +1203,89 @@ The override rows, as data. Deliberately WITHOUT label or icon: those are
 copied from upstream's own menu at build time by the script below, so a
 rename upstream follows through instead of being frozen into this repo.
 
+<a id="backup-and-recovery-one-menu-542"></a>
+### Backup and recovery, one menu (#542)
+
+```nix
+"system.recovery" = {
+```
+
+"How do I get back?" used to be answered in two menus: Roll back and
+Back up configuration under System, the other five -- the two
+snapshot rows, the two home-backup rows, and the reinstall image --
+under Trigger, the catch-all upstream uses for one-off actions and a
+poor fit for "my disk died". The moment somebody needs one of these
+seven is the moment they are least willing to hunt through two menus
+for it, so all seven now live under one parent, `system.recovery`,
+Backup and recovery.
+
+A new parent under an existing top-level menu is precedented:
+trigger.box (#226) and trigger.vm both nest a group under Trigger the
+same way this nests one under System -- see "The Sandboxes group"
+below for the shape.
+
+Restores come before backups: the proposal in #542 puts Roll back,
+Restore from snapshot and Restore desktop config first, then Snapshot
+home, Back up desktop config, Back up configuration and Build
+reinstall image, on the reasoning that somebody opening this menu in
+an emergency wants the first half and somebody doing housekeeping can
+scroll. Menu.qml lists a parent's children in the order this file
+declares their ids, so getting that order right is a matter of
+writing the seven rows in that order and nothing else.
+
+No `when` on the parent. Rollback and the two snapshot rows carry no
+gate at all -- they work on every nixarchy machine -- and the other
+four keep the gates they had (`test -e /etc/nixarchy/managed` for
+Back up configuration, `nixarchy-home-backup --check` for the
+home-backup pair, `nixarchy-reinstall-iso --check` for the image).
+Gating the parent as well would hide the whole group, including the
+three rows that always work, on a machine where only one of the four
+gated rows fails its check. "Hidden children are hidden individually"
+below is the general form of the same rule.
+
+Two of the seven -- Restore from snapshot and Restore desktop
+config -- need an explicit `parent = "system.recovery";`.
+MenuModel.js's default parent for an id is that id with its last
+dot-segment dropped, which for `system.recovery.snapshot.restore` is
+`system.recovery.snapshot` -- the sibling "Snapshot home" row, not
+this menu. Left to the default, both restore rows would render one
+level too deep: invisible when browsing System > Backup and recovery
+(a screen only lists a child whose `parent` field equals the screen's
+own id), reachable only by typing into search. That was already true
+of `trigger.snapshot.restore` under Trigger before this change, and
+is the reason the fragmentation in #542 was worth fixing rather than
+just relabelling.
+
+Ids renamed, not aliased. All seven were already ids nixarchy
+invented -- `system.rollback`, `system.backup`,
+`trigger.snapshot(.restore)`, `trigger.home-backup(.restore)`,
+`trigger.reinstall-iso` -- not ids upstream ships, so nothing outside
+this repo has a contract with their spelling: no upstream row
+references them, and `programs.nixarchy.menu.extraEntries` (the one
+place a user's own configuration could name one) is new enough that
+nothing in this repo's history uses the old spellings. Keeping the
+old ids alive as silent redirects would be permanent complexity
+bought for hypothetical muscle memory, on a project with no released
+version and no stated compatibility promise for menu ids.
+`omarchy menu summon trigger.snapshot` after this change returns
+nothing, the same as summoning any id that was never real -- not a
+crash, not a stale row, just not found. If that turns out to matter
+in practice, `menu.extraEntries."trigger.snapshot".target =
+"system.recovery.snapshot"` is the same one-line fix a user reaching
+for the old name would need.
+
 <a id="beside-roll-back-because-they-are-the-two-halves-o"></a>
 ### Beside Roll back, because they are the two halves of the same
 
 ```nix
-"system.backup" = {
+"system.recovery.backup" = {
 ```
 
 Beside Roll back, because they are the two halves of the same
 question: a generation brings this machine back on this disk, and a
-pushed configuration brings it back on any other one.
+pushed configuration brings it back on any other one. Both now live
+under `system.recovery` -- see "Backup and recovery, one menu"
+above -- but the pairing this paragraph describes is unchanged.
 
 Reachable deliberately rather than only by notification. The command
 existed for a while with no way to reach it except a nudge on a boot
@@ -1229,7 +1302,7 @@ command itself gates on -- see modules/nixos.nix.
 ### The off-disk half, beside the on-disk one
 
 ```nix
-"trigger.home-backup" = {
+"system.recovery.home-backup.restore" = {
 ```
 
 The off-disk half, beside the on-disk one.
@@ -1237,7 +1310,9 @@ The off-disk half, beside the on-disk one.
 A snapshot and a backup read as the same thing to someone who has
 not lost a disk yet, so the two pairs sit together deliberately:
 snapshots are instant and local, these two survive the hardware.
-The descriptions are where that difference is actually said.
+The descriptions are where that difference is actually said. Both
+pairs now live under `system.recovery` -- see "Backup and recovery,
+one menu" above -- alongside Roll back and the reinstall image.
 
 `when` hides both rows on a machine nixarchy did not install --
 the same gate the script itself enforces, so an imported

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -311,51 +311,64 @@ let
           description = "Every package, NixOS option and Omarchy app, in one picker";
         };
 
-        # Every rebuild leaves the last one bootable and nothing said so.
-        #
-        # Under System because it is the system this restores. Upstream's
-        # nearest equivalent is a snapper snapshot picked from the boot menu,
-        # which is a different thing on NixOS: `@` here holds almost no
-        # operating system, so a generation is what carries one. The snapshot
-        # rows under Trigger cover the other half -- home, and service state
-        # -- which no generation touches.
-        "system.rollback" = {
+        # Why: modules/AGENTS.md#backup-and-recovery-one-menu-542
+        "system.recovery" = {
+          icon = "󰁯";
+          label = "Backup and recovery";
+          aliases = [
+            "recovery"
+            "restore"
+            "backup"
+          ];
+        };
+
+        # Restores before backups, in source order: #542 wants an emergency
+        # read left-to-right as "what to try first", and Menu.qml lists a
+        # parent's children in the order this file declares their ids in.
+        "system.recovery.rollback" = {
           icon = "󰕍";
           label = "Roll back";
           action = "omarchy-launch-floating-terminal-with-presentation nixarchy-rollback";
           description = "Switch to an earlier system generation. Your home directory is not touched";
         };
 
-        # Why: modules/AGENTS.md#beside-roll-back-because-they-are-the-two-halves-o
-        "system.backup" = {
-          icon = "󰆔";
-          label = "Back up configuration";
-          when = "test -e /etc/nixarchy/managed";
-          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-config-repo";
-          description = "Commit and push this machine's NixOS configuration, so a reinstall can bring it back";
+        # Explicit `parent`: MenuModel.js's default parent for this id is
+        # "system.recovery.snapshot" (its own id with the last segment
+        # dropped) -- the PEER row below, not this menu. Left to the
+        # default, this row would render one level too deep: invisible when
+        # browsing System > Backup and recovery, reachable only by search --
+        # the same trap trigger.snapshot.restore was already in under
+        # Trigger, and the reason system.recovery.home-backup.restore below
+        # needs the same override.
+        "system.recovery.snapshot.restore" = {
+          icon = "󰦛";
+          label = "Restore from snapshot";
+          parent = "system.recovery";
+          action = "omarchy-launch-floating-terminal-with-presentation omarchy-snapshot restore";
+          description = "Open an earlier version of your home directory and copy back what you want";
         };
 
-        # Snapshots under Trigger, beside the other "do a thing now" rows.
-        #
-        # Upstream's are taken by its updater and restored from the boot menu,
-        # and neither happens here. These are new rows, so they carry their
-        # own label and icon.
-        "trigger.snapshot" = {
+        # Why: modules/AGENTS.md#the-off-disk-half-beside-the-on-disk-one
+        "system.recovery.home-backup.restore" = {
+          icon = "󰇚";
+          label = "Restore desktop config";
+          parent = "system.recovery";
+          when = "nixarchy-home-backup --check";
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-home-backup restore";
+          description = "Copy your bar, keybindings and themes back out of the backup. Works on a new machine";
+        };
+
+        # Upstream's snapshots are taken by its updater and restored from
+        # the boot menu, and neither happens here. This is a new row, so it
+        # carries its own label and icon.
+        "system.recovery.snapshot" = {
           icon = "󰆓";
           label = "Snapshot home";
           action = "omarchy-launch-floating-terminal-with-presentation omarchy-snapshot create";
           description = "Save your home directory as it is now. Instant, and costs nothing until files change";
         };
 
-        "trigger.snapshot.restore" = {
-          icon = "󰦛";
-          label = "Restore from snapshot";
-          action = "omarchy-launch-floating-terminal-with-presentation omarchy-snapshot restore";
-          description = "Open an earlier version of your home directory and copy back what you want";
-        };
-
-        # Why: modules/AGENTS.md#the-off-disk-half-beside-the-on-disk-one
-        "trigger.home-backup" = {
+        "system.recovery.home-backup" = {
           icon = "󰁯";
           label = "Back up desktop config";
           when = "nixarchy-home-backup --check";
@@ -363,19 +376,20 @@ let
           description = "Push your bar, keybindings and themes to a private git repository. Survives the disk";
         };
 
-        "trigger.home-backup.restore" = {
-          icon = "󰇚";
-          label = "Restore desktop config";
-          when = "nixarchy-home-backup --check";
-          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-home-backup restore";
-          description = "Copy your bar, keybindings and themes back out of the backup. Works on a new machine";
+        # Why: modules/AGENTS.md#beside-roll-back-because-they-are-the-two-halves-o
+        "system.recovery.backup" = {
+          icon = "󰆔";
+          label = "Back up configuration";
+          when = "test -e /etc/nixarchy/managed";
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-config-repo";
+          description = "Commit and push this machine's NixOS configuration, so a reinstall can bring it back";
         };
 
         # Deliberately not called "backup" -- #478 names the trap: someone
         # loses a disk, boots the "backup", and gets a clean machine with
         # none of their files. The image reinstalls the SYSTEM; files come
-        # back from the two rows above.
-        "trigger.reinstall-iso" = {
+        # back from the rows above.
+        "system.recovery.reinstall-iso" = {
           icon = "󰗮";
           label = "Build reinstall image";
           when = "nixarchy-reinstall-iso --check";
@@ -498,8 +512,8 @@ let
       // lib.optionalAttrs boxesEnabled (
         {
           # A new parent under Trigger, appended after upstream's own rows --
-          # the same precedent trigger.snapshot and trigger.home-backup above
-          # already set for this file, and the one #226 set for sandboxes.
+          # the same precedent system.recovery above already set for this
+          # file (#542), and the one #226 set for sandboxes.
           # `when` is the runtime half of the gate: whether podman is
           # actually usable THIS login is only knowable now, not at rebuild
           # time -- the Nix-level half is `boxesEnabled` just above, which
@@ -1577,6 +1591,7 @@ in
                 pkgs.gnused
                 pkgs.gawk
                 pkgs.jq
+                pkgs.diffutils
                 config.nix.package
                 cfg.package # omarchy-notification-send
               ];
@@ -1629,10 +1644,16 @@ in
                 # package that was already there.
                 other=false
                 want_channel=""
+                # --dry-run answers #495: show the diff before touching the
+                # user's file. It costs nothing extra -- everything below
+                # already edits $file with $backup as the pre-edit copy, so
+                # dry-run's whole job is to diff those two and put $file back.
+                dry_run=false
                 while [ $# -gt 0 ]; do
                   case "$1" in
                     --stable)   other=true; want_channel=stable;   shift ;;
                     --unstable) other=true; want_channel=unstable; shift ;;
+                    --dry-run)  dry_run=true; shift ;;
                     --) shift; break ;;
                     -*) echo "nixarchy-pkg-add: unknown option '$1'" >&2; exit 1 ;;
                     *) break ;;
@@ -1691,13 +1712,15 @@ in
                   if can_pick; then
                     exec nixarchy-search
                   fi
-                  echo "usage: nixarchy-pkg-add [--stable|--unstable] <nixpkgs-attribute>..." >&2
+                  echo "usage: nixarchy-pkg-add [--stable|--unstable] [--dry-run] <nixpkgs-attribute>..." >&2
                   echo "  e.g. nixarchy-pkg-add ripgrep fd" >&2
                   echo "  or run 'nixarchy-search' to browse everything" >&2
                   echo >&2
                   echo "  --stable / --unstable take ONE package from the other" >&2
                   echo "  channel. The two share no store paths even at the same" >&2
                   echo "  version, so each one costs its whole closure." >&2
+                  echo >&2
+                  echo "  --dry-run shows the diff to $file without writing it." >&2
                   exit 1
                 fi
 
@@ -1959,6 +1982,44 @@ in
                   restore
                   echo "nixarchy: that would have left $file unparseable. Nothing was changed." >&2
                   exit 1
+                fi
+
+                # $file has been edited in place all along, with $backup as
+                # the pre-edit copy every restore above already relies on --
+                # so the diff nobody has seen yet is just the two of them,
+                # compared now that the result is known to parse.
+                #
+                # NIXARCHY_IN_PICKER means fzf already collected a yes a
+                # moment ago; asking again here would be a second prompt for
+                # the same choice. can_pick's own guard is why: a menu pick
+                # runs with no terminal attached at all, where a prompt would
+                # not double-ask, it would hang.
+                interactive() {
+                  [ -z "''${NIXARCHY_IN_PICKER:-}" ] && [ -t 0 ] && [ -t 1 ]
+                }
+
+                if [ "$dry_run" = true ] || interactive; then
+                  echo "-- $file --"
+                  diff -u --label "$file (before)" --label "$file (after)" "$backup" "$file" || true
+                  echo
+                fi
+
+                if [ "$dry_run" = true ]; then
+                  restore
+                  echo "dry run: nothing written to $file"
+                  exit 0
+                fi
+
+                if interactive; then
+                  printf 'Write this to %s? [Y/n] ' "$file"
+                  read -r reply || reply=n
+                  case "$reply" in
+                    [nN]*)
+                      restore
+                      echo "Nothing changed."
+                      exit 0
+                      ;;
+                  esac
                 fi
 
                 count=$(grep -c '#@pkg ' "$file" || true)

--- a/pkgs/omarchy/nix-bin/omarchy-snapshot
+++ b/pkgs/omarchy/nix-bin/omarchy-snapshot
@@ -69,7 +69,7 @@ fi
 # verbatim copy in its own repo, and disko only ever ran at install time.
 #
 # The failure mode this exists for is not an error. It is the absence of one:
-# somebody sees `trigger.snapshot` in the menu, believes they have an undo,
+# somebody sees `system.recovery.snapshot` in the menu, believes they have an undo,
 # and finds out they never did at the moment they reach for it. So every
 # subcommand refuses here rather than letting snapper succeed into a plain
 # directory that no `list` will ever show anything from.

--- a/tests/home-backup-menu.py
+++ b/tests/home-backup-menu.py
@@ -20,8 +20,8 @@ menu = json.loads(re.sub(r",(\s*[}\]])", r"\1", raw))
 GATE = "nixarchy-home-backup --check"
 
 for row_id, want_action in (
-    ("trigger.home-backup", "nixarchy-home-backup"),
-    ("trigger.home-backup.restore", "nixarchy-home-backup restore"),
+    ("system.recovery.home-backup", "nixarchy-home-backup"),
+    ("system.recovery.home-backup.restore", "nixarchy-home-backup restore"),
 ):
     row = menu.get(row_id)
     if row is None:
@@ -34,8 +34,8 @@ for row_id, want_action in (
             "It would be offered on a machine where the command refuses."
         )
     # MenuModel.js falls back to the raw id for a missing label and to "" for
-    # everything else, so an omitted key renders as "trigger.home-backup"
-    # rather than inheriting anything.
+    # everything else, so an omitted key renders as
+    # "system.recovery.home-backup" rather than inheriting anything.
     for key in ("label", "icon", "description"):
         if not row.get(key):
             sys.exit(f"{row_id} has no {key}; the menu renders the raw id")

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -1610,7 +1610,7 @@ pkgs.runCommand "nixarchy-options"
           # answer in the interface. The row is also the drift path's front
           # door: running it on an armed repository is what commits and pushes
           # what has piled up since.
-          row=$(sed -n '/"system.backup"/,/^  }/p' "$vm/etc/nixarchy/omarchy-menu.jsonc")
+          row=$(sed -n '/"system.recovery.backup"/,/^  }/p' "$vm/etc/nixarchy/omarchy-menu.jsonc")
           test -n "$row" || {
             echo "the menu has no System > Back up configuration row" >&2
             echo "  nixarchy-config-repo is then reachable only by acting on a" >&2


### PR DESCRIPTION
Backup and recovery in one menu, and a diff before your file is touched

Closes #542. Closes #495. Part of #491.

Two changes in one pull request because they are in one file, a thousand lines
apart, and landing them separately is how #539 and #540 spent this afternoon
conflicting on `modules/apps.nix`.

## #542 -- recovery answers stop being split across two menus

"How do I get back?" was answered in two places: `Roll back` and `Back up
configuration` under **System**, and the snapshot pair, the home-backup pair and
the reinstall image under **Trigger** -- Omarchy's catch-all for one-off
actions, and the last place somebody looks when a disk has just died.

All seven now sit under **System ▸ Backup and recovery**, ordered by what went
wrong rather than by when they were written: the three restores first, the four
that produce something after. Somebody opening this menu in an emergency wants
the first half; somebody doing housekeeping can scroll.

Every `when` gate travelled with its row -- `test -e /etc/nixarchy/managed` on
the config backup, `nixarchy-home-backup --check` on the home pair,
`nixarchy-reinstall-iso --check` on the image. The parent deliberately carries
none, so one gated sibling failing its check cannot hide the three ungated ones.

### The bug this turned up, which the issue did not know about

Two rows shipped **invisible**, and have been since they were written.

`shell/plugins/menu/MenuModel.js:18` derives a row's parent by dropping the last
dot-segment when none is declared, and `Menu.qml:589` lists a row only when
`entry.parent === active`. So `trigger.snapshot.restore` derived the parent
`trigger.snapshot` -- which is a leaf ACTION, not a menu screen. Nothing ever
listed it. `Restore from snapshot` and `Restore desktop config` were reachable
by search and `omarchy menu summon` and by no amount of browsing.

Reproducing that one level down would have made #542 cosmetic: seven rows
grouped, five of them visible. Both restore rows now carry an explicit
`parent = "system.recovery"`, and the trap is written into `modules/AGENTS.md`
so the next row added under a leaf's namespace is not the third.

### Ids renamed, not aliased

All seven ids were nixarchy's own invention -- no upstream row references them,
and nothing in this repository's history targets the old spellings through
`menu.extraEntries`. Keeping hidden redirect rows would be permanent complexity
bought for hypothetical muscle memory on a project with no released version and
no stated compatibility contract for menu ids. The three places outside
`apps.nix` that named the old ids by string were updated with them.

## #495 -- see the diff before your file is edited

`nixarchy-pkg-add` edits `~/.config/nixarchy/apps.nix`, which is the user's own
NixOS module. It now shows exactly what it is about to write.

Scoped to `pkg-add` on purpose. `nixarchy-app-remove` already shows the line
that would go in its fzf preview pane, and the enable/disable commands are
one-line toggles; adding a second confirmation to those would be ceremony, not
safety.

**The path that matters is the one with no terminal.** A menu row runs these
with stdin closed, and a prompt there would hang a desktop action nobody can
answer. Verified, not assumed:

| path | behaviour |
|---|---|
| `--dry-run` | shows the diff, writes **nothing** -- file byte-identical before and after |
| picker or menu (`NIXARCHY_IN_PICKER=1`, no tty) | writes, no diff, no prompt -- unchanged from before |
| an interactive terminal | diff, then `Write this to <file>? [Y/n]`; declining restores and exits 0 |

`NIXARCHY_IN_PICKER` is reused rather than a new guard invented: it already
means "a yes was collected a moment ago via fzf", which is exactly the case a
second confirmation would be wrong for.

## Verification

| | |
|---|---|
| the two agents' regions | 314-515 and 1579-1973 -- no overlap, both patches applied clean |
| `nix fmt --ci` / statix / `deadnix --fail` | clean, each read from its own exit code |
| the vm evaluates | yes |
| `writeShellApplication` shellcheck on `nixarchy-pkg-add` | pass |
| `--dry-run` leaves the file untouched | **byte-identical**, diffed against a copy taken first |
| non-interactive path prints no prompt and still writes | 0 prompts, line present |
| the two restore rows are real children | explicit `parent`, read back out of the source |

I first reported the dry run as writing to the file. That was my test being
wrong, not the code -- I had grepped stale terminal output rather than the file.
Diffing against a copy taken beforehand is what settled it, and is why the row
above says byte-identical rather than "looks right".

The menu rows were not built through `checks.options` or `checks.menu-verbs`
locally: CI had install jobs on this shared host, and AGENTS.md section 6 exists
because a local build of mine starved them once already. CI builds them.
