### PR TITLE
The manual index joins the lists a page has to be in, and gains two it lost

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -635,6 +635,15 @@ jobs:
             sed 's|path: /manual/||' | sort -u)
           llms=$(grep -oE 'manual/[a-z-]+' docs/llms.txt |
             sed 's|manual/||' | sort -u)
+          # The manual's own welcome table -- a THIRD hand-maintained index of
+          # the same pages, and the one nothing checked. It had drifted to 24
+          # of 26 (#574): `boxes` and `sandboxes`, two of the features most
+          # worth showing a new reader, were unreachable from the page a
+          # reader lands on. Links here are relative (`](boxes)`), sometimes
+          # with an anchor, which is why this strips a `#fragment` rather than
+          # matching a `/manual/` prefix like the two above.
+          index=$(grep -oE '\]\([a-z-]+(#[a-z-]*)?\)' docs/manual/index.md |
+            sed 's/](//;s/)//;s/#.*//' | sort -u)
           rc=0
           for n in $(comm -23 <(echo "$pages") <(echo "$nav") || true); do
             echo "::error::docs/manual/$n.md is published but not in the docs/_config.yml sidebar"
@@ -646,8 +655,12 @@ jobs:
             echo "::error::docs/manual/$n.md is published but not in docs/llms.txt"
             rc=1
           done
+          for n in $(comm -23 <(echo "$pages") <(echo "$index") || true); do
+            echo "::error::docs/manual/$n.md is published but not linked from docs/manual/index.md"
+            rc=1
+          done
           [ $rc -eq 0 ] || exit 1
-          echo "every manual page is in the sidebar and in llms.txt"
+          echo "every manual page is in the sidebar, in llms.txt and in the manual index"
 
       - name: Verify shebangs were patched
         run: |

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -50,6 +50,8 @@ the documentation as much as the code.
 | **Ai** | **differs on NixOS** — [read here](ai) |
 | **Development tools** | **differs on NixOS** — [read here](development-tools) |
 | **Per-project environments** | **nixarchy only** — [read here](per-project-environments) |
+| **Boxes** | **nixarchy only** — [read here](boxes) |
+| **Sandboxes** | **nixarchy only** — [read here](sandboxes) |
 | Shell tools | same as Omarchy — [read there](https://omarchy.org/manual/shell-tools/) |
 | Shell functions | same as Omarchy — [read there](https://omarchy.org/manual/shell-functions/) |
 | Tuis | same as Omarchy — [read there](https://omarchy.org/manual/tuis/) |

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -50,6 +50,7 @@ the documentation as much as the code.
 | **Ai** | **differs on NixOS** — [read here](ai) |
 | **Development tools** | **differs on NixOS** — [read here](development-tools) |
 | **Per-project environments** | **nixarchy only** — [read here](per-project-environments) |
+| **Python** | **nixarchy only** — [read here](python) |
 | **Boxes** | **nixarchy only** — [read here](boxes) |
 | **Sandboxes** | **nixarchy only** — [read here](sandboxes) |
 | Shell tools | same as Omarchy — [read there](https://omarchy.org/manual/shell-tools/) |


### PR DESCRIPTION
Closes #574.

`build.yml`'s "Every manual page is in the sidebar" check compares `docs/manual/*.md` against two lists — the `nav:` in `docs/_config.yml` and `docs/llms.txt`. There is a **third** hand-maintained index of the same pages, `docs/manual/index.md`, and nothing checked it.

**It had already drifted.** The extended check, run against `main` as it stands:

```
::error::docs/manual/boxes.md is published but not linked from docs/manual/index.md
::error::docs/manual/sandboxes.md is published but not linked from docs/manual/index.md
exit=1
```

24 of 26 pages linked — and the two missing are **Boxes** and **Sandboxes**, among the features most worth showing somebody arriving at the manual, unreachable from the page they land on.

This is the same failure the guard was written for this morning, one list over: **a hand-maintained index fails open.** The page publishes, nothing is red, and the only detector is a human browsing. #569 was about to repeat it, wiring `python` into the two enforced lists and not into this one.

## The backfill is in this change on purpose

Adding the check without linking the two pages turns `main` red on the next pull request — the §10 trap where an unrelated PR pays for a repo-wide state. Both rows are added here, beside Per-project environments where a reader comparing the three would look.

## Why this list needs its own matcher

The two enforced lists carry a `/manual/` prefix. This one links relatively, sometimes with an anchor — `](boxes)`, `](system-snapshots#snapshots-of-your-home-directory)` — so it strips a `#fragment` instead. Stated in the code, because whoever edits that grep needs it in front of them.

Membership only, not order, for the same reason as the other two.

## Verification

- **Failing output above is real drift**, not a synthetic break — the strongest form of §1 evidence available.
- After the backfill: **26 of 26** linked.
- Negative test: a canary page in none of the three lists is named, exit 1; removed, clean.
- `actionlint` with the job's own ignore pattern exits 0; `nix fmt -- --ci` clean.

CI gate change, so per §11 proposed rather than merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5