### PR TITLE
A docs-only pull request stops evicting the install slot (#548)

### DIFF
--- a/.github/workflows/install-check.yml
+++ b/.github/workflows/install-check.yml
@@ -176,8 +176,38 @@ jobs:
     # Raising the in-VM timeout was the obvious alternative and is worse: it
     # would hide a real slowdown, and the number it hid would be the one that
     # tells you the host is oversubscribed.
+    # The group is conditional, and #548 is why. It used to be the constant
+    # `nixarchy-install-vm`, which meant a run with NOTHING TO DO still joined
+    # the queue for the scarcest resource in the repository -- and GitHub
+    # retains only ONE pending job per group, so each arrival evicted whoever
+    # was waiting. Four occurrences in one day across #545 and #546, both
+    # docs-only:
+    #
+    #   conclusion=cancelled  runner=  labels=ubuntu-latest  steps=0
+    #
+    # Zero steps, no runner, reaped in 60-80 seconds. Not starved of a runner:
+    # evicted from a queue before allocation.
+    #
+    # That is worse than wasted time, because `cancelled` renders as a failure
+    # and A CANCELLED REQUIRED CHECK SILENTLY DISABLES AUTO-MERGE. The pull
+    # request then sits there with nothing visibly wrong. Re-running does not
+    # help -- the workflow-level group above has cancel-in-progress true on a
+    # pull request, so a re-run reaps itself within a second of the gate
+    # finishing (confirmed three times on #545). The only way out was a new
+    # head commit, which is a strange thing to demand of a one-line README
+    # change.
+    #
+    # So an irrelevant run gets its own private group and reports success in
+    # seconds without ever touching the shared slot. Every property the block
+    # below defends is untouched: a RELEVANT run still lands in
+    # `nixarchy-install-vm`, still one at a time, machine-wide.
+    #
+    # `needs` is available in a job-level `concurrency:` -- that is what makes
+    # this expressible at all, and it is the same context `runs-on` below
+    # already reads for the runner labels. The two must agree: a run that asks
+    # for a hosted runner must not hold the VM group.
     concurrency:
-      group: nixarchy-install-vm
+      group: ${{ needs.gate.outputs.relevant == 'true' && 'nixarchy-install-vm' || format('install-noop-{0}', github.ref) }}
       cancel-in-progress: false
 
     # No `if:` on this job, and that is the whole fix -- measured, not assumed.
@@ -198,10 +228,6 @@ jobs:
     # takes an expression, but a label LIST has to arrive as JSON.
     runs-on: ${{ fromJSON(needs.gate.outputs.runner) }}
 
-    # No job-level concurrency: the `concurrency:` at the top of this file
-    # already says it, and saying it twice is how the first version came to
-    # look protected while being cancelled every time.
-    #
     # 90, not 45: this job does two full installs now. The old number was sized
     # for one, and a timeout is recorded as `cancelled` -- which reads like
     # somebody pressed a button rather than like the job running out of road,


### PR DESCRIPTION
Closes #548.

## The bug

`install` carried a **constant** concurrency group, `nixarchy-install-vm`, so a run the gate had *already decided was irrelevant* still joined the queue for the scarcest resource in the repo. GitHub retains only **one pending job per group**, so each arrival evicted whoever was waiting:

```
conclusion=cancelled  runner=  labels=ubuntu-latest  steps=0
```

Zero steps, no runner, reaped in 60–80s. Four occurrences in one day across #545 and #546 — README-only and comments-only, neither able to change an install closure.

The cost isn't the wasted minute. **`cancelled` renders as a failure, and a cancelled required check silently disables auto-merge** — the PR sits there with nothing visibly wrong. Re-running can't clear it either: the workflow-level group sets `cancel-in-progress` true on a PR, so a re-run reaps itself within a second of the gate finishing (three attempts on #545 confirmed). The only escape was a new head commit.

## The fix

Option **1** of the four listed in #548 — the group becomes conditional on the gate's own verdict:

```yaml
group: ${{ needs.gate.outputs.relevant == 'true' && 'nixarchy-install-vm' || format('install-noop-{0}', github.ref) }}
```

Preferred because it changes no other property: the job still has **no `if:`**, so it still reports rather than reporting `skipped`, and the required-check contract is untouched. Every measurement in the block below it still holds — a relevant run is still one install VM at a time, machine-wide.

## Verification — both branches, with the real gate

`pr-touches-build.sh` accepts a file list on stdin, so the verdict driving the expression is *run*, not assumed:

| file changed | `relevant` | resulting group |
|---|---|---|
| `.github/workflows/install-check.yml` (this PR) | `true` | `nixarchy-install-vm` |
| `installer/cd.nix` | `true` | `nixarchy-install-vm` |
| `README.md` (#545's shape) | `false` | `install-noop-<ref>` |
| `docs/manual/channels.md` | `false` | `install-noop-<ref>` |

And the three paths that must never lose the real slot:

```
push to main        relevant=true
workflow_dispatch   relevant=true
empty file list     relevant=true   (the script's existing fail-safe)
```

**So this can only divert runs the gate had already decided to skip — it cannot reduce install coverage.** `runs-on` reads the same `needs.gate.outputs` for its runner labels, so the two agree by construction: a run asking for a hosted runner no longer holds the VM group.

`actionlint` exits 0, which also confirms `needs` is a valid context in a job-level `concurrency:` — the property that makes this expressible at all.

**This PR tests itself**: it edits `install-check.yml`, which the gate's first case arm marks `relevant=true`, so it takes the real slot and exercises the unchanged path. A docs-only PR exercises the other one — #549 is one, if you want a live pair.

## One stale comment removed

Twenty lines below the block it contradicts, the file said *"No job-level concurrency: the `concurrency:` at the top of this file already says it."* There has been a job-level `concurrency:` since the VM cap landed. It describes the file before that change and reads as a statement about the current one — the #546 failure mode exactly. The `timeout-minutes` reasoning it sat on is kept.

## For a human, not an agent

Per AGENTS.md §11 this is a CI gate change, so it is proposed rather than merged: **a human decides.** #548 reached the same conclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5