### PR TITLE
The README agrees with the installer about seven questions, a check keeps it true, and the showcase table stops restating What works

### DIFF
--- a/.github/scripts/readme-counts.sh
+++ b/.github/scripts/readme-counts.sh
@@ -195,6 +195,18 @@ repl_word=$(word_for "$repl_n")
 skills=$(find -L "$omarchy" -name SKILL.md 2>/dev/null | wc -l)
 skills_word=$(word_for "$skills" | tr '[:upper:]' '[:lower:]')
 
+# The installer's question count (#557), which the README stated twice with two
+# different numbers and nothing checking either. The authority is
+# validate_answers in installer/install.sh: the answers a full install REQUIRES
+# -- device, encrypt, hostname, username, password, timezone, keymap -- are
+# exactly the questions the wizard exists to ask. Counted from the required-key
+# guards (`[ -n "$var" ] || problems+=`), deduplicated because the --host branch
+# repeats the password guard. The optional recovery passphrase and the two
+# confirmations are not answers the machine needs, and are not counted.
+questions=$(grep -oE '\[ -n "\$[a-z_]+" \] \|\| problems' "$root/installer/install.sh" |
+  sort -u | wc -l)
+questions_word=$(word_for "$questions" | tr '[:upper:]' '[:lower:]')
+
 quantity "commands" "$commands" \
   '.*\*\*([0-9]+) shell commands\*\*.*' \
   's/\*\*[0-9]+ shell commands\*\*/**'"$commands"' shell commands**/'
@@ -242,13 +254,22 @@ quantity "apps-indexed" "$a_indexed" \
 quantity "apps-nixpkgs-row" "$a_untouched" \
   '.*\| nixpkgs \(([0-9]+) of [0-9]+ apps\) \|.*' \
   "s/\| nixpkgs \([0-9]+ of [0-9]+ apps\) \|/| nixpkgs ($a_untouched of $a_total apps) |/"
+# The same number in two sentences, so each gets its own pattern: quantity
+# compares only the FIRST match, and one pattern over both lines would report
+# calm while the second line disagreed -- which is #557 verbatim.
+quantity "installer-questions" "$questions_word" \
+  '.*bootable ISO, (five|six|seven|eight|nine|ten) questions.*' \
+  's/bootable ISO, (five|six|seven|eight|nine|ten) questions/bootable ISO, '"$questions_word"' questions/'
+quantity "installer-questions-iso" "$questions_word" \
+  '.*and answer (five|six|seven|eight|nine|ten) questions.*' \
+  's/and answer (five|six|seven|eight|nine|ten) questions/and answer '"$questions_word"' questions/'
 
-# A floor. Eleven quantities are declared above; a run that checked fewer means
-# something stopped matching and this reported calm about numbers it never
-# looked at.
+# A floor. Fourteen quantities are declared above; a run that checked fewer
+# means something stopped matching and this reported calm about numbers it
+# never looked at.
 checked=$(printf '%b' "$report" | grep -c .)
-if [ "$fail" -eq 0 ] && [ "$checked" -lt 11 ]; then
-  echo "::error::only $checked of 11 quantities were accounted for" >&2
+if [ "$fail" -eq 0 ] && [ "$checked" -lt 14 ]; then
+  echo "::error::only $checked of 14 quantities were accounted for" >&2
   fail=1
 fi
 

--- a/README.md
+++ b/README.md
@@ -32,30 +32,24 @@ only then does anything build.*
 
 ## What you can do with it
 
-Every row ships today, and links to its page in
-**[the manual](https://olafkfreund.github.io/nixarchy/)**.
+Every row ships today. The left column links to the feature's page in
+**[the manual](https://olafkfreund.github.io/nixarchy/)**; what each one is
+made of, and which are on by default, is in [What works](#what-works) below.
 
 | | |
 |---|---|
-| **Install apps from a menu** | A pick writes a *declaration*, not a package. [`Install ▸ Search`](https://olafkfreund.github.io/nixarchy/manual/other-packages) then puts every nixpkgs package and every NixOS option one key away — 137k rows. |
-| **Try an app before installing it** | [`nixarchy try <name>`](https://olafkfreund.github.io/nixarchy/manual/try-it-first) runs something once, from the same pinned nixpkgs an install would use, and offers to keep it when you exit. Your configuration is untouched. |
-| **Look before you switch** | [`nixarchy preview`](https://olafkfreund.github.io/nixarchy/manual/preview) boots your *pending* configuration in a VM window, so you see a change before the machine takes it. |
-| **Disposable VMs** | [`nixarchy vm run`](https://olafkfreund.github.io/nixarchy/manual/sandboxes) boots a NixOS **MicroVM** sharing the host's `/nix/store` — real isolation, no root, no rebuild, gone when you close it. |
-| **Arch or Debian, when NixOS will not do** | [`nixarchy box create dev --template archlinux`](https://olafkfreund.github.io/nixarchy/manual/boxes) drops you into an Arch or Debian userland through rootless **podman** and **distrobox** — for the binary that insists on an FHS. |
-| **Get this machine back** | [`nixarchy reinstall iso`](https://olafkfreund.github.io/nixarchy/manual/reinstall-image) builds a bootable image **from this machine's own configuration** — the one way back that survives losing the disk, beside [generations, snapshots and a home backup](https://olafkfreund.github.io/nixarchy/manual/system-snapshots). |
-| **One flake, many machines** | [Roll a change out to a fleet](https://olafkfreund.github.io/nixarchy/manual/many-machines) from one repository, and let machines pull their own configuration on a timer. |
-| **Stable or unstable** | [*Update ▸ Channel*](https://olafkfreund.github.io/nixarchy/manual/channels) moves nixpkgs and home-manager together — and a single package can come from the other channel. |
-| **A toolchain per project** | [`nixarchy dev init react`](https://olafkfreund.github.io/nixarchy/manual/per-project-environments) scaffolds a [devenv](https://devenv.sh) project that activates on `cd`, in bash, zsh and fish. |
-| **Your phone on the desktop** | [`scrcpy` mirrors the phone you own, `nixarchy android` pairs it over Wi-Fi](https://olafkfreund.github.io/nixarchy/manual/android), and Waydroid runs Android apps without one. |
-| **The desktop from anywhere** | [`hypr-rdp`](https://olafkfreund.github.io/nixarchy/manual/remote-desktop) serves the *running* Hyprland session to any RDP client, from an encrypted password, with the firewall closed. |
-| **Ask the machine** | [Agent skills written for NixOS](https://olafkfreund.github.io/nixarchy/manual/ai), in the menu — and they can run against a [local model](#a-local-model), so nothing leaves the machine. |
-
-Five of those are **off until you ask for them** — sandboxes, boxes,
-per-project environments, Android and remote desktop, each one line of Nix. The
-rest are commands and menu rows that ship with the desktop. Undoing a *declared*
-change is `nixos-rebuild --rollback`; a box or a VM you created by hand is not
-part of a generation and has its own removal path, which
-[its page says](https://olafkfreund.github.io/nixarchy/manual/boxes).
+| **[Install apps from a menu](https://olafkfreund.github.io/nixarchy/manual/other-packages)** | a pick writes a *declaration* — `Install ▸ Search` covers all of nixpkgs |
+| **[Try an app before installing it](https://olafkfreund.github.io/nixarchy/manual/try-it-first)** | `nixarchy try <name>` |
+| **[Look before you switch](https://olafkfreund.github.io/nixarchy/manual/preview)** | `nixarchy preview` boots the pending configuration in a VM window |
+| **[Disposable VMs](https://olafkfreund.github.io/nixarchy/manual/sandboxes)** | `nixarchy vm run` |
+| **[Arch or Debian, when NixOS will not do](https://olafkfreund.github.io/nixarchy/manual/boxes)** | `nixarchy box create` |
+| **[Get this machine back](https://olafkfreund.github.io/nixarchy/manual/reinstall-image)** | `nixarchy reinstall iso` — an install image built from your own configuration |
+| **[One flake, many machines](https://olafkfreund.github.io/nixarchy/manual/many-machines)** | roll a change out to a fleet from one repository |
+| **[Stable or unstable](https://olafkfreund.github.io/nixarchy/manual/channels)** | `Update ▸ Channel`, per machine or per package |
+| **[A toolchain per project](https://olafkfreund.github.io/nixarchy/manual/per-project-environments)** | `nixarchy dev init react` |
+| **[Your phone on the desktop](https://olafkfreund.github.io/nixarchy/manual/android)** | `nixarchy android`, mirrored or emulated |
+| **[The desktop from anywhere](https://olafkfreund.github.io/nixarchy/manual/remote-desktop)** | `hypr-rdp`, the running session over RDP |
+| **[Ask the machine](https://olafkfreund.github.io/nixarchy/manual/ai)** | agent skills written for NixOS, even against a [local model](#a-local-model) |
 
 ![The Omarchy desktop on NixOS](docs/screenshots/00-desktop.jpg)
 
@@ -934,8 +928,8 @@ any conflict to warn you.
 
 ## Installing on a fresh machine
 
-There is an ISO now. Download it, write it to a stick, boot it, and answer nine
-questions.
+There is an ISO now. Download it, write it to a stick, boot it,
+and answer seven questions.
 
 > [!CAUTION]
 > **This is the least mature part of nixarchy, and it partitions disks.**


### PR DESCRIPTION
> [!NOTE]
> **Stacks on #552** (`docs/readme-showcase`) and should merge after it — the base of this PR is that branch, not `main`.

## What this changes, and why

Closes #557. Closes #560.

**#557** — the README said the installer asks *seven* questions in "What works" and *nine* in "Installing on a fresh machine", and `readme-counts.sh` guarded neither. The true number is **seven**, established from `validate_answers` in `installer/install.sh`: a full install requires exactly seven answers — `device`, `encrypt`, `hostname`, `username`, `password`, `timezone`, `keymap` — and those are the questions the interactive wizard asks (the recovery passphrase is optional and skipped with Enter, the two `gum confirm`s are consent rather than answers, and the disk-mode and Wi-Fi screens are conditional). Both sentences now say seven, and `readme-counts.sh` gains **two** quantities (13 and 14) — one per sentence, because `quantity` compares only the *first* match of its pattern, so one pattern covering both lines would report calm while the second line disagreed, which is #557 verbatim. The value is derived by counting the unique required-key guards (`[ -n "$var" ] || problems+=`) in `validate_answers`, deduplicated because the `--host` branch repeats the password guard. The floor moves to 14, and its comment stops claiming eleven quantities when twelve were declared.

**#560** — option 2 from the issue: the showcase table keeps its twelve rows and its framing, but each row now names the feature (linked to its manual page) and carries only the command or a single clause. The descriptions, defaults and mechanics live in "What works" alone, which the table's preamble now points at. The "Five of those are off until you ask for them" paragraph is gone with the duplication it summarised — the per-row *Off by default* markers in "What works" are the single source now (that paragraph is where the contradiction fixed in `a3a7ae7` lived).

## How I proved the check fails

Run with `OMARCHY_TREE=/run/current-system/sw` (the live machine's built omarchy tree — nothing was built locally, per CLAUDE.md §6; the `skills` refusal below is an artifact of that tree and does not occur against `./result` in CI).

With the README deliberately set back to "nine" at the ISO sentence:

```
::error::installer-questions-iso: README says nine, the repository says seven
  ...
  installer-questions: seven
exit=1
```

With the "What works" row broken to "nine" instead:

```
::error::installer-questions: README says nine, the repository says seven
  installer-questions-iso: seven
```

Restored, both green:

```
  installer-questions: seven
  installer-questions-iso: seven
```

All fourteen patterns (the twelve existing plus the two new) were additionally verified to match `README.md` **exactly once** each, under bash.

## Checks run locally

Docs + script change only; no `.nix` file touched, so no flake checks. `readme-counts.sh --check` run in full as above; `shellcheck` on the script reports only the pre-existing SC2012 info on an untouched line.

- [x] `nix fmt` / statix / deadnix are clean (no Nix files changed)
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [ ] If this adds an option: `tests/options.nix` covers both states (n/a)
- [ ] If this adds a `checks.*` entry: a PR-triggered workflow builds it (n/a — extends an existing script CI already runs)

## What this cost, and where it is written down

Nothing general. One specific fact for the log: the floor said 11 while twelve quantities were declared — stale from when the twelfth landed — corrected here to the real count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
