### PR TITLE
Development tools documents the two rows that are not toolchains

### DIFF
--- a/docs/manual/development-tools.md
+++ b/docs/manual/development-tools.md
@@ -113,6 +113,29 @@ without direnv. It is off by default and it costs a second lockfile;
 [Per-project environments](per-project-environments) is the whole story,
 including when not to.
 
+## Two tools that are not toolchains
+
+Both are rows in _Install ▸ Development_, and neither is a language, so
+neither is in the table above.
+
+**Git LFS** is selected as a NixOS option rather than a bare package, and
+the difference matters. Installing the binary alone is a trap: `git-lfs` only
+does anything once its filter configuration is written, and until then a clone
+of a repository using LFS **silently hands you pointer files instead of
+content** — a few lines of text where the asset should be. Nothing errors. The
+checkout looks corrupt rather than incomplete, which is why people lose an
+afternoon to it. Selecting the row turns on `programs.git.lfs`, which installs
+the package *and* writes `filter.lfs` into the system git configuration, so
+`git lfs install` is never something you have to know about.
+
+**`uv`** is the Python package and project manager. The `python` devenv preset
+already pins its own copy per project, so this row is the machine-wide one —
+for `uv tool install`, `uvx`, and the quick script that is not a project yet.
+If what you want is a project with a pinned interpreter, use
+[per-project environments](per-project-environments); if what you want is
+`pip install` to work at all, [Python](python) is the page that explains why
+it sometimes does not.
+
 ## Docker
 
 Docker and Docker Compose are enabled by `virtualisation.docker.enable`,


### PR DESCRIPTION
Closes #577. Unblocked by #571, which landed `Git LFS` and `uv` on `main`.

`docs/manual/development-tools.md` is the page a developer reads first, and it knew nothing about either row — both of which appear under _Install ▸ Development_ beside the thirteen toolchains.

## They are not in the toolchain table, on purpose

Neither is a language, and the table's count is **load-bearing prose**: *"the thirteen toolchains in Install ▸ Development"* is asserted two paragraphs above it. A row added there would make that sentence wrong while looking tidy. So they get a short section of their own.

**The diff changes zero table lines** — verified, not asserted.

## Git LFS earns the longer half

`data/apps.nix:682` wires it as `option = [ "programs" "git" "lfs" ]` rather than a bare `attr`, and the entry's own comment says why: the package alone is a trap. Until the filter config is written, cloning a repository that uses LFS **silently hands you pointer files instead of content**. Nothing errors.

That is the part worth documenting — the checkout reads as *corrupt* rather than *incomplete*, which is exactly why people lose an afternoon to it rather than going looking for a missing tool.

## Verification

Checked against the tree rather than against #571's description:

- the row label is **`Git LFS`** — not `git-lfs`, which is what I wrote first and corrected
- the option path is `[ "programs" "git" "lfs" ]` as quoted
- `uv` ships as `attr = "uv"`
- both linked pages (`per-project-environments`, `python`) exist
- the toolchain table still holds thirteen rows
- the three-list page guard is unaffected — no new page

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5