### PR TITLE
The Roadmap names the escape hatches epic (#566)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1934,6 +1934,7 @@ somebody who only uses nixarchy, and that is the gap those posts fill.
 | --- | --- | --- |
 | [#478](https://github.com/olafkfreund/nixarchy/issues/478) | **A reinstall image** — build a bootable image from this machine's own configuration, so it can be rebuilt on new hardware. Not a backup: it carries no `/home` and booting it erases the target | 6 filed |
 | [#491](https://github.com/olafkfreund/nixarchy/issues/491) | **The package picker, remade** — a miss opens the picker instead of a URL, rows say what they cost, and packages can be removed as well as added | 6 filed |
+| [#566](https://github.com/olafkfreund/nixarchy/issues/566) | **The escape hatches** — a downloaded binary finds its libraries, `/bin` and `/usr/bin` resolve, AppImages run, and software in no repository gets a draft derivation you own | 7 filed |
 
 **Recently finished:**
 [choose a channel](https://github.com/olafkfreund/nixarchy/issues/525)


### PR DESCRIPTION
Part one of three for filing #566, in the order §12 requires.

#566 is the epic for the rungs between `nix-ld` and a whole distro: a real library set for the loader, `envfs`, AppImages, `git-lfs` and `uv`, a doctor that recognises a failed dynamic link, and `nixarchy pkg new <url>` for software in no repository.

## Why the row comes first

§12's guard fails a PR when an open epic has no Roadmap row, and that has turned `main` red **five times** (#105, #148, #159, #174, #221/#230) — every time because the label went on first and the row was treated as follow-up.

Its other half only complains about a roadmap number that is a **closed epic**, so a row naming an issue that is not yet labelled is safe. That is what makes this ordering possible rather than merely cautious: **#566 carries no `epic` label yet**, and gets it once this is on `main`.

Simulated both halves against the live issue list before committing:

```
roadmap now: 478 491 566
open epics:  478 491
```

Half one satisfied — every open epic is listed. Half two has nothing to say about 566.

Docs only; the guarded README numbers still match exactly once each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5