### PR TITLE
Section 6 and the workflows page catch up with the install job CI actually runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,24 +277,33 @@ your question:
 | `omarchy` (package) | the vendored tree assembles | minutes |
 | `installer-ui`, `installer-wizard` | the installer's screens and questions | minutes |
 | `session`, `coexist`, `integration`, `plugin` | booted VMs | ~10–20 min each |
-| `install` | full install onto a blank disk, reboot, rebuild-builds-nothing | ~29 min, one self-hosted runner |
-| `free-space` | install beside an existing OS, which survives | ~27 min, same runner, same job |
+| `install` | full install onto a blank disk, reboot, rebuild-builds-nothing | self-hosted, shares the one VM slot |
+| `free-space` | install beside an existing OS, which survives | same job, same nix invocation |
+| `installer-refusal` | a dark substituter is refused, disk left intact | ~2–3 min, same job — a VM too |
 | `install-iso`, `iso-budget` | the ISO installs offline, and fits | nightly only |
 
-`install` and `free-space` are one job. `install-check.yml` runs them
-back to back on the single self-hosted machine, so the number that
-governs your merge latency is **their sum: 55 minutes of a 58-minute job,
-against a 90-minute timeout** (run 33798891329; every other step in that job
-totalled four seconds). It gates every pull request, and with
-runs that long a handful of concurrent PRs queue for hours. Every push
-to your branch cancels and restarts your own run (that is deliberate — a PR
-only needs an answer about its current head), but the queue is shared:
+`install`, `free-space` and `installer-refusal` are one job.
+`install-check.yml` builds all three in a single `nix build --max-jobs 3`,
+so they **overlap** rather than run in sequence — the old serial model, and
+its "55 minutes of a 58-minute job" sum, no longer exists. What governs your
+merge latency now: the build step took **16–19 minutes on a warm store**
+(runs 34573539340, 34509257501, 2026-09-10/11) against a 90-minute timeout,
+and a cold store can push it toward that limit (#434 timed out at the cap
+three times). There are **four self-hosted runners** — p510-nixarchy,
+p510-nixarchy-2, p620-nixarchy, p620-nixarchy-2 — with identical labels and
+separate stores, but the `nixarchy-install-vm` concurrency group still admits
+**one relevant install job at a time, machine-wide**: 3–4 concurrent installs
+all fail at the in-guest timeout (measured 2026-09-09). So the check gates
+every pull request, the queue for that one slot is shared, and concurrent PRs
+still wait on it. Every push to your branch cancels and restarts your own run
+(that is deliberate — a PR only needs an answer about its current head), but
 batching your pushes is a courtesy to everyone else's merge latency.
 
 **Do not build a VM check locally while CI has an install job in flight.**
 The concurrency group in `install-check.yml` serialises GitHub *jobs*; it
 knows nothing about a `nix build .#checks.x86_64-linux.session` you start by
-hand on the same machine. The runners are on p620 and so is your shell.
+hand on the same machine. Two of the four runners are on p620, and so is
+your shell.
 
 What it looks like when you do is not "your build was slow" — it is somebody
 else's check failing, on a line that has nothing to do with their change:

--- a/docs/internals/workflows.md
+++ b/docs/internals/workflows.md
@@ -128,7 +128,15 @@ with the machine, guest-side ones do not. Four at once on one box turned
 "slower" into "failed", and the failure named the test rather than the
 contention. Two concurrent jobs is what demonstrably passes.
 
-**If your install check sits queued for twenty minutes, the cap is working.**
+**A queued install check may be the cap working — or a job about to be
+evicted.** The two look identical from the outside (#548 measured it). GitHub
+retains only **one pending job** per concurrency group, so when a second run
+queues into `nixarchy-install-vm`, the next arrival cancels whoever was
+waiting. A `cancelled` install renders as a **failure**, and a cancelled
+required check **silently disables auto-merge** — the pull request then sits
+there with nothing visibly wrong. #550 gave runs the gate rules irrelevant
+their own `install-noop-<ref>` group, so a docs-only PR no longer touches the
+shared slot at all; for relevant runs the eviction remains, tracked in #555.
 
 ### What that cap costs, and what is done instead
 


### PR DESCRIPTION
## What this changes, and why

Docs only, two files: `AGENTS.md` §6 and `docs/internals/workflows.md`. Closes #556 and closes #558.

§6 described an install job that no longer exists: install and free-space "back to back" on "the single self-hosted machine", summing to "55 minutes of a 58-minute job". `install-check.yml` now builds **three** checks (`install`, `free-space`, `installer-refusal`) in one `nix build --max-jobs 3`, overlapping, on a pool of **four** runners that still admit one relevant install job at a time via `nixarchy-install-vm`. §6 is edited **in place** — no section inserted or renumbered, so the cross-references from `build.yml`, `omarchy.yml`, `tests/bus-mcp.nix` and the PR template are untouched.

The old 55-of-58 sum derived from the serial model, so it was replaced with what recent runs actually show rather than a recomputed sum: the build step took 16–19 minutes on a warm store (runs 34573539340 and 34509257501, 2026-09-10/11) against the 90-minute timeout, with the #434 cold-store caveat kept.

`workflows.md:131` told readers a queued install check means the cap is working. #548 proved a queued job and an about-to-be-evicted job look identical; the line now says a queued run may be either, that `cancelled` renders as a failure and silently disables auto-merge, that #550's `install-noop-<ref>` group keeps irrelevant runs off the shared slot, and that #555 tracks the eviction that remains for relevant runs — referenced as open, not claimed fixed.

Every claim written was verified against a file:

- one `nix build --max-jobs 3` with three checks — `install-check.yml` lines 309–314
- four runners with identical labels and separate stores — `install-check.yml` lines 126–133, 252–256
- one relevant install at a time / 3–4 concurrent fail at the in-guest timeout — `install-check.yml` lines 146–178
- what `installer-refusal` proves and its ~2–3 min cost — `tests/installer-refusal.nix` header
- 16–19 min build step — `gh run view 34573539340` / `34509257501` step timings
- `install-noop-<ref>` group and #548 eviction shape — `install-check.yml` lines 179–211
- #555 still open — `gh issue view 555`

## How I proved the check fails

This PR genuinely needs no check: it edits prose in two Markdown files. No `checks.*` entry can go red or green on it, and the install gate should rule it irrelevant (`install-noop-*` path — the very mechanism the text now documents).

```
(no check exists for prose; docs-only)
```

## Checks run locally

None built — docs-only, and CLAUDE.md §6 says not to build VM checks locally while CI may have an install job in flight. `nix fmt` untouched (no .nix files changed).

- [x] `nix fmt` / statix / deadnix are clean (no Nix files touched)
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [ ] If this adds an option: `tests/options.nix` covers both states (n/a)
- [ ] If this adds a `checks.*` entry: a PR-triggered workflow builds it (n/a)

## What this cost, and where it is written down

Nothing general — the PR *is* the write-back: §6 catching up with the workflow it budgets against.

- [x] A general lesson is recorded in `AGENTS.md`, or nothing general came up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
