### PR TITLE
nixpkgs: 4 app version(s) move

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -585,11 +585,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1788881743,
-        "narHash": "sha256-2V9GZGvPfrNzxFozhI9dcqV+c3QdA8YZrvAAzqEB+dI=",
+        "lastModified": 1789006805,
+        "narHash": "sha256-xB8mKMOx1IA9vTDNLmJZ6n4wCMq/cuWBBOzGCRnqxrU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d6524aaca2ff07876657ae2b323f24be4874944b",
+        "rev": "8ce4ef6cb6f871616146b9fe26d2a5ae594e94fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Nightly bump of the `nixpkgs` input. Only that input: the others
are left where they are, because at least one of them is pinned on
purpose.

| app | was | now |
|---|---|---|
| `google-chrome` | 152.0.7977.82 | 153.0.8010.36 |
| `claude-code` | 2.1.263 | 2.1.266 |
| `code-cursor` | 3.17.21 | 3.19.13 |
| `zed-editor` | 1.17.2 | 1.19.2 |

Verified before this PR was opened:

- `.#checks.x86_64-linux.vm-toplevel` evaluates
- `.#checks.x86_64-linux.reference-toplevel` evaluates

That is an evaluation check, not a build. **The gate is the CI on
this pull request**, which runs because the PR was opened with
`BUMP_TOKEN`; it merges when the required contexts report green and
not before.

What CI does not cover: an app that builds and then misbehaves at
runtime. If a package here is one you rely on, launch it before
this lands, or roll back afterwards with `nixos-rebuild --rollback`.