### PR TITLE
The loader hatches are proven on a booted machine, not just in evaluation

### DIFF
--- a/tests/session.nix
+++ b/tests/session.nix
@@ -15,6 +15,34 @@ let
     rev = "553638f04efc12f4439debd413eaf3ac838a1f9a";
     hash = "sha256-DkuuYlxYYh4hZrL+2dUVnrlxfP3uXsbuIJWRVaZcmGk=";
   };
+
+  # A downloaded binary, faithfully: FHS interpreter, no rpath, and a
+  # DT_NEEDED on libGL.so.1 -- the exact library of the #566 ImportError,
+  # in modules/nixos.nix's nix-ld set and NOT in nixpkgs' base set, so it
+  # only resolves if OUR contribution reaches the loader. Everything #572
+  # shipped was asserted at evaluation only; this is the first time a
+  # binary actually starts under the stub loader.
+  loaderProbe =
+    pkgs.runCommandCC "loader-probe"
+      {
+        buildInputs = [ pkgs.libGL ];
+        nativeBuildInputs = [ pkgs.patchelf ];
+      }
+      ''
+        cat > probe.c <<'EOF'
+        #include <stdio.h>
+        int main(void) { puts("loader-probe: libGL loaded"); return 0; }
+        EOF
+        mkdir -p $out/bin
+        # --no-as-needed, or the linker drops the unused libGL and the
+        # probe passes forever with nix-ld gone -- the exact green light
+        # CLAUDE.md section 1 is about. The print-needed grep below is the
+        # guard on that guard.
+        cc -o $out/bin/loader-probe probe.c -Wl,--no-as-needed -lGL
+        patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 \
+          --remove-rpath $out/bin/loader-probe
+        patchelf --print-needed $out/bin/loader-probe | grep -qx libGL.so.1
+      '';
 in
 # Drives a real Omarchy session and reports what it logged.
 #
@@ -184,6 +212,45 @@ pkgs.testers.runNixOSTest {
     machine.succeed("grep -q 'brave.enable' /etc/nixos/nixarchy/apps.nix")
     machine.succeed("grep -q './nixarchy/apps.nix' /etc/nixos/nixarchy-apps.nix")
     print("selection reached /etc/nixos/nixarchy/apps.nix, and the stub imports it")
+
+    # ---- the loader hatches actually open (#572) -------------------------
+    # Deliberately before anything graphical, like the block above: nix-ld
+    # and envfs are multi-user.target properties, and a local run of this
+    # check dies later at the wallpaper comparison, so pre-greeter is the
+    # only place a developer can still watch these fail.
+    #
+    # `su - omarchy`, a login shell, because that is where a user runs a
+    # downloaded binary: NIX_LD_LIBRARY_PATH arrives via /etc/set-environment,
+    # which the test driver's backdoor shell never sources.
+    probe = machine.succeed(
+        "su - omarchy -c '${loaderProbe}/bin/loader-probe' 2>&1")
+    print(f"loader probe: {probe.strip()!r}")
+    assert "loader-probe: libGL loaded" in probe, (
+        "a binary with an FHS interpreter and a DT_NEEDED on libGL.so.1 did "
+        "not start; the nix-ld library set is not reaching the stub loader: "
+        + probe)
+
+    # envfs: the two paths every foreign script hardcodes. /bin/sh exists on
+    # bare NixOS, so it proves nothing; /bin/bash and /usr/bin/env exist only
+    # if envfs is mounted and resolving.
+    machine.succeed("/bin/bash -c 'echo envfs resolved /bin/bash'")
+    machine.succeed("/usr/bin/env true")
+    print("envfs resolves /bin/bash and /usr/bin/env")
+
+    # AppImage: only the binfmt registration is asserted -- the kernel will
+    # hand an AppImage to the wrapper. Running a real AppImage would need one
+    # built hermetically in-sandbox, and a fake with the right magic bytes
+    # would test appimage-run's error path, not the feature. Execution stays
+    # unproven; this line is the honest boundary.
+    # Two registrations, by ELF magic: nixpkgs' programs.appimage names them
+    # appimage_type_1 and appimage_type_2. Asserting a single "appimage" entry
+    # was tried first and failed on this exact line -- the name was wrong, and
+    # the failure is what said so.
+    for reg in ("appimage_type_1", "appimage_type_2"):
+        binfmt = machine.succeed("cat /proc/sys/fs/binfmt_misc/" + reg)
+        print(reg + ": " + binfmt.splitlines()[0])
+        assert "enabled" in binfmt, (
+            "the " + reg + " binfmt registration is not enabled: " + binfmt)
 
     # ---- the menu extension belongs to the user (#210) ------------------
     # Omarchy reads two menu files and merges the second over the first: the


### PR DESCRIPTION
#572 shipped the curated `nix-ld` library set, `envfs` and AppImage support. **All of it was verified at evaluation only** — `checks.options` asserts the options take effect in both states, and nothing had ever run a binary. Nobody had confirmed the `libGL.so.1: cannot open shared object file` error was actually gone.

That is CLAUDE.md §3's situation exactly: name the variable that separates a passing suite from a real machine. Here it was **does a dynamically-linked binary that needs one of those libraries actually start?**

## What it proves

A probe built with `runCommandCC`, linked against **`libGL`** — in our set, **not** in nixpkgs' base set (verified: 2 hits in ours, 0 in `nix-ld.nix`'s base list) — then:

```
patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 --remove-rpath
```

so it is a faithful "downloaded binary" rather than a store path that would have resolved anyway. It runs from a login shell on the booted machine.

Plus `envfs` (`/bin/bash -c …` and `/usr/bin/env true`; `/bin/sh` deliberately avoided since it exists on bare NixOS) and both AppImage binfmt registrations reading back `enabled`.

## The guard that stops this being a green light

```
cc -o $out/bin/loader-probe probe.c -Wl,--no-as-needed -lGL
patchelf --print-needed $out/bin/loader-probe | grep -qx libGL.so.1
```

Without `--no-as-needed` the linker drops the unused `libGL` and the probe passes forever regardless of the library set — **a check that cannot fail**, which is #133's defect precisely. The `--print-needed` assertion makes that failure a build error rather than a silent pass.

## §1 — every assertion watched failing

Probe relinked against `libSDL2`, which the set does not provide:

```
machine: output: /nix/store/…-loader-probe/bin/loader-probe: error while loading
shared libraries: libSDL2-2.0.so.0: cannot open shared object file: No such file or directory
!!! RequestedAssertionFailed: command `su - omarchy -c '…loader-probe' 2>&1` failed (exit code 127)
```

And a second, **unplanned** live failure: the first binfmt assertion used the name `appimage` and went red — `cat: /proc/sys/fs/binfmt_misc/appimage: No such file or directory` — because the registrations are `appimage_type_1/2`. So every assertion in the block has been observed failing.

Passing, restored:

```
loader probe: 'loader-probe: libGL loaded'
envfs resolves /bin/bash and /usr/bin/env
appimage_type_1: enabled
appimage_type_2: enabled
```

## Placement, and the honest limit

Extends `checks.session` rather than adding a check. A new VM check lands in `build.yml`'s generated "no other job claims" step, which **has no KVM** — the `wifi-hwsim` trap — so it would need a workflow edit (§11, a human's call). `session` is already in the `claimed` list, already boots exactly the system #572 configured. **No workflow change needed** — verified.

The block sits pre-greeter deliberately: nix-ld and envfs are `multi-user.target` properties, and that is the only placement a local run can reach.

**The local run did not complete the whole check.** It proceeded through login and stopped at the wallpaper comparison (`delta 191`) — a pre-existing, documented local-only failure under software GL (`tests/session.nix:76-83`: a screenshot "came back pure black and made the wallpaper check fail on a machine whose desktop was fine"), identical on unmodified `main`. So: **the loader block passed locally; the surrounding check was truncated by a known local rendering limit.** CI's `system` job is the arbiter for the full green, and the new `print()` lines should be visible in its log.

**Not proven:** actually *executing* an AppImage. Only kernel routing is asserted — a hermetic in-sandbox AppImage build would be needed, and a fake with magic bytes would test the error path rather than the feature.

`nix fmt -- --ci`, statix and deadnix clean. Waited out the install-check queue before both VM builds (§6). One file, +67 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5