### PR TITLE
The nightly's watchdog watches every nightly job, and a check says so

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,6 +173,50 @@ jobs:
           nix shell --inputs-from . nixpkgs#actionlint -c \
             actionlint -ignore 'SC[0-9]+:(info|style):'
 
+      # The nightly's watchdog watches every job the nightly runs -- #592.
+      #
+      # `nightly.yml`'s `report` job turns a nightly failure into a filed
+      # issue, and `if: failure()` observes only what is in `needs`. So a job
+      # missing from that list fails into silence: red in a workflow run
+      # nobody opens, which is §4's "a check that nothing surfaces is worse
+      # than no check" one level up.
+      #
+      # It had already happened twice. The report job's own comment was
+      # written after install-iso died in a way it did not catch -- "a
+      # watchdog that only barks at one of the two ways its subject can die is
+      # not a watchdog" -- and `reinstall-vm`, a 200-minute check, was absent
+      # from `needs` for months after that was written.
+      #
+      # So the list is compared rather than maintained. `schedule` is the
+      # gate every other job depends on and `report` cannot need itself;
+      # everything else must be watched.
+      - name: The nightly's report job watches every nightly job
+        run: |
+          jobs=$(awk '/^jobs:/{f=1;next} f&&/^  [a-z][a-z0-9-]*:$/{gsub(/[ :]/,"");print}' \
+            .github/workflows/nightly.yml | sort)
+          watched=$(awk '/^  report:/{f=1} f&&/^    needs:/{print;exit}' \
+            .github/workflows/nightly.yml |
+            grep -oE '[a-z][a-z0-9-]*' | grep -v '^needs$' | sort -u)
+          # The two that are structurally exempt, named rather than inferred.
+          expected=$(printf '%s\n' "$jobs" | grep -vxE 'report|schedule')
+
+          missing=$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$watched") || true)
+          if [ -n "$missing" ]; then
+            for j in $missing; do
+              echo "::error::nightly.yml job '$j' is not in the report job's needs, so its failure files no issue"
+            done
+            exit 1
+          fi
+
+          # A floor: if the parse stops matching, this must fail rather than
+          # report calm about a list it never read.
+          n=$(printf '%s\n' "$expected" | grep -c .)
+          if [ "$n" -lt 5 ]; then
+            echo "::error::only $n nightly jobs parsed -- the extraction is wrong, not the workflow" >&2
+            exit 1
+          fi
+          echo "the report job watches all $n nightly jobs"
+
   # Every preset in data/devenv-presets.nix, scaffolded with the real
   # `nixarchy dev init` and handed to a real devenv to evaluate.
   #

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -411,7 +411,7 @@ jobs:
     # dependencies, and reported SUCCESS. The encrypted install is the DEFAULT
     # answer to the installer's own question, and it was the one failure that
     # filed no issue.
-    needs: [install, install-encrypted, install-iso, microvm, cache, canary, pkg-new]
+    needs: [install, install-encrypted, install-iso, microvm, cache, canary, pkg-new, reinstall-vm]
     # cancelled() too. On 2026-09-02 install-iso hit its 180-minute timeout,
     # which GitHub records as cancelled rather than failed, and this job --
     # the one whose whole purpose is that a 03:00 failure does not cost a day
@@ -458,6 +458,16 @@ jobs:
             # jobs later. It also collides with the dedupe search, appending a
             # sandbox failure to the install issue.
             title="nightly: a sandbox will not boot"
+          elif [ "${{ needs.reinstall-vm.result }}" != "success" ] &&
+            [ "${{ needs.install.result }}" = "success" ] &&
+            [ "${{ needs.install-encrypted.result }}" = "success" ] &&
+            [ "${{ needs.install-iso.result }}" = "success" ]; then
+            # The image builds from this machine's own configuration and the
+            # installs are fine, so the reinstall path broke on its own rather
+            # than riding an installer regression -- #592. This job ran for
+            # months with reinstall-vm absent from `needs`, which meant a
+            # 200-minute check could fail nightly and file nothing.
+            title="nightly: a machine can no longer be rebuilt from its own image"
           elif [ "${{ needs.pkg-new.result }}" != "success" ] &&
             [ "${{ needs.install.result }}" = "success" ] &&
             [ "${{ needs.install-encrypted.result }}" = "success" ] &&


### PR DESCRIPTION
Closes #592. **Stacks on #591** (base `ci/582-nightly-pkg-new`), which added the `pkg-new` job this list now also covers — retarget to `main` once the stack lands.

`nightly.yml`'s `report` job turns a nightly failure into a filed issue, and `if: failure()` observes only the jobs in `needs`. **`reinstall-vm` was not in that list** — so a 200-minute check (build a user image, boot it, reinstall, boot the result) could fail every night and tell nobody. Red in a workflow run nobody opens is §4's *"a check that nothing surfaces is worse than no check"*, one level up: it reads as coverage and isn't.

## This had already happened once

The report job's own comment is the record of it:

> install-iso hit its timeout, which GitHub records as `cancelled` rather than `failed`, and this job — the one whose whole purpose is that a failure does not cost a day — did not run. **A watchdog that only barks at one of the two ways its subject can die is not a watchdog.**

That comment was written, and then `reinstall-vm` sat unwatched beside it for months. Fixing the one name would leave the next job to rediscover this.

## So the list is compared, not maintained

`build.yml` gains a step that extracts the nightly's job names and the report job's `needs`, and fails on any job that isn't watched.

`schedule` and `report` are the two structural exemptions — the gate everything depends on, and a job that can't need itself — and they are **named rather than inferred**, so a third exemption has to be argued for in a diff somebody reads.

A **floor** comes with it: fewer than five jobs parsed means the extraction stopped matching, which must fail rather than report calm about a list it never read. Same shape as `readme-counts.sh`'s floor, for the same reason.

## Proved against the real bug, not a synthetic one

Run against the tree with `reinstall-vm` removed from `needs` — which is exactly the state `main` is in today:

```
::error::nightly.yml job 'reinstall-vm' is not in the report job's needs, so its failure files no issue
exit=1
```

With it present: `the report job watches all 8 nightly jobs`, exit 0. `actionlint` with the repo's ignore pattern exits 0.

`reinstall-vm` also gains its own branch in the failure ladder, in the shape the others have: when the installs pass and it doesn't, the reinstall path broke on its own rather than riding an installer regression.

CI-gate change — per §11, proposed rather than merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5