### PR TITLE
The manual answers "I just want pip to work" before it answers "here is a flake"

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -48,6 +48,7 @@ nav:
   - { path: /manual/making-your-own-theme,    title: Making Your Own Theme }
   - { path: /manual/development-tools,        title: Development Tools }
   - { path: /manual/per-project-environments, title: Per-Project Environments }
+  - { path: /manual/python,                   title: Python }
   - { path: /manual/boxes,                    title: Boxes }
   - { path: /manual/sandboxes,                title: Sandboxes }
   - { path: /manual/ai,                       title: AI }

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -112,6 +112,7 @@ Key facts an assistant should know before answering questions about nixarchy:
 - [Making Your Own Theme](https://olafkfreund.github.io/nixarchy/manual/making-your-own-theme): overlaying or forking a stock theme out of the read-only store
 - [Development Tools](https://olafkfreund.github.io/nixarchy/manual/development-tools): editors, and the 13 language toolchains from nixpkgs instead of mise
 - [Per-Project Environments](https://olafkfreund.github.io/nixarchy/manual/per-project-environments): nixarchy dev init and devenv — a pinned toolchain that activates on cd (opt-in)
+- [Python](https://olafkfreund.github.io/nixarchy/manual/python): pip in a venv works today; why an import dies on libGL.so.1 (the loader, not pip), the nix-ld fix, then the project preset and uv
 - [Boxes](https://olafkfreund.github.io/nixarchy/manual/boxes): Arch or Debian userlands via rootless podman and distrobox, ad hoc or declared (opt-in)
 - [Sandboxes](https://olafkfreund.github.io/nixarchy/manual/sandboxes): disposable NixOS MicroVMs sharing the host store, and the declarative always-up half (opt-in)
 - [AI](https://olafkfreund.github.io/nixarchy/manual/ai): the ten NixOS agent skills, the Ask menu, choosing an agent, and running it all locally

--- a/docs/manual/boxes.md
+++ b/docs/manual/boxes.md
@@ -41,7 +41,9 @@ leave the directory. A box is a whole userland; devenv is a version of `node`.
 | anything in nixpkgs | nixpkgs -- always first |
 | a package you are not sure you want yet | [`nixarchy try`](try-it-first) -- runs it once, installs nothing, isolates nothing |
 | a GUI app that is not, and you want it contained | Flatpak |
-| a loose prebuilt binary | `nix-ld`, already on |
+| a loose prebuilt binary | `nix-ld`, already on -- [Python](python) covers growing its library set |
+| a pip wheel that installs but dies on `libGL.so.1` at import | the same loader problem -- [Python](python) |
+| pip compiling C against system libraries | a [devenv](per-project-environments) with the libraries added, or an FHS shell (`pkgs.buildFHSEnv`) |
 | a toolchain this project needs | [devenv](per-project-environments) |
 | software that wants a distro | a box |
 

--- a/docs/manual/python.md
+++ b/docs/manual/python.md
@@ -1,0 +1,134 @@
+---
+title: Python
+---
+
+# Python
+
+Two different people open a Python guide on NixOS, and most guides answer
+only one of them.
+
+Someone **following a tutorial** wants `pip install` to work, right now, in
+whatever directory the tutorial says. That is not a packaging problem and it
+does not need a flake -- it needs a virtualenv, ordinary wheels from PyPI,
+and a loader that can find the libraries those wheels were built against.
+This page serves that person first.
+
+Someone **building a project** wants the environment to be the same on every
+machine, next year. That person gets the second half of the page: the
+`python` preset from [per-project environments](per-project-environments),
+`uv`, and where Nix-built Python actually earns its keep.
+
+## I just want pip to work
+
+`python3` is already on every nixarchy machine -- it is a dependency of
+Omarchy's own scripts, and _Install ▸ Development ▸ Python_ makes it part of
+your configuration explicitly. So the tutorial path is the tutorial path:
+
+```sh
+python3 -m venv .venv
+source .venv/bin/activate
+pip install requests
+```
+
+This works, unmodified, for most of PyPI. A pure-Python package -- requests,
+flask, click, most of what a tutorial asks for -- installs and imports on
+NixOS exactly as it does anywhere else. Nothing about the venv-and-wheels
+workflow is wrong here, and nothing below asks you to give it up.
+
+## The error this page exists for
+
+Then you install numpy, or opencv, or matplotlib, and `pip install`
+succeeds -- and the `import` dies:
+
+```
+ImportError: libGL.so.1: cannot open shared object file: No such file or directory
+```
+
+Read that error precisely, because it names the real problem. The wheel is
+fine. pip is fine. Your venv is fine. A wheel with compiled code in it is an
+ordinary Linux binary, built on an ordinary distro, and at import time the
+dynamic loader goes looking for the shared libraries it was linked against --
+`libGL.so.1`, `libstdc++.so.6`, `libz.so.1` -- in the places ordinary
+distros keep them: `/usr/lib`, `/lib`. NixOS deliberately has no `/usr/lib`.
+Every library lives in `/nix/store` under a versioned path, and only
+programs built by Nix know where. The binary is asking a reasonable
+question in a filesystem that answers it for nobody.
+
+So this is a **loader** problem, not a Python problem. The same failure, with
+a different library name in it, hits Node native modules, Electron apps,
+PyTorch and Playwright -- anything that ships prebuilt compiled code.
+
+## What fixes it
+
+NixOS's answer to loose prebuilt binaries is
+[nix-ld](https://github.com/nix-community/nix-ld): a shim at the path
+binaries expect the loader at, which supplies a configured set of libraries.
+It is already enabled on every nixarchy machine. What it can hand a wheel is
+whatever `programs.nix-ld.libraries` holds -- and today nixarchy leaves that
+at the NixOS default, a minimal set, which is why the import above still
+dies. A curated library set that covers the common wheels is being added
+under [#566](https://github.com/olafkfreund/nixarchy/issues/566); until it
+lands, the fix is one option in your own configuration, naming the library
+the error names:
+
+```nix
+programs.nix-ld.libraries = with pkgs; [
+  libGL
+  zlib
+  stdenv.cc.cc.lib   # libstdc++.so.6
+];
+```
+
+Rebuild, open a new shell, and the same venv -- no reinstall -- imports.
+Each new `cannot open shared object file` is one more entry in that list:
+the error tells you the library, [search](other-packages) tells you the
+package.
+
+## When the project matters more than the tutorial
+
+Once the code is a project -- a repo, a colleague, a deadline -- pin the
+environment instead of relying on whatever the machine has:
+
+```sh
+nixarchy dev init python
+```
+
+This is the `python` preset from
+[per-project environments](per-project-environments) (the devenv service,
+opt-in): a `devenv.nix` with `languages.python.enable` and
+`venv.enable`, so devenv creates and enters a virtualenv for you and
+`pip install` lands in the project rather than in your home directory. The
+lock file makes it the same Python on every machine that clones the repo.
+
+For dependency management itself, [uv](https://docs.astral.sh/uv/) is the
+current answer -- `uv.lock` as the source of truth. And when you need Nix to
+*build* the project from that lock,
+[uv2nix](https://pyproject-nix.github.io/uv2nix/introduction.html) exists --
+whose own documentation says to skip it for day-to-day development and just
+use uv. That is a useful signal, not a criticism: reach for uv2nix when
+something must consume the project as a Nix package, not before.
+
+## What still will not work, and why
+
+Honesty about the limits, so the failure you hit next is not a surprise:
+
+- **pip compiling C from source.** nix-ld helps *prebuilt* binaries find
+  libraries at run time. A package with no wheel for your platform runs a C
+  compiler against headers at *install* time, and no loader shim provides
+  headers. That needs the C libraries in the environment -- a devenv with the
+  packages added, a `nix-shell` with them, or an FHS environment
+  (`pkgs.buildFHSEnv`, plain nixpkgs) that fakes the whole `/usr` layout.
+- **Scripts with hard-coded paths.** A tool that execs `/usr/bin/python` or
+  `#!/bin/bash` fails before any loader is involved, because those paths do
+  not exist here. (`envfs`, which resolves them, is another rung of
+  [#566](https://github.com/olafkfreund/nixarchy/issues/566) and is not
+  shipped yet; today the fix is running the script with the interpreter
+  named explicitly.)
+- **Installers that manage their own binaries.** conda and friends download
+  whole toolchains of foreign binaries; some run under nix-ld once the
+  library list is grown far enough, none are supported. If a tool insists on
+  a whole distro's worth of assumptions, that is what a
+  [box](boxes) is for.
+
+The full ladder -- which rung for which failure -- is the decision table on
+the [Boxes](boxes) page.


### PR DESCRIPTION
## What this changes, and why

Closes #568 (child of #566). Every Python-on-NixOS guide conflates two users: someone following a tutorial who wants `pip install` to work (a loader problem — venv, wheels, nix-ld), and someone building a project who wants reproducibility (devenv's `python` preset, uv, uv2nix). The new `docs/manual/python.md` serves the first user first: the venv path that works today, the `libGL.so.1` error explained in plain language, the `programs.nix-ld.libraries` fix that exists right now, and only then the project rung — plus an honest list of what still will not work. The decision table in `docs/manual/boxes.md` gains the missing rungs. Not an Arch bug: the loader failure is NixOS-specific by construction.

**Scope note:** the page does not depend on the unmerged nix-ld library-set child of #566. It states today's truth (nix-ld enabled, library list at the NixOS default) and names the curated set as coming under #566, with the user-side `programs.nix-ld.libraries` option as the fix that works now. It can merge in any order relative to that sibling; when the library set lands, one paragraph softens.

## How I proved the check fails

Docs only — the relevant existing check is build.yml's "Every manual page is in the sidebar". I ran its exact comparison as a bash script against a copy of the tree with the wiring reverted (page present, nav and llms.txt entries removed):

```
::error::docs/manual/python.md is published but not in the docs/_config.yml sidebar
::error::docs/manual/python.md is published but not in docs/llms.txt
broken exit=1
```

and against this branch:

```
real exit=0
```

## Checks run locally

The sidebar/llms.txt comparison above, under bash (§1's zsh trap noted). No `.nix` files change, so no `nix fmt`/statix/deadnix delta and no VM checks.

- [x] `nix fmt` / statix / deadnix are clean (no .nix changes)
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [ ] If this adds an option: `tests/options.nix` covers both states (n/a)
- [ ] If this adds a `checks.*` entry: a PR-triggered workflow builds it (n/a)

## What this cost, and where it is written down

- [x] Nothing general came up.

Claims verified against the tree: nix-ld enable-only (`modules/nixos.nix:639`), no envfs/uv/git-lfs shipped (grep over `modules/`, `data/`), `nixarchy dev init python` preset and its venv note (`data/devenv-presets.nix:96`), python3 present by default (`data/apps.nix:662`, `docs/manual/development-tools.md`). Agent bus read before starting: nothing new bearing on this task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
