### PR TITLE
git-lfs and uv reach the machine, and the python devenv preset creates its venv through uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ the parts that assume Arch, rather than reimplementing it in Nix.
 Tracking an upstream release is a source bump, not a re-port.
 
 What that buys you: the Install menu writes to a Nix config instead of running
-pacman, **64 applications** are selectable that way, **every other package and
+pacman, **66 applications** are selectable that way, **every other package and
 NixOS option is one `Install ▸ Search` away**, plugins and themes still install
 from a git URL at runtime the way upstream intends, and every command that
 assumed `/usr` either points at what NixOS uses or says why it cannot.
@@ -104,7 +104,7 @@ sandboxes, themes and plugins, throughout
 | **`nixarchy` command** | this port's own commands, and a way through to Omarchy's 444 |
 | **Remove menu** | deselects apps, never touches your own config |
 | **Update menu** | `nh os switch --update <flake>` |
-| 64 apps in the selection | 49 from nixpkgs, 4 as NixOS modules, 9 built here, 2 with no equivalent |
+| 66 apps in the selection | 50 from nixpkgs, 5 as NixOS modules, 9 built here, 2 with no equivalent |
 | Learn menu | NixOS wiki, `search.nixos.org` packages and options |
 | Shell functions | bash and zsh source the chain; fish derives it from the same files |
 | RetroArch | 13 libretro cores, resolved from the store rather than `/usr/lib` |
@@ -499,7 +499,7 @@ from a terminal:
   enter to select · tab for several · esc to cancel
 ```
 
-**137,599 rows: 25,102 NixOS options, 112,443 packages, and 62 of the 64 apps
+**137,599 rows: 25,102 NixOS options, 112,443 packages, and 64 of the 66 apps
 (the two with no nixpkgs equivalent cannot be indexed).** Three kinds,
 one picker, because you should not have to know which kind you want before you
 can look. They are not interchangeable and the rows say so — picking Tailscale
@@ -1523,7 +1523,7 @@ done
 
 Almost nothing here waits on a maintainer.
 
-**53 of the 64 apps never touch this repo.** Brave, VSCode, Signal and the rest
+**55 of the 66 apps never touch this repo.** Brave, VSCode, Signal and the rest
 are installed as `pkgs.<name>` from **your** nixpkgs, and the five
 module-backed ones (Steam, 1Password, Tailscale, Firefox, Xbox controllers)
 come from there too — the module is NixOS', not this repo's. Your own
@@ -1582,7 +1582,7 @@ Most of it is not our job, and should not be:
 
 | where the app comes from | who updates it |
 |---|---|
-| nixpkgs (53 of 64 apps) | **nobody** — your own `nix flake update` |
+| nixpkgs (55 of 66 apps) | **nobody** — your own `nix flake update` |
 | pinned in this repo (2) | a nightly bot, opening a PR |
 | `zen` | upstream's own flake |
 | `retroarch` | nixpkgs, via this flake's own pin — it is a rebuild with cores |

--- a/data/apps.nix
+++ b/data/apps.nix
@@ -678,4 +678,36 @@
     attr = "ocaml";
     arch = "ocaml";
   };
+
+  git-lfs = {
+    # An option, not an attr, because the package alone is a trap: git-lfs
+    # only works after its filter config is written, and without it a clone
+    # of an LFS repo silently hands you pointer files instead of content.
+    # NixOS's programs.git.lfs module installs the package AND writes
+    # filter.lfs into the system gitconfig, so no user ever has to know
+    # `git lfs install` exists (#566).
+    #
+    # No menuId and no arch: upstream ships no Install row for it, the row
+    # generator fails on a menuId upstream does not ship, and an invented
+    # arch name would fire on somebody else's package -- same reasoning as
+    # scrcpy.
+    label = "Git LFS";
+    category = "Development";
+    option = [
+      "programs"
+      "git"
+      "lfs"
+    ];
+    note = "Installs git-lfs and writes the LFS filter config system-wide, so cloning an LFS repo just works.";
+  };
+
+  uv = {
+    # No menuId and no arch, as git-lfs above. The `python` devenv preset
+    # pins uv per project; this is the machine-wide copy for everything
+    # outside a project -- `uv tool install`, `uvx`, a quick script (#566).
+    label = "uv";
+    category = "Development";
+    attr = "uv";
+    note = "Astral's Python package and project manager. `nixarchy dev init python` gives each project its own; this one is for everywhere else.";
+  };
 }

--- a/data/devenv-presets.nix
+++ b/data/devenv-presets.nix
@@ -93,15 +93,21 @@
     note = "Node, npm, tsc and the TypeScript language server. The javascript lines come too -- devenv's typescript module is the compiler, not a runtime.";
   };
 
+  # uv.enable, not uv.sync.enable: sync runs `uv sync` on entering the shell,
+  # which wants a pyproject.toml a freshly scaffolded project does not have.
+  # With uv.enable devenv creates the venv through uv and puts uv itself on
+  # the project's PATH; `uv sync` is one documented line for a project that
+  # grows a pyproject.toml. Checked against src/modules/languages/python.
   python = {
     label = "Python";
     lines = ''
       languages.python = {
         enable = true;
         venv.enable = true;
+        uv.enable = true;
       };
     '';
-    note = "Python with a virtualenv devenv creates and enters for you, so `pip install` lands in the project rather than in your home directory.";
+    note = "Python with uv and a virtualenv devenv creates and enters for you, so `uv pip install` and `pip install` land in the project rather than in your home directory.";
   };
 
   go = {


### PR DESCRIPTION
## What this changes, and why

Two developer tools from #566 that were missing from the machine entirely. `git-lfs` appeared nowhere in the tree, so cloning an LFS repo silently handed you pointer files instead of content; it lands as an app row (`programs.nixarchy.apps.git-lfs`) wired to NixOS's `programs.git.lfs` module rather than as a bare package, because the package alone reproduces the silent failure — the module installs git-lfs **and** writes the `filter.lfs` config into the system gitconfig, so a clone just works and nobody has to know `git lfs install` exists (verified the option exists on the pinned nixpkgs: `programs.git.lfs.enable`/`.package`; `programs.git.enable` is already mkDefault true in modules/nixos.nix, which the lfs config gates on). `uv` existed only inside the microvm python template; it gains an app row (nixpkgs' `uv`), and the `python` devenv preset adds `languages.python.uv.enable` so a scaffolded project gets uv on its PATH and its venv created through uv. `uv.sync.enable` stays off deliberately: it runs `uv sync` on shell entry, which wants a `pyproject.toml` a fresh scaffold does not have — option names verified against devenv's `src/modules/languages/python/default.nix`, not memory. Neither app row has a `menuId` or `arch` (upstream ships no Install row for either; the generator fails on an invented menuId, and an invented arch name would fire on somebody else's package — the scrcpy precedent). Both rows are opt-in: Mode A untouched, nothing turns on for someone who did not ask.

README app counts move with the catalogue: 64 → 66 total, 49 → 50 nixpkgs, 4 → 5 modules, 53 → 55 never-touch-this-repo, 62 → 64 indexed — recomputed with the same field predicates `readme-counts.sh` uses (`x ? option`, `x.ours or false`, `x ? unavailable`), which need only `data/apps.nix`, so the numbers are derived rather than guessed even though I did not build the omarchy tree locally (§6). The `readme-counts` CI step is the arbiter.

## How I proved the check fails

Broke the git-lfs row's option path (`"lfs"` → `"lfsx"`), ran `nix build .#checks.x86_64-linux.options`:

```
       … while evaluating attribute 'autoUpdateDates' of derivation 'nixarchy-options'
         at .../tests/options.nix:1149:5:

       error: The option `programs.git.lfsx' does not exist. Definition values:
       - In `/nix/store/wr3njgpzrbmxfcdys91h0x23i9v12551-source/flake.nix':
           {
             _type = "if";
             condition = true;
             ...
       Did you mean `programs.git.lfs', `programs.git.config' or `programs.git.enable'?
```

So the check evaluates the row with the app enabled and a wrong option path is a hard red, not a quiet no-op. Restored the path; the check passes again (exit 0).

## Checks run locally

- `nix build .#checks.x86_64-linux.options` — green (and red with the row broken, above)
- `nix fmt -- --ci` — clean (0 changed of 119)
- statix / deadnix — clean

Not run locally, and why: the `devenv-presets` CI job scaffolds every preset and evaluates it against a real devenv (network + IFD), which cannot run here — the `uv.enable` option was instead verified against devenv's own `src/modules/languages/python/default.nix` (options at lines 492–505, uv-created venv at line 123). That job is the one to watch on this PR. `readme-counts` --check runs in CI with the built omarchy tree; the five app-count figures were updated to the derived values above.

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [x] If this adds an option: `tests/options.nix` covers both states (app options are generated from the catalogue and asserted in both states; the red run above is that coverage firing)
- [ ] If this adds a `checks.*` entry: n/a — no new check entry

## What this cost, and where it is written down

- [x] Nothing general came up. The one near-trap — an invented `arch`/`menuId` on a row upstream does not ship — is already written down in `data/apps.nix` on the scrcpy row, and the new rows point at it.

Agent bus (§9): read `#nixarchy-agents` before starting — nothing new bearing on this task.

Part of #566 — the "`git-lfs` and `uv` exist on the machine" child (no standalone child issue exists; it is a checkbox on the epic). **Do not merge** — awaiting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
