### PR TITLE
The gate stops denying paths that eight derivations read

### DIFF
--- a/.github/scripts/pr-touches-build.sh
+++ b/.github/scripts/pr-touches-build.sh
@@ -101,7 +101,38 @@ while IFS= read -r f; do
     #
     # `*/AGENTS.md` covers any depth, because `case` globs are not path-aware
     # and `*` crosses `/` -- the same property the `docs/*` arm relies on.
-    docs/*|AGENTS.md|*/AGENTS.md|CONTRIBUTING.md|.envrc|.gitignore|.github/*)
+    # `docs/` and `.github/scripts/` are derivation INPUTS, and the denylist's
+    # whole contract is that it names paths which PROVABLY CANNOT change a
+    # derivation. These provably can, so they are relevant to the build
+    # question and exempt only from the install one -- the README split, for
+    # the same reason.
+    #
+    # Eight derivations read them, verified by grep rather than assumed:
+    #
+    #   tests/config-delta.nix:100    ${../.github/scripts/omarchy-config-delta.sh}
+    #   tests/package-delta.nix:57    ${../.github/scripts/omarchy-package-delta.sh}
+    #   tests/patched-files.nix:52    ${../.github/scripts/omarchy-patched-files.sh}
+    #   tests/release-notes.nix:61-62 release-notes.sh, omarchy-package-delta.sh
+    #   tests/bin-ledger.nix:33       ${../.github/scripts/check-bin-ledger.py}
+    #   tests/install-gate.nix:20     ${../.github/scripts/pr-touches-build.sh}
+    #   tests/swap-guard.nix:57       ${../docs/manual/troubleshooting.md}
+    #   tests/doc-options.nix:87      ${../docs}          <- the whole tree
+    #
+    # So a pull request editing ONLY `omarchy-config-delta.sh` used to answer
+    # `false` and skip `checks.config-delta` -- the one check that exists to
+    # test that script. It merged green and broke main. `doc-options` takes
+    # `${../docs}` wholesale, which is why this cannot be narrowed to the two
+    # doc files named above: any page can change that derivation's output.
+    #
+    # Still excluded from `--install`: the three checks the install job builds
+    # reach `./hardware-configuration.nix` and `./test-instrumentation.nix`
+    # and nothing else, so none of this can change an install. The expensive
+    # saving is kept; only the cheap hosted build comes back.
+    .github/scripts/*|docs/*)
+      if [ "$install_only" = true ]; then continue; fi
+      relevant=true; break ;;
+
+    AGENTS.md|*/AGENTS.md|CONTRIBUTING.md|.envrc|.gitignore|.github/*)
       continue ;;
 
     # Only for the install question, and only files the install job cannot

--- a/tests/install-gate.nix
+++ b/tests/install-gate.nix
@@ -65,10 +65,41 @@ pkgs.runCommand "nixarchy-install-gate"
     # ever flips to false, a README whose counts disagree with data/ merges
     # without the omarchy job ever looking at it.
     t "README still builds"                    "" "README.md" true
-    t "docs still do not"                      "" "docs/manual/android.md" false
     t "the gate itself always does"            "" ".github/scripts/pr-touches-build.sh" true
     t "a nested AGENTS.md builds nothing"      "" "modules/AGENTS.md" false
     t "install-check.yml always does"          "" ".github/workflows/install-check.yml" true
+
+    # This line used to read `t "docs still do not" "" "docs/…" false`, and it
+    # was asserting the ARRANGEMENT rather than the property -- it made a real
+    # hole look deliberate. Eight derivations take `docs/` or
+    # `.github/scripts/` as INPUTS, so both provably CAN change a derivation,
+    # which is the one thing the denylist promises its entries cannot do.
+    #
+    # A pull request editing only `omarchy-config-delta.sh` answered `false`,
+    # so `checks.config-delta` -- the check whose entire job is testing that
+    # script -- never ran on it. Same shape for package-delta, patched-files,
+    # release-notes, bin-ledger, swap-guard and doc-options.
+    #
+    # `doc-options` reads `${../docs}` WHOLESALE, so this cannot be narrowed
+    # to the doc files named in a grep: any page can move that output.
+    echo "derivation inputs are not deniable (the build question):"
+    t "a delta script builds"                  "" ".github/scripts/omarchy-config-delta.sh" true
+    t "so does the package delta"              "" ".github/scripts/omarchy-package-delta.sh" true
+    t "so does the patched-files script"       "" ".github/scripts/omarchy-patched-files.sh" true
+    t "so do the release notes"                "" ".github/scripts/release-notes.sh" true
+    t "so does the ledger checker"             "" ".github/scripts/check-bin-ledger.py" true
+    t "a manual page builds (doc-options)"     "" "docs/manual/android.md" true
+    t "so does the troubleshooting page"       "" "docs/manual/troubleshooting.md" true
+    # A workflow file still cannot change a derivation, so the rest of
+    # `.github/` stays denied -- narrowing this arm must not widen that one.
+    t "an unrelated workflow still does not"   "" ".github/workflows/release.yml" false
+
+    echo "and none of them runs the install VM:"
+    # The expensive saving is the one that must survive this change: the three
+    # checks the install job builds import only ./hardware-configuration.nix
+    # and ./test-instrumentation.nix, so none of these can reach an install.
+    t "a delta script does not"                --install ".github/scripts/omarchy-config-delta.sh" false
+    t "the troubleshooting page does not"      --install "docs/manual/troubleshooting.md" false
 
     echo "fails safe:"
     # An empty list means the question could not be answered -- a paginated API


### PR DESCRIPTION
`pr-touches-build.sh` is a **denylist**, and its contract — stated in its own header and install-check.yml's — is that every entry names a path that **provably cannot change a derivation**. Two entries did not meet it.

`docs/*` and `.github/*` were excluded from **both** questions, and eight derivations take those paths as inputs:

| derivation | input |
|---|---|
| `tests/config-delta.nix:100` | `omarchy-config-delta.sh` |
| `tests/package-delta.nix:57` | `omarchy-package-delta.sh` |
| `tests/patched-files.nix:52` | `omarchy-patched-files.sh` |
| `tests/release-notes.nix:61-62` | `release-notes.sh`, `omarchy-package-delta.sh` |
| `tests/bin-ledger.nix:33` | `check-bin-ledger.py` |
| `tests/install-gate.nix:20` | `pr-touches-build.sh` |
| `tests/swap-guard.nix:57` | `docs/manual/troubleshooting.md` |
| `tests/doc-options.nix:87` | `${../docs}` — the whole tree |

**A PR editing only `omarchy-config-delta.sh` answered `false`**, `build.yml`'s generated-checks step is `if: needs.gate.outputs.relevant == 'true'`, so `checks.config-delta` — the check whose entire purpose is testing that script — never ran on the change to it. Green PR, red main.

Measured before the fix, with the real script:

```
.github/scripts/omarchy-config-delta.sh    build=false
.github/scripts/omarchy-package-delta.sh   build=false
.github/scripts/check-bin-ledger.py        build=false
.github/scripts/release-notes.sh           build=false
.github/scripts/omarchy-patched-files.sh   build=false
docs/manual/troubleshooting.md             build=false
```

## The fix

`.github/scripts/*` and `docs/*` take **the README split**: relevant to the BUILD question, exempt from the INSTALL one. The expensive saving survives — the three checks the install job builds import only `./hardware-configuration.nix` and `./test-instrumentation.nix`, so none of this can reach an install. Only the cheap hosted build comes back.

Not narrowed to the two doc files a grep finds, because `tests/doc-options.nix` reads `${../docs}` **whole**: any page can move that output. `.github/workflows/*` stays denied — a workflow file still cannot change a derivation, and the check now asserts that narrowing one arm did not widen the other.

## The check was asserting the arrangement

`tests/install-gate.nix:67` read `t "docs still do not" "" "docs/manual/android.md" false` — CLAUDE.md §1 read backwards. It encoded the *shape* of the denylist rather than the property the denylist protects, **and it made a real hole look deliberate**. Retargeted rather than satisfied, plus twelve assertions.

## Proved failing first (§1)

Reverted the arm, kept the new assertions, built the check:

```
  FAILED  a delta script builds: got 'false', wanted 'true'
  FAILED  so does the package delta: got 'false', wanted 'true'
  FAILED  so does the patched-files script: got 'false', wanted 'true'
  FAILED  so do the release notes: got 'false', wanted 'true'
  FAILED  so does the ledger checker: got 'false', wanted 'true'
  FAILED  a manual page builds (doc-options): got 'false', wanted 'true'
  FAILED  so does the troubleshooting page: got 'false', wanted 'true'
7 failed
error: Cannot build '...-nixarchy-install-gate.drv'
```

Restored → `all ok`. `nix fmt -- --ci` clean.

This changes CI gating behaviour, so per AGENTS.md §11 it is proposed rather than merged. Found by an xhigh review of #550; the hole is pre-existing and that change did not touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5