### PR TITLE
The install verdict on main is per commit, and a garbled gate output fails loudly instead of skipping the install

### DIFF
--- a/.github/workflows/install-check.yml
+++ b/.github/workflows/install-check.yml
@@ -66,7 +66,23 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: install-check-${{ github.ref }}
+  # Per COMMIT on main, per branch everywhere else -- the same shape as
+  # build.yml's workflow-level group, for the same reason (#561). Only one run
+  # per group may be PENDING, and a newer arrival cancels the previously
+  # pending one -- a rule `cancel-in-progress: false` does not touch. The old
+  # `install-check-${{ github.ref }}` was a constant on main, so in a burst of
+  # merges run 2 was cancelled by run 3, run 3 by run 4, and only the first
+  # and last ever reported. The commit in the middle never got an install
+  # verdict, nothing re-tests a merged commit, and main's install is the only
+  # check that can catch the CLAUDE.md section-9 failure: two PRs each green
+  # against a main that lacked the other. With the SHA in the group each merge
+  # gets a group of its own, which nothing can supersede. The cost is the one
+  # build.yml already accepted -- a burst of merges queues rather than drops,
+  # and the job-level `nixarchy-install-vm` group below still keeps the VM to
+  # one at a time.
+  group: >-
+    install-check-${{ github.ref }}-${{
+      github.ref == 'refs/heads/main' && github.sha || 'shared' }}
   # Not a constant, and #144 assumed it was one: it read this file as already
   # having `cancel-in-progress`, and it has it set to false. On main that is
   # right and deliberate -- the whole reason this file was split out of
@@ -118,6 +134,23 @@ jobs:
           # how one of them goes stale while both are still trusted. The
           # reasoning that was here is there, next to the list.
           relevant=$(.github/scripts/pr-touches-build.sh --install)
+
+          # The script promises exactly `true` or `false`, and every consumer
+          # in `install` gates on `== 'true'` -- so any THIRD value (empty
+          # output, a renamed field, a step dying after printing nothing)
+          # would read as "skip" and produce a green install that installed
+          # nothing, inverting the script's own fail-safe policy (#559).
+          # Enforce the contract here instead of making every consumer
+          # defensive: a failed gate makes `install` report `skipped`, which
+          # is not `success`, so the merge is blocked -- the failure is loud,
+          # not a false pass.
+          case "$relevant" in
+            true | false) ;;
+            *)
+              echo "::error::pr-touches-build.sh printed '$relevant'; the contract is exactly 'true' or 'false'"
+              exit 1
+              ;;
+          esac
 
           echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
 
@@ -201,6 +234,20 @@ jobs:
     # seconds without ever touching the shared slot. Every property the block
     # below defends is untouched: a RELEVANT run still lands in
     # `nixarchy-install-vm`, still one at a time, machine-wide.
+    #
+    # And that means the eviction described above STILL APPLIES to relevant
+    # runs (#555) -- #548's fix covered only the runs the gate rules
+    # irrelevant. GitHub retains one pending job per group, so with one
+    # relevant run building and two waiting, each newcomer evicts whoever was
+    # queued. More than one pending run is the normal state here, not an edge
+    # case. The evicted job reports `cancelled`, which renders as a failure
+    # and SILENTLY DISABLES AUTO-MERGE on that PR; re-running cannot clear it,
+    # because the workflow-level PR group reaps the re-run within a second of
+    # the gate finishing. The only escape is a new head commit. A real fix is
+    # a small pool of slot groups sized to the runners that can take the work,
+    # but that changes the contention model the measurements above defend
+    # (2 concurrent succeed, 3-4 fail), so it wants doing against real numbers
+    # -- #555 tracks it. Until then this hole is documented, not closed.
     #
     # `needs` is available in a job-level `concurrency:` -- that is what makes
     # this expressible at all, and it is the same context `runs-on` below


### PR DESCRIPTION
## What this changes, and why

Three findings from the xhigh review of #550, all in `install-check.yml`. Closes #561, closes #559, and documents the hole #555 describes (the slot-pool redesign stays open in #555 — it wants real contention measurements, not arithmetic). NixOS-CI-specific; nothing here would break on Arch.

- **#561** — the workflow-level concurrency group was `install-check-${{ github.ref }}`, a constant on main. GitHub keeps one *pending* run per group, so in a burst of merges only the first and last ever reported; the middle commits — the only place the CLAUDE.md §9 failure can surface — lost their install verdict and nothing re-tests a merged commit. The group now appends `github.sha` on main, the exact shape `build.yml:55-58` already carries. `cancel-in-progress` keeps this file's existing semantics: `${{ github.event_name == 'pull_request' }}` (PR = cancel superseded heads, main = never cancel).
- **#559** — `pr-touches-build.sh` promises exactly `true`/`false`, but `install` gates every real step on `== 'true'`, so any third value (empty output, renamed field, script dying after printing nothing) read as "skip" and produced a green install that installed nothing. Option 1 from the issue: the gate step now `case`-validates the output and fails on anything else. On the `needs: gate` interaction the issue warns about: a failed gate makes `install` report `skipped`, and `skipped` is not `success` (measured in this file's own no-`if:` comment), so the merge **blocks loudly** instead of falsely passing — the fail-safe direction, thought through rather than accidental.
- **#555** — the job-level comment claimed "every property the block below defends is untouched" without recording that relevant runs still evict each other from `nixarchy-install-vm`'s single pending slot, that a `cancelled` required check silently disables auto-merge, that a re-run reaps itself, and that the only escape is a new head commit. The comment now states all of that plainly and points at #555 for the redesign. No behaviour change.

Agent bus read before starting (§9): nothing there bears on this change.

## How I proved the check fails

**#559 — the gate validation.** The step's `case` block, verbatim, run under bash with the script's output substituted:

Broken (the failure mode #559 describes — empty and garbled output), RED:

```
--- broken: script prints empty output (the #559 failure mode)
::error::pr-touches-build.sh printed ''; the contract is exactly 'true' or 'false'
exit=1
--- broken: script prints a garbled value
::error::pr-touches-build.sh printed 'tru e'; the contract is exactly 'true' or 'false'
exit=1
```

Working (the two contract values), GREEN:

```
--- working: true
relevant=true  (accepted)
exit=0
--- working: false
relevant=false  (accepted)
exit=0
```

Before this PR, all four cases flowed straight into `$GITHUB_OUTPUT`, and the first two skipped the install with a green check.

**#561 — the concurrency expression**, proven through the lint gate: broke the expression (`|||`), watched actionlint fail, restored, watched it pass:

```
$ actionlint ...   # with the expression deliberately broken
.github/workflows/install-check.yml:84:96: got unexpected character ' ' while lexing || operator, expecting '|' [expression]
actionlint exit=1
$ actionlint ...   # restored
actionlint exit=0
```

The runtime behaviour (one group per merged SHA) cannot be exercised locally; the expression is character-for-character the shape `build.yml` has run in production since its own fix, with `install-check-` in place of `${{ github.workflow }}`.

**#555** is a comment-only change; no check applies.

## Checks run locally

- `nix shell --inputs-from . nixpkgs#actionlint -c actionlint -ignore 'SC[0-9]+:(info|style):'` — exit 0
- `nix fmt -- --ci` — exit 0
- No VM checks run locally, deliberately (§6); this PR's own CI run exercises the gate for real, since `.github/workflows/install-check.yml` is re-included by the denylist.

- [x] `nix fmt` / statix / deadnix are clean (no .nix files touched)
- [x] New files are `git add`ed (none added)
- [ ] If this adds an option: n/a
- [ ] If this adds a `checks.*` entry: n/a

## What this cost, and where it is written down

- [x] Nothing general came up; the specific reasoning lives in the workflow's own comment blocks, which is where this file keeps it.

## Deliberately not done

- No slot-pool redesign for #555 (the issue itself says it wants real measurements first) — #555 stays open.
- No change to `.github/scripts/pr-touches-build.sh`, `README.md`, `docs/`, or `AGENTS.md` — owned elsewhere (#553).
- Not merging: this is a CI-gate change; CLAUDE.md §11 reserves the merge for a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
