### PR TITLE
Two sidebar labels stop being sentences

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -58,8 +58,8 @@ nav:
   - { path: /manual/security,                 title: Security }
   - { path: /manual/remote-desktop,           title: Remote Desktop }
   - { path: /manual/system-snapshots,         title: System Snapshots }
-  - { path: /manual/many-machines,            title: "Many machines, one repo" }
-  - { path: /manual/reinstall-image,          title: "A reinstall image of this machine" }
+  - { path: /manual/many-machines,            title: Many Machines }
+  - { path: /manual/reinstall-image,          title: Reinstall Image }
   - { path: /manual/dual-boot-install,        title: Dual Boot Install }
   - { path: /manual/unattended-installs,      title: Unattended Installs }
   - { path: /manual/how-this-is-tested,       title: How This Is Tested }


### PR DESCRIPTION
The manual's sidebar is a column of short Title Case labels — Boxes, Sandboxes, Remote Desktop, System Snapshots — and two entries were written as sentences:

```
Many machines, one repo
A reinstall image of this machine
```

The second is **33 characters and wraps onto a second line** in the rendered sidebar, so the entry reads as two rows and the column breaks. The first does not wrap but is the only sentence-cased label in the list.

Tellingly, they were the **only two quoted strings** in `nav:` — which is what a value that does not fit the pattern looks like in YAML.

Now `Many Machines` and `Reinstall Image`. Longest remaining label is `Per-Project Environments` at 24, down from 33.

## Only the sidebar label changed

Each page keeps its own descriptive heading. `# A reinstall image of this machine` is right at the top of a page, where a full phrase reads as a title rather than as a cramped nav entry — the frontmatter `title:` and the `# ` heading in both pages are untouched. This is `docs/_config.yml`'s `nav:` alone.

## Why this cannot break the page guard

`build.yml`'s three-list check matches on **paths**, never on labels. Verified rather than assumed — diffing the extracted `path: /manual/...` lines against `main` returns identical output.

Docs only, two lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5