### PR TITLE
A nixpkgs miss names pkg new, and the option scaffold prompts scalars and seeds the rest from the option's example

### DIFF
--- a/docs/manual/other-packages.md
+++ b/docs/manual/other-packages.md
@@ -30,9 +30,14 @@ directory and offers to run `nh os switch <flake>`.
 package, every NixOS option and the curated app list, with each entry's type,
 default and description in a preview pane. Picking a row routes it: an app is
 enabled as an app, a package is appended as a package, and an option is written
-as a line of its own -- booleans and enums get a value picker, anything more
-complicated is written commented out with its type and docs beside it, for you
-to fill in.
+as a line of its own. Booleans and enums get a value picker. Simple scalars --
+a port, a string, a path -- prompt for the value with the default in sight;
+leave the prompt empty and nothing is written, because the default is already
+in force and a copied-out default reads like a choice. Anything more
+complicated is written commented out with its type and docs beside it, seeded
+with the option's own example (or its default) as a starting shape, for you to
+edit rather than invent. The seeded scaffold stays commented: the picker knows
+the shape, not your value.
 
 The index comes from this machine's own nixpkgs and its own options rather than
 from search.nixos.org, which costs about a minute once per system generation and
@@ -183,6 +188,17 @@ starting point for a person to review, not a finished package, and this
 command never pretends otherwise. A draft pins one revision of one upstream;
 updating it when upstream releases is yours to do, by editing the version and
 hashes in the file.
+
+Two ways to find this without knowing the command's name. `nixarchy pkg add`
+names it whenever nixpkgs has no such package -- that miss is the moment you
+have proved the package is not there, so it is the reliable signpost. The
+Search picker also carries a static row for it (_Missing from nixpkgs? Draft a
+new package from a source URL_), which asks for the URL and runs the same
+command -- but the picker is a single fuzzy search, so that row only appears
+when your query happens to match its own words (try `missing` or `draft`).
+Searching for the absent package's *name* matches nothing and simply closes
+the picker; nothing runs on an empty result, so the picker itself cannot point
+you onward.
 
 ## Removing
 

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -215,6 +215,20 @@ let
     + "This is the only row here that needs a network, and the only one that can offer an app nobody has checked. A hit that is in nixarchy's catalogue is enabled the normal way; anything else prints a line for you to paste, because writing an unchecked app id into your configuration is not this tool's call to make.\n"
   );
 
+  # The tier below the Flathub row: software in no repository at all (#581).
+  # Same five-field shape, whole row on one line, preview newlines escaped --
+  # the same rules the flathub row above documents. One static row, so
+  # `nixarchy pkg new` is findable from the picker at all. Findable is the
+  # honest word: the picker is a single fzf call, so this row appears only
+  # when the query happens to match its own text -- a search for the missing
+  # package's NAME matches nothing and closes the picker. The reliable
+  # signpost is nixarchy-pkg-add's miss message, which names the command;
+  # docs/manual/other-packages.md states the limitation.
+  pkgNewIndexRow = pkgs.writeText "nixarchy-pkg-new-row.tsv" (
+    "new	pkg-new	Missing from nixpkgs? Draft a new package from a source URL		"
+    + "NOT IN NIXPKGS\\n\\nWhen nixpkgs, the app list and Flathub all miss, this drafts a derivation from the software's own source URL (e.g. a GitHub repo) with nix-init, builds it once, and keeps the draft either way.\\n\\nPicking this asks for the URL, then runs:\\n  nixarchy pkg new <url>\\n\\nNeeds a network. The result is a draft for you to review, not a finished package.\n"
+  );
+
   flatpakRow =
     name: fp:
     let
@@ -1951,6 +1965,9 @@ in
                     echo >&2
                     echo "Search for the right name:" >&2
                     echo "  nixarchy-search $attr" >&2
+                    echo >&2
+                    echo "If nixpkgs genuinely does not have it, draft a package from its source:" >&2
+                    echo "  nixarchy pkg new <url>" >&2
                     exit 1
                   fi
 
@@ -2013,6 +2030,12 @@ in
                 open_missed() {
                   [ ''${#missed[@]} -gt 0 ] || return 0
                   echo "no exact match for ''${missed[*]} -- opening the picker on it"
+                  # Said here, before exec, because the picker itself cannot:
+                  # its miss is fzf exiting empty, and no script runs after
+                  # that. This is the one moment a user has proved nixpkgs
+                  # lacks a name, so the way onward is named now (#581).
+                  echo "  (if nothing there matches either, nixpkgs may not have it --"
+                  echo "   'nixarchy pkg new <url>' drafts a package from its source)"
                   exec nixarchy-search "''${missed[@]}"
                 }
 
@@ -2222,6 +2245,7 @@ in
                 appindex=${appIndexTable}
                 apptable=${appAttrTable}
                 flatpakrows=${flatpakIndexRows}
+                pkgnewrow=${pkgNewIndexRow}
                 optionsjson=${optionsJsonPath}
                 nixpkgs=${pkgs.path}
                 walk=${./pkg-index.nix}
@@ -2342,6 +2366,9 @@ in
                   # they are local, so building the index still needs no network.
                   cat "$flatpakrows" >> "$tmp"
 
+                  # The tier below those: draft a package nixpkgs lacks (#581).
+                  cat "$pkgnewrow" >> "$tmp"
+
                   mv "$tmp" "$index"
                   readlink -f /run/current-system > "$stamp"
                 }
@@ -2436,6 +2463,7 @@ in
                       app | pkg) nixarchy try "$name" || true ;;
                       opt) echo "$name is a NixOS option -- there is nothing to run, so nothing to try" ;;
                       flatpak) echo "$name is a flatpak -- nothing to try; enable it and apply instead" ;;
+                      new) echo "nothing to try yet -- picking this row asks for a source URL to draft from" ;;
                     esac
                   done <<< "$selection"
                   exit 0
@@ -2463,6 +2491,21 @@ in
                   mv "$tmp" "$file"
                 }
 
+                # One option's default or example, structured, straight out of
+                # options.json -- not parsed back out of the index's preview
+                # text, which flattened it for display (#581). Both fields are
+                # rendered `{ _type: literalExpression, text: ... }` in modern
+                # options.json; a bare JSON value is the fallback shape. Empty
+                # when this system builds no manual, and every caller degrades
+                # to the pre-#581 behaviour on empty.
+                opt_field() {
+                  [ -n "$optionsjson" ] && [ -f "$optionsjson" ] || return 0
+                  jq -r --arg p "$1" --arg f "$2" \
+                    '.[$p][$f]? // empty
+                     | if type == "object" then (.text // tostring) else tojson end' \
+                    "$optionsjson"
+                }
+
                 add_option() {
                   path=$1
                   type=$2
@@ -2481,6 +2524,36 @@ in
                       value=$(printf '%s' "''${type#one of }" | grep -oE '"[^"]*"' |
                         fzf --height=12 --prompt="$path = ") || return 0
                       ;;
+                    # Simple scalars: ask, with the default in sight (#581).
+                    # /dev/tty, because stdin here is the picker's selection
+                    # herestring. Empty input keeps the default by writing
+                    # NOTHING -- a copied-out default is a line that reads as
+                    # a choice and is not one. The patterns are anchored
+                    # whole-string, so "list of string" and "null or path"
+                    # fall through to the scaffold below, as they should:
+                    # their values are not one prompted word.
+                    "signed integer"* | "unsigned integer"* | *" bit unsigned integer"* | "positive integer"* | string | "string,"* | "string "* | path | "path,"* | "absolute path"*)
+                      default=$(opt_field "$path" default || true)
+                      default=''${default//$'\n'/ }
+                      if ! read -r -p "$path [''${default:-no default}] = " value < /dev/tty; then
+                        return 0
+                      fi
+                      if [ -z "$value" ]; then
+                        echo "kept the default for $path -- nothing written"
+                        return 0
+                      fi
+                      # A string or path needs Nix quotes; typing them is the
+                      # sort of homework this prompt exists to remove. Already
+                      # quoted input passes through untouched.
+                      case "$type" in
+                        string* | path* | "absolute path"*)
+                          case "$value" in
+                            \"*) ;;
+                            *) value="\"''${value//\"/\\\"}\"" ;;
+                          esac
+                          ;;
+                      esac
+                      ;;
                   esac
 
                   if [ -n "$value" ]; then
@@ -2495,11 +2568,30 @@ in
                   # function, a package, a list of them -- and a picker that pretended
                   # otherwise would write plausible-looking wrong configuration. So it writes
                   # what it does know, commented out, in the right file, and leaves the
-                  # expression to you.
+                  # expression to you -- seeded with the option's own example (or its
+                  # default, when there is no example) as a starting shape to edit,
+                  # rather than a shape to invent (#581).
+                  #
+                  # The seed lines are COMMENTS above the marked line, and the marked
+                  # line itself keeps the exact `# <path> = ;  #@opt <path>` bytes:
+                  # nixarchy-opt-remove keys its walk up the comment block on that
+                  # shape, which is what lets a scaffold leave byte for byte
+                  # (checks.options asserts it, seed included).
+                  seed=$(opt_field "$path" example || true)
+                  seedsrc=example
+                  if [ -z "$seed" ]; then
+                    seed=$(opt_field "$path" default || true)
+                    seedsrc=default
+                  fi
                   {
                     printf '\n'
                     grep -P "^opt\t\Q$path\E\t" "$index" | head -1 |
                       cut -f5 | sed 's/\\n/\n/g' | sed 's/^/  # /'
+                    if [ -n "$seed" ]; then
+                      printf '  #\n'
+                      printf "  # a starting shape, from the option's %s -- yours to edit:\n" "$seedsrc"
+                      printf '%s\n' "$seed" | awk -v p="$path" 'NR == 1 { $0 = p " = " $0 } { print "  #   " $0 }'
+                    fi
                     printf '  # %s = ;  #@opt %s\n' "$path" "$path"
                   } > "$cache/scaffold.$$"
                   insert_line "$(cat "$cache/scaffold.$$")
@@ -2574,6 +2666,20 @@ in
                         flathub_search
                       else
                         nixarchy-service-enable "$name" && changed=1
+                      fi
+                      ;;
+                    # Software in no repository at all (#581). The binary, not
+                    # `nixarchy pkg new`: the same session-PATH route every
+                    # other writer in this case uses, without leaning on the
+                    # dispatcher's routing. /dev/tty, because stdin here is
+                    # the selection herestring and a bare read would eat the
+                    # next picked row. `|| true`: a draft that fails to build
+                    # is a reported outcome, not a reason to abort the loop.
+                    # No changed=1 -- nixarchy-pkg-new validates its own write
+                    # and prints its own guidance.
+                    new)
+                      if read -r -p "Source URL (e.g. https://github.com/someone/tool): " url < /dev/tty; then
+                        [ -z "$url" ] || nixarchy-pkg-new "$url" || true
                       fi
                       ;;
                   esac

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -2764,6 +2764,28 @@ pkgs.runCommand "nixarchy-options"
         fi
         [ "$optbase" = "$(cksum < "$appfile")" ] || {
           echo "a refused opt removal still changed the file" >&2; exit 1; }
+        # A SEEDED scaffold (#581): the doc block now carries a starting
+        # shape from the option's example (or default), as comment lines
+        # above the marked line. The removal walk keys on the marked line's
+        # exact bare shape, so the seed must ride in the comment block --
+        # this pins that arrangement: one unit in, one unit out, seed
+        # included. Two writer pins first, matching the calls, not prose.
+        grep -qF '"  #   " $0' "$vm/sw/bin/nixarchy-search" || {
+          echo "add_option no longer writes seed lines as '  #   ' comments" >&2
+          echo "  an uncommented seed breaks nixarchy-opt-remove's comment walk" >&2
+          exit 1
+        }
+        grep -qF "a starting shape, from the option's %s" "$vm/sw/bin/nixarchy-search" || {
+          echo "add_option no longer announces the seed's source (example/default)" >&2
+          echo "  update the simulated seeded scaffold below to the new shape" >&2
+          exit 1
+        }
+        simulate_add '\n  # NIXOS OPTION  services.demo.settings\n  #\n  # type:     attribute set\n  #\n  # a starting shape, from the option'"'"'s example -- yours to edit:\n  #   services.demo.settings = { port = 8080; }\n  # services.demo.settings = ;  #@opt services.demo.settings\n'
+        run nixarchy-opt-remove services.demo.settings >/dev/null
+        [ "$optbase" = "$(cksum < "$appfile")" ] || {
+          echo "opt add/remove is not symmetric for a seeded scaffold" >&2
+          exit 1
+        }
         echo "a picker-written option can be removed, byte for byte, scaffold included"
 
         # The Remove picker must SEE all three kinds -- being removable from
@@ -2779,6 +2801,28 @@ pkgs.runCommand "nixarchy-options"
           }
         done
         echo "the Remove picker lists apps, packages and options"
+
+        # ---- pkg new is findable where nixpkgs misses (#581) ----
+        #
+        # The Search picker is one fzf call: a miss exits before any script
+        # runs, so no empty-result hook can name `nixarchy pkg new`. What CAN
+        # is asserted here instead: pkg-add's miss message (the moment a user
+        # has proved nixpkgs lacks a name), the line printed before the
+        # picker takes over, and the picker's own static row with its
+        # dispatch. Match the calls and the command name, not prose.
+        for pair in \
+          "nixarchy-pkg-add:nixarchy pkg new" \
+          "nixarchy-search:pkgnewrow=" \
+          "nixarchy-search:nixarchy-pkg-new \"\$url\""; do
+          bin=''${pair%%:*}
+          needle=''${pair#*:}
+          grep -qF -- "$needle" "$vm/sw/bin/$bin" || {
+            echo "$bin no longer carries '$needle':" >&2
+            echo "  the route from 'nixpkgs does not have it' to 'nixarchy pkg new' is broken" >&2
+            exit 1
+          }
+        done
+        echo "a nixpkgs miss names nixarchy pkg new, and the picker's row dispatches to it"
 
         # And the ROUTE, not just the call site: #498 shipped `nixarchy try`
         # advertised and unreachable, because nothing asserted the dispatcher


### PR DESCRIPTION
**Stacks on #590** (`feat/581-pkg-new`) — the base of this branch is that PR's head, so the diff here is only this change. Do not merge before it.

## What this changes, and why

Two halves of #581's usability. **Findability:** the Install ▸ Search picker is one `fzf` call and a miss exits at `|| exit 0` before any script code runs, so there is no empty-result hook — the picker structurally cannot say "nixpkgs may not have it". So `nixarchy pkg new` is named at the three places that can: a static index row (same five-field shape as the Flathub row, dispatched via a `new)` branch that asks for the source URL on `/dev/tty`), `nixarchy-pkg-add`'s "nixpkgs has no package" message — the one moment a user has *proved* nixpkgs lacks a name — and the line pkg-add prints before handing a typo to the picker. The row's reach is deliberately documented as partial in `docs/manual/other-packages.md`: it appears only when the query fuzzily matches its own words; searching for the missing package's *name* matches nothing and closes the picker. The dispatch reaches `nixarchy-pkg-new` through the session PATH, the same route every other writer in that `case` uses (`nixarchy-app-enable`, `nixarchy-pkg-add`, …) — not via `runtimeInputs`, which would be a second, divergent route for one sibling command.

**A better option scaffold:** `add_option` now `jq`s the one picked option out of `options.json` (path already computed at `optionsJsonPath`; every caller degrades to the old behaviour when `documentation.nixos.enable` is off) for **structured** `default` and `example`, instead of parsing preview text. Simple scalars (int/string/path types) prompt with the default in sight — empty input keeps the default by writing **nothing**. Everything else keeps the honest commented scaffold, now seeded with the option's example (else default) as a starting shape.

Before (a `services.foo.settings`-style pick):

```
  # NIXOS OPTION  services.foo.settings
  # type: attribute set …docs…
  # services.foo.settings = ;  #@opt services.foo.settings
```

After:

```
  # NIXOS OPTION  services.foo.settings
  # type: attribute set …docs…
  #
  # a starting shape, from the option's example -- yours to edit:
  #   services.foo.settings = {
  #     port = 8080;
  #   }
  # services.foo.settings = ;  #@opt services.foo.settings
```

The seed rides as **comment lines above the marked line**, and the marked line keeps its exact bare `# <path> = ;  #@opt <path>` bytes — `nixarchy-opt-remove` keys its comment-block walk on that shape, so a seed in the assignment slot would leave the doc block behind on removal and break add/remove symmetry. Proven with the untouched remover: a seeded scaffold in the good shape removes byte-for-byte; the same scaffold with an uncommented seed line leaves residue.

Prompts read `< /dev/tty` because stdin inside the dispatch loop is the selection herestring — a bare `read` consumes the next picked row. (Observation, not fixed here: `flathub_search`'s existing `read -r -p "Search Flathub for: "` looks affected by exactly this — with one selected row it hits EOF and `|| return 0` silently no-ops. Posted to the agent bus; outside this PR's territory.)

## How I proved the check fails

`checks.options` extends the byte-for-byte symmetry section with a seeded-scaffold unit plus writer pins, and pins the pkg-add→pkg-new route. Both red first.

With the writer reverted to the base branch (seed writer absent — the "bug reintroduced" state):

```
> an added package can be removed, byte for byte
> add_option no longer writes seed lines as '  #   ' comments
>   an uncommented seed breaks nixarchy-opt-remove's comment walk
error: builder for '/nix/store/zpfahf92mq0lpc3qxkqlv3m1hyfj8iyd-nixarchy-options.drv' failed
```

With the writer present but the miss message stripped of `nixarchy pkg new`:

```
> a picker-written option can be removed, byte for byte, scaffold included
> the Remove picker lists apps, packages and options
> nixarchy-pkg-add no longer carries 'nixarchy pkg new':
>   the route from 'nixpkgs does not have it' to 'nixarchy pkg new' is broken
error: builder for '/nix/store/dwa00f30ah63lhq5h8cp8yppm5v8wv7a-nixarchy-options.drv' failed
```

Restored, green:

```
nixarchy-options> a picker-written option can be removed, byte for byte, scaffold included
nixarchy-options> the Remove picker lists apps, packages and options
nixarchy-options> a nixpkgs miss names nixarchy pkg new, and the picker's row dispatches to it
```

And the removal-walk property itself, standalone against the unchanged `remove_one` awk: good seeded shape → byte-for-byte PASS; seed line uncommented → residue (`# NIXOS OPTION …` + the seed line left behind), confirming the arrangement the check pins is the one that matters.

## Checks run locally

`nix build .#checks.x86_64-linux.options` (red twice as above, then green). No VM checks run locally (CI had install jobs in flight). Also verified: the built `nixarchy-pkg-new-row.tsv` is one line of five tab-separated fields with escaped `\n` in the preview; the `opt_field` jq against literalExpression, bare-value and missing-field shapes; the seed renderer's output shape.

- [x] `nix fmt` / statix / deadnix are clean (`nix fmt -- --ci`: 0 changed)
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [x] If this adds an option: n/a — no new options
- [x] If this adds a `checks.*` entry: n/a — extends the existing `checks.options`

## What this cost, and where it is written down

Nothing general beyond what the code comments and the bus post now carry: the herestring-stdin trap and the remove-walk shape constraint are both noted at the lines they protect in `modules/apps.nix` and pinned by `checks.options`; the flathub_search observation is on `#nixarchy-agents` for whoever owns that function.

- [x] A general lesson is recorded, or nothing general came up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
