### PR TITLE
A draft from pkg new can be removed from the selection, and redrafted with --update

### DIFF
--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -1303,11 +1303,12 @@ in
             # Remove > Package row. Upstream offers a fuzzy picker over installed
             # pacman packages; this is the same shape over the app selection.
             #
-            # All three kinds the Install picker can write, because "Remove" that
-            # only sees one of them is a menu row that lies (#494, #522): curated
+            # All four kinds the pickers can write, because "Remove" that
+            # only sees some of them is a menu row that lies (#494, #522): curated
             # apps (`id.enable` lines), extra packages (`#@pkg` markers from
-            # nixarchy-pkg-add) and options (`#@opt` markers from the Search
-            # picker's add_option).
+            # nixarchy-pkg-add), options (`#@opt` markers from the Search
+            # picker's add_option) and drafts (`#@draft` markers from
+            # nixarchy-pkg-new).
             (pkgs.writeShellApplication {
               name = "nixarchy-app-remove";
               runtimeInputs = [
@@ -1338,6 +1339,10 @@ in
                   [ -n "$name" ] || continue
                   entries+=("opt"$'\t'"$name")
                 done < <(grep -o '#@opt .*' "$file" | sed 's/^#@opt //' | sort -u)
+                while IFS= read -r name; do
+                  [ -n "$name" ] || continue
+                  entries+=("draft"$'\t'"$name")
+                done < <(grep -oE '#@draft [A-Za-z0-9_.-]+$' "$file" | sed 's/^#@draft //')
 
                 if [ ''${#entries[@]} -eq 0 ]; then
                   echo "Nothing is selected. Install > Package lists what is available."
@@ -1358,16 +1363,19 @@ in
                 # one notification per kind rather than per line.
                 pkgsel=()
                 optsel=()
+                draftsel=()
                 while IFS=$'\t' read -r kind name; do
                   [ -n "$name" ] || continue
                   case "$kind" in
                     app) nixarchy-app-disable "$name" ;;
                     pkg) pkgsel+=("$name") ;;
                     opt) optsel+=("$name") ;;
+                    draft) draftsel+=("$name") ;;
                   esac
                 done <<< "$chosen"
                 [ ''${#pkgsel[@]} -eq 0 ] || nixarchy-pkg-remove "''${pkgsel[@]}"
                 [ ''${#optsel[@]} -eq 0 ] || nixarchy-opt-remove "''${optsel[@]}"
+                [ ''${#draftsel[@]} -eq 0 ] || nixarchy-pkg-undraft "''${draftsel[@]}"
 
                 echo
                 echo "Run 'nixarchy-apply' to rebuild without them."
@@ -1456,6 +1464,106 @@ in
                   echo "removed $attr from $file"
                 done
                 echo "it stays installed until 'nixarchy-apply' rebuilds"
+              '';
+            })
+
+            # The inverse of the apps.nix line `nixarchy pkg new` wrote, and
+            # deliberately NOT of its draft file: deleting
+            # ~/.config/nixarchy/packages/<name>.nix, or the copy
+            # nixarchy-apply put in the flake, is an edit to a tree the user
+            # owns, not this tool's call -- so this drops the marked line and
+            # prints where the draft file still is. The `#@draft` marker
+            # survives the user uncommenting the line (the same property
+            # `#@opt` has), so the commented and the live form are both
+            # removable, by the same sed.
+            (pkgs.writeShellApplication {
+              name = "nixarchy-pkg-undraft";
+              runtimeInputs = [
+                pkgs.coreutils
+                pkgs.gnugrep
+                pkgs.gnused
+                pkgs.fzf
+                config.nix.package
+                cfg.package # omarchy-notification-send
+              ];
+              text = ''
+                file="''${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/apps.nix"
+                [ -f "$file" ] || { echo "no $file" >&2; exit 1; }
+
+                list_drafts() {
+                  grep -oE '#@draft [A-Za-z0-9_.-]+$' "$file" | sed 's/^#@draft //'
+                }
+
+                if [ $# -eq 0 ]; then
+                  mapfile -t names < <(list_drafts)
+                  if [ ''${#names[@]} -eq 0 ]; then
+                    echo "No drafts are in $file. 'nixarchy pkg new <url>' drafts one."
+                    exit 0
+                  fi
+                  chosen=$(printf '%s\n' "''${names[@]}" | fzf --multi \
+                    --prompt="remove draft > " \
+                    --header="tab to select several, enter to confirm" \
+                    --preview "grep -F -- '#@draft '{} '$file'" \
+                    --preview-window='down,3,wrap') || exit 0
+                  [ -n "$chosen" ] || exit 0
+                  mapfile -t picked <<< "$chosen"
+                  set -- "''${picked[@]}"
+                fi
+
+                # Reverted as a unit if anything goes wrong, exactly as
+                # nixarchy-pkg-remove's edits are: the file is the user's own
+                # NixOS module.
+                backup=$(mktemp)
+                cp "$file" "$backup"
+                trap 'rm -f "$backup"' EXIT
+                restore() { cp "$backup" "$file"; }
+
+                removed=()
+                for name in "$@"; do
+                  # Same alphabet nixarchy-pkg-new accepts. Anything else would
+                  # reach the sed address below as a pattern, not a name.
+                  case "$name" in
+                    "" | -* | .* | *..* | *[!A-Za-z0-9_.-]*)
+                      restore
+                      echo "'$name' is not a draft name." >&2
+                      exit 1
+                      ;;
+                  esac
+                  # Exact string, not a substring: `#@draft foo` must not
+                  # answer for `#@draft foobar`.
+                  if ! list_drafts | grep -qFx -- "$name"; then
+                    restore
+                    echo "nixarchy: no draft '$name' in $file. Nothing was changed." >&2
+                    echo "'nixarchy pkg remove' takes out a #@pkg line instead." >&2
+                    exit 1
+                  fi
+                  # The marked line wherever the user moved it, commented or
+                  # uncommented. Dots escaped: the name lands in a sed address.
+                  sed -i "/#@draft ''${name//./\\.}\$/d" "$file"
+                  removed+=("$name")
+                done
+
+                [ ''${#removed[@]} -gt 0 ] || exit 0
+
+                if ! nix-instantiate --parse "$file" >/dev/null 2>&1; then
+                  restore
+                  echo "nixarchy: that would have left $file unparseable. Nothing was changed." >&2
+                  exit 1
+                fi
+
+                if command -v omarchy-notification-send >/dev/null 2>&1; then
+                  omarchy-notification-send -r 8471 -t 8000 -u normal \
+                    "''${removed[*]} removed from your selection" \
+                    "The draft file itself is kept. Click here to run nixos-rebuild and apply it." \
+                    --exec omarchy-launch-floating-terminal-with-presentation nixarchy-apply || true
+                fi
+                pkgdir="''${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/packages"
+                for name in "''${removed[@]}"; do
+                  echo "removed $name from $file"
+                  [ ! -e "$pkgdir/$name.nix" ] || \
+                    echo "the draft file is yours and stays at $pkgdir/$name.nix"
+                done
+                echo "a draft that was live stays installed until 'nixarchy-apply' rebuilds"
               '';
             })
 
@@ -2554,6 +2662,7 @@ in
                       add) shift 2; exec nixarchy-pkg-add "$@" ;;
                       remove) shift 2; exec nixarchy-pkg-remove "$@" ;;
                       new) shift 2; exec nixarchy-pkg-new "$@" ;;
+                      undraft) shift 2; exec nixarchy-pkg-undraft "$@" ;;
 
                     esac
                     ;;
@@ -2640,6 +2749,7 @@ in
                   nixarchy pkg add <attr>     Add a nixpkgs package to the app selection
                   nixarchy pkg remove [attr]  Take one out again (no argument picks interactively)
                   nixarchy pkg new <url>      Draft a derivation for software in no repository
+                  nixarchy pkg undraft [name] Take a draft's line out again (the draft file stays)
                   nixarchy app enable <id>    Select an app from the curated list
                   nixarchy app disable <id>   Deselect one
                   nixarchy app remove         Pick apps, packages and options to remove

--- a/pkgs/pkg-new.sh
+++ b/pkgs/pkg-new.sh
@@ -15,17 +15,18 @@ set -euo pipefail
 nixpkgs='@nixpkgs@'
 
 usage() {
-  echo "usage: nixarchy pkg new <url> [--rev REV] [--name NAME]"
+  echo "usage: nixarchy pkg new <url> [--rev REV] [--name NAME] [--update]"
   echo "  e.g. nixarchy pkg new https://github.com/someone/tool"
   echo
   echo "  Drafts a derivation into ~/.config/nixarchy/packages/<name>.nix"
   echo "  with nix-init, then builds it once and reports the result."
-  echo "  The draft is yours to edit either way."
+  echo "  The draft is yours to edit either way. --update redrafts over an"
+  echo "  existing draft; without it, an existing draft is never overwritten."
   echo
   echo "  For software nixpkgs already carries, use: nixarchy pkg add <attr>"
 }
 
-url="" rev="" name=""
+url="" rev="" name="" update=false
 while [ $# -gt 0 ]; do
   case "$1" in
     --rev)
@@ -37,6 +38,10 @@ while [ $# -gt 0 ]; do
       name="${2:-}"
       [ -n "$name" ] || { echo "--name needs a value" >&2; exit 1; }
       shift 2
+      ;;
+    --update)
+      update=true
+      shift
       ;;
     -h | --help)
       usage
@@ -82,12 +87,24 @@ esac
 
 pkgdir="${XDG_CONFIG_HOME:-$HOME/.config}/nixarchy/packages"
 draft="$pkgdir/$name.nix"
-if [ -e "$draft" ]; then
+# The default is a refusal, not a prompt: the existing draft may carry the
+# user's edits, and silently overwriting them is the failure --update exists
+# to make deliberate.
+if [ -e "$draft" ] && [ "$update" != true ]; then
   echo "$draft already exists." >&2
-  echo "Edit it, or remove it and run this again to redraft." >&2
+  echo "Edit it, or redraft over it with: nixarchy pkg new --update $url" >&2
   exit 1
 fi
 mkdir -p "$pkgdir"
+
+# Under --update the old draft is held aside, so a failed redraft gives it
+# back instead of trading an edited draft for nothing.
+old=""
+if [ -e "$draft" ]; then
+  old=$(mktemp)
+  cp "$draft" "$old"
+  rm -f "$draft"
+fi
 
 echo "drafting  $draft"
 initargs=(--headless --url "$url" -n "$nixpkgs")
@@ -102,8 +119,14 @@ if ! nix-init "${initargs[@]}" "$draft" || [ ! -s "$draft" ]; then
   # A failed nix-init can leave an empty file behind; an empty draft is not
   # a starting point, it is a landmine for the next run's already-exists check.
   rm -f "$draft"
+  if [ -n "$old" ]; then
+    cp "$old" "$draft"
+    rm -f "$old"
+    echo "Your existing draft at $draft was left as it was." >&2
+  fi
   exit 1
 fi
+[ -z "$old" ] || rm -f "$old"
 
 log=$(mktemp)
 trap 'rm -f "$log"' EXIT
@@ -151,7 +174,11 @@ entry="(callPackage ./packages/$name.nix { })"
 # project wrote get rewritten. The #@pkgs-end marker is nixarchy-pkg-add's own
 # block, so inserting there -- commented out -- is within it; a file without
 # the marker is the user's shape, and gets the edit printed instead.
-if [ -f "$appsfile" ] && grep -q '#@pkgs-end' "$appsfile" && ! grep -qF "packages/$name.nix" "$appsfile"; then
+if [ -f "$appsfile" ] && grep -qF "packages/$name.nix" "$appsfile"; then
+  # An update, or a re-run after `nixarchy pkg undraft` left the file: the
+  # line is already in the user's hands, so there is nothing to write.
+  :
+elif [ -f "$appsfile" ] && grep -q '#@pkgs-end' "$appsfile"; then
   tmp=$(mktemp)
   awk -v line="    # $entry  #@draft $name" '
     /#@pkgs-end/ && !done { print line; done = 1 }

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -2673,6 +2673,48 @@ pkgs.runCommand "nixarchy-options"
         fi
         echo "an added package can be removed, byte for byte"
 
+        # A draft (#581). nixarchy-pkg-new needs a network to run for real,
+        # so the add is simulated with the writer's own byte shape -- and the
+        # grep below pins the WRITER's format string, so if pkg-new changes
+        # what it writes, this goes red here rather than drifting apart
+        # silently. Undraft must be the exact inverse, and must also take the
+        # line after the user uncommented it: the marker is the anchor, not
+        # the comment.
+        grep -qF -- '  #@draft $name' "$vm/sw/bin/nixarchy-pkg-new" || {
+          echo "nixarchy-pkg-new no longer writes '...  #@draft <name>'" >&2
+          echo "  update the simulated draft add below to the new shape" >&2
+          exit 1
+        }
+        simulate_draft() {
+          tmp2=$(mktemp)
+          awk -v line="$1" '
+            /#@pkgs-end/ && !done { print line; done = 1 }
+            { print }
+          ' "$appfile" > "$tmp2"
+          mv "$tmp2" "$appfile"
+        }
+        draftbase=$(cksum < "$appfile")
+        simulate_draft '    # (callPackage ./packages/tool.nix { })  #@draft tool'
+        run nixarchy-pkg-undraft tool >/dev/null
+        [ "$draftbase" = "$(cksum < "$appfile")" ] || {
+          echo "draft add/undraft is not symmetric for the commented line pkg-new writes" >&2
+          exit 1
+        }
+        simulate_draft '    (callPackage ./packages/tool.nix { })  #@draft tool'
+        run nixarchy-pkg-undraft tool >/dev/null
+        [ "$draftbase" = "$(cksum < "$appfile")" ] || {
+          echo "draft add/undraft is not symmetric for a line the user uncommented" >&2
+          exit 1
+        }
+        # A name that is not there must change nothing and say so.
+        if run nixarchy-pkg-undraft no-such-draft >/dev/null 2>&1; then
+          echo "nixarchy-pkg-undraft succeeded on a draft that is not in the file" >&2
+          exit 1
+        fi
+        [ "$draftbase" = "$(cksum < "$appfile")" ] || {
+          echo "a refused undraft still changed the file" >&2; exit 1; }
+        echo "a drafted line can be un-drafted, byte for byte, commented or live"
+
         # An option. add_option lives inside nixarchy-search's fzf loop and
         # cannot be driven without a tty, so the add is simulated with the
         # writer's own byte shapes -- and those two greps below pin the
@@ -2729,7 +2771,7 @@ pkgs.runCommand "nixarchy-options"
         # different coat. Comments stripped first; match the greps and the
         # dispatch, not prose.
         appremove=$(grep -v '^[[:space:]]*#' "$vm/sw/bin/nixarchy-app-remove")
-        for needle in '#@pkg ' '#@opt ' nixarchy-pkg-remove nixarchy-opt-remove; do
+        for needle in '#@pkg ' '#@opt ' '#@draft ' nixarchy-pkg-remove nixarchy-opt-remove nixarchy-pkg-undraft; do
           printf '%s' "$appremove" | grep -qF -- "$needle" || {
             echo "nixarchy-app-remove does not handle $needle:" >&2
             echo "  the Remove menu is then blind to a kind the Install picker writes" >&2
@@ -2783,6 +2825,27 @@ pkgs.runCommand "nixarchy-options"
             ;;
         esac
         echo "nixarchy pkg new routes to nixarchy-pkg-new"
+
+        # And `pkg undraft`, in the same shape: advertised, routed, and the
+        # route proven by reaching the command's own refusal.
+        grep -q 'nixarchy pkg undraft' "$vm/sw/bin/nixarchy" || {
+          echo "the dispatcher's usage does not advertise 'nixarchy pkg undraft'" >&2
+          exit 1
+        }
+        if r=$(run "$vm/sw/bin/nixarchy" pkg undraft nosuchdraft 2>&1); then
+          echo "nixarchy pkg undraft succeeded on a draft that is not in the file:" >&2
+          printf '%s\n' "$r" >&2
+          exit 1
+        fi
+        case "$r" in
+          *"no draft 'nosuchdraft'"*) ;;
+          *)
+            echo "nixarchy pkg undraft did not reach nixarchy-pkg-undraft; it said:" >&2
+            printf '%s\n' "$r" >&2
+            exit 1
+            ;;
+        esac
+        echo "nixarchy pkg undraft routes to nixarchy-pkg-undraft"
 
           touch $out
       ''

--- a/tests/pkg-new.nix
+++ b/tests/pkg-new.nix
@@ -110,7 +110,37 @@ pkgs.runCommand "nixarchy-pkg-new"
 
     if o=$(bash pkg-new.sh https://example.org/x/tool 2>&1); then
       fail "an existing draft was overwritten"
-    else ok "an existing draft refuses a redraft"; fi
+    else
+      ok "an existing draft refuses a redraft"
+      printf '%s' "$o" | grep -q -- '--update' \
+        && ok "the refusal names --update as the deliberate way" \
+        || fail "the refusal does not say how to redraft on purpose"
+    fi
+
+    # -- --update redrafts over the existing draft -------------------------
+    echo '# my edits' >> "$draft"
+    lines_before=$(grep -c '#@draft tool$' "$cfg/apps.nix")
+    if ! o=$(bash pkg-new.sh --update https://example.org/x/tool 2>&1); then
+      printf '%s\n' "$o" | sed 's/^/          | /'
+      fail "--update did not redraft over an existing draft"
+    else
+      grep -q '# my edits' "$draft" \
+        && fail "--update kept the old draft instead of redrafting" \
+        || ok "--update replaced the draft with a fresh one"
+      [ "$lines_before" = "$(grep -c '#@draft tool$' "$cfg/apps.nix")" ] \
+        && ok "--update did not duplicate the apps.nix line" \
+        || fail "--update wrote a second #@draft line into apps.nix"
+    fi
+
+    # -- --update, but nix-init fails: the edited draft comes back ---------
+    echo '# my edits' >> "$draft"
+    if o=$(STUB_INIT_FAIL=1 bash pkg-new.sh --update https://example.org/x/tool 2>&1); then
+      fail "--update reported success though nix-init failed"
+    elif grep -q '# my edits' "$draft"; then
+      ok "a failed --update gives the edited draft back"
+    else
+      fail "a failed --update traded the edited draft for nothing"
+    fi
 
     # -- the build fails: reported as a failure, draft KEPT ----------------
     rm -rf "$cfg"; mkapps


### PR DESCRIPTION
> **Stacks on #590** (`feat/581-pkg-new`): this branch is cut from `origin/feat/581-pkg-new`, so the diff against `main` includes that PR's commit. Review only the top commit here; rebase onto `main` once #590 merges.

Files touched: `pkgs/pkg-new.sh`, `modules/apps.nix` (the remove region and the `pkg)` dispatch), `tests/pkg-new.nix`, `tests/options.nix`.

Bus note acted on: the `#nixarchy-agents` correction about nix-init needing `nix` on PATH at runtime concerns #591's nightly run; `nixarchy-pkg-new` already declares `config.nix.package`, so nothing here changes for it.

## What this changes, and why

`nixarchy pkg new` writes a commented `#@draft <name>` line into `~/.config/nixarchy/apps.nix`, and nothing could take it out again: `nixarchy-app-remove` enumerates exactly three kinds of line, so drafts were invisible to Remove — the same structural lie #494/#522 fixed for packages and options. The picker now lists drafts as a fourth kind and dispatches them to a new `nixarchy-pkg-undraft` (routed as `nixarchy pkg undraft`), which reuses `nixarchy-pkg-remove`'s shape: backup, marker-anchored `sed`, `nix-instantiate --parse`, restore as a unit on any failure. The marker survives the user uncommenting the line, so both the commented and the live form are removable. The draft **file** is deliberately left alone — removing `~/.config/nixarchy/packages/<name>.nix` (or the copy `nixarchy-apply` made in the flake) is an edit to a tree the user owns, per `nixarchy-apply`'s own comment — so removal drops the line and prints where the file still is. And `nixarchy pkg new --update <url>` redrafts over an existing draft; the bare command keeps refusing (now naming `--update`), because silently overwriting somebody's edited draft is the failure to avoid. A failed `--update` restores the edited draft. NixOS-only tooling, nothing to route upstream.

## How I proved the check fails

**`checks.pkg-new`** — removed the restore-on-failure block from `--update` in `pkgs/pkg-new.sh`:

```
       >   ok      --update did not duplicate the apps.nix line
       > grep: /build/home/.config/nixarchy/packages/tool.nix: No such file or directory
       >   FAILED  a failed --update traded the edited draft for nothing
       ...
       > 1 assertion(s) failed
```

**`checks.options`** — removed the `undraft)` row from the dispatcher (the exact #498 failure mode the assertion exists for):

```
       > nixarchy pkg new routes to nixarchy-pkg-new
       > nixarchy pkg undraft did not reach nixarchy-pkg-undraft; it said:
       > Unknown Omarchy command: omarchy pkg undraft nosuchdraft
       > Did you mean: omarchy pkg ?
```

Both restored, both green:

```
nixarchy-pkg-new>   ok      --update replaced the draft with a fresh one
nixarchy-pkg-new>   ok      --update did not duplicate the apps.nix line
nixarchy-pkg-new>   ok      a failed --update gives the edited draft back
...
nixarchy-options> a drafted line can be un-drafted, byte for byte, commented or live
nixarchy-options> nixarchy pkg undraft routes to nixarchy-pkg-undraft
```

The symmetry assertions also follow `tests/options.nix`'s existing pattern of pinning the WRITER's format string (`grep -qF '  #@draft $name'` against the built `nixarchy-pkg-new`), so a change to what pkg-new writes goes red here instead of drifting apart from the simulated add.

## Checks run locally

- `nix build .#checks.x86_64-linux.pkg-new` — fail (broken) then pass
- `nix build .#checks.x86_64-linux.options` — fail (broken) then pass
- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [x] If this adds an option: `tests/options.nix` covers both states — no new option; the new command and route are asserted there instead
- [x] If this adds a `checks.*` entry: no new `checks.*` entry — both extended checks are already workflow-run

## What this cost, and where it is written down

- [x] Nothing general came up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5