### PR TITLE
Search all of Flathub asks the terminal, and a check keeps it that way

### DIFF
--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -2606,7 +2606,13 @@ in
                 # Why: modules/AGENTS.md#ask-flathub-org-directly
                 flathub_search() {
                   local query hits picked id line
-                  read -r -p "Search Flathub for: " query || return 0
+                  # /dev/tty, because stdin here is the picker's selection --
+                  # this function is called from inside `done <<< "$selection"`,
+                  # which has already consumed it. Without this the read hits
+                  # EOF, `|| return 0` fires, and the row that exists for
+                  # "the other three sources have failed you" silently does
+                  # NOTHING. It failed quietly, which is why it survived (#596).
+                  read -r -p "Search Flathub for: " query < /dev/tty || return 0
                   [ -n "$query" ] || return 0
 
                   # --fail so an HTTP error is an error rather than an error page

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -2824,6 +2824,33 @@ pkgs.runCommand "nixarchy-options"
         done
         echo "a nixpkgs miss names nixarchy pkg new, and the picker's row dispatches to it"
 
+        # ---- a prompt inside the picker reads the TERMINAL, not the loop ----
+        #
+        # #596: `flathub_search`'s `read` had no redirect, and the picker
+        # dispatches through `done <<< "$selection"`. So stdin was the
+        # herestring the loop had already consumed: the read hit EOF,
+        # `|| return 0` fired, and "Search all of Flathub" -- the row whose own
+        # comment calls it "precisely the row someone needs when the other
+        # three sources have failed them" -- silently did NOTHING.
+        #
+        # It failed QUIETLY, which is why it survived. That is the shape this
+        # asserts: every prompt reachable from the dispatch loop names a tty.
+        # The prompts in nixarchy-pkg-add and nixarchy-apply are deliberately
+        # NOT here -- they run at top level with a real terminal, and adding a
+        # redirect they do not need would make this check about style.
+        while IFS= read -r prompt; do
+          case "$prompt" in
+            *"/dev/tty"*) ;;
+            *)
+              echo "a prompt in the picker's dispatch does not read /dev/tty:" >&2
+              echo "  $prompt" >&2
+              echo "  stdin there is the selection herestring, so it reads EOF and no-ops (#596)" >&2
+              exit 1
+              ;;
+          esac
+        done < <(grep -E 'read -r -p' "$vm/sw/bin/nixarchy-search")
+        echo "every prompt in the picker reads the terminal, not the loop"
+
         # And the ROUTE, not just the call site: #498 shipped `nixarchy try`
         # advertised and unreachable, because nothing asserted the dispatcher
         # had a row for it. Run the dispatcher itself; a missing route falls


### PR DESCRIPTION
Closes #596. **Stacks on #595** (base `feat/581-entry-and-scaffold`).

`flathub_search`'s prompt had no redirect, and the picker dispatches through `done <<< "$selection"` — so stdin was the herestring the loop had already consumed. The read hit EOF, `|| return 0` fired, and **the row did nothing**. No prompt, no error, nothing written.

Reproduced in isolation before touching anything:

```
$ bash repro.sh < /dev/null
  read FAILED (stdin exhausted) -> function returns doing nothing
```

## Why this one matters more than a dead row

That row's own comment states its job:

> A row rather than a flag, because a flag nobody knows about is not a search anyone finds — and **this is precisely the row someone needs when the other three sources have failed them.**

The single escape hatch offered to a user whom nixpkgs, the catalogue and the options index have all missed was the one that silently no-opped. **It failed quietly, which is why it survived.**

## Only the one that was actually broken

I checked every `read` in the file. Three prompts lack a tty redirect; the other two — `nixarchy-pkg-add`'s confirmations and `nixarchy-apply`'s *"Build and switch now?"* — run at **top level with a real terminal** and are fine. Adding a redirect they don't need would turn a correctness fix into a style rule. They're named in the check's comment as deliberately excluded.

## The check is the point

A prompt that silently no-ops is exactly the shape that survives for months, so the invariant is asserted rather than remembered: every `read -r -p` in `nixarchy-search` names a tty.

Proved against the **real** bug by reverting the redirect:

```
a prompt in the picker's dispatch does not read /dev/tty:
  stdin there is the selection herestring, so it reads EOF and no-ops (#596)
error: Cannot build '...-nixarchy-options.drv'
```

Restored → passes. `nix fmt -- --ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5