### PR TITLE
The reinstall check has its green nightly run, and the header stops claiming a debt that is paid (#484)

### DIFF
--- a/tests/reinstall-vm.nix
+++ b/tests/reinstall-vm.nix
@@ -30,14 +30,14 @@
 # interface holds: read the marker cd.nix wrote and compare it to the
 # toplevel this file built, not to a name borrowed from either side.
 #
-# What is still owed, so the next reader does not have to work it out: this
-# check is written, wired, and scheduled, and has not yet been watched through
-# a green end-to-end run -- boot, CARRIED, INSTALLED, OFFLINE, and back up into
-# the reinstalled closure. It is in `nightly_only` because it builds a SECOND
-# full image, so the run that can answer is the nightly, not a pull request.
-# #478's remaining child stays open until one is green; a check that has never
-# completed is a claim, and this file's whole argument is that a claim is not
-# evidence.
+# The debt the paragraph above used to describe is paid: the nightly of
+# 2026-09-11 (run 34557396063) ran this file end to end and every marker came
+# back 0 -- CARRIED, INSTALLED under --max-jobs 0, COPIED, OFFLINE, SAME,
+# BOOTENTRY -- and the reinstalled closure booted to multi-user on its own
+# disk. It stays in `nightly_only` because it builds a SECOND full image, so
+# the nightly is the run that answers, not a pull request. And it has been
+# seen failing as well as passing: its first run is what found #514, so this
+# is a check in the AGENTS.md 1 sense, not a green light.
 # ---------------------------------------------------------------------------
 #
 # Everything about DRIVING the machine -- no test instrumentation, send_chars


### PR DESCRIPTION
## What this changes, and why

Issue #484 asked for a VM check that builds a user image, boots it, reinstalls, and boots the result — asserting the #436 property: **nothing built, nothing fetched**. That check already exists in full: `tests/reinstall-vm.nix` landed in #512, is wired as `checks.reinstall-vm`, listed in `build.yml`'s `nightly_only` set, scheduled in `nightly.yml` (`timeout-minutes: 200`), and watched by the report job (#592). The header was corrected once already in #546.

What was still owed — by the file's own header — was a watched green end-to-end run. The nightly of 2026-09-11 delivered it: [run 34557396063, job 103132862874](https://github.com/olafkfreund/nixarchy/actions/runs/34557396063/job/103132862874). Every marker returned 0 — `CARRIED` (the image names the user's `kepler` toplevel, not a reference one), `INSTALLED` under `--max-jobs 0` (so a single attempted build would have failed loudly), `COPIED` (the exact store path, by name, off the baked-marker branch), `OFFLINE` (no `copying path ... from 'https://'`; every copy in the log is `to 'local'` — and per §4, `unable to download` is deliberately NOT used as a fetch proxy), `SAME`, `BOOTENTRY`, `FALLBACK`, `SERIAL` — then the target machine booted the carried closure to multi-user:

```
installer # INSTALLED-0-X
installer # COPIED-0-X
installer # OFFLINE-0-X
installer # SAME-0-X
installer # BOOTENTRY-0-X
the install completed -- under --max-jobs 0, so nothing was built
and downloaded nothing
the bootloader the reinstall wrote is running, from the ESP it wrote
the closure the image carried booted to multi-user, offering a login
test script finished in 523.24s
```

This PR changes only the header paragraph that claimed no such run had been watched, replacing it with the record of the run. Per the header's own contract ("#478's remaining child stays open until one is green"), this closes #484.

Closes #484

## How I proved the check fails

This PR adds no check — it is a comment correction. The check it documents has been seen failing for real: its **first run found #514** (the `/etc/nixarchy-reference-*` markers named the reference toplevel instead of the user's, so `CARRIED` failed), which is the §1 contract satisfied by history rather than by a staged revert. I did not re-break a nightly-only 200-minute check to reproduce that; the failing run is on the record in #514/#512.

```
(no new check; the historical failing run is #514, found by this file's first execution)
```

## Checks run locally

Nothing that builds a VM (§6 — CI had jobs in flight on this machine). What I did run and read:

- `nix fmt -- --ci tests/reinstall-vm.nix` — clean (0 changed)
- The full nightly job log for run 34557396063: driver derivation built and executed last night (not a cached result — `building '...-test-run-nixarchy-reinstall-vm.drv'` is in the log), all step markers present with exit 0

- [x] `nix fmt` / statix / deadnix are clean (comment-only change; fmt verified)
- [x] New files are `git add`ed (no new files)
- [x] If this adds an option: n/a
- [x] If this adds a `checks.*` entry: none added — `reinstall-vm` is already claimed in `build.yml`'s `nightly_only` and built by `nightly.yml`

## What this cost, and where it is written down

- [x] Nothing general came up. The specific fact — the run id that turned the header's claim false — is in the commit message and the header itself.
