### PR TITLE
A push to main stops spending the install slot on a docs-only merge

### DIFF
--- a/.github/scripts/pr-touches-build.sh
+++ b/.github/scripts/pr-touches-build.sh
@@ -46,9 +46,49 @@ fi
 
 if [ "${1:-}" = "-" ]; then
   files=$(cat)
+elif [ "${EVENT_NAME:-}" = "push" ] && [ "$install_only" = true ] &&
+  before=$(jq -r '.before // empty' "${GITHUB_EVENT_PATH:-/dev/null}" 2>/dev/null) &&
+  [ -n "$before" ] &&
+  [ "$before" != "0000000000000000000000000000000000000000" ] &&
+  [ -n "${GITHUB_SHA:-}" ]; then
+  # A push to main, asked the INSTALL question only -- #554.
+  #
+  # This branch used to be part of the blanket `not a pull request, so not
+  # filtered` below, and the result was that #550's saving lasted exactly one
+  # event: a docs-only pull request skipped the install, merged, and its push
+  # to main then ran install + free-space + installer-refusal for ~55 minutes
+  # on a self-hosted runner for a README edit -- holding the mutex every
+  # other pull request queues behind.
+  #
+  # What makes filtering main SAFE here is narrow and worth stating, because
+  # the blanket rule was not an oversight:
+  #
+  #   - It is the BUILD question that must never be filtered on main. Two
+  #     pull requests green apart can break main together (CLAUDE.md §9,
+  #     #137 + #141), and build.yml calls this script WITHOUT `--install`,
+  #     so that path is untouched and still answers `true` below.
+  #   - The denylist's entries provably cannot change an install closure. If
+  #     the squashed commit touched only such paths, main's closure is the
+  #     one the previous push already installed, so there is nothing new to
+  #     test -- regardless of what any other pull request did.
+  #
+  # `.before` and `GITHUB_SHA` rather than `git diff HEAD~1`: actions/checkout
+  # gives this job one commit, so a local diff needs a deepened fetch whose
+  # depth is a guess -- the same argument the pull request path below makes,
+  # and the reason both use the API.
+  #
+  # Every way this can fail falls through to the blanket `true`: a zeroed
+  # `.before` (a new branch or a force push), no event payload, no `jq`, an
+  # API that errors. Unknown means run everything.
+  files=$(gh api "repos/$GH_REPO/compare/$before...$GITHUB_SHA" \
+    --jq '.files[].filename' 2>/dev/null || true)
+  if [ -z "$(printf '%s' "$files" | tr -d '[:space:]')" ]; then
+    echo true
+    exit 0
+  fi
 elif [ "${EVENT_NAME:-}" != "pull_request" ]; then
-  # Not a pull request, so not filtered. main and workflow_dispatch always
-  # ran the real thing and still do.
+  # Not a pull request, so not filtered. The build question on main, and
+  # workflow_dispatch, always ran the real thing and still do.
   echo true
   exit 0
 else

--- a/tests/install-gate.nix
+++ b/tests/install-gate.nix
@@ -101,6 +101,33 @@ pkgs.runCommand "nixarchy-install-gate"
     t "a delta script does not"                --install ".github/scripts/omarchy-config-delta.sh" false
     t "the troubleshooting page does not"      --install "docs/manual/troubleshooting.md" false
 
+    # #554 gave a push to main its own diff for the INSTALL question, so a
+    # docs-only merge stops spending 55 minutes of the one VM slot. Every way
+    # that can fail must fall back to running everything, and these are the
+    # paths that need no network to assert -- the API path itself is tested
+    # against real commits in the pull request, because a sandboxed
+    # derivation has neither a token nor a network.
+    #
+    # If one of these ever answers `false`, main stops installing and nothing
+    # says so.
+    echo "a push whose diff cannot be established runs everything:"
+    pushq() {
+      got=$(EVENT_NAME=push GH_REPO=o/r GITHUB_SHA=deadbeef GITHUB_EVENT_PATH=$2 \
+        bash $gate --install 2>/dev/null || true)
+      if [ "$got" = true ]; then echo "  ok      $1"
+      else echo "  FAILED  $1: got '$got', wanted 'true'"; fails=$((fails + 1)); fi
+    }
+    printf '{"before":"0000000000000000000000000000000000000000"}' > zeroed.json
+    printf '{}' > nobefore.json
+    pushq "a zeroed before (new branch, force push)" zeroed.json
+    pushq "an event payload without .before"        nobefore.json
+    pushq "no event payload at all"                 /nonexistent-event.json
+    # The build question on main is never filtered: two pull requests green
+    # apart can break main together, and main's build is what catches it.
+    got=$(EVENT_NAME=push bash $gate 2>/dev/null || true)
+    if [ "$got" = true ]; then echo "  ok      the build question on a push is never filtered"
+    else echo "  FAILED  build question on push: got '$got', wanted 'true'"; fails=$((fails + 1)); fi
+
     echo "fails safe:"
     # An empty list means the question could not be answered -- a paginated API
     # call that returned nothing, a renamed field. Unknown must mean run


### PR DESCRIPTION
Closes #554. **Stacked on #553** — base is `fix/gate-derivation-inputs`, retarget to `main` once that merges.

#550 moved irrelevant *pull requests* out of `nixarchy-install-vm`. The saving lasted exactly one event: that PR merged, and `pr-touches-build.sh:49-53` short-circuited every non-`pull_request` event to `true`, so the push to main ran install + free-space + installer-refusal for **~55 minutes on a self-hosted runner for a README edit** — holding the mutex every other PR queues behind.

This is **option 1** of the three in #554, scoped to the question that can afford it.

## Why filtering main is safe here, and only here

The blanket rule wasn't an oversight, so the narrowing must say what it relies on:

- **Only the INSTALL question is filtered.** `build.yml` calls this script *without* `--install` and still answers `true` on every push — so the guards that catch CLAUDE.md §9 (two PRs green apart, broken together — #137 + #141) are untouched. The roadmap and README-counts steps are gated on `github.event_name != 'pull_request'` and don't read this output at all.
- **The denylist's entries provably cannot change an install closure.** If the squashed commit touched only those paths, main's closure is the one the previous push already installed. Nothing new to test, whatever any other PR did.

`.before` + `GITHUB_SHA` through the compare API rather than `git diff HEAD~1`: actions/checkout gives this job one commit, so a local diff needs a deepened fetch whose depth is a guess — the argument the PR path already makes. Reading the event payload means **no workflow file changes**, which also keeps this clear of #563, which owns `install-check.yml`.

## Measured against real merges

| commit | changed | result |
|---|---|---|
| `f46c29f` roadmap epics | `README.md` only | `install=false` — **was true**, 55 min for a README edit |
| `c191d8b` install-slot fix | `install-check.yml` | `install=true` — unchanged |
| `f46c29f`, **build** question | | `build=true` — §9 guarantee intact |

Every failure path falls back to running everything:

```
zeroed before (new branch, force push)   true
event payload with no .before            true
no event payload at all                  true
workflow_dispatch                        true
the API errors                           true
no GITHUB_SHA                            true
```

## Proved failing first (§1)

Four fail-safes are assertable without a network, so they're in `tests/install-gate.nix`. Breaking the fallback they rely on:

```
  FAILED  a zeroed before (new branch, force push): got 'false', wanted 'true'
  FAILED  an event payload without .before: got 'false', wanted 'true'
  FAILED  no event payload at all: got 'false', wanted 'true'
  FAILED  build question on push: got 'false', wanted 'true'
4 failed
```

Restored → `all ok`. `nix fmt -- --ci` clean.

**Honest limit:** the compare-API path itself cannot be asserted in a derivation — no token, no network — so it is measured above instead, and the check's comment says so rather than implying coverage it does not have.

CI gate change: per §11, proposed, not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5