### PR TITLE
The loader hatches for prebuilt binaries: nix-ld gets a deliberate library set, envfs resolves shebangs, and AppImages are double-clickable

### DIFF
--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -636,7 +636,75 @@ in
       };
 
       # Why: modules/AGENTS.md#mise-is-in-omarchys-base-packages-and-its-dev-env-
-      nix-ld.enable = lib.mkDefault true;
+      nix-ld = {
+        enable = lib.mkDefault true;
+
+        # What a desktop's downloaded binaries actually dlopen. Plain
+        # assignment: this MERGES with nixpkgs' own base set (zlib, openssl,
+        # libxml2, curl, systemd, ...), it does not replace it -- and
+        # mkDefault here would silently drop the whole list the moment a
+        # user adds one library of their own (see modules/services/
+        # default.nix). Each entry names what dies without it, in the same
+        # register as pkgs/omarchy/default.nix's runtime list: a missing
+        # library is a runtime ImportError no build ever sees.
+        libraries = with pkgs; [
+          # libstdc++/libgcc_s -- nearly every C++ or Rust prebuilt binary;
+          # without it the loader stops at libstdc++.so.6. In nixpkgs' base
+          # set too, but it is the one entry nothing here can afford to lose
+          # to upstream drift.
+          stdenv.cc.cc.lib
+          # libGL.so.1 -- the #566 ImportError: anything that renders, from
+          # matplotlib and opencv wheels to downloaded games.
+          libGL
+          # Wayland client socket -- this is a Wayland desktop; a prebuilt
+          # GUI binary that speaks Wayland needs libwayland-client.so.0.
+          wayland
+          # Keyboard maps for both Wayland and X clients (libxkbcommon.so.0);
+          # SDL and GLFW binaries fail to create a window without it.
+          libxkbcommon
+          # The X client stack, for everything that runs under XWayland:
+          # Electron, Java AWT, SDL/GLFW games. libX11 is the core protocol;
+          # the rest are the extensions Chromium's own sandbox probes for.
+          xorg.libX11
+          xorg.libxcb
+          xorg.libXcursor
+          xorg.libXrandr
+          xorg.libXi
+          xorg.libXext
+          # Text on screen: fontconfig finds the fonts, freetype rasterises
+          # them. A GUI binary without them renders blank labels or aborts.
+          fontconfig
+          freetype
+          # GObject/GIO (libglib-2.0.so.0) -- Electron, GTK-adjacent
+          # binaries, and gdk-pixbuf loaders all pull it in.
+          glib
+          # NSS/NSPR -- Chromium's TLS stack; every Electron app dlopens
+          # libnss3.so at startup and exits without it.
+          nss
+          nspr
+          # libasound.so.2 -- sound for games and Electron; PipeWire serves
+          # the ALSA API but the client library still has to exist.
+          alsa-lib
+          # libav*/libsw* -- media wheels (pyav, opencv-python's videoio,
+          # torchaudio) link these rather than bundling them.
+          ffmpeg
+          # In nixpkgs' base set today, but load-bearing enough to pin here
+          # deliberately: libz (Pillow, every compressed asset), libssl/
+          # libcrypto (anything speaking TLS), libxml2 (lxml and friends).
+          zlib
+          openssl
+          libxml2
+        ];
+      };
+
+      # The AppImage rung of #566's ladder: binfmt registration is what makes
+      # a downloaded AppImage double-clickable rather than "run it through
+      # appimage-run", which nobody who just downloaded one knows to do. The
+      # wrapper extracts and runs it against the nix-ld set above.
+      appimage = {
+        enable = lib.mkDefault true;
+        binfmt = lib.mkDefault true;
+      };
 
       # See programs.nixarchy.bashIntegration. This lands in /etc/bashrc, which
       # bash sources BEFORE ~/.bashrc, so a user's own aliases still win.
@@ -832,6 +900,13 @@ in
     # mkForce their way out one option at a time. Their setting wins now, and
     # they lose only the feature that depended on it.
     services = {
+      # The shebang half of #566: a script starting `#!/bin/bash` or
+      # `#!/usr/bin/env python` fails with "no such file or directory" on a
+      # bare NixOS, because /bin holds only sh and /usr/bin only env. envfs
+      # mounts both as a FUSE view of the current PATH, so every tutorial
+      # script and every downloaded installer's shebang resolves.
+      envfs.enable = lib.mkDefault true;
+
       # Why: modules/AGENTS.md#passed-straight-through
       flatpak.uninstallUnmanaged = lib.mkDefault cfg.flatpaks.uninstallUnmanaged;
 

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -111,6 +111,35 @@ let
 
   hasOmarchySession = cfg: builtins.elem "omarchy" (pkgs.lib.flatten (sessionNames cfg));
 
+  # ---- the escape hatches for prebuilt binaries (#566) ----------------
+  #
+  # nix-ld's library set, envfs and AppImage support all ride on
+  # programs.nixarchy.enable rather than on options of their own, so their
+  # "off" state is the Mode A machine: the module imported, nothing enabled.
+  # That machine must carry none of them -- no FUSE mount over /usr/bin, no
+  # binfmt handler, no loader library set -- because every one of them is a
+  # system-wide behaviour change on a configuration somebody already runs.
+  loaderOff =
+    (inputs.nixpkgs.lib.nixosSystem {
+      inherit system;
+      modules = [
+        inputs.self.nixosModules.nixarchy
+        {
+          boot.loader.grub.device = "/dev/sda";
+          fileSystems."/" = {
+            device = "/dev/sda1";
+            fsType = "ext4";
+          };
+          system.stateVersion = "25.05";
+        }
+      ];
+    }).config;
+
+  # By name rather than builtins.elem on the derivation: the nixosSystem
+  # under test instantiates its own pkgs, and outPath equality across two
+  # instantiations is a coincidence, not a property.
+  hasNixLdLib = cfg: name: builtins.any (p: pkgs.lib.getName p == name) cfg.programs.nix-ld.libraries;
+
   # Each case is (what it should look like on, what it should look like off).
   cases = {
     # ---- nixi, on for everyone, and provably gone when told ----
@@ -207,6 +236,33 @@ let
       off =
         builtins.any (p: (p.pname or "") == "Pinta")
           (configWith { preinstalls = false; }).environment.systemPackages;
+    };
+
+    # ---- #566: the loader set, probed by entries nixpkgs' base list ----
+    # lacks. nss and alsa-lib are ours alone, so a refactor that dropped the
+    # deliberate list while leaving nix-ld enabled fails here -- against the
+    # base set alone both probes are false. "off" is the Mode A machine,
+    # where nix-ld is off and the list is empty.
+    nixLdLibraries = {
+      on =
+        hasNixLdLib (configWith { }) "nss"
+        && hasNixLdLib (configWith { }) "alsa-lib"
+        && (configWith { }).programs.nix-ld.enable;
+      off = hasNixLdLib loaderOff "nss" || loaderOff.programs.nix-ld.enable;
+    };
+
+    # envfs mounts a PATH-derived view over /bin and /usr/bin -- exactly the
+    # kind of thing a Mode A machine must never grow unasked.
+    envfs = {
+      on = (configWith { }).services.envfs.enable;
+      off = loaderOff.services.envfs.enable;
+    };
+
+    # Both halves of AppImage support: without binfmt the package is a
+    # wrapper nobody knows to call, so double-clickability is the property.
+    appimage = {
+      on = (configWith { }).programs.appimage.enable && (configWith { }).programs.appimage.binfmt;
+      off = loaderOff.programs.appimage.enable || loaderOff.programs.appimage.binfmt;
     };
 
     # The unit itself, both ways. "off" is the half that matters: a nixarchy


### PR DESCRIPTION
## What this changes, and why

Three children of #566, all in `modules/nixos.nix`. nix-ld was enabled for mise (`modules/AGENTS.md#mise-is-in-omarchys…`) but `programs.nix-ld.libraries` was never set, so the loader served only nixpkgs' base set (derived from systemd and nix — no libGL, no X/Wayland client libs, no NSS). That is why `pip install` succeeds and `import` dies with `libGL.so.1: cannot open shared object file`. This PR:

- gives nix-ld a deliberate library set — each entry carries a note naming what breaks without it, in the register of `pkgs/omarchy/default.nix`'s runtime list. Plain assignment, so it **merges** with nixpkgs' base set and with a user's own additions (mkDefault on a merging type silently drops the whole contribution — `modules/services/default.nix`);
- enables `services.envfs`, so `#!/bin/bash` and `#!/usr/bin/env python` shebangs resolve;
- enables `programs.appimage` with `binfmt = true`, so a downloaded AppImage is double-clickable.

envfs and appimage are `lib.mkDefault` (scalars), and all three ride on `programs.nixarchy.enable`, so a Mode A machine that imports the module and enables nothing is untouched — asserted in `tests/options.nix` against exactly that machine. Would not break on Arch: these are NixOS loader/FHS mechanics.

None of these add a `programs.nixarchy.*` option; they are part of what `enable` means, like pipewire and gpu-screen-recorder above them.

## How I proved the check fails

Reintroduced the bug (`git restore --worktree --source=HEAD -- modules/nixos.nix`, i.e. the module without the three additions) while keeping the new cases, then built `checks.options`:

```
nixarchy-options>   appimage: on= off=
nixarchy-options>   envfs: on= off=
nixarchy-options>   nixLdLibraries: on= off=
nixarchy-options> these options do not take effect both ways: appimage envfs nixLdLibraries
error: Cannot build '/nix/store/832bp892g0jkkcz52g3cma2pkpvd9j73-nixarchy-options.drv'.
       Reason: builder failed with exit code 1.
```

Restored the fix; `nix build .#checks.x86_64-linux.options` exits 0. The `nixLdLibraries` case probes by entries nixpkgs' base list lacks (`nss`, `alsa-lib`), so it fails against nix-ld-enabled-but-unconfigured — the exact state this PR replaces — not merely against nix-ld-off.

## Checks run locally

- `nix build .#checks.x86_64-linux.options` — red with the bug reintroduced, green with the fix (evaluation-only; four CI runs were in flight, so no VM check was built locally per §6)
- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [x] If this adds an option: `tests/options.nix` covers both states (no new option; the three behaviours are still asserted both ways, with the Mode A machine as the off state)
- [x] If this adds a `checks.*` entry: none added — the cases live in the existing `checks.options`

## What this cost, and where it is written down

- [x] Nothing general came up. One useful specific fact is in the code comment: nixpkgs' nix-ld module declares `libraries` with `default = []` and adds its base set inside `config`, so a plain-assignment list **merges with** the base set rather than replacing it.

Closes the first three children of #566: the nix-ld library set, envfs, and AppImage support.
