### PR TITLE
Every list of the agent skills is guarded the way the README's count already was

### DIFF
--- a/.github/scripts/readme-counts.sh
+++ b/.github/scripts/readme-counts.sh
@@ -73,7 +73,7 @@ quantity() {
 
   current=$(sed -nE "s/$find/\1/p" "$readme" | head -1)
   if [ -z "$current" ]; then
-    echo "::error::$name: nothing in README.md matches its pattern" >&2
+    echo "::error::$name: nothing in $(basename "$readme") matches its pattern" >&2
     echo "::error::  the wording moved, or the pattern is wrong. Not guessing." >&2
     fail=1
     return
@@ -85,7 +85,7 @@ quantity() {
   fi
 
   if [ "$mode" = "--check" ]; then
-    echo "::error::$name: README says $current, the repository says $value" >&2
+    echo "::error::$name: $(basename "$readme") says $current, the repository says $value" >&2
     fail=1
   else
     # $repl is already a complete sed expression. Wrapping it in another
@@ -193,7 +193,8 @@ repl_word=$(word_for "$repl_n")
 # script refuses rather than reporting a wrong number. Which is the guard
 # working, but it cost a run to see.
 skills=$(find -L "$omarchy" -name SKILL.md 2>/dev/null | wc -l)
-skills_word=$(word_for "$skills" | tr '[:upper:]' '[:lower:]')
+skills_cap=$(word_for "$skills")
+skills_word=$(printf '%s' "$skills_cap" | tr '[:upper:]' '[:lower:]')
 
 # The installer's question count (#557), which the README stated twice with two
 # different numbers and nothing checking either. The authority is
@@ -264,12 +265,49 @@ quantity "installer-questions-iso" "$questions_word" \
   '.*and answer (five|six|seven|eight|nine|ten) questions.*' \
   's/and answer (five|six|seven|eight|nine|ten) questions/and answer '"$questions_word"' questions/'
 
-# A floor. Fourteen quantities are declared above; a run that checked fewer
+# The docs state the skill count too, and #506 is what happens when only the
+# README is guarded: nixos-android shipped, the README moved to thirteen, and
+# docs/llms.txt and docs/manual/ai.md went on saying ten and twelve. quantity
+# reads the $readme global, so point it at each docs file in turn.
+readme_saved=$readme
+readme="$root/docs/llms.txt"
+quantity "skills-llms" "$skills_cap" \
+  '^- (Ten|Eleven|Twelve|Thirteen|Fourteen|Fifteen) AI agent skills written.*' \
+  's/^- (Ten|Eleven|Twelve|Thirteen|Fourteen|Fifteen) AI agent skills written/- '"$skills_cap"' AI agent skills written/'
+quantity "skills-llms-manual" "$skills_word" \
+  '.*the (ten|eleven|twelve|thirteen|fourteen|fifteen) NixOS agent skills.*' \
+  's/the (ten|eleven|twelve|thirteen|fourteen|fifteen) NixOS agent skills/the '"$skills_word"' NixOS agent skills/'
+readme="$root/docs/manual/ai.md"
+quantity "skills-manual-ai" "$skills_word" \
+  '^(ten|eleven|twelve|thirteen|fourteen|fifteen) skills instead of one:$' \
+  's/^(ten|eleven|twelve|thirteen|fourteen|fifteen) skills instead of one:$/'"$skills_word"' skills instead of one:/'
+readme=$readme_saved
+
+# The count says a number moved; this says which skill a table forgot. Every
+# skill that ships must have a row in each table that lists them all -- the
+# README's and docs/manual/ai.md's. Check-only in both modes: writing a row's
+# prose is a decision, not a calculation.
+skill_names=$(find -L "$omarchy" -name SKILL.md -printf '%h\n' 2>/dev/null |
+  sed 's|.*/||' | sort)
+if [ -z "$skill_names" ]; then
+  echo "::error::skill-rows: no SKILL.md in the built tree -- refusing" >&2
+  fail=1
+fi
+for f in "$readme" "$root/docs/manual/ai.md"; do
+  for s in $skill_names; do
+    if ! grep -qE "^\| (\*\*)?\`$s\`" "$f"; then
+      echo "::error::skill-rows: $(basename "$f") has no table row for \`$s\`" >&2
+      fail=1
+    fi
+  done
+done
+
+# A floor. Seventeen quantities are declared above; a run that checked fewer
 # means something stopped matching and this reported calm about numbers it
 # never looked at.
 checked=$(printf '%b' "$report" | grep -c .)
-if [ "$fail" -eq 0 ] && [ "$checked" -lt 14 ]; then
-  echo "::error::only $checked of 14 quantities were accounted for" >&2
+if [ "$fail" -eq 0 ] && [ "$checked" -lt 17 ]; then
+  echo "::error::only $checked of 17 quantities were accounted for" >&2
   fail=1
 fi
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -93,7 +93,7 @@ Key facts an assistant should know before answering questions about nixarchy:
   run. nixpkgs first, always.
 - Unfree packages are allowed by default (`programs.nixarchy.allowUnfree =
   false;` restores nixpkgs' policy).
-- Ten AI agent skills written for NixOS ship with the desktop and are exposed
+- Thirteen AI agent skills written for NixOS ship with the desktop and are exposed
   through Menu ▸ Trigger ▸ Ask; `programs.nixarchy.localAi.enable = true`
   runs them against local models via Ollama (needs a supported GPU).
 
@@ -116,7 +116,7 @@ Key facts an assistant should know before answering questions about nixarchy:
 - [Prebuilt binaries](https://olafkfreund.github.io/nixarchy/manual/prebuilt-binaries): the three on-by-default answers to a downloaded Linux binary -- nix-ld and its curated library set, envfs for shebangs, binfmt-registered AppImages -- and where each stops
 - [Boxes](https://olafkfreund.github.io/nixarchy/manual/boxes): Arch or Debian userlands via rootless podman and distrobox, ad hoc or declared (opt-in)
 - [Sandboxes](https://olafkfreund.github.io/nixarchy/manual/sandboxes): disposable NixOS MicroVMs sharing the host store, and the declarative always-up half (opt-in)
-- [AI](https://olafkfreund.github.io/nixarchy/manual/ai): the ten NixOS agent skills, the Ask menu, choosing an agent, and running it all locally
+- [AI](https://olafkfreund.github.io/nixarchy/manual/ai): the thirteen NixOS agent skills, the Ask menu, choosing an agent, and running it all locally
 - [Gaming](https://olafkfreund.github.io/nixarchy/manual/gaming): Steam, RetroArch, the launchers and cloud gaming — how each Install ▸ Gaming row lands on NixOS
 - [Android](https://olafkfreund.github.io/nixarchy/manual/android): running Android apps — scrcpy mirroring a phone, and Waydroid in a container
 - [Security](https://olafkfreund.github.io/nixarchy/manual/security): the firewall, disk encryption, and what the port changes

--- a/docs/manual/ai.md
+++ b/docs/manual/ai.md
@@ -38,7 +38,7 @@ location, so most harnesses load it automatically. nixarchy keeps the
 mechanism — `omarchy-provision-user` symlinks every directory under
 `$OMARCHY_PATH/default/agents/skills/` into `~/.claude/skills`,
 `~/.agents/skills`, `~/.codex/skills` and `~/.pi/agent/skills` — but ships
-twelve skills instead of one:
+thirteen skills instead of one:
 
 | skill | owns |
 |---|---|
@@ -52,6 +52,7 @@ twelve skills instead of one:
 | `nixos-security` | firewall and nftables, SSH, sudo, systemd sandboxing, kernel hardening |
 | `nixos-doctor` | the whole-machine sweep to run before forming a theory |
 | `nixos-config-repo` | getting the configuration into git, and keeping it there |
+| `nixos-android` | mirroring a phone with scrcpy over USB or Wi-Fi, and Waydroid in a container |
 | `devenv` | per-project environments: `devenv.nix`, the lockfile, and whether a tool belongs to the project or the machine |
 | `diagnose-crash` | working out why a process dumped core, and where to report it if it is a distribution bug |
 


### PR DESCRIPTION
## What this changes, and why

Fixes #506. `pkgs/omarchy/skills/nixos-android/` ships (13 skills do), but two docs lists never learned: `docs/llms.txt` said "Ten AI agent skills" twice, and `docs/manual/ai.md` said "twelve skills instead of one" and listed twelve — no `nixos-android` row. The README was already correct and guarded by `readme-counts.sh`; the docs were not guarded by anything, which is exactly how #459's drift survived there.

So instead of a one-time correction, `readme-counts.sh` now covers the docs too:

- three new quantities derive the skill count in `docs/llms.txt` (twice) and `docs/manual/ai.md` from the built tree, with `--check`/`--fix` behaviour identical to the README's — `quantity` reads the `$readme` global, so the docs quantities point it at each file in turn;
- a row check asserts every shipped skill (every `SKILL.md` in the built package, so `diagnose-crash` counts) has a table row in both the README's and ai.md's skill tables. The count only says a number moved; this names the skill a list forgot, which is #459's actual failure — a count can auto-fix on a bump while the forgotten row stays forgotten. Check-only in both modes: writing a row's prose is a decision, not a calculation;
- the floor moves 14 → 17 accordingly.

No workflow change needed: `build.yml` already runs `readme-counts.sh --check` on pull requests and `omarchy.yml` runs `--fix` on bumps, so the new guards ride the existing steps. NixOS-only, nothing here applies to Arch upstream.

## How I proved the check fails

Reintroduced the bug (reverted the docs edits, removed ai.md's row), ran `--check` under bash against the built tree:

```
::error::skills-llms: llms.txt says Ten, the repository says Thirteen
::error::skills-llms-manual: llms.txt says ten, the repository says thirteen
::error::skills-manual-ai: ai.md says twelve, the repository says thirteen
::error::skill-rows: ai.md has no table row for `nixos-android`
exit=1
```

Also removed the README's `nixos-android` row separately:

```
::error::skill-rows: README.md has no table row for `nixos-android`
```

And proved `--fix` repairs the counts (it produced the final docs numbers in this PR):

```
  skills-llms: Ten -> Thirteen  (fixed)
  skills-llms-manual: ten -> thirteen  (fixed)
  skills-manual-ai: twelve -> thirteen  (fixed)
```

With the fix restored, `--check` passes with all 17 quantities accounted for, `skills: thirteen` among them.

## Checks run locally

- `.github/scripts/readme-counts.sh --check` under bash against a freshly built `nix build .#omarchy` tree — all 17 quantities pass
- `nix build .#checks.x86_64-linux.doc-options` — passes ("67 `programs.nixarchy.*` paths quoted in prose, all of them real")
- shellcheck on the script: no warnings (only the pre-existing SC2012 info)

- [x] `nix fmt` / statix / deadnix are clean (no `.nix` files touched)
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [ ] If this adds an option: `tests/options.nix` covers both states — n/a
- [ ] If this adds a `checks.*` entry: a PR-triggered workflow builds it — n/a, the new guards live inside a script CI already runs

## What this cost, and where it is written down

- [x] A general lesson is recorded in `AGENTS.md`, or nothing general came up — nothing general; the traps I hit (find `-L`, verify under bash, pipeline status) are already §1 and §5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
