### PR TITLE
The manual's sidebar stops hiding two shipped features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -616,6 +616,39 @@ jobs:
       - name: Every derived number in the README
         run: .github/scripts/readme-counts.sh --check
 
+      # docs/_config.yml carries the manual's sidebar as an explicit list,
+      # because alphabetical would open the manual on "AI" and bury Getting
+      # Started. The cost of stating the order is that a page added to
+      # manual/ and not listed is published at its URL and reachable from
+      # nothing -- its own comment says so, and four pages had drifted out of
+      # the nav that way (channels, preview, reinstall-image,
+      # how-this-is-tested) before anyone noticed the manual never mentioned
+      # two shipped features.
+      #
+      # Order still is not checked, only membership: where a page belongs in
+      # a reading order is a judgement, whether it is reachable at all is not.
+      - name: Every manual page is in the sidebar
+        run: |
+          pages=$(ls docs/manual/*.md | xargs -n1 basename |
+            sed 's/\.md$//' | grep -v '^index$' | sort)
+          nav=$(grep -oE 'path: /manual/[a-z-]+' docs/_config.yml |
+            sed 's|path: /manual/||' | sort -u)
+          llms=$(grep -oE 'manual/[a-z-]+' docs/llms.txt |
+            sed 's|manual/||' | sort -u)
+          rc=0
+          for n in $(comm -23 <(echo "$pages") <(echo "$nav") || true); do
+            echo "::error::docs/manual/$n.md is published but not in the docs/_config.yml sidebar"
+            rc=1
+          done
+          # llms.txt is the same list for a reader that is a model rather than
+          # a person, and it had drifted further than the sidebar had.
+          for n in $(comm -23 <(echo "$pages") <(echo "$llms") || true); do
+            echo "::error::docs/manual/$n.md is published but not in docs/llms.txt"
+            rc=1
+          done
+          [ $rc -eq 0 ] || exit 1
+          echo "every manual page is in the sidebar and in llms.txt"
+
       - name: Verify shebangs were patched
         run: |
           # Line 1 only. Several scripts legitimately contain `#!/bin/bash`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -629,7 +629,7 @@ jobs:
       # a reading order is a judgement, whether it is reachable at all is not.
       - name: Every manual page is in the sidebar
         run: |
-          pages=$(ls docs/manual/*.md | xargs -n1 basename |
+          pages=$(basename -a docs/manual/*.md |
             sed 's/\.md$//' | grep -v '^index$' | sort)
           nav=$(grep -oE 'path: /manual/[a-z-]+' docs/_config.yml |
             sed 's|path: /manual/||' | sort -u)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -40,6 +40,8 @@ nav:
   - { path: /manual/getting-started,          title: Getting Started }
   - { path: /manual/updating-nixos,           title: Updating NixOS }
   - { path: /manual/updates,                  title: Updates }
+  - { path: /manual/preview,                  title: Preview Changes }
+  - { path: /manual/channels,                 title: Stable or Unstable }
   - { path: /manual/other-packages,           title: Packages }
   - { path: /manual/try-it-first,             title: Try It First }
   - { path: /manual/dotfiles,                 title: Dotfiles }
@@ -55,6 +57,8 @@ nav:
   - { path: /manual/remote-desktop,           title: Remote Desktop }
   - { path: /manual/system-snapshots,         title: System Snapshots }
   - { path: /manual/many-machines,            title: "Many machines, one repo" }
+  - { path: /manual/reinstall-image,          title: "A reinstall image of this machine" }
   - { path: /manual/dual-boot-install,        title: Dual Boot Install }
   - { path: /manual/unattended-installs,      title: Unattended Installs }
+  - { path: /manual/how-this-is-tested,       title: How This Is Tested }
   - { path: /manual/troubleshooting,          title: Troubleshooting }

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -103,8 +103,9 @@ Key facts an assistant should know before answering questions about nixarchy:
 - [The NixOS Philosophy](https://olafkfreund.github.io/nixarchy/manual/philosophy): why installs are declarations, what is yours to edit imperatively vs. what a rebuild owns
 - [Getting Started](https://olafkfreund.github.io/nixarchy/manual/getting-started): building and booting the installer ISO, the seven install questions, and the first hour on the desktop
 - [Updating NixOS](https://olafkfreund.github.io/nixarchy/manual/updating-nixos): flake updates, the rebuild modes, generations, rollback, and the stale-session trap
-- [Updates](https://olafkfreund.github.io/nixarchy/manual/updates): what Update ▸ Nixarchy does here, why release channels do not exist, firmware updates, rolling back
+- [Updates](https://olafkfreund.github.io/nixarchy/manual/updates): what Update ▸ Nixarchy does here, the two release channels that have a NixOS meaning, firmware updates, rolling back
 - [Preview changes](https://olafkfreund.github.io/nixarchy/manual/preview): booting a config change in a VM before switching to it — the disk lifecycle, and what a green preview does not prove
+- [Stable or unstable](https://olafkfreund.github.io/nixarchy/manual/channels): Update ▸ Channel follows nixos-26.05 or nixos-unstable, moving home-manager with it; stable is less tested here, not more, and a single package can come from the other channel
 - [Packages](https://olafkfreund.github.io/nixarchy/manual/other-packages): the app selection, apps.nix and nixarchy-apply, Install ▸ Search, services.nix, unfree software, removing apps
 - [Try It First](https://olafkfreund.github.io/nixarchy/manual/try-it-first): nixarchy try runs an app once, from the pinned nixpkgs, without installing — no isolation, no launcher entry, and it stays in /nix/store until garbage collection nobody schedules
 - [Dotfiles](https://olafkfreund.github.io/nixarchy/manual/dotfiles): which config files are yours, which are seeded, and how the menu is extended
@@ -115,12 +116,15 @@ Key facts an assistant should know before answering questions about nixarchy:
 - [Sandboxes](https://olafkfreund.github.io/nixarchy/manual/sandboxes): disposable NixOS MicroVMs sharing the host store, and the declarative always-up half (opt-in)
 - [AI](https://olafkfreund.github.io/nixarchy/manual/ai): the ten NixOS agent skills, the Ask menu, choosing an agent, and running it all locally
 - [Gaming](https://olafkfreund.github.io/nixarchy/manual/gaming): Steam, RetroArch, the launchers and cloud gaming — how each Install ▸ Gaming row lands on NixOS
+- [Android](https://olafkfreund.github.io/nixarchy/manual/android): running Android apps — scrcpy mirroring a phone, and Waydroid in a container
 - [Security](https://olafkfreund.github.io/nixarchy/manual/security): the firewall, disk encryption, and what the port changes
 - [Remote Desktop](https://olafkfreund.github.io/nixarchy/manual/remote-desktop): serving the running Hyprland session over RDP (opt-in)
 - [System Snapshots](https://olafkfreund.github.io/nixarchy/manual/system-snapshots): generations replace snapper for the system; snapper covers /home on installer-built machines
 - [Many machines, one repo](https://olafkfreund.github.io/nixarchy/manual/many-machines): one flake for a fleet, and machines that pull their configuration on a timer
+- [A reinstall image of this machine](https://olafkfreund.github.io/nixarchy/manual/reinstall-image): nixarchy reinstall iso builds a bootable image from this machine's own configuration — the only way back that survives losing the disk
 - [Dual Boot Install](https://olafkfreund.github.io/nixarchy/manual/dual-boot-install): the installer's free-space mode — installing into unpartitioned space beside an existing OS
 - [Unattended Installs](https://olafkfreund.github.io/nixarchy/manual/unattended-installs): an answers file so an image boots, installs and reboots with nobody at the keyboard
+- [How this is tested](https://olafkfreund.github.io/nixarchy/manual/how-this-is-tested): what CI runs, when, what each check proves — and what it does not prove
 - [Troubleshooting](https://olafkfreund.github.io/nixarchy/manual/troubleshooting): start with `nix run github:olafkfreund/nixarchy#doctor`, then the specific failures and their fixes
 
 ## Source

--- a/docs/manual/updates.md
+++ b/docs/manual/updates.md
@@ -43,23 +43,36 @@ on disk as a generation; see [rolling back](#rolling-back-bad-updates).
 The update-available icon next to the clock is upstream's, and it is driven by
 `omarchy-update-available`, which has been replaced to fit this model.
 
-## Channels do not exist here
+## Channels: two of upstream's four mean something here
 
-Upstream's four channels — stable, RC, edge, dev — are a choice of pacman
-repository and, for dev, a git checkout in `~/omarchy`. Neither exists on
-NixOS. Your "channel" is whatever the flake's `omarchy` input is pinned to,
-and the `nixpkgs` input decides whether your packages track a stable release
-or unstable.
+Upstream has four — stable, RC, edge, dev. Two of them have a NixOS meaning
+and two do not, so _Update ▸ Channel_ offers exactly the two:
 
-So _Update > Channel_ is hidden from the menu, and `omarchy-channel-set` is
-one of the roughly fifteen scripts that still shell out to pacman. Those get a
-shim that explains what replaced them and exits non-zero rather than
-`pacman: command not found`.
+| upstream | here |
+|---|---|
+| stable | `nixos-26.05`, and the matching home-manager |
+| edge | `nixos-unstable`, what nixarchy is developed against |
+| RC, dev | hidden — pacman repositories with no NixOS equivalent |
 
-If you want the equivalent of edge, point your `nixpkgs` input at
-`nixos-unstable` in `flake.nix`. If you want to develop nixarchy itself, point
-the `nixarchy` input at a local checkout. Both are edits to your own flake,
-which nixarchy does not make for you.
+`rc` and `dev` are left out rather than given an invented meaning: a row that
+does something other than what its name says is the failure this menu guards
+against hardest.
+
+The rows run `nixarchy channel`, which edits your `flake.nix` under the rule
+`nixarchy-unfreeze` set — only lines this project wrote get rewritten, and a
+flake you have reshaped is yours, so the edit is printed for you to make
+instead of guessed at. nixpkgs and home-manager always move together, because
+neither project supports the mismatch.
+
+**"Stable" sounds safer and here it is less tested** — nixarchy is developed
+against unstable, and what CI proves about stable is a twenty-second
+evaluation, not a booted machine. That trade-off, the per-package escape from
+one channel to the other, and what switching costs you in rebuild time are all
+in **[stable or unstable](channels)**.
+
+`omarchy-channel-set` and `omarchy-channel-current` are still carried
+unchanged and are still unreachable: the UI entry points they served are
+replaced by `pkgs/omarchy/nix-bin`.
 
 ## Firmware updates
 


### PR DESCRIPTION
## What was wrong

`docs/_config.yml` carries the manual sidebar as an explicit list, and its own comment states the cost:

> A page added to `manual/` and not listed here will not appear in the nav.

Four pages had drifted out of it — `channels`, `reinstall-image`, `preview`, `how-this-is-tested`. All four are live and return **200**; nothing in the manual links to them. The sidebar rendered on the `channels` page does not contain `channels`.

The practical effect: **the stable/unstable channel choice and the reinstall image — the two most recently shipped features — were unreachable from the manual.** That is how this was found.

`docs/llms.txt` had drifted further: the same four, plus `android`.

## The stale half

`updates.md` *is* in the nav, so it is the page a reader lands on, and it told them the feature does not exist:

> ## Channels do not exist here
> So _Update > Channel_ is hidden from the menu

Both halves stopped being true in #539. `modules/apps.nix:448-470` defines `update.channel` with Stable and Unstable rows invoking `nixarchy-channel`; only `rc` and `dev` remain hidden, being pacman repositories with no NixOS equivalent. Rewritten to say which two of upstream's four carry over and why the other two do not, handing off to [channels](docs/manual/channels.md) rather than restating the trade-off.

Its claim that `omarchy-channel-set` gets "a shim that explains what replaced them" also did not match `data/bin-ledger.nix:307`, which records it as `class = "vendor"` — vendored unchanged and unreachable. Corrected to what the ledger says.

## Why a guard

Adding the four entries fixes today's four. The list is hand-maintained and fails **silently** — published, reachable from nothing, no check notices — which is how four accumulated. `build.yml` gains a membership check over both lists, beside the existing README roadmap and counts guards.

Order is deliberately **not** checked: where a page belongs in a reading order is a judgement; whether it is reachable at all is not.

## Verification

- Guard run against the tree before the fix (names all four) and after (passes).
- Negative test: a canary page added to `manual/` and listed in neither file — guard names it and exits 1; passes again once removed.
- Both YAML files parse; the workflow's script block passes `bash -n`.
- Live URLs confirmed 200 for all four pages, and the rendered sidebar confirmed to omit them.

Docs and CI only. No module, package or test changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5