### PR TITLE
The real nix-init gets one nightly run, and the stub-only coverage is written down

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -351,6 +351,56 @@ jobs:
           echo
           echo "both toplevels evaluate against tomorrow's inputs"
 
+  # The one real run of `nixarchy pkg new`. tests/pkg-new.nix drives the same
+  # script against STUB nix-init and nix, because a sandboxed derivation has
+  # no network and nix-init's whole job is to fetch -- so nothing on a pull
+  # request has ever executed a real `nix-init --headless`. This does, and it
+  # is a job rather than a flake check for the same reason devenv-presets is
+  # (build.yml's comment on that job, and docs/internals/flake.md): work that
+  # needs the network cannot be a `checks` entry at all.
+  #
+  # Non-gating, like the canary and for the same reason: a red here means
+  # GitHub's API moved, or nix-init's inference changed under a nixpkgs bump
+  # -- not that a PR broke something, so it blocks nobody. The report job
+  # below files it as its own issue.
+  #
+  # The target is hexyl at a PINNED release tag: a small Rust CLI whose
+  # repository has been stable for years, small enough that the draft builds
+  # in minutes, and Rust because that reaches the cargoHash-placeholder loop
+  # -- the one part of the script the stubs can only imitate. The pin means
+  # upstream commits cannot move this job; the residual risk is the
+  # repository vanishing or the GitHub API changing shape, and either of
+  # those is exactly the upstream movement this job exists to notice.
+  pkg-new:
+    name: draft a real package with headless nix-init
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-nix
+
+      - name: Draft hexyl with real nix-init and build the draft
+        env:
+          # nix-init asks the GitHub API for the licence and description;
+          # unauthenticated calls from a shared Actions IP are a rate-limit
+          # lottery.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -o pipefail
+          # The same splice modules/apps.nix performs: @nixpkgs@ becomes the
+          # tree the draft is parsed and built against.
+          nixpkgs=$(nix eval --raw --inputs-from . nixpkgs#path)
+          sed "s|@nixpkgs@|$nixpkgs|" pkgs/pkg-new.sh > "$RUNNER_TEMP/pkg-new.sh"
+          export XDG_CONFIG_HOME="$RUNNER_TEMP/config"
+          nix shell --inputs-from . nixpkgs#nix-init -c \
+            bash "$RUNNER_TEMP/pkg-new.sh" \
+            https://github.com/sharkdp/hexyl --rev v0.17.0 | tee "$RUNNER_TEMP/out"
+          # The script itself exits nonzero when the draft does not build;
+          # these two are for the quieter failure, an exit 0 that produced
+          # nothing.
+          test -s "$RUNNER_TEMP/config/nixarchy/packages/hexyl.nix"
+          grep -qF 'building  hexyl ... ok' "$RUNNER_TEMP/out"
+
   report:
     name: report a failure
     runs-on: ubuntu-latest
@@ -361,7 +411,7 @@ jobs:
     # dependencies, and reported SUCCESS. The encrypted install is the DEFAULT
     # answer to the installer's own question, and it was the one failure that
     # filed no issue.
-    needs: [install, install-encrypted, install-iso, microvm, cache, canary]
+    needs: [install, install-encrypted, install-iso, microvm, cache, canary, pkg-new]
     # cancelled() too. On 2026-09-02 install-iso hit its 180-minute timeout,
     # which GitHub records as cancelled rather than failed, and this job --
     # the one whose whole purpose is that a 03:00 failure does not cost a day
@@ -408,6 +458,14 @@ jobs:
             # jobs later. It also collides with the dedupe search, appending a
             # sandbox failure to the install issue.
             title="nightly: a sandbox will not boot"
+          elif [ "${{ needs.pkg-new.result }}" != "success" ] &&
+            [ "${{ needs.install.result }}" = "success" ] &&
+            [ "${{ needs.install-encrypted.result }}" = "success" ] &&
+            [ "${{ needs.install-iso.result }}" = "success" ]; then
+            # Its own identity, same shape as the canary: a failure here means
+            # upstream moved under a real nix-init run, and the install checks
+            # are the wrong place to send the reader.
+            title="nightly: a real nix-init draft no longer builds"
           else
             title="nightly: the install checks are failing"
           fi

--- a/docs/manual/other-packages.md
+++ b/docs/manual/other-packages.md
@@ -154,6 +154,36 @@ translate it: fonts are answered with `fonts.packages`, PHP extensions with
 `hardware.graphics.enable32Bit`, because each of those is a different shape on
 NixOS and `systemPackages` would be the wrong answer.
 
+## Software in no repository at all
+
+When nixpkgs, the curated list and Flathub all miss, the answer used to be
+"write a derivation" — which needs the language this desktop was installed to
+avoid. `nixarchy pkg new` gets you a first draft instead:
+
+```sh
+nixarchy pkg new https://github.com/someone/tool
+```
+
+runs [nix-init](https://github.com/nix-community/nix-init) headless: it picks
+a builder, prefetches the hashes, infers dependencies for Rust, Go and Python,
+and detects the licence. The result lands in
+`~/.config/nixarchy/packages/tool.nix`, and is then **built once** before
+anything is claimed. If the build has to learn a hash the draft could not know
+in advance (Rust's `cargoHash`, Go's `vendorHash`), the failed build names it
+and the draft is corrected automatically.
+
+If it builds, a commented-out line is added to the packages block of
+`~/.config/nixarchy/apps.nix`; review the draft, uncomment the line, and
+`nixarchy apply` carries both into your flake. If it does not build, that is
+said out loud and the draft is **kept** — a failed draft is still a better
+starting point than a blank file.
+
+Either way it is a draft: nix-init's authors are explicit that it produces a
+starting point for a person to review, not a finished package, and this
+command never pretends otherwise. A draft pins one revision of one upstream;
+updating it when upstream releases is yours to do, by editing the version and
+hashes in the file.
+
 ## Removing
 
 _Remove > App / package_ runs `nixarchy-app-remove`, a picker over everything

--- a/flake.nix
+++ b/flake.nix
@@ -1541,6 +1541,14 @@
             omarchy = self.packages.${system}.omarchy;
           };
 
+          # `nixarchy pkg new` against stub nix-init and nix: the draft is
+          # kept when its build fails, the placeholder hash is filled in from
+          # the failed build, and a reshaped apps.nix is printed at rather
+          # than edited. See tests/pkg-new.nix.
+          pkg-new = import ./tests/pkg-new.nix {
+            pkgs = pkgsFor.${system};
+          };
+
           # What a network install would have to build, before it formats
           # anything. See tests/substitutable.nix.
           substitutable = import ./tests/substitutable.nix {

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -2070,6 +2070,28 @@ in
               '';
             })
 
+            # `nixarchy pkg new <url>`: a draft derivation for software in no
+            # repository (#581). The body lives in pkgs/pkg-new.sh, spliced
+            # here the way flake.nix splices pkgs/doctor.sh, so a check can
+            # run the raw file against stubs -- see tests/pkg-new.nix.
+            (pkgs.writeShellApplication {
+              name = "nixarchy-pkg-new";
+              runtimeInputs = [
+                pkgs.coreutils
+                pkgs.gnugrep
+                pkgs.gnused
+                pkgs.gawk
+                pkgs.nix-init
+                # nix-init resolves GitHub URLs entirely on its own (proven
+                # under a PATH holding nothing else), but shells out for the
+                # rest of its fetchers; an undeclared command here reads as
+                # "cannot draft this", not "git is missing".
+                pkgs.git
+                config.nix.package
+              ];
+              text = lib.replaceStrings [ "@nixpkgs@" ] [ "${pkgs.path}" ] (builtins.readFile ../pkgs/pkg-new.sh);
+            })
+
             # Why: modules/AGENTS.md#search-everything-this-machine-could-install-and-r
             (pkgs.writeShellApplication {
               name = "nixarchy-search";
@@ -2531,6 +2553,8 @@ in
                     case "''${2:-}" in
                       add) shift 2; exec nixarchy-pkg-add "$@" ;;
                       remove) shift 2; exec nixarchy-pkg-remove "$@" ;;
+                      new) shift 2; exec nixarchy-pkg-new "$@" ;;
+
                     esac
                     ;;
                   app)
@@ -2615,6 +2639,7 @@ in
                   nixarchy search [query]     Every package, NixOS option and app, in one picker
                   nixarchy pkg add <attr>     Add a nixpkgs package to the app selection
                   nixarchy pkg remove [attr]  Take one out again (no argument picks interactively)
+                  nixarchy pkg new <url>      Draft a derivation for software in no repository
                   nixarchy app enable <id>    Select an app from the curated list
                   nixarchy app disable <id>   Deselect one
                   nixarchy app remove         Pick apps, packages and options to remove
@@ -2720,6 +2745,26 @@ in
                   cp "$src" "$dst"
                   copied="$copied $part"
                 done
+
+                # Draft derivations from `nixarchy pkg new` ride along:
+                # apps.nix names them as ./packages/<name>.nix, a path
+                # relative to the COPY, so they must sit beside it or the
+                # uncommented line fails evaluation with "path does not
+                # exist". Copies accumulate and are never deleted here --
+                # removing a draft from the flake is an edit to a tree the
+                # user owns, not this tool's call.
+                if [ -d "$srcdir/packages" ]; then
+                  mkdir -p "$base/nixarchy/packages"
+                  for src in "$srcdir"/packages/*.nix; do
+                    [ -f "$src" ] || continue
+                    dst="$base/nixarchy/packages/$(basename "$src")"
+                    if [ -f "$dst" ] && diff -q "$src" "$dst" >/dev/null; then
+                      continue
+                    fi
+                    cp "$src" "$dst"
+                    copied="$copied packages/$(basename "$src")"
+                  done
+                fi
 
                 # Only what exists is imported. A machine seeded before
                 # services.nix existed has two files, not three, and a stub

--- a/pkgs/pkg-new.sh
+++ b/pkgs/pkg-new.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# nixarchy pkg new <url> -- draft a derivation for software in no repository.
+#
+# Spliced into a writeShellApplication in modules/apps.nix; @nixpkgs@ becomes
+# the generation's own nixpkgs, the same tree nixarchy-pkg-add parses against.
+# nix-init does the drafting, headless. Its authors call the output a draft,
+# and so does everything this prints: the builder, the dependencies and the
+# licence are guesses for a person to review, not a package.
+#
+# Build before claiming (#581): the draft is built once, and a failure is
+# reported as one -- with the draft KEPT, because a failed draft is still a
+# better starting point than a blank file.
+set -euo pipefail
+
+nixpkgs='@nixpkgs@'
+
+usage() {
+  echo "usage: nixarchy pkg new <url> [--rev REV] [--name NAME]"
+  echo "  e.g. nixarchy pkg new https://github.com/someone/tool"
+  echo
+  echo "  Drafts a derivation into ~/.config/nixarchy/packages/<name>.nix"
+  echo "  with nix-init, then builds it once and reports the result."
+  echo "  The draft is yours to edit either way."
+  echo
+  echo "  For software nixpkgs already carries, use: nixarchy pkg add <attr>"
+}
+
+url="" rev="" name=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --rev)
+      rev="${2:-}"
+      [ -n "$rev" ] || { echo "--rev needs a value" >&2; exit 1; }
+      shift 2
+      ;;
+    --name)
+      name="${2:-}"
+      [ -n "$name" ] || { echo "--name needs a value" >&2; exit 1; }
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "nixarchy-pkg-new: unknown option '$1'" >&2
+      exit 1
+      ;;
+    *)
+      if [ -n "$url" ]; then
+        echo "nixarchy-pkg-new: one URL at a time" >&2
+        exit 1
+      fi
+      url="$1"
+      shift
+      ;;
+  esac
+done
+[ -n "$url" ] || { usage >&2; exit 1; }
+case "$url" in
+  https://* | http://*) ;;
+  *)
+    echo "'$url' does not look like a URL this can fetch (expected https://...)." >&2
+    echo "For something already in nixpkgs, use: nixarchy pkg add <attribute>" >&2
+    exit 1
+    ;;
+esac
+
+if [ -z "$name" ]; then
+  name="${url%/}"
+  name="${name##*/}"
+  name="${name%.git}"
+fi
+# Same alphabet nixarchy-pkg-add accepts, and for the same reason: the name
+# lands inside a nix expression and a file path.
+case "$name" in
+  "" | .* | *[!A-Za-z0-9_.-]*)
+    echo "cannot make a package name out of '$name'; pass --name <name>." >&2
+    exit 1
+    ;;
+esac
+
+pkgdir="${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/packages"
+draft="$pkgdir/$name.nix"
+if [ -e "$draft" ]; then
+  echo "$draft already exists." >&2
+  echo "Edit it, or remove it and run this again to redraft." >&2
+  exit 1
+fi
+mkdir -p "$pkgdir"
+
+echo "drafting  $draft"
+initargs=(--headless --url "$url" -n "$nixpkgs")
+if [ -n "$rev" ]; then
+  initargs+=(--rev "$rev")
+fi
+if ! nix-init "${initargs[@]}" "$draft" || [ ! -s "$draft" ]; then
+  echo
+  echo "nix-init could not draft anything from $url." >&2
+  echo "It understands release URLs and repositories on GitHub, GitLab," >&2
+  echo "Codeberg, SourceHut, crates.io and PyPI." >&2
+  # A failed nix-init can leave an empty file behind; an empty draft is not
+  # a starting point, it is a landmine for the next run's already-exists check.
+  rm -f "$draft"
+  exit 1
+fi
+
+log=$(mktemp)
+trap 'rm -f "$log"' EXIT
+try_build() {
+  nix build --no-link --impure \
+    --expr "(import $nixpkgs { }).callPackage $draft { }" >"$log" 2>&1
+}
+
+printf 'building  %s ... ' "$name"
+built=false
+# Up to three rounds: nix-init leaves a placeholder where a hash cannot be
+# known before the first build (cargoHash, vendorHash), and the failed build
+# names the real one. Fill it in and go again; anything else is a real failure.
+for _ in 1 2 3; do
+  if try_build; then
+    built=true
+    break
+  fi
+  spec=$(sed -n 's/.*specified:[[:space:]]*\(sha256-[A-Za-z0-9+/=]*\).*/\1/p' "$log" | head -1)
+  got=$(sed -n 's/.*got:[[:space:]]*\(sha256-[A-Za-z0-9+/=]*\).*/\1/p' "$log" | head -1)
+  if [ -n "$spec" ] && [ -n "$got" ] && grep -qF "$spec" "$draft"; then
+    sed -i "s|$spec|$got|" "$draft"
+  else
+    break
+  fi
+done
+
+if [ "$built" != true ]; then
+  echo "FAILED"
+  echo
+  tail -n 15 "$log" | sed 's/^/  | /'
+  echo
+  echo "The draft did NOT build. It is kept at"
+  echo "  $draft"
+  echo "because a failed draft is still a better starting point than a blank"
+  echo "file. Edit it, then rebuild with:"
+  echo "  nix build --impure --expr '(import $nixpkgs { }).callPackage $draft { }'"
+  exit 1
+fi
+echo "ok"
+
+appsfile="${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/apps.nix"
+entry="(callPackage ./packages/$name.nix { })"
+# Consent rule (nixarchy-unfreeze's, via nixarchy-channel): only lines this
+# project wrote get rewritten. The #@pkgs-end marker is nixarchy-pkg-add's own
+# block, so inserting there -- commented out -- is within it; a file without
+# the marker is the user's shape, and gets the edit printed instead.
+if [ -f "$appsfile" ] && grep -q '#@pkgs-end' "$appsfile" && ! grep -qF "packages/$name.nix" "$appsfile"; then
+  tmp=$(mktemp)
+  awk -v line="    # $entry  #@draft $name" '
+    /#@pkgs-end/ && !done { print line; done = 1 }
+    { print }
+  ' "$appsfile" >"$tmp" && mv "$tmp" "$appsfile"
+  echo "added     $name to $appsfile (commented out)"
+else
+  echo "add it to your configuration yourself, e.g. in $appsfile:"
+  echo "  environment.systemPackages = [ (pkgs.callPackage ./packages/$name.nix { }) ];"
+fi
+echo
+echo "This is a DRAFT: nix-init guessed the builder, the dependencies and the"
+echo "licence. It builds, which is not the same as being right. Review it,"
+echo "uncomment the line, then: nixarchy apply"

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -100,6 +100,24 @@ touches `installer/disk-config.nix`. Both an online and an offline whole-disk
 install through it passed on 2026-09-08, which is what "no check covers this"
 is allowed to mean here: measured by a person, written down, and repeatable.
 
+## The stub-only one: `pkg-new` never runs a real nix-init here
+
+`tests/pkg-new.nix` drives the real `pkgs/pkg-new.sh` against **stub**
+`nix-init` and `nix`, because the real ones fetch and a sandboxed derivation
+has no network. The stubs are enough for the script's own promises — the
+draft kept on a failed build, the placeholder cargoHash filled in from the
+failed build's `got:` line, the apps.nix edit staying inside the
+`#@pkgs-end` block — but they imitate nix-init's output rather than produce
+it. Whether `nix-init --headless` still drafts something buildable from a
+real repository, with the real GitHub API and the real hash-mismatch text,
+no check here can say.
+
+That real run lives in `.github/workflows/nightly.yml` (`pkg-new` job): it
+drafts hexyl at a pinned tag with real nix-init and builds the draft.
+Non-gating, per-night, filed as its own issue by the report job — a job
+rather than a check for the same reason devenv-presets is (see build.yml's
+comment on that job).
+
 ## The cheap ones, which is where new checks usually belong
 
 `installer-ui`, `installer-wizard`, `installer-refusal`, `installer-lock`,

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -2711,6 +2711,28 @@ pkgs.runCommand "nixarchy-options"
         esac
         echo "nixarchy pkg remove routes to nixarchy-pkg-remove"
 
+        # Same shape for `pkg new` (#581): advertised in the usage, routed by
+        # the dispatcher, and the route proven by reaching the command's own
+        # refusal -- its URL check needs no network and touches no file.
+        grep -q 'nixarchy pkg new' "$vm/sw/bin/nixarchy" || {
+          echo "the dispatcher's usage does not advertise 'nixarchy pkg new'" >&2
+          exit 1
+        }
+        if r=$(run "$vm/sw/bin/nixarchy" pkg new not-a-url 2>&1); then
+          echo "nixarchy pkg new accepted something that is not a URL:" >&2
+          printf '%s\n' "$r" >&2
+          exit 1
+        fi
+        case "$r" in
+          *"does not look like a URL"*) ;;
+          *)
+            echo "nixarchy pkg new did not reach nixarchy-pkg-new; it said:" >&2
+            printf '%s\n' "$r" >&2
+            exit 1
+            ;;
+        esac
+        echo "nixarchy pkg new routes to nixarchy-pkg-new"
+
           touch $out
       ''
     else

--- a/tests/pkg-new.nix
+++ b/tests/pkg-new.nix
@@ -1,0 +1,146 @@
+{ pkgs }:
+# `nixarchy pkg new` against stub nix-init and nix, offline.
+#
+# What only this check can reach: the command's promises that need a network
+# to exercise for real. The draft is KEPT when the build fails (#581's
+# decision 2 -- a failed draft beats a blank file); the placeholder hash
+# nix-init leaves for cargo/vendor deps is filled in from the failed build's
+# own "got:" line; the apps.nix line is inserted COMMENTED OUT, and only
+# inside the #@pkgs-end block nixarchy-pkg-add wrote -- a reshaped file gets
+# instructions, not an edit. checks.options covers the dispatcher route and
+# the refusals that need no stubs; nothing automated covers a real nix-init
+# run, which needs the network (see tests/AGENTS.md).
+#
+# Stubs shadow the real commands because this runs the RAW pkgs/pkg-new.sh,
+# not the writeShellApplication -- the installed command's PATH is strict and
+# cannot be stubbed, which is exactly why the body lives in its own file.
+pkgs.runCommand "nixarchy-pkg-new"
+  {
+    nativeBuildInputs = [
+      pkgs.gnugrep
+      pkgs.gnused
+      pkgs.gawk
+      pkgs.coreutils
+    ];
+  }
+  ''
+    export HOME=$PWD/home
+    export XDG_CONFIG_HOME=$HOME/.config
+    mkdir -p "$HOME" stub
+
+    sed 's|@nixpkgs@|/stub-nixpkgs|' ${../pkgs/pkg-new.sh} > pkg-new.sh
+
+    # A draft the way headless nix-init leaves one for Rust: the src hash
+    # prefetched, the cargoHash a placeholder only a build can name.
+    cat > stub/nix-init <<'EOF'
+    #!/bin/sh
+    for last; do :; done
+    if [ "''${STUB_INIT_FAIL:-}" = 1 ]; then echo "error: no clue" >&2; : > "$last"; exit 1; fi
+    printf '{ rustPlatform }:\nrustPlatform.buildRustPackage {\n  pname = "tool";\n  cargoHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";\n}\n' > "$last"
+    EOF
+
+    # A build that fails with a hash mismatch until the draft carries the
+    # real hash, then succeeds -- fetchCargoVendor's actual behaviour, minus
+    # the network. STUB_NIX_FAIL=1 is a build that is simply broken.
+    cat > stub/nix <<'EOF'
+    #!/bin/sh
+    draft=$(ls "$XDG_CONFIG_HOME"/nixarchy/packages/*.nix)
+    if [ "''${STUB_NIX_FAIL:-}" = 1 ]; then echo "error: builder failed with exit code 1" >&2; exit 1; fi
+    if grep -q 'sha256-GOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOT=' "$draft"; then exit 0; fi
+    echo "error: hash mismatch in fixed-output derivation:" >&2
+    echo "         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" >&2
+    echo "            got:    sha256-GOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOT=" >&2
+    exit 1
+    EOF
+    chmod +x stub/nix-init stub/nix
+    export PATH=$PWD/stub:$PATH
+
+    fails=0
+    fail() { echo "  FAILED  $1"; fails=$((fails + 1)); }
+    ok() { echo "  ok      $1"; }
+    cfg=$XDG_CONFIG_HOME/nixarchy
+    draft=$cfg/packages/tool.nix
+
+    # The block nixarchy-pkg-add writes, in the shape it writes it.
+    mkapps() {
+      mkdir -p "$cfg"
+      cat > "$cfg/apps.nix" <<'EOF'
+    { pkgs, ... }:
+    {
+      environment.systemPackages = with pkgs; [  #@pkgs-begin
+      ];  #@pkgs-end
+    }
+    EOF
+    }
+
+    # -- refusals, before anything is touched ------------------------------
+    if o=$(bash pkg-new.sh not-a-url 2>&1); then fail "a non-URL was accepted"
+    elif printf '%s' "$o" | grep -q "does not look like a URL"; then ok "a non-URL is refused, naming pkg add"
+    else fail "the non-URL refusal does not say why"; fi
+
+    if o=$(bash pkg-new.sh 2>&1); then fail "no argument was accepted"
+    else ok "no argument prints usage and fails"; fi
+
+    # -- nix-init failing leaves nothing behind ----------------------------
+    mkapps
+    if o=$(STUB_INIT_FAIL=1 bash pkg-new.sh https://example.org/x/tool 2>&1); then
+      fail "a failed nix-init reported success"
+    elif [ -e "$draft" ]; then fail "a failed nix-init left an empty draft, which blocks the next run"
+    else ok "a failed nix-init leaves no draft behind"; fi
+
+    # -- the happy path: placeholder hash filled in from the failed build --
+    if ! o=$(bash pkg-new.sh https://example.org/x/tool 2>&1); then
+      printf '%s\n' "$o" | sed 's/^/          | /'
+      fail "the draft-builds path did not succeed"
+    else
+      grep -q 'sha256-GOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOTGOT=' "$draft" \
+        && ok "the placeholder hash was filled in from the failed build" \
+        || fail "the placeholder hash is still in the draft"
+      printf '%s' "$o" | grep -q "DRAFT" \
+        && ok "the result is presented as a draft, not a package" \
+        || fail "nothing in the output says DRAFT"
+      grep -q '^    # (callPackage ./packages/tool.nix { })  #@draft tool$' "$cfg/apps.nix" \
+        && ok "apps.nix gained the line, commented out" \
+        || fail "apps.nix did not gain the commented line"
+      # Inserted INSIDE the block: before the end marker, after the begin.
+      awk '/#@pkgs-begin/{b=NR} /#@draft tool/{d=NR} /#@pkgs-end/{e=NR} END{exit !(b<d && d<e)}' "$cfg/apps.nix" \
+        && ok "the line sits inside the #@pkgs block" \
+        || fail "the line is outside the #@pkgs block"
+    fi
+
+    if o=$(bash pkg-new.sh https://example.org/x/tool 2>&1); then
+      fail "an existing draft was overwritten"
+    else ok "an existing draft refuses a redraft"; fi
+
+    # -- the build fails: reported as a failure, draft KEPT ----------------
+    rm -rf "$cfg"; mkapps
+    if o=$(STUB_NIX_FAIL=1 bash pkg-new.sh https://example.org/x/tool 2>&1); then
+      fail "a draft that does not build was reported as success"
+    else
+      [ -f "$draft" ] \
+        && ok "the failed draft is kept for editing" \
+        || fail "the failed draft was discarded"
+      printf '%s' "$o" | grep -q "did NOT build" \
+        && ok "the failure is named out loud" \
+        || fail "the failure report does not say the draft did not build"
+      grep -q '#@draft' "$cfg/apps.nix" \
+        && fail "a draft that does not build was still added to apps.nix" \
+        || ok "apps.nix is untouched by a failed draft"
+    fi
+
+    # -- a reshaped apps.nix is not edited ---------------------------------
+    rm -rf "$cfg"; mkdir -p "$cfg"
+    echo '{ ... }: { }' > "$cfg/apps.nix"
+    before=$(cksum < "$cfg/apps.nix")
+    if o=$(bash pkg-new.sh https://example.org/x/tool 2>&1); then
+      [ "$before" = "$(cksum < "$cfg/apps.nix")" ] \
+        && ok "a file without the marker is left alone" \
+        || fail "a file without nixarchy-pkg-add's marker was edited"
+      printf '%s' "$o" | grep -q "add it to your configuration yourself" \
+        && ok "the edit is printed instead" \
+        || fail "nothing told the user what to add by hand"
+    else fail "a marker-less apps.nix broke the drafting"; fi
+
+    [ "$fails" -eq 0 ] || { echo; echo "$fails assertion(s) failed"; exit 1; }
+    touch $out
+  ''


### PR DESCRIPTION
**Stacks on #590** (`feat/581-pkg-new`) — the base of this PR is that branch, so the diff here is one commit. Rebase onto main after #590 lands.

**This is a CI-gate-adjacent change (AGENTS.md §11): it edits a workflow. Proposed for a human to merge — do not let an agent merge it.**

## What this changes, and why

`tests/pkg-new.nix` is stub-driven: it fakes `nix-init` and `nix`, because a sandboxed derivation has no network and nix-init's whole job is to fetch. So nothing anywhere has ever executed a real `nix-init --headless`. This adds a `pkg-new` job to `nightly.yml` that runs the real `pkgs/pkg-new.sh` (with the same `@nixpkgs@` splice `modules/apps.nix` performs) against a real repository, and asserts the draft exists and builds. It is a **job, not a flake check**, for the reason `build.yml` states on `devenv-presets` and `docs/internals/flake.md` elaborates — network work cannot be a `checks` entry — and it is **non-gating** for the reason the canary is: a red means GitHub's API or nix-init's inference moved, not that a PR broke something. The `report` job gains it in `needs` and a ladder branch of its own (`nightly: a real nix-init draft no longer builds`), so a failure files an issue instead of dying silently. `tests/AGENTS.md` gains the section the check's own header points at: what the stubs cover, what only a real run can, and where that run now lives.

**Target choice**: `https://github.com/sharkdp/hexyl` at pinned tag `v0.17.0`. Small (a Rust CLI that builds in minutes), stable and maintained for years, unlikely to vanish, and Rust on purpose — it exercises the cargoHash-placeholder loop, the one part of the script the stubs can only imitate. The pin means upstream commits cannot move the job; the residual risk (repository deleted, GitHub API reshaped) is exactly the class of upstream movement the job exists to notice, stated in the job comment.

Agent-bus note (§9): the room carries a finding from the #581 agent that headless nix-init drafts GitHub URLs with almost nothing on PATH. One correction from this run: `nix-init` shells out to `nix flake prefetch` for the src hash, so it does need `nix` at runtime — present on the runner via `setup-nix`.

## How I proved the check fails

**I cannot prove a nightly job green on a pull request**, and I have **not dispatched** `nightly.yml`: dispatch runs the whole workflow (there is no per-job dispatch), which is four install-class VMs on the self-hosted pool — and an `install check` run for this PR's own base branch (34622716984) was in flight, which is the measured 3–4-concurrent-installs failure mode from AGENTS.md §6. Dispatch it once the queue is idle if you want the in-Actions run before merging.

What I ran instead is the job's **exact step payload**, verbatim, under bash with the real network (script kept at the step's shape; only `RUNNER_TEMP` and the target args are parameterised).

Broken — a rev that does not exist, real nix-init, real GitHub API, exit 1:

```
drafting  /tmp/tmp.S66pwWnUqa/config/nixarchy/packages/hexyl.nix
$ nix flake prefetch --extra-experimental-features 'nix-command flakes' --json github:sharkdp/hexyl/v999.0.0
error: unable to download 'https://api.github.com/repos/sharkdp/hexyl/commits/v999.0.0': HTTP error 422
       {"message":"No commit found for SHA: v999.0.0", ...}

nix-init could not draft anything from https://github.com/sharkdp/hexyl.
It understands release URLs and repositories on GitHub, GitLab,
Codeberg, SourceHut, crates.io and PyPI.
exit=1
```

Restored — the pinned tag, drafted, built, both trailing asserts held:

```
drafting  /tmp/tmp.cvmmhCZk74/config/nixarchy/packages/hexyl.nix
    Updating crates.io index
building  hexyl ... ok
add it to your configuration yourself, e.g. in /tmp/tmp.cvmmhCZk74/config/nixarchy/apps.nix:
  environment.systemPackages = [ (pkgs.callPackage ./packages/hexyl.nix { }) ];

This is a DRAFT: nix-init guessed the builder, the dependencies and the
licence. It builds, which is not the same as being right. Review it,
uncomment the line, then: nixarchy apply
PAYLOAD_PASS exit=0
```

## Checks run locally

- `actionlint -ignore 'SC[0-9]+:(info|style):'` — exit 0
- The job's step payload under bash, failing and passing (above)
- No `.nix` files touched, so no `nix fmt` / statix / deadnix surface; no new `checks.*` entry, so the coverage guard in `build.yml` is unaffected (verified it enumerates `checks` names, which this adds none of)

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [ ] If this adds an option: `tests/options.nix` covers both states — n/a
- [ ] If this adds a `checks.*` entry: a PR-triggered workflow builds it — n/a, deliberately: this is a job, not a check

## What this cost, and where it is written down

Nothing general beyond what the PR itself writes down: the stub-only hole is now in `tests/AGENTS.md`, per §3. One observation for a human, not fixed here (§10): `reinstall-vm` is **not** in the `report` job's `needs`, so a reinstall-vm failure files no issue — the same watchdog-cannot-see-its-subject class the `install-encrypted` comment in that job describes.

- [x] A general lesson is recorded in `AGENTS.md`, or nothing general came up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
