### PR TITLE
The manual and the front page catch up with the escape hatches that shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ made of, and which are on by default, is in [What works](#what-works) below.
 | **[Look before you switch](https://olafkfreund.github.io/nixarchy/manual/preview)** | `nixarchy preview` boots the pending configuration in a VM window |
 | **[Disposable VMs](https://olafkfreund.github.io/nixarchy/manual/sandboxes)** | `nixarchy vm run` |
 | **[Arch or Debian, when NixOS will not do](https://olafkfreund.github.io/nixarchy/manual/boxes)** | `nixarchy box create` |
+| **[Run the binary you just downloaded](https://olafkfreund.github.io/nixarchy/manual/python)** | `nix-ld`, `envfs` and AppImages, on by default — `nixarchy-doctor <binary>` names what is still missing |
 | **[Get this machine back](https://olafkfreund.github.io/nixarchy/manual/reinstall-image)** | `nixarchy reinstall iso` — an install image built from your own configuration |
 | **[One flake, many machines](https://olafkfreund.github.io/nixarchy/manual/many-machines)** | roll a change out to a fleet from one repository |
 | **[Stable or unstable](https://olafkfreund.github.io/nixarchy/manual/channels)** | `Update ▸ Channel`, per machine or per package |
@@ -109,6 +110,7 @@ sandboxes, themes and plugins, throughout
 | **Boxes** | `nixarchy box create dev --template archlinux` drops you into an Arch or Debian userland via rootless podman and [distrobox](https://distrobox.it), for software NixOS will not run — [the page](docs/manual/boxes.md). Off by default |
 | **Remote desktop** | `programs.nixarchy.services.hypr-rdp` serves the running Hyprland session to any RDP client, from an encrypted password, with the firewall closed — [the page](docs/manual/remote-desktop.md). Off by default |
 | **Sandboxes** | `nixarchy vm run` boots a disposable NixOS MicroVM sharing the host's `/nix/store`, no root and no rebuild — [the page](docs/manual/sandboxes.md). Off by default |
+| **Prebuilt binaries** | `nix-ld` with a curated library set — a downloaded binary finds `libGL`, the X/Wayland stack, NSS and friends; `envfs` resolves `/bin` and `/usr/bin` shebangs; binfmt makes AppImages double-clickable — [the page](docs/manual/python.md). **On by default** |
 | Branded boot splash | the wordmark animates in with [ttfx](https://github.com/omacom/ttfx), over a progress bar that is on for every boot |
 | **The guide** | [nixi](https://github.com/olafkfreund/nixi-nixarchy) — a hands-on tour, an offline manual search and a tutor grounded in your machine, offered in the bar — [the page](docs/manual/getting-started.md#the-guide). **On by default**; `services.nixi.enable = false` removes it entirely |
 | **Agent skills** | from `nixarchy` and `nixos` to `nixos-gpu` and `nixos-android` — rewritten for NixOS, not Omarchy's Arch originals |

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -49,6 +49,7 @@ nav:
   - { path: /manual/development-tools,        title: Development Tools }
   - { path: /manual/per-project-environments, title: Per-Project Environments }
   - { path: /manual/python,                   title: Python }
+  - { path: /manual/prebuilt-binaries,        title: Prebuilt Binaries }
   - { path: /manual/boxes,                    title: Boxes }
   - { path: /manual/sandboxes,                title: Sandboxes }
   - { path: /manual/ai,                       title: AI }

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,6 +90,31 @@ you own, and only then a rebuild:
 
 See **[other packages](manual/other-packages)** for the whole flow.
 
+## The binary you just downloaded runs
+
+NixOS deliberately has no `/usr/lib`, so a prebuilt Linux binary — a pip
+wheel with compiled code, an Electron app, a game — normally dies with
+`libGL.so.1: cannot open shared object file`. nixarchy turns the escape
+hatches on by default:
+
+- **[nix-ld](https://github.com/nix-community/nix-ld)**, loaded with a
+  curated set of what desktop downloads actually link against — `libGL`, the
+  X and Wayland client stacks, fontconfig, NSS for Electron, ALSA, ffmpeg —
+  so most prebuilt binaries simply run.
+- **envfs** mounts `/bin` and `/usr/bin`, so a script whose shebang says
+  `#!/usr/bin/python3` runs instead of reporting "No such file or directory"
+  about a file you are looking at.
+- **AppImages are double-clickable**: binfmt registration runs them directly,
+  no `appimage-run` incantation to know about.
+
+And when something still fails, `nixarchy-doctor <binary>` runs the loader's
+own resolution against that file and names the missing library and the
+`programs.nix-ld.libraries` line that supplies it — instead of leaving you
+to decode `cannot open shared object file` yourself.
+
+See **[Python](manual/python)** — the page is named for where people hit
+this first, but the loader story covers Node, Electron and games too.
+
 ## An agent that knows this machine
 
 Omarchy symlinks its agent skills into every harness's skill directory. Upstream

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -113,6 +113,7 @@ Key facts an assistant should know before answering questions about nixarchy:
 - [Development Tools](https://olafkfreund.github.io/nixarchy/manual/development-tools): editors, and the 13 language toolchains from nixpkgs instead of mise
 - [Per-Project Environments](https://olafkfreund.github.io/nixarchy/manual/per-project-environments): nixarchy dev init and devenv — a pinned toolchain that activates on cd (opt-in)
 - [Python](https://olafkfreund.github.io/nixarchy/manual/python): pip in a venv works today; why an import dies on libGL.so.1 (the loader, not pip), the nix-ld fix, then the project preset and uv
+- [Prebuilt binaries](https://olafkfreund.github.io/nixarchy/manual/prebuilt-binaries): the three on-by-default answers to a downloaded Linux binary -- nix-ld and its curated library set, envfs for shebangs, binfmt-registered AppImages -- and where each stops
 - [Boxes](https://olafkfreund.github.io/nixarchy/manual/boxes): Arch or Debian userlands via rootless podman and distrobox, ad hoc or declared (opt-in)
 - [Sandboxes](https://olafkfreund.github.io/nixarchy/manual/sandboxes): disposable NixOS MicroVMs sharing the host store, and the declarative always-up half (opt-in)
 - [AI](https://olafkfreund.github.io/nixarchy/manual/ai): the ten NixOS agent skills, the Ask menu, choosing an agent, and running it all locally

--- a/docs/manual/boxes.md
+++ b/docs/manual/boxes.md
@@ -41,7 +41,8 @@ leave the directory. A box is a whole userland; devenv is a version of `node`.
 | anything in nixpkgs | nixpkgs -- always first |
 | a package you are not sure you want yet | [`nixarchy try`](try-it-first) -- runs it once, installs nothing, isolates nothing |
 | a GUI app that is not, and you want it contained | Flatpak |
-| a loose prebuilt binary | `nix-ld`, already on -- [Python](python) covers growing its library set |
+| a loose prebuilt binary | `nix-ld`, already on -- [Prebuilt binaries](prebuilt-binaries) covers its library set |
+| a downloaded AppImage | just run it -- binfmt registration is on ([Prebuilt binaries](prebuilt-binaries)) |
 | a pip wheel that installs but dies on `libGL.so.1` at import | the same loader problem -- [Python](python) |
 | pip compiling C against system libraries | a [devenv](per-project-environments) with the libraries added, or an FHS shell (`pkgs.buildFHSEnv`) |
 | a toolchain this project needs | [devenv](per-project-environments) |

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -51,6 +51,7 @@ the documentation as much as the code.
 | **Development tools** | **differs on NixOS** — [read here](development-tools) |
 | **Per-project environments** | **nixarchy only** — [read here](per-project-environments) |
 | **Python** | **nixarchy only** — [read here](python) |
+| **Prebuilt binaries** | **nixarchy only** — [read here](prebuilt-binaries) |
 | **Boxes** | **nixarchy only** — [read here](boxes) |
 | **Sandboxes** | **nixarchy only** — [read here](sandboxes) |
 | Shell tools | same as Omarchy — [read there](https://omarchy.org/manual/shell-tools/) |

--- a/docs/manual/prebuilt-binaries.md
+++ b/docs/manual/prebuilt-binaries.md
@@ -1,0 +1,120 @@
+---
+title: Prebuilt Binaries
+---
+
+# Prebuilt Binaries
+
+You download an ordinary Linux binary -- a release tarball from GitHub, a
+vendor CLI, an AppImage -- and on NixOS it dies before it starts:
+
+```
+bash: ./tool: No such file or directory
+```
+
+The file plainly exists. What does not exist is what the binary asks for
+first: a loader at `/lib64/ld-linux-x86-64.so.2`, libraries in `/usr/lib`,
+an interpreter at `/bin/bash`. NixOS keeps all of those in `/nix/store`
+under versioned paths, and only programs built by Nix know where. The
+binary is asking a reasonable question in a filesystem that answers it for
+nobody.
+
+Every nixarchy machine ships three answers to that, all on by default.
+This page is what each one does -- and, just as important, where each one
+stops.
+
+## nix-ld: the loader and its libraries
+
+[nix-ld](https://github.com/nix-community/nix-ld) puts a shim at the path
+binaries expect the loader at. When a foreign binary starts, the shim
+supplies the libraries in `programs.nix-ld.libraries` -- and nixarchy
+curates that list beyond the NixOS default, covering what a desktop's
+downloaded binaries actually load:
+
+- **`libstdc++`/`libgcc_s`** -- nearly every prebuilt C++ or Rust binary
+- **`libGL`** -- anything that renders: matplotlib and opencv wheels,
+  downloaded games
+- **the Wayland and X client stacks** (`libwayland-client`, `libxkbcommon`,
+  `libX11` and friends) -- GUI binaries, Electron, SDL/GLFW games under
+  XWayland
+- **fontconfig and freetype** -- text on screen
+- **glib, NSS/NSPR** -- every Electron app dlopens `libnss3.so` at startup
+  and exits without it
+- **`libasound`** -- sound; PipeWire serves the ALSA API but the client
+  library still has to exist
+- **ffmpeg's libraries** -- media wheels (pyav, torchaudio) link these
+  rather than bundling them
+- **zlib, openssl, libxml2** -- compressed assets, TLS, lxml
+
+The list merges with nixpkgs' own base set rather than replacing it, and
+the exact entries with the reason for each are in
+[`modules/nixos.nix`](https://github.com/olafkfreund/nixarchy/blob/main/modules/nixos.nix).
+
+When a binary wants a library the list does not carry, the error names it:
+
+```
+error while loading shared libraries: libfoo.so.2: cannot open shared object file
+```
+
+The fix is one line in your own configuration -- your entries merge with
+nixarchy's, they do not replace them:
+
+```nix
+programs.nix-ld.libraries = with pkgs; [ foo ];
+```
+
+Then rebuild and **log out and back in**: `NIX_LD_LIBRARY_PATH` is set at
+login, so a running session keeps the old list. To go from a soname to the
+package that carries it, `nix-locate lib/libfoo.so.2` (from nix-index) or
+search the file name at [search.nixos.org](https://search.nixos.org). And
+`nixarchy-doctor <path-or-command>` does the whole diagnosis for you --
+[Troubleshooting](troubleshooting) has the entry.
+
+## envfs: shebangs and /usr/bin
+
+A script starting `#!/bin/bash` or `#!/usr/bin/env python` fails with
+"no such file or directory" on a bare NixOS, because `/bin` holds only `sh`
+and `/usr/bin` only `env`. [envfs](https://github.com/Mic92/envfs) mounts
+both directories as a FUSE view of your current `PATH`, so every tutorial
+script and every downloaded installer's shebang resolves -- to whatever
+that name means on your `PATH` right now. A name that is not on your
+`PATH` still fails, because there is genuinely nothing to resolve it to.
+
+## AppImages: double-clickable
+
+`programs.appimage` is on, with binfmt registration -- the kernel
+recognises the AppImage format itself, so a downloaded AppImage runs
+directly:
+
+```sh
+chmod +x ./Tool.AppImage
+./Tool.AppImage
+```
+
+or from the file manager, without knowing that `appimage-run` exists.
+Underneath, NixOS's wrapper unpacks the image and runs it in an
+environment that supplies the common libraries. An AppImage bundles most
+of what it needs by design, which is why this rung is the least likely to
+need any per-app work.
+
+## Where the ladder stops
+
+Honesty about the limits, so the failure you hit next is not a surprise:
+
+- **Compiling from source.** All three mechanisms serve binaries at *run*
+  time. `pip install` of a package with no wheel runs a C compiler against
+  headers at *install* time, and no loader shim provides headers. That
+  needs a [devenv](per-project-environments) with the packages added, or
+  an FHS shell (`pkgs.buildFHSEnv`).
+- **A library that exists but does not fit.** nix-ld can only hand over
+  what nixpkgs has. A binary built against a different glibc era or a
+  different ABI of the same soname loads and then misbehaves, and no list
+  entry fixes that.
+- **Installers that manage their own toolchains.** conda and friends
+  download whole trees of foreign binaries; some run under nix-ld once the
+  library list is grown far enough, none are supported.
+- **Software that wants a whole distro** -- `/opt`, postinstall scripts, a
+  package manager of its own. That is what a [box](boxes) is for, and the
+  decision table on that page is the full ladder in one place.
+
+The Python-specific version of this story -- venvs, wheels, and the
+`libGL.so.1` import error -- is the [Python](python) page.

--- a/docs/manual/python.md
+++ b/docs/manual/python.md
@@ -37,8 +37,9 @@ workflow is wrong here, and nothing below asks you to give it up.
 
 ## The error this page exists for
 
-Then you install numpy, or opencv, or matplotlib, and `pip install`
-succeeds -- and the `import` dies:
+Then you install a wheel with compiled code in it, `pip install`
+succeeds -- and on a bare NixOS (or for a library nixarchy's shipped set
+does not carry) the `import` dies:
 
 ```
 ImportError: libGL.so.1: cannot open shared object file: No such file or directory
@@ -63,26 +64,25 @@ PyTorch and Playwright -- anything that ships prebuilt compiled code.
 NixOS's answer to loose prebuilt binaries is
 [nix-ld](https://github.com/nix-community/nix-ld): a shim at the path
 binaries expect the loader at, which supplies a configured set of libraries.
-It is already enabled on every nixarchy machine. What it can hand a wheel is
-whatever `programs.nix-ld.libraries` holds -- and today nixarchy leaves that
-at the NixOS default, a minimal set, which is why the import above still
-dies. A curated library set that covers the common wheels is being added
-under [#566](https://github.com/olafkfreund/nixarchy/issues/566); until it
-lands, the fix is one option in your own configuration, naming the library
-the error names:
+It is already enabled on every nixarchy machine, and nixarchy curates
+`programs.nix-ld.libraries` beyond the NixOS default -- `libGL`, `zlib`,
+`libstdc++` and the rest of what common wheels load are in the shipped set,
+so the import above works out of the box.
+[Prebuilt binaries](prebuilt-binaries) is the full story of that set.
+
+When a wheel wants a library the set does not carry, the error names it,
+and the fix is one option in your own configuration -- your entries merge
+with nixarchy's rather than replacing them:
 
 ```nix
-programs.nix-ld.libraries = with pkgs; [
-  libGL
-  zlib
-  stdenv.cc.cc.lib   # libstdc++.so.6
-];
+programs.nix-ld.libraries = with pkgs; [ libpulseaudio ];
 ```
 
-Rebuild, open a new shell, and the same venv -- no reinstall -- imports.
-Each new `cannot open shared object file` is one more entry in that list:
-the error tells you the library, [search](other-packages) tells you the
-package.
+Rebuild, log out and back in (`NIX_LD_LIBRARY_PATH` is set at login), and
+the same venv -- no reinstall -- imports. Each new
+`cannot open shared object file` is one more entry in that list: the error
+tells you the library, [search](other-packages) tells you the package, and
+`nixarchy-doctor <path-or-command>` does the diagnosis for you.
 
 ## When the project matters more than the tutorial
 
@@ -118,12 +118,13 @@ Honesty about the limits, so the failure you hit next is not a surprise:
   headers. That needs the C libraries in the environment -- a devenv with the
   packages added, a `nix-shell` with them, or an FHS environment
   (`pkgs.buildFHSEnv`, plain nixpkgs) that fakes the whole `/usr` layout.
-- **Scripts with hard-coded paths.** A tool that execs `/usr/bin/python` or
-  `#!/bin/bash` fails before any loader is involved, because those paths do
-  not exist here. (`envfs`, which resolves them, is another rung of
-  [#566](https://github.com/olafkfreund/nixarchy/issues/566) and is not
-  shipped yet; today the fix is running the script with the interpreter
-  named explicitly.)
+- **Hard-coded paths to a name that is not on your `PATH`.** `envfs` is
+  shipped and on: it mounts `/bin` and `/usr/bin` as a view of your current
+  `PATH`, so `#!/bin/bash` and `/usr/bin/env python` resolve
+  ([Prebuilt binaries](prebuilt-binaries) covers it). But it can only
+  resolve a name to something your `PATH` actually has -- a script that
+  execs a command you never installed still fails, and the fix is
+  installing that command, not the loader.
 - **Installers that manage their own binaries.** conda and friends download
   whole toolchains of foreign binaries; some run under nix-ld once the
   library list is grown far enough, none are supported. If a tool insists on

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -25,6 +25,42 @@ actual problem on a NixOS host:
 | Boot splash | Whether Omarchy's Plymouth theme is the one in use, or stylix's |
 | TLP | TLP is on, so power-profiles-daemon is off and `omarchy powerprofiles` cannot work |
 
+### `libGL.so.1: cannot open shared object file: No such file or directory`
+
+Or `libstdc++.so.6`, or any other `.so` -- from a pip wheel at `import`, a
+Node native module, or a downloaded binary. The binary is a prebuilt Linux
+binary looking for its libraries where every other distro keeps them, and
+NixOS keeps them elsewhere; [Prebuilt binaries](prebuilt-binaries) is the
+full story. The machine can diagnose it -- hand the doctor the binary, as a
+path or a command name:
+
+```sh
+nixarchy-doctor ~/.venv/lib/python3.12/site-packages/cv2/cv2.so
+nixarchy-doctor some-downloaded-tool
+```
+
+It runs the loader's own resolution against the nix-ld library set, names
+each missing library, and for the common ones prints the
+`programs.nix-ld.libraries` line that fixes it -- for the rest, how to find
+the package that carries the file. After the rebuild, **log out and back in**:
+`NIX_LD_LIBRARY_PATH` is set at login, so the session you are sitting in
+keeps the old list.
+
+What it cannot do, so a clean report is not a guarantee:
+
+- It checks only the files you name. The report's no-argument scan covers
+  `~/.local/bin` and nothing else -- it does not crawl your venvs or
+  `node_modules`, so for a broken import, name the actual `.so` inside the
+  package (the traceback usually names it for you).
+- It answers "is every library findable", not "is every library right". A
+  library that is present but the wrong ABI or the wrong generation loads
+  cleanly and misbehaves later; the doctor reports it as found.
+- It resolves what the binary declares it needs. A library the program
+  `dlopen`s by hand at run time is invisible until that moment, so a
+  binary can pass the check and still fail later with the same error --
+  bring the doctor the library name from *that* error and add it the same
+  way.
+
 ### I broke my system with an update!
 
 Roll back the generation, from the desktop or from the boot menu; see


### PR DESCRIPTION
Closes #575, #576, #578. Two commits, one per concern, cherry-picked from separate agents working disjoint file sets — no file is touched by both.

## The urgent half: two pages were telling readers the fix does not exist

#572 shipped the curated `programs.nix-ld.libraries`, `envfs` and AppImage support. `docs/manual/python.md` — **live on the public site** — still said:

> today nixarchy leaves that at the NixOS default, a minimal set, **which is why the import above still dies**. A curated library set … **is being added** under #566; until it lands, the fix is one option in your own configuration

Every clause of that is false as of #572. It actively discouraged readers from trying the thing that now works, and handed them a workaround they no longer need. A second sentence called `envfs` "another rung of #566 … not shipped yet".

**Both defects arrived by merge order, not by anyone writing something wrong at the time** — the #546 failure mode. So the fix is not just the two sentences: every `is being added` / `until it lands` / `not shipped yet` / `is another rung` phrasing across `docs/` and `README.md` was swept, and the tree is now clean of them.

## What landed

**A new page, `docs/manual/prebuilt-binaries.md`** — the ladder: nix-ld and its curated set, `envfs` for shebangs, AppImages via binfmt, and a "where the ladder stops" section (compiling from source, wrong-ABI libraries, conda-style toolchains, whole-distro software → boxes). Placed between Python and Boxes in reading order, in **all three** lists the guard now enforces.

**`docs/manual/troubleshooting.md`** gains an entry keyed on the symptom a user actually sees — `libGL.so.1: cannot open shared object file` — showing `nixarchy-doctor <path-or-command>` for both a venv `.so` and a bare command name, and stating three things the doctor **cannot** detect: it checks only named files (the default scan is `~/.local/bin` alone), found-but-wrong-ABI libraries, and `dlopen`-only sonames invisible to `ldd`.

**`docs/manual/boxes.md`** gains the AppImage row, and its loose-binary row now points at the new page.

**`README.md` and `docs/index.md`** — `nix-ld` scored **zero** in the README and had been enabled for months. Now one row in `What works`, one in the showcase table (linking rather than restating, per #560), and a front-page section.

## Verification

- **The three-list guard passes** — nav, `llms.txt` and `docs/manual/index.md`. Proved failing first: with the nav line removed it reports `::error::docs/manual/prebuilt-binaries.md is published but not in the docs/_config.yml sidebar`, exit 1.
- **All 13 guarded `readme-counts.sh` match patterns still hit exactly once**, checked under `bash` — the first attempt ran under zsh and produced nonsense, which is §1's own recorded trap.
- **The `libpulseaudio` escape-hatch example is honest**: absent from both our curated list *and* nixpkgs' base set, so it genuinely is a library the shipped set does not carry.
- Claims verified against `modules/nixos.nix:639/704/903-908`, `pkgs/doctor.sh`, `flake.nix:282`.

## Deliberately not here

`git-lfs` and `uv` (#577) are **not** on `main` — PR #571 has not merged — so they are documented nowhere in this change. Documenting unshipped behaviour is the defect this PR exists to clean up.

The `checks.session` runtime proof and the #555 slot fix are separate PRs, so this can land without waiting on either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5