### PR TITLE
Two install slots instead of one, at the concurrency the measurements support

### DIFF
--- a/.github/workflows/install-check.yml
+++ b/.github/workflows/install-check.yml
@@ -78,8 +78,8 @@ concurrency:
   # against a main that lacked the other. With the SHA in the group each merge
   # gets a group of its own, which nothing can supersede. The cost is the one
   # build.yml already accepted -- a burst of merges queues rather than drops,
-  # and the job-level `nixarchy-install-vm` group below still keeps the VM to
-  # one at a time.
+  # and the job-level `nixarchy-install-vm-{1,2}` slot groups below still cap
+  # the install VMs at two at a time.
   group: >-
     install-check-${{ github.ref }}-${{
       github.ref == 'refs/heads/main' && github.sha || 'shared' }}
@@ -109,6 +109,7 @@ jobs:
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
       runner: ${{ steps.filter.outputs.runner }}
+      slot: ${{ steps.filter.outputs.slot }}
     steps:
       # This job used to need no checkout at all -- it asked the API for the
       # file list and decided from that. It needs one now only because the
@@ -170,13 +171,25 @@ jobs:
             echo 'runner=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
           fi
 
-          echo "relevant=$relevant" >> "$GITHUB_STEP_SUMMARY"
+          # Which of the two VM slot groups this ref belongs to (#555).
+          # Computed here in shell because workflow expressions have no
+          # string-hash function -- hashFiles hashes files, not strings.
+          # cksum is POSIX and stable across runs, so a given ref always
+          # lands in the same slot: a PR's re-runs queue behind themselves,
+          # never migrate to the other slot, and main always maps to one
+          # fixed slot. The reasoning for two -- and only two -- is on the
+          # `install` job's concurrency block below.
+          slot=$(( ($(printf %s "$GITHUB_REF" | cksum | cut -d' ' -f1) % 2) + 1 ))
+          echo "slot=$slot" >> "$GITHUB_OUTPUT"
+
+          echo "relevant=$relevant slot=$slot" >> "$GITHUB_STEP_SUMMARY"
 
   install:
     name: install
     needs: gate
 
-    # One install VM at a time, machine-wide.
+    # At most TWO install VMs at a time, fleet-wide -- two slot groups, not
+    # one, and not three.
     #
     # This job boots a nested QEMU VM and runs an installer inside it against a
     # THIRTY MINUTE budget -- tests/install.nix:495, `timeout=1800`. That budget
@@ -231,30 +244,44 @@ jobs:
     # change.
     #
     # So an irrelevant run gets its own private group and reports success in
-    # seconds without ever touching the shared slot. Every property the block
-    # below defends is untouched: a RELEVANT run still lands in
-    # `nixarchy-install-vm`, still one at a time, machine-wide.
+    # seconds without ever touching the shared slots.
     #
-    # And that means the eviction described above STILL APPLIES to relevant
-    # runs (#555) -- #548's fix covered only the runs the gate rules
-    # irrelevant. GitHub retains one pending job per group, so with one
-    # relevant run building and two waiting, each newcomer evicts whoever was
-    # queued. More than one pending run is the normal state here, not an edge
-    # case. The evicted job reports `cancelled`, which renders as a failure
-    # and SILENTLY DISABLES AUTO-MERGE on that PR; re-running cannot clear it,
-    # because the workflow-level PR group reaps the re-run within a second of
-    # the gate finishing. The only escape is a new head commit. A real fix is
-    # a small pool of slot groups sized to the runners that can take the work,
-    # but that changes the contention model the measurements above defend
-    # (2 concurrent succeed, 3-4 fail), so it wants doing against real numbers
-    # -- #555 tracks it. Until then this hole is documented, not closed.
+    # RELEVANT runs land in one of TWO slot groups, and #555 is why it is two
+    # rather than the single constant #548 left behind. The single group
+    # capped concurrency at one when the measurement above says two is safe --
+    # and it destroyed the runs it excluded rather than delaying them: GitHub
+    # retains one PENDING job per group (a RUNNING job blocks nothing), so
+    # with one relevant run building and two waiting, each newcomer evicted
+    # whoever was queued. Measured on 2026-09-10, driving eight PRs through
+    # the mutex: #553, #563, #571, #572 and #580 all reported `cancelled`
+    # without being broken, which SILENTLY DISABLES AUTO-MERGE, and re-running
+    # cannot clear it because the workflow-level PR group reaps the re-run
+    # within a second of the gate finishing. The only escape was a new head
+    # commit.
+    #
+    # The slot is `cksum(github.ref) % 2`, computed by the gate (workflow
+    # expressions have no string hash). Deterministic per ref: a branch never
+    # changes slot between pushes, and main always occupies the same one. Two
+    # groups admit at most two concurrent installs -- exactly the measured
+    # ceiling, never the 3-4 that all fail. Do not add a third slot without a
+    # new measurement.
+    #
+    # What this does NOT solve, stated so nobody reads it as solved: the
+    # one-pending-job rule still applies WITHIN each slot. Three relevant PRs
+    # hashed to the same slot still evict each other's pending jobs, and a
+    # pending main install shares that fate with whatever PRs share its slot
+    # -- the workflow-level per-commit group (#561/#563) protects main's RUN
+    # from cancellation, not its install job's place in this queue. Hashing
+    # halves the collision population; it does not repeal the rule. The full
+    # fix would be a scheduler that queues arbitrarily deep, which GitHub
+    # does not offer -- #555 stays open on the residue.
     #
     # `needs` is available in a job-level `concurrency:` -- that is what makes
     # this expressible at all, and it is the same context `runs-on` below
     # already reads for the runner labels. The two must agree: a run that asks
     # for a hosted runner must not hold the VM group.
     concurrency:
-      group: ${{ needs.gate.outputs.relevant == 'true' && 'nixarchy-install-vm' || format('install-noop-{0}', github.ref) }}
+      group: ${{ needs.gate.outputs.relevant == 'true' && format('nixarchy-install-vm-{0}', needs.gate.outputs.slot) || format('install-noop-{0}', github.ref) }}
       cancel-in-progress: false
 
     # No `if:` on this job, and that is the whole fix -- measured, not assumed.


### PR DESCRIPTION
Closes #555 in part — see **what this does not solve** below, which stays open.

## The evidence this is built on

#555 asked for real measurements before redesigning. Driving eighteen pull requests through this mutex in one day produced them:

- **Repeated evictions** across #553, #563, #571, #572 and #580 — every one reported `cancelled`, **none was broken**. Each cost a new head commit to clear, because a re-run reaps itself.
- A `main` install that ran **38 minutes** (run 34593241760), against a ~20-25 min norm.
- The decisive mechanical fact, learned the hard way: **a RUNNING job blocks nothing; only a PENDING job is evicted.** `main` running plus one PR pending is safe — eviction begins at the *second* pending job. Three separate supervisor designs failed because they assumed a running job was the blocker.
- Once re-triggers were paced on "no *queued* install" rather than "queue empty", #572, #563 and #580 each passed **first time, with a 0-second wait**.

## The change

The gate gains a `slot` output — `cksum(GITHUB_REF) % 2 + 1`, computed in shell because workflow expressions have no string hash (`hashFiles` hashes files). The install job's group for relevant runs becomes `nixarchy-install-vm-{1,2}`.

**Why two, and only two.** The block's own measurement is the ceiling: *2 concurrent install jobs both succeeded (~36 min); 3-4 concurrent and every one FAILED at the in-guest timeout*, because `tests/install.nix`'s `timeout=1800` is wall-clock **inside the guest** and does not scale with host contention. The cap today is effectively **1** — one runs, the rest are destroyed. Two is what the data supports; the comment warns against a third without a new measurement.

`cksum` is POSIX and deterministic, so a ref never migrates slots between pushes: a PR's re-runs queue behind *themselves*, and `main` maps to one **fixed** slot rather than floating — so it occupies one of the two rather than becoming a third.

Preserved: #563's per-commit group on `main` (verified present on this branch, unchanged), the no-`if:` reporting property, #563's gate-output validation, `cancel-in-progress: false`, and the `install-noop-{ref}` group for irrelevant runs.

## What is proven, and what is not

- `actionlint` with the repo's ignore pattern exits **0**.
- A **model** of the slot expression over real refs — stated as a model, not a scheduler test:
  ```
  refs/heads/main       -> nixarchy-install-vm-1
  refs/pull/553/merge   -> nixarchy-install-vm-1
  refs/pull/563/merge   -> nixarchy-install-vm-2
  refs/pull/571/merge   -> nixarchy-install-vm-2
  refs/pull/572/merge   -> nixarchy-install-vm-2
  refs/pull/580/merge   -> nixarchy-install-vm-1
  ```
  Both slots occur, deterministic, provably confined to {1,2}.
- **Not proven:** GitHub's scheduler itself. One-pending-per-group, eviction order, and that two groups actually yield two parallel jobs cannot be reproduced locally. They are asserted from the documented rule plus the observations above, and the comment says so.

## What this does not solve

The one-pending rule applies **within** each slot. Three relevant pull requests hashing to the same slot still evict each other, and a pending `main` install shares that fate with the PRs in its slot. **Hashing halves the collision population; it does not repeal the rule.** #555 should stay open on that residue rather than be closed by this.

Branch verified not stale where it matters: the two commits it is behind (#582, #571) touch no workflow file.

CI gate change — per §11, proposed rather than merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5