### PR TITLE
nixarchy pkg new drafts a derivation with headless nix-init, builds it before claiming anything, and keeps a failed draft

### DIFF
--- a/docs/manual/other-packages.md
+++ b/docs/manual/other-packages.md
@@ -154,6 +154,36 @@ translate it: fonts are answered with `fonts.packages`, PHP extensions with
 `hardware.graphics.enable32Bit`, because each of those is a different shape on
 NixOS and `systemPackages` would be the wrong answer.
 
+## Software in no repository at all
+
+When nixpkgs, the curated list and Flathub all miss, the answer used to be
+"write a derivation" — which needs the language this desktop was installed to
+avoid. `nixarchy pkg new` gets you a first draft instead:
+
+```sh
+nixarchy pkg new https://github.com/someone/tool
+```
+
+runs [nix-init](https://github.com/nix-community/nix-init) headless: it picks
+a builder, prefetches the hashes, infers dependencies for Rust, Go and Python,
+and detects the licence. The result lands in
+`~/.config/nixarchy/packages/tool.nix`, and is then **built once** before
+anything is claimed. If the build has to learn a hash the draft could not know
+in advance (Rust's `cargoHash`, Go's `vendorHash`), the failed build names it
+and the draft is corrected automatically.
+
+If it builds, a commented-out line is added to the packages block of
+`~/.config/nixarchy/apps.nix`; review the draft, uncomment the line, and
+`nixarchy apply` carries both into your flake. If it does not build, that is
+said out loud and the draft is **kept** — a failed draft is still a better
+starting point than a blank file.
+
+Either way it is a draft: nix-init's authors are explicit that it produces a
+starting point for a person to review, not a finished package, and this
+command never pretends otherwise. A draft pins one revision of one upstream;
+updating it when upstream releases is yours to do, by editing the version and
+hashes in the file.
+
 ## Removing
 
 _Remove > App / package_ runs `nixarchy-app-remove`, a picker over everything

--- a/flake.nix
+++ b/flake.nix
@@ -1541,6 +1541,14 @@
             omarchy = self.packages.${system}.omarchy;
           };
 
+          # `nixarchy pkg new` against stub nix-init and nix: the draft is
+          # kept when its build fails, the placeholder hash is filled in from
+          # the failed build, and a reshaped apps.nix is printed at rather
+          # than edited. See tests/pkg-new.nix.
+          pkg-new = import ./tests/pkg-new.nix {
+            pkgs = pkgsFor.${system};
+          };
+
           # What a network install would have to build, before it formats
           # anything. See tests/substitutable.nix.
           substitutable = import ./tests/substitutable.nix {

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -2070,6 +2070,28 @@ in
               '';
             })
 
+            # `nixarchy pkg new <url>`: a draft derivation for software in no
+            # repository (#581). The body lives in pkgs/pkg-new.sh, spliced
+            # here the way flake.nix splices pkgs/doctor.sh, so a check can
+            # run the raw file against stubs -- see tests/pkg-new.nix.
+            (pkgs.writeShellApplication {
+              name = "nixarchy-pkg-new";
+              runtimeInputs = [
+                pkgs.coreutils
+                pkgs.gnugrep
+                pkgs.gnused
+                pkgs.gawk
+                pkgs.nix-init
+                # nix-init resolves GitHub URLs entirely on its own (proven
+                # under a PATH holding nothing else), but shells out for the
+                # rest of its fetchers; an undeclared command here reads as
+                # "cannot draft this", not "git is missing".
+                pkgs.git
+                config.nix.package
+              ];
+              text = lib.replaceStrings [ "@nixpkgs@" ] [ "${pkgs.path}" ] (builtins.readFile ../pkgs/pkg-new.sh);
+            })
+
             # Why: modules/AGENTS.md#search-everything-this-machine-could-install-and-r
             (pkgs.writeShellApplication {
               name = "nixarchy-search";
@@ -2531,6 +2553,8 @@ in
                     case "''${2:-}" in
                       add) shift 2; exec nixarchy-pkg-add "$@" ;;
                       remove) shift 2; exec nixarchy-pkg-remove "$@" ;;
+                      new) shift 2; exec nixarchy-pkg-new "$@" ;;
+
                     esac
                     ;;
                   app)
@@ -2615,6 +2639,7 @@ in
                   nixarchy search [query]     Every package, NixOS option and app, in one picker
                   nixarchy pkg add <attr>     Add a nixpkgs package to the app selection
                   nixarchy pkg remove [attr]  Take one out again (no argument picks interactively)
+                  nixarchy pkg new <url>      Draft a derivation for software in no repository
                   nixarchy app enable <id>    Select an app from the curated list
                   nixarchy app disable <id>   Deselect one
                   nixarchy app remove         Pick apps, packages and options to remove
@@ -2720,6 +2745,26 @@ in
                   cp "$src" "$dst"
                   copied="$copied $part"
                 done
+
+                # Draft derivations from `nixarchy pkg new` ride along:
+                # apps.nix names them as ./packages/<name>.nix, a path
+                # relative to the COPY, so they must sit beside it or the
+                # uncommented line fails evaluation with "path does not
+                # exist". Copies accumulate and are never deleted here --
+                # removing a draft from the flake is an edit to a tree the
+                # user owns, not this tool's call.
+                if [ -d "$srcdir/packages" ]; then
+                  mkdir -p "$base/nixarchy/packages"
+                  for src in "$srcdir"/packages/*.nix; do
+                    [ -f "$src" ] || continue
+                    dst="$base/nixarchy/packages/$(basename "$src")"
+                    if [ -f "$dst" ] && diff -q "$src" "$dst" >/dev/null; then
+                      continue
+                    fi
+                    cp "$src" "$dst"
+                    copied="$copied packages/$(basename "$src")"
+                  done
+                fi
 
                 # Only what exists is imported. A machine seeded before
                 # services.nix existed has two files, not three, and a stub

--- a/pkgs/pkg-new.sh
+++ b/pkgs/pkg-new.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# nixarchy pkg new <url> -- draft a derivation for software in no repository.
+#
+# Spliced into a writeShellApplication in modules/apps.nix; @nixpkgs@ becomes
+# the generation's own nixpkgs, the same tree nixarchy-pkg-add parses against.
+# nix-init does the drafting, headless. Its authors call the output a draft,
+# and so does everything this prints: the builder, the dependencies and the
+# licence are guesses for a person to review, not a package.
+#
+# Build before claiming (#581): the draft is built once, and a failure is
+# reported as one -- with the draft KEPT, because a failed draft is still a
+# better starting point than a blank file.
+set -euo pipefail
+
+nixpkgs='@nixpkgs@'
+
+usage() {
+  echo "usage: nixarchy pkg new <url> [--rev REV] [--name NAME]"
+  echo "  e.g. nixarchy pkg new https://github.com/someone/tool"
+  echo
+  echo "  Drafts a derivation into ~/.config/nixarchy/packages/<name>.nix"
+  echo "  with nix-init, then builds it once and reports the result."
+  echo "  The draft is yours to edit either way."
+  echo
+  echo "  For software nixpkgs already carries, use: nixarchy pkg add <attr>"
+}
+
+url="" rev="" name=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --rev)
+      rev="${2:-}"
+      [ -n "$rev" ] || { echo "--rev needs a value" >&2; exit 1; }
+      shift 2
+      ;;
+    --name)
+      name="${2:-}"
+      [ -n "$name" ] || { echo "--name needs a value" >&2; exit 1; }
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "nixarchy-pkg-new: unknown option '$1'" >&2
+      exit 1
+      ;;
+    *)
+      if [ -n "$url" ]; then
+        echo "nixarchy-pkg-new: one URL at a time" >&2
+        exit 1
+      fi
+      url="$1"
+      shift
+      ;;
+  esac
+done
+[ -n "$url" ] || { usage >&2; exit 1; }
+case "$url" in
+  https://* | http://*) ;;
+  *)
+    echo "'$url' does not look like a URL this can fetch (expected https://...)." >&2
+    echo "For something already in nixpkgs, use: nixarchy pkg add <attribute>" >&2
+    exit 1
+    ;;
+esac
+
+if [ -z "$name" ]; then
+  name="${url%/}"
+  name="${name##*/}"
+  name="${name%.git}"
+fi
+# Same alphabet nixarchy-pkg-add accepts, and for the same reason: the name
+# lands inside a nix expression and a file path.
+case "$name" in
+  "" | .* | *[!A-Za-z0-9_.-]*)
+    echo "cannot make a package name out of '$name'; pass --name <name>." >&2
+    exit 1
+    ;;
+esac
+
+pkgdir="${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/packages"
+draft="$pkgdir/$name.nix"
+if [ -e "$draft" ]; then
+  echo "$draft already exists." >&2
+  echo "Edit it, or remove it and run this again to redraft." >&2
+  exit 1
+fi
+mkdir -p "$pkgdir"
+
+echo "drafting  $draft"
+initargs=(--headless --url "$url" -n "$nixpkgs")
+if [ -n "$rev" ]; then
+  initargs+=(--rev "$rev")
+fi
+if ! nix-init "${initargs[@]}" "$draft" || [ ! -s "$draft" ]; then
+  echo
+  echo "nix-init could not draft anything from $url." >&2
+  echo "It understands release URLs and repositories on GitHub, GitLab," >&2
+  echo "Codeberg, SourceHut, crates.io and PyPI." >&2
+  # A failed nix-init can leave an empty file behind; an empty draft is not
+  # a starting point, it is a landmine for the next run's already-exists check.
+  rm -f "$draft"
+  exit 1
+fi
+
+log=$(mktemp)
+trap 'rm -f "$log"' EXIT
+try_build() {
+  nix build --no-link --impure \
+    --expr "(import $nixpkgs { }).callPackage $draft { }" >"$log" 2>&1
+}
+
+printf 'building  %s ... ' "$name"
+built=false
+# Up to three rounds: nix-init leaves a placeholder where a hash cannot be
+# known before the first build (cargoHash, vendorHash), and the failed build
+# names the real one. Fill it in and go again; anything else is a real failure.
+for _ in 1 2 3; do
+  if try_build; then
+    built=true
+    break
+  fi
+  spec=$(sed -n 's/.*specified:[[:space:]]*\(sha256-[A-Za-z0-9+/=]*\).*/\1/p' "$log" | head -1)
+  got=$(sed -n 's/.*got:[[:space:]]*\(sha256-[A-Za-z0-9+/=]*\).*/\1/p' "$log" | head -1)
+  if [ -n "$spec" ] && [ -n "$got" ] && grep -qF "$spec" "$draft"; then
+    sed -i "s|$spec|$got|" "$draft"
+  else
+    break
+  fi
+done
+
+if [ "$built" != true ]; then
+  echo "FAILED"
+  echo
+  tail -n 15 "$log" | sed 's/^/  | /'
+  echo
+  echo "The draft did NOT build. It is kept at"
+  echo "  $draft"
+  echo "because a failed draft is still a better starting point than a blank"
+  echo "file. Edit it, then rebuild with:"
+  echo "  nix build --impure --expr '(import $nixpkgs { }).callPackage $draft { }'"
+  exit 1
+fi
+echo "ok"
+
+appsfile="${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/apps.nix"
+entry="(callPackage ./packages/$name.nix { })"
+# Consent rule (nixarchy-unfreeze's, via nixarchy-channel): only lines this
+# project wrote get rewritten. The #@pkgs-end marker is nixarchy-pkg-add's own
+# block, so inserting there -- commented out -- is within it; a file without
+# the marker is the user's shape, and gets the edit printed instead.
+if [ -f "$appsfile" ] && grep -q '#@pkgs-end' "$appsfile" && ! grep -qF "packages/$name.nix" "$appsfile"; then
+  tmp=$(mktemp)
+  awk -v line="    # $entry  #@draft $name" '
+    /#@pkgs-end/ && !done { print line; done = 1 }
+    { print }
+  ' "$appsfile" >"$tmp" && mv "$tmp" "$appsfile"
+  echo "added     $name to $appsfile (commented out)"
+else
+  echo "add it to your configuration yourself, e.g. in $appsfile:"
+  echo "  environment.systemPackages = [ (pkgs.callPackage ./packages/$name.nix { }) ];"
+fi
+echo
+echo "This is a DRAFT: nix-init guessed the builder, the dependencies and the"
+echo "licence. It builds, which is not the same as being right. Review it,"
+echo "uncomment the line, then: nixarchy apply"

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -2711,6 +2711,28 @@ pkgs.runCommand "nixarchy-options"
         esac
         echo "nixarchy pkg remove routes to nixarchy-pkg-remove"
 
+        # Same shape for `pkg new` (#581): advertised in the usage, routed by
+        # the dispatcher, and the route proven by reaching the command's own
+        # refusal -- its URL check needs no network and touches no file.
+        grep -q 'nixarchy pkg new' "$vm/sw/bin/nixarchy" || {
+          echo "the dispatcher's usage does not advertise 'nixarchy pkg new'" >&2
+          exit 1
+        }
+        if r=$(run "$vm/sw/bin/nixarchy" pkg new not-a-url 2>&1); then
+          echo "nixarchy pkg new accepted something that is not a URL:" >&2
+          printf '%s\n' "$r" >&2
+          exit 1
+        fi
+        case "$r" in
+          *"does not look like a URL"*) ;;
+          *)
+            echo "nixarchy pkg new did not reach nixarchy-pkg-new; it said:" >&2
+            printf '%s\n' "$r" >&2
+            exit 1
+            ;;
+        esac
+        echo "nixarchy pkg new routes to nixarchy-pkg-new"
+
           touch $out
       ''
     else

--- a/tests/pkg-new.nix
+++ b/tests/pkg-new.nix
@@ -1,0 +1,146 @@
+{ pkgs }:
+# `nixarchy pkg new` against stub nix-init and nix, offline.
+#
+# What only this check can reach: the command's promises that need a network
+# to exercise for real. The draft is KEPT when the build fails (#581's
+# decision 2 -- a failed draft beats a blank file); the placeholder hash
+# nix-init leaves for cargo/vendor deps is filled in from the failed build's
+# own "got:" line; the apps.nix line is inserted COMMENTED OUT, and only
+# inside the #@pkgs-end block nixarchy-pkg-add wrote -- a reshaped file gets
+# instructions, not an edit. checks.options covers the dispatcher route and
+# the refusals that need no stubs; nothing automated covers a real nix-init
+# run, which needs the network (see tests/AGENTS.md).
+#
+# Stubs shadow the real commands because this runs the RAW pkgs/pkg-new.sh,
+# not the writeShellApplication -- the installed command's PATH is strict and
+# cannot be stubbed, which is exactly why the body lives in its own file.
+pkgs.runCommand "nixarchy-pkg-new"
+  {
+    nativeBuildInputs = [
+      pkgs.gnugrep
+      pkgs.gnused
+      pkgs.gawk
+      pkgs.coreutils
+    ];
+  }
+  ''
+    export HOME=$PWD/home
+    export XDG_CONFIG_HOME=$HOME/.config
+    mkdir -p "$HOME" stub
+
+    sed 's|@nixpkgs@|/stub-nixpkgs|' ${../pkgs/pkg-new.sh} > pkg-new.sh
+
+    # A draft the way headless nix-init leaves one for Rust: the src hash
+    # prefetched, the cargoHash a placeholder only a build can name.
+    cat > stub/nix-init <<'EOF'
+    #!/bin/sh
+    for last; do :; done
+    if [ "''${STUB_INIT_FAIL:-}" = 1 ]; then echo "error: no clue" >&2; : > "$last"; exit 1; fi
+    printf '{ rustPlatform }:\nrustPlatform.buildRustPackage {\n  pname = "tool";\n  cargoHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";\n}\n' > "$last"
+    EOF
+
+    # A build that fails with a hash mismatch until the draft carries the
+    # real hash, then succeeds -- fetchCargoVendor's actual behaviour, minus
+    # the network. STUB_NIX_FAIL=1 is a build that is simply broken.
+    cat > stub/nix <<'EOF'
+    #!/bin/sh
+    draft=$(ls "$XDG_CONFIG_HOME"/nixarchy/packages/*.nix)
+    if [ "''${STUB_NIX_FAIL:-}" = 1 ]; then echo "error: builder failed with exit code 1" >&2; exit 1; fi
+    if grep -q 'sha256-GOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOT=' "$draft"; then exit 0; fi
+    echo "error: hash mismatch in fixed-output derivation:" >&2
+    echo "         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" >&2
+    echo "            got:    sha256-GOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOT=" >&2
+    exit 1
+    EOF
+    chmod +x stub/nix-init stub/nix
+    export PATH=$PWD/stub:$PATH
+
+    fails=0
+    fail() { echo "  FAILED  $1"; fails=$((fails + 1)); }
+    ok() { echo "  ok      $1"; }
+    cfg=$XDG_CONFIG_HOME/nixarchy
+    draft=$cfg/packages/tool.nix
+
+    # The block nixarchy-pkg-add writes, in the shape it writes it.
+    mkapps() {
+      mkdir -p "$cfg"
+      cat > "$cfg/apps.nix" <<'EOF'
+    { pkgs, ... }:
+    {
+      environment.systemPackages = with pkgs; [  #@pkgs-begin
+      ];  #@pkgs-end
+    }
+    EOF
+    }
+
+    # -- refusals, before anything is touched ------------------------------
+    if o=$(bash pkg-new.sh not-a-url 2>&1); then fail "a non-URL was accepted"
+    elif printf '%s' "$o" | grep -q "does not look like a URL"; then ok "a non-URL is refused, naming pkg add"
+    else fail "the non-URL refusal does not say why"; fi
+
+    if o=$(bash pkg-new.sh 2>&1); then fail "no argument was accepted"
+    else ok "no argument prints usage and fails"; fi
+
+    # -- nix-init failing leaves nothing behind ----------------------------
+    mkapps
+    if o=$(STUB_INIT_FAIL=1 bash pkg-new.sh https://example.org/x/tool 2>&1); then
+      fail "a failed nix-init reported success"
+    elif [ -e "$draft" ]; then fail "a failed nix-init left an empty draft, which blocks the next run"
+    else ok "a failed nix-init leaves no draft behind"; fi
+
+    # -- the happy path: placeholder hash filled in from the failed build --
+    if ! o=$(bash pkg-new.sh https://example.org/x/tool 2>&1); then
+      printf '%s\n' "$o" | sed 's/^/          | /'
+      fail "the draft-builds path did not succeed"
+    else
+      grep -q 'sha256-GOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOT=' "$draft" \
+        && ok "the placeholder hash was filled in from the failed build" \
+        || fail "the placeholder hash is still in the draft"
+      printf '%s' "$o" | grep -q "DRAFT" \
+        && ok "the result is presented as a draft, not a package" \
+        || fail "nothing in the output says DRAFT"
+      grep -q '^    # (callPackage ./packages/tool.nix { })  #@draft tool$' "$cfg/apps.nix" \
+        && ok "apps.nix gained the line, commented out" \
+        || fail "apps.nix did not gain the commented line"
+      # Inserted INSIDE the block: before the end marker, after the begin.
+      awk '/#@pkgs-begin/{b=NR} /#@draft tool/{d=NR} /#@pkgs-end/{e=NR} END{exit !(b<d && d<e)}' "$cfg/apps.nix" \
+        && ok "the line sits inside the #@pkgs block" \
+        || fail "the line is outside the #@pkgs block"
+    fi
+
+    if o=$(bash pkg-new.sh https://example.org/x/tool 2>&1); then
+      fail "an existing draft was overwritten"
+    else ok "an existing draft refuses a redraft"; fi
+
+    # -- the build fails: reported as a failure, draft KEPT ----------------
+    rm -rf "$cfg"; mkapps
+    if o=$(STUB_NIX_FAIL=1 bash pkg-new.sh https://example.org/x/tool 2>&1); then
+      fail "a draft that does not build was reported as success"
+    else
+      [ -f "$draft" ] \
+        && ok "the failed draft is kept for editing" \
+        || fail "the failed draft was discarded"
+      printf '%s' "$o" | grep -q "did NOT build" \
+        && ok "the failure is named out loud" \
+        || fail "the failure report does not say the draft did not build"
+      grep -q '#@draft' "$cfg/apps.nix" \
+        && fail "a draft that does not build was still added to apps.nix" \
+        || ok "apps.nix is untouched by a failed draft"
+    fi
+
+    # -- a reshaped apps.nix is not edited ---------------------------------
+    rm -rf "$cfg"; mkdir -p "$cfg"
+    echo '{ ... }: { }' > "$cfg/apps.nix"
+    before=$(cksum < "$cfg/apps.nix")
+    if o=$(bash pkg-new.sh https://example.org/x/tool 2>&1); then
+      [ "$before" = "$(cksum < "$cfg/apps.nix")" ] \
+        && ok "a file without the marker is left alone" \
+        || fail "a file without nixarchy-pkg-add's marker was edited"
+      printf '%s' "$o" | grep -q "add it to your configuration yourself" \
+        && ok "the edit is printed instead" \
+        || fail "nothing told the user what to add by hand"
+    else fail "a marker-less apps.nix broke the drafting"; fi
+
+    [ "$fails" -eq 0 ] || { echo; echo "$fails assertion(s) failed"; exit 1; }
+    touch $out
+  ''


### PR DESCRIPTION
Closes #581. Territory: `pkgs/pkg-new.sh` (new), `modules/apps.nix`, `tests/pkg-new.nix` (new), `tests/options.nix`, `flake.nix`, `docs/manual/other-packages.md`.

## What this changes, and why

The first vertical slice of `nixarchy pkg new <url>` — the last unbuilt child of #566, and the one hatch that answers "package this yourself" rather than "run someone else's build". A URL in, `nix-init --headless` out: the draft lands in `~/.config/nixarchy/packages/<name>.nix`, is **built once** against the generation's own nixpkgs, and the result is reported honestly. Headless nix-init sometimes leaves `cargoHash`/`vendorHash` as the `sha256-AAAA…` placeholder, so the build loop fills in the failed build's own `got:` hash and retries (up to three rounds). A draft that builds is added to `apps.nix` **commented out** — inside the `#@pkgs-end` block `nixarchy-pkg-add` wrote, under `nixarchy-unfreeze`'s consent rule; a reshaped file gets the edit printed instead. A draft that does not build is **kept**, the failure said out loud, and `apps.nix` untouched. `nixarchy-apply` now copies `packages/` beside its `apps.nix` copy, so the uncommented `./packages/<name>.nix` line resolves in the flake.

The issue's four open decisions, answered on evidence:

1. **Where the overlay lives / how apply picks it up** — no overlay at all for the slice: drafts are `callPackage`-style files in `~/.config/nixarchy/packages/`, referenced by relative path from the packages block `apps.nix` already has, and ridden along by `nixarchy-apply`. Making a draft visible as `pkgs.<name>` (a true overlay) is deferred — nothing in the slice needs it.
2. **A draft that does not build** — kept, and `tests/pkg-new.nix` fails if it is ever discarded (the red run below is exactly that bug reintroduced).
3. **nix-init non-interactively** — settled: nix-init 0.3.6 has `--headless` (requires `--url`), and it drafted real derivations with a PATH holding nothing but its own bin. No need to drive nurl + our own template, so the builder/dependency/licence inference is kept. Posted to the agent bus.
4. **`nixarchy channel`** — noted, not solved: the trial build runs against the generation's baked `pkgs.path` (the same tree `nixarchy-pkg-add` parses against), but once applied the draft evaluates against whatever channel the user's flake follows, and a channel switch can break a draft that built. Named here and in the manual section ("a draft pins one revision of one upstream; updating it is yours"); a real answer belongs to a later slice.

**No `data/bin-ledger.nix` row, deliberately**: the command is a `writeShellApplication` in `modules/apps.nix` like its siblings `nixarchy-pkg-add`/`remove`/`apply` (none of which have rows) — the ledger's own header says a row is a claim about a file shipped from `pkgs/omarchy/nix-bin`, and `check-bin-ledger.py` derives classes only from that tree. Module-built was chosen over nix-bin so the script gets a **strict `runtimeInputs` PATH** (§7) and a baked `pkgs.path`, and so its body (`pkgs/pkg-new.sh`, spliced the way `flake.nix` splices `pkgs/doctor.sh`) can be run raw against stubs by the check — the installed command's PATH cannot be stubbed.

Real end-to-end smoke on this machine: `pkg new https://github.com/charmbracelet/glow` drafted `buildGoModule`, built it for real, and inserted `# (callPackage ./packages/glow.nix { })  #@draft glow` before the end marker. Also proven: nix-init failing leaves no empty draft behind (an empty file would jam the next run's already-exists check).

## How I proved the check fails

**`checks.pkg-new`** — reintroduced decision 2's bug (`rm -f "$draft"` in the failure branch):

```
>   ok      an existing draft refuses a redraft
>   FAILED  the failed draft was discarded
>   ok      the failure is named out loud
> 1 assertion(s) failed
error: Cannot build '/nix/store/k1q6ypm3rrrhwpdc3i49gb1sfws2i3fx-nixarchy-pkg-new.drv'.
```

Green with the fix restored: all 13 assertions `ok`.

**`checks.options`** — removed the dispatcher's `new)` row (the exact #498/#538 failure shape):

```
> nixarchy pkg remove routes to nixarchy-pkg-remove
> nixarchy pkg new did not reach nixarchy-pkg-new; it said:
> Unknown Omarchy command: omarchy pkg new not-a-url
error: builder for '/nix/store/3zkfspzcl45bzfmy5mj8c4bswcnwj5di-nixarchy-options.drv' failed
```

Green with the row restored: `nixarchy pkg new routes to nixarchy-pkg-new`.

## Checks run locally

- `nix build .#checks.x86_64-linux.pkg-new` — red then green as above
- `nix build .#checks.x86_64-linux.options` — red then green as above
- real-nix-init smoke run of the raw script (glow: drafted, built, wired)

- [x] `nix fmt` / statix / deadnix are clean (`nix fmt -- --ci`: 0 changed)
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [x] If this adds an option: no new option
- [x] If this adds a `checks.*` entry: a PR-triggered workflow builds it — `checks.pkg-new` is picked up by build.yml's "Build every check no other job claims" step, which builds every entry no job claims; no workflow edit was needed or made

## What this cost, and where it is written down

- [x] Nothing general came up — the one reusable finding (nix-init `--headless` works under a bare PATH; the placeholder-hash retry it forces) is in this PR, the issue's decision record, and on the agent bus.

## What this slice does NOT do

- No Install ▸ Search miss-path entry point (out of scope by design) — the command is reachable only as `nixarchy pkg new`.
- No true overlay: a draft is not `pkgs.<name>`, so nothing else can depend on it.
- No update story: a draft pins one rev; bumping it is a hand edit.
- No removal: deleting a draft and its `#@draft` line is a hand edit (`nixarchy pkg remove` knows only `#@pkg` lines).
- Nothing automated exercises a **real** nix-init run — that needs the network, which no check here has; the stub check covers the command's own logic, and the real path was proven by hand above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5