### PR TITLE
The network reinstall image, and the two preflights that predict what a target could not fetch

### DIFF
--- a/docs/manual/reinstall-image.md
+++ b/docs/manual/reinstall-image.md
@@ -61,6 +61,31 @@ compression is most of it.
 The image lands at `~/.local/share/nixarchy/reinstall-iso/`, and the command
 prints the exact path and size.
 
+## The network variant
+
+```
+nixarchy reinstall iso --net
+```
+
+About 1.5 GB instead of 6–10, because it carries the configuration and
+fetches the system from the binary caches as it installs. The trade is
+explicit: the target needs a network, and the image is only honest if the
+caches actually hold your system.
+
+They often do not hold all of it. `cache.nixos.org` carries **no unfree
+packages** — vscode, zoom, every IDE with a licence — and anything built on
+your machine (an overlay, a patched package) is in no cache anywhere. A
+target would have to *compile* those, mid-install, which is the failure the
+command exists to get in front of: before offering the build, it asks your
+own store what a fresh machine could not fetch, lists it with sizes, and
+points at the offline image — which carries everything and needs no such
+answer. The installer asks the same question again on the target, before
+anything is formatted.
+
+If your closure comes back clean — everything fetchable — the network image
+is the cheaper artifact to keep and re-make. If it does not, burn the big
+one.
+
 ## Writing it to a USB stick
 
 ```
@@ -125,6 +150,12 @@ reinstalls correctly in a VM; it says nothing about whether your new laptop's
 wifi chip has a driver in the closure you baked. If the new machine's hardware
 differs from the old one, expect to edit `hosts/<name>/hardware-configuration.nix`
 after the first boot, and to rebuild — which needs a network.
+
+The network variant's prediction is tested against real `nix path-info`
+shapes, but no automated check can watch a network image actually fail to
+fetch — every store CI touches is warm, and every closure it installs is
+cached. If `--net` predicted "all fetchable" and the install still had to
+build something, that is a bug in the prediction: please report it.
 
 ## Related
 

--- a/flake.nix
+++ b/flake.nix
@@ -1329,8 +1329,10 @@
             flake,
             host,
             # Offline by default, because the whole point is a machine that can
-            # be rebuilt when there is nothing to fetch from. The network
-            # variant is #483.
+            # be rebuilt when there is nothing to fetch from. false is the
+            # network variant (#483): ~1.5 GB, fetching at install time --
+            # honest only for a closure the caches hold, which
+            # `nixarchy reinstall iso --net` checks before offering the build.
             offline ? true,
           }:
           let

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -96,6 +96,13 @@ fi
 # where the reasoning did hold.
 SUBSTITUTE_FLAGS=(--option always-allow-substitutes true)
 
+# Derivations every machine assembles for itself -- /etc fragments, units,
+# activation scripts. Expected in any build plan and cheap anywhere, so any
+# report about what a plan REALLY builds filters them out, or the entries that
+# matter drown under a thousand that do not. Shared by preflight_build and the
+# offline failure report: two filters would disagree about the same plan.
+PLAN_TRIVIA='-(etc|activate|dry-activate|system-path|system-units|user-units|unit-|X-Restart|initrd|boot\.json|users-groups|nixos-system|.*\.conf|.*\.service|hosts|.*-hostname)'
+
 dry_run=false
 answers_file=""
 answers_fetched=""
@@ -2243,7 +2250,7 @@ rescue_build() {
       # etc fragments and units -- those are expected to be built and are
       # cheap. A compiler appearing under any of them is the actual finding.
       for drv in $(printf '%s\n' "$builds" \
-        | grep -vE -- '-(etc|activate|dry-activate|system-path|system-units|user-units|unit-|X-Restart|initrd|boot\.json|users-groups|nixos-system|.*\.conf|.*\.service|hosts|.*-hostname)' \
+        | grep -vE -- "$PLAN_TRIVIA" \
         | head -3); do
         echo >&2
         echo "  Why this system needs $(basename "$drv"):" >&2
@@ -2336,6 +2343,40 @@ rescue_build() {
 # of either kind and a seeded store -- keying on anything but the net image's
 # own marker would make a passing check demand a network and fail, which is
 # the trap the ask_network comment already names.
+
+# The plan succeeded; now what does it SAY (#483). `nix build --dry-run`
+# lists what no reachable cache could supply under "will be built", and on
+# this image a real package there is compiled on the target, mid-install,
+# into the live session's RAM-backed store. cache.nixos.org carries no
+# unfree packages at all, and nothing built on the source machine is in any
+# cache -- so a USER's closure (a reinstall-iso-net image) can plan cleanly
+# and still be mostly a build. Name it while refusal still costs nothing.
+# Asking is interactive-only: the reference image's closure is fully cached,
+# and a stray small derivation must not hang an unattended install on a
+# prompt nobody is there to answer.
+preflight_report_builds() {
+  local builds
+  builds=$(sed -n 's|^ *\(/nix/store/[^ ]*\.drv\)$|\1|p' <<<"$1" \
+    | grep -vE -- "$PLAN_TRIVIA" || true)
+  [ -n "$builds" ] || return 0
+
+  local count
+  count=$(printf '%s\n' "$builds" | grep -c .)
+  echo >&2
+  echo "nixarchy-install: not everything can be fetched." >&2
+  echo >&2
+  echo "  No cache this image can reach has these $count, so they would be" >&2
+  echo "  BUILT on this machine, over the install:" >&2
+  printf '%s\n' "$builds" | head -12 | sed 's|^/nix/store/[^-]*-|    |' >&2
+  [ "$count" -gt 12 ] && echo "    ... and $((count - 12)) more" >&2
+  echo >&2
+  ui_interactive || return 0
+  gum confirm --padding "$(ui_gum_pad)" \
+    "Install anyway, building these here first?" && return 0
+  echo "Nothing was written: the disk has not been touched." >&2
+  return 1
+}
+
 preflight_build() {
   on_net_image || return 0
 
@@ -2358,8 +2399,11 @@ preflight_build() {
   git -C "$work" init -q
   git -C "$work" add -A
   local plan
-  plan=$(nix "${NIX_FLAGS[@]}" build --dry-run "${SUBSTITUTE_FLAGS[@]}" \
-    "$work#nixosConfigurations.$hostname.config.system.build.toplevel" 2>&1) && return 0
+  if plan=$(nix "${NIX_FLAGS[@]}" build --dry-run "${SUBSTITUTE_FLAGS[@]}" \
+    "$work#nixosConfigurations.$hostname.config.system.build.toplevel" 2>&1); then
+    preflight_report_builds "$plan"
+    return
+  fi
 
   echo "nixarchy-install: the system cannot be planned, so no install was started." >&2
   echo >&2

--- a/installer/template/flake.nix
+++ b/installer/template/flake.nix
@@ -111,28 +111,35 @@
       # embeds the flake as git sees it -- which is also why the command
       # refuses on an uncommitted tree.
       packages.x86_64-linux =
-        lib.genAttrs hosts (
-          name:
-          nixarchy.lib.mkUserIso {
-            flake = self;
-            host = name;
-          }
-        )
-        // {
-          # The bare name, for the common case of one machine. With several,
+        let
+          image =
+            offline: host:
+            nixarchy.lib.mkUserIso {
+              inherit host offline;
+              flake = self;
+            };
+          # The bare names, for the common case of one machine. With several,
           # the command names the one it means.
-          reinstall-iso =
+          only =
+            offline: suffix:
             if lib.length hosts == 1 then
-              nixarchy.lib.mkUserIso {
-                flake = self;
-                host = lib.head hosts;
-              }
+              image offline (lib.head hosts)
             else
               throw ''
                 This repository has ${toString (lib.length hosts)} machines, so
-                "reinstall-iso" does not say which one. Name it:
-                ${lib.concatStringsSep "\n" (map (h: "  nix build .#${h}") hosts)}
+                "reinstall-iso${suffix}" does not say which one. Name it:
+                ${lib.concatStringsSep "\n" (map (h: "  nix build .#${h}${suffix}") hosts)}
               '';
+        in
+        lib.genAttrs hosts (image true)
+        # The -net twins fetch the closure at install time instead of carrying
+        # it: ~1.5 GB, a network on the target, and only honest when the
+        # caches hold this system -- which `nixarchy reinstall iso --net`
+        # checks before offering the build.
+        // lib.listToAttrs (map (name: lib.nameValuePair "${name}-net" (image false name)) hosts)
+        // {
+          reinstall-iso = only true "";
+          reinstall-iso-net = only false "-net";
         };
     };
 }

--- a/pkgs/omarchy/nix-bin/nixarchy-reinstall-iso
+++ b/pkgs/omarchy/nix-bin/nixarchy-reinstall-iso
@@ -2,7 +2,7 @@
 
 # nixarchy:new
 # omarchy:summary=Build a bootable image that reinstalls this machine's system. Not a backup.
-# omarchy:args=[--check]
+# omarchy:args=[--check|--net]
 # omarchy:examples=nixarchy reinstall iso
 
 # The fifth leg of getting back (#478): generations cover a bad change,
@@ -48,13 +48,22 @@ FLAKE="${NIXARCHY_FLAKE:-/etc/nixos}"
 # named differently, and for the tests.
 REINSTALL_ATTR="${NIXARCHY_REINSTALL_ATTR:-$FLAKE#reinstall-iso}"
 
+# The network twin (#483): ~1.5 GB, fetching the closure at install time
+# instead of carrying it. Same seam, same reasons -- and only offered after
+# the preflight below has said whether the caches can actually supply this
+# machine, because an image that boots and then cannot fetch is the failure
+# a warm-store CI never sees.
+REINSTALL_NET_ATTR="${NIXARCHY_REINSTALL_NET_ATTR:-$FLAKE#reinstall-iso-net}"
+
 red() { printf "\033[0;31m%s\033[0m\n" "$1"; }
 dim() { printf "\033[0;90m%s\033[0m\n" "$1"; }
 bold() { printf "\033[1m%s\033[0m\n" "$1"; }
 
 usage() {
-  echo "Usage: nixarchy-reinstall-iso [--check]"
+  echo "Usage: nixarchy-reinstall-iso [--check|--net]"
   echo "  (no argument)  build the image, after the preflights"
+  echo "  --net          the ~1.5 GB variant that fetches the system over the"
+  echo "                 network as it installs, instead of carrying it"
   echo "  --check        exit 0 if this machine is one nixarchy installed. Prints nothing."
 }
 
@@ -127,6 +136,35 @@ drift_verdict() {
   fi
 }
 
+# fetchable | build | unknown, over installer/substitutable.sh's exit code.
+# unknown is a verdict of its own and never collapses into fetchable:
+# "nothing to build" is the answer that strands an installer on a
+# half-fetched machine, so it is only ever given when the script said it.
+substitutable_verdict() {
+  local script=$1 top=$2 rc=0
+  [ -n "$script" ] && [ -n "$top" ] || { echo unknown; return; }
+  bash "$script" "$top" >&2 || rc=$?
+  case "$rc" in
+    0) echo fetchable ;;
+    1) echo build ;;
+    *) echo unknown ;;
+  esac
+}
+
+# Where the prediction script lives: inside the nixarchy input this flake
+# already pins, so there is no second copy to drift and no second install.
+# `nix flake archive --dry-run` names the inputs' store paths without
+# copying anything, and they are already local on a machine that evaluates
+# its own flake. Any failure prints nothing, which the verdict above reads
+# as unknown -- never as fetchable.
+substitutable_script() {
+  local src
+  src=$(nix flake archive --json --dry-run "$FLAKE" 2>/dev/null \
+    | jq -r '.inputs.nixarchy.path // empty' 2>/dev/null) || return 0
+  [ -n "$src" ] && [ -f "$src/installer/substitutable.sh" ] || return 0
+  printf '%s\n' "$src/installer/substitutable.sh"
+}
+
 # Closure size of the running system in MB, empty when it cannot be read.
 closure_mb() {
   local bytes
@@ -141,8 +179,11 @@ closure_mb() {
 # Flags
 # ---------------------------------------------------------------------------
 
+net=false
+
 case "${1:-}" in
   "") ;;
+  --net) net=true ;;
   --check)
     installed_by_nixarchy || exit 1
     exit 0
@@ -187,12 +228,27 @@ echo
 dim "It also goes stale: rebuild it after meaningful configuration changes."
 echo
 
+if [ "$net" = true ]; then
+  echo "The NETWORK variant: about 1.5 GB instead of 6-10, because it fetches"
+  echo "the system from the caches as it installs instead of carrying it."
+  echo "That needs a network on the target -- and it is only honest if the"
+  echo "caches actually hold this system, which is checked below."
+  echo
+fi
+
 # ---------------------------------------------------------------------------
 # Preflight 1: space. ~1x the closure for the image, ~2x transient in /nix.
 # ---------------------------------------------------------------------------
 
 closure=$(closure_mb)
-if [ -n "$closure" ]; then
+if [ "$net" = true ]; then
+  # No closure on the image, so no closure in the math: the live environment
+  # squashfs is the bulk of it, and the number barely varies per machine.
+  dim "The network image is about 1.5 GB; the build wants a few GB of"
+  dim "transient disk, and the image itself lands in /nix/store."
+  echo
+  check_disk /nix/store 6000 "building the image" || exit 1
+elif [ -n "$closure" ]; then
   need=$((closure * 2))
   dim "The running system's closure is ${closure} MB; the build wants roughly"
   dim "twice that in transient disk, and the image itself lands in /nix/store."
@@ -282,8 +338,60 @@ case "$(drift_verdict "$running" "$evaluated")" in
 esac
 
 # ---------------------------------------------------------------------------
+# Preflight 4, --net only: what the target could NOT fetch (#483, the whole
+# scope of the network variant). cache.nixos.org builds no unfree packages
+# at all, nixarchy.cachix.org holds the reference closure rather than this
+# machine's app selection, and anything built here is in no cache anywhere.
+# The local store already knows which paths no cache vouched for --
+# installer/substitutable.sh explains why it is asked instead of the caches
+# -- and discovering the answer after a disk is formatted is the failure
+# this question exists to prevent.
+# ---------------------------------------------------------------------------
+
+if [ "$net" = true ]; then
+  echo
+  bold "What a fresh machine could fetch, and what it could not"
+  top=${evaluated:-$running}
+  case "$(substitutable_verdict "${NIXARCHY_SUBSTITUTABLE:-$(substitutable_script)}" "$top")" in
+    fetchable)
+      dim "Every path in this system can be fetched from a cache; the network"
+      dim "image is honest for this machine."
+      ;;
+    build)
+      echo
+      red "Some of this system is in NO cache."
+      echo "  The paths above would be COMPILED on the target, mid-install,"
+      echo "  over the network image's live session -- unfree packages are"
+      echo "  not in cache.nixos.org by policy, and locally built ones are in"
+      echo "  no cache by definition. The offline image carries all of them"
+      echo "  instead:"
+      echo
+      bold "    nixarchy reinstall iso"
+      echo
+      printf "Build the network image anyway? [y/N] "
+      read -r reply
+      case "$reply" in [yY]*) ;; *) echo "Nothing built."; exit 0 ;; esac
+      ;;
+    unknown)
+      red "Whether the target could fetch this system could not be answered."
+      echo "  Do not read that as 'it can all be fetched' -- that is the"
+      echo "  answer that strands an installer on a machine it cannot finish."
+      echo "  The offline image needs no answer: nixarchy reinstall iso."
+      echo
+      printf "Build the network image anyway? [y/N] "
+      read -r reply
+      case "$reply" in [yY]*) ;; *) echo "Nothing built."; exit 0 ;; esac
+      ;;
+  esac
+fi
+
+# ---------------------------------------------------------------------------
 # Confirm, build, report.
 # ---------------------------------------------------------------------------
+
+if [ "$net" = true ]; then
+  REINSTALL_ATTR=$REINSTALL_NET_ATTR
+fi
 
 echo
 printf "Build the image? It takes tens of minutes. [y/N] "
@@ -291,6 +399,7 @@ read -r reply
 case "$reply" in [yY]*) ;; *) echo "Nothing built."; exit 0 ;; esac
 
 outlink="$HOME/.local/share/nixarchy/reinstall-iso"
+[ "$net" = true ] && outlink="$outlink-net"
 mkdir -p "$(dirname "$outlink")"
 
 echo
@@ -318,9 +427,14 @@ echo "Write it to a USB stick (this ERASES the stick):"
 dim "  sudo dd if=$iso of=/dev/sdX bs=4M status=progress oflag=sync"
 echo
 echo "Keep it OFF this machine -- an image on the disk it exists to replace"
-echo "protects nothing. And keep it private: it contains your /etc/nixos and"
-echo "any unfree packages your system uses, which are yours to keep and not"
-echo "yours to publish."
+echo "protects nothing. And keep it private: it contains your /etc/nixos"
+if [ "$net" = true ]; then
+  echo "(the system itself is fetched at install time, so a network on the"
+  echo "target is part of the deal)."
+else
+  echo "and any unfree packages your system uses, which are yours to keep"
+  echo "and not yours to publish."
+fi
 echo
 red "Remember what it is not: booting it erases the target disk and brings"
 red "back the system, not your files. Files come back from your backups."

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -118,6 +118,20 @@ Non-gating, per-night, filed as its own issue by the report job — a job
 rather than a check for the same reason devenv-presets is (see build.yml's
 comment on that job).
 
+## The cold-cache one: nobody here can watch a network image fail to fetch
+
+The network reinstall image (#483) is only honest for a closure the caches
+hold, and every store CI touches is warm and every closure it installs is
+cached. So the failure the feature is about — a target that formats, then
+cannot fetch an unfree or locally built path — cannot be produced by any
+layer here. What IS covered: the prediction's classification against real
+`nix path-info` shapes (`substitutable`), the build-machine verdict wiring
+(`reinstall-iso`), and the target-side plan report with plans nix really
+prints (`installer-store-space`). What is not: a real `reinstall-iso-net`
+image, booted against real caches, missing a real unfree package. That run
+needs a human with vscode in their closure and a machine to lose; until one
+reports back, the prediction is tested and the event it predicts is not.
+
 ## The cheap ones, which is where new checks usually belong
 
 `installer-ui`, `installer-wizard`, `installer-refusal`, `installer-lock`,

--- a/tests/installer-store-space.nix
+++ b/tests/installer-store-space.nix
@@ -289,8 +289,14 @@ pkgs.runCommand "nixarchy-installer-store-space" { } ''
   # the build could start. Same doctrine as above -- the function on its own,
   # driven with stubs that lie.
   # ------------------------------------------------------------------------
-  sed -n '/^preflight_build()/,/^}/p' ${installScript} > pf.sh
-  test -s pf.sh || { echo "preflight_build is not in install.sh any more" >&2; exit 1; }
+  grep '^PLAN_TRIVIA=' ${installScript} > pf.sh
+  test -s pf.sh || { echo "PLAN_TRIVIA is not in install.sh any more" >&2; exit 1; }
+  sed -n '/^preflight_report_builds()/,/^}/p' ${installScript} >> pf.sh
+  grep -q 'preflight_report_builds()' pf.sh \
+    || { echo "preflight_report_builds is not in install.sh any more" >&2; exit 1; }
+  sed -n '/^preflight_build()/,/^}/p' ${installScript} >> pf.sh
+  grep -q 'preflight_build()' pf.sh \
+    || { echo "preflight_build is not in install.sh any more" >&2; exit 1; }
   grep '^on_net_image()' ${installScript} >> pf.sh
 
   cat > pt.sh <<'EOF'
@@ -302,6 +308,9 @@ pkgs.runCommand "nixarchy-installer-store-space" { } ''
   wipefs() { touch wipefs-called; }
   git() { :; }
   curl() { [ "$CURL_OK" = 1 ]; }
+  ui_interactive() { [ "$UI" = 1 ]; }
+  ui_gum_pad() { echo "0 0"; }
+  gum() { [ "$GUM_YES" = 1 ]; }
   nix() {
     if [ "$NIX_OK" = 1 ]; then echo 'these 0 derivations will be built'; else
       # Long on purpose: a real dry-run of a desktop closure is thousands of
@@ -342,6 +351,47 @@ pkgs.runCommand "nixarchy-installer-store-space" { } ''
   ! grep -qi 'broken pipe' out || { echo "  FAILED  refusal is preceded by Broken pipe noise"; fails=$((fails+1)); }
   # And a network that works installs as before.
   t proceed "net image, everything answers"      net  1 1
+
+  # preflight_report_builds (#483): a plan that SUCCEEDS can still be mostly
+  # a build -- a user's reinstall-iso-net closure holds unfree and locally
+  # built paths no cache has. The report must name the real packages, filter
+  # the trivia every machine assembles for itself, and only ever ask when
+  # somebody is there to answer.
+  plan_builds='these 3 derivations will be built:
+  /nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-vscode-1.90.0.drv
+  /nix/store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-etc-fstab.drv
+  /nix/store/cccccccccccccccccccccccccccccccc-unit-nginx.service.drv
+  these 2 paths will be fetched (0.10 MiB download):
+  /nix/store/dddddddddddddddddddddddddddddddd-firefox-140.0'
+  plan_trivia='these 2 derivations will be built:
+  /nix/store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-etc-fstab.drv
+  /nix/store/cccccccccccccccccccccccccccccccc-unit-nginx.service.drv'
+
+  r() {
+    want=$1 name=$2 plan=$3 ui=$4 gumyes=$5
+    if UI=$ui GUM_YES=$gumyes preflight_report_builds "$plan" >rout 2>&1; then got=proceed; else got=refuse; fi
+    if [ "$got" = "$want" ]; then
+      echo "  ok      $name ($got)"
+    else
+      echo "  FAILED  $name: wanted $want, got $got"; sed 's/^/            /' rout
+      fails=$((fails + 1))
+    fi
+  }
+
+  # Unattended: say it, never hang on a prompt nobody answers.
+  r proceed "real build in the plan, unattended"   "$plan_builds" 0 0
+  grep -q 'vscode' rout || { echo "  FAILED  the report does not name vscode"; fails=$((fails+1)); }
+  # The fetched section must not be misread as builds.
+  ! grep -q 'firefox' rout || { echo "  FAILED  a FETCHED path reported as a build"; fails=$((fails+1)); }
+  # Somebody at the terminal declines: refused before the wipe.
+  r refuse  "real build in the plan, declined"     "$plan_builds" 1 0
+  r proceed "real build in the plan, accepted"     "$plan_builds" 1 1
+  # Trivia alone -- etc fragments, units -- is every install's plan, and a
+  # report about it would cry wolf on the reference image.
+  r proceed "only trivia in the plan"              "$plan_trivia" 1 0
+  ! grep -q 'not everything can be fetched' rout || {
+    echo "  FAILED  trivia-only plan still warned"; fails=$((fails+1));
+  }
 
   # An ENCRYPTED install must pin the ENCRYPTED module list.
   #
@@ -385,6 +435,13 @@ pkgs.runCommand "nixarchy-installer-store-space" { } ''
   # written, extracted, asserted, and run by nothing.
   # `|| true` because stdenv sets pipefail, and a grep with no match must
   # reach the named refusal below rather than kill the script mid-pipe.
+  # The report function is tested above and must also be WIRED: a successful
+  # dry-run hands its plan over, or #483's prediction never runs anywhere.
+  grep -q 'preflight_report_builds "$plan"' ${installScript} || {
+    echo "preflight_build no longer hands its plan to preflight_report_builds (#483)" >&2
+    exit 1
+  }
+
   pf_line=$(grep -n 'preflight_build || exit 1' ${installScript} | cut -d: -f1 | head -1 || true)
   fmt_line=$(grep -n '^    format_disk &&' ${installScript} | cut -d: -f1 | head -1 || true)
   [ -n "$pf_line" ] || { echo "main() no longer calls preflight_build" >&2; exit 1; }

--- a/tests/reinstall-iso.nix
+++ b/tests/reinstall-iso.nix
@@ -112,6 +112,45 @@ pkgs.runCommand "nixarchy-reinstall-iso" { } ''
   EOF
   bash dvt.sh
 
+  # ------------------------------------------------------------------------
+  # substitutable_verdict (#483): the network image is only honest for a
+  # closure the caches hold, and installer/substitutable.sh answers that
+  # with its exit code. The mapping must keep the three verdicts apart --
+  # above all, nothing but a real exit 0 may read as fetchable, because
+  # "nothing to build" is the answer that strands a target mid-install.
+  # ------------------------------------------------------------------------
+  sed -n '/^substitutable_verdict()/,/^}/p' ${reinstallScript} > sv.sh
+  test -s sv.sh || { echo "substitutable_verdict is not in nixarchy-reinstall-iso any more" >&2; exit 1; }
+
+  cat > svt.sh <<'EOF'
+  . ./sv.sh
+  echo 'exit 0' > can-fetch.sh
+  echo 'exit 1' > must-build.sh
+  echo 'exit 2' > cannot-say.sh
+  echo 'exit 127' > broke.sh
+  fails=0
+  t() {
+    want=$1 name=$2 script=$3 top=$4
+    g=$(substitutable_verdict "$script" "$top" 2>/dev/null)
+    if [ "$g" = "$want" ]; then
+      echo "  ok      $name -> $g"
+    else
+      echo "  FAILED  $name: wanted $want, got '$g'"
+      fails=$((fails + 1))
+    fi
+  }
+  t fetchable "every path in a cache"          can-fetch.sh  /nix/store/aaa-toplevel
+  t build     "something must be built"        must-build.sh /nix/store/aaa-toplevel
+  t unknown   "the question was not answered"  cannot-say.sh /nix/store/aaa-toplevel
+  # Tolerance both ways: a script that broke, went missing, or was never
+  # found is unknown -- never fetchable, never a crash.
+  t unknown   "the script itself broke"        broke.sh      /nix/store/aaa-toplevel
+  t unknown   "no script was located"          ""            /nix/store/aaa-toplevel
+  t unknown   "no toplevel to ask about"       can-fetch.sh  ""
+  exit $fails
+  EOF
+  bash svt.sh
+
   echo "the three preflights refuse what they must and only that"
 
   # ------------------------------------------------------------------------
@@ -122,7 +161,7 @@ pkgs.runCommand "nixarchy-reinstall-iso" { } ''
   # ------------------------------------------------------------------------
   build_line=$(grep -n 'nix build "$REINSTALL_ATTR"' ${reinstallScript} | cut -d: -f1 | head -1 || true)
   [ -n "$build_line" ] || { echo "the script no longer builds via REINSTALL_ATTR; retarget this check" >&2; exit 1; }
-  for probe in 'check_disk /nix/store' 'committed_verdict "$FLAKE"' 'drift_verdict "$running"'; do
+  for probe in 'check_disk /nix/store' 'committed_verdict "$FLAKE"' 'drift_verdict "$running"' 'case "$(substitutable_verdict'; do
     line=$(grep -n "$probe" ${reinstallScript} | cut -d: -f1 | head -1 || true)
     [ -n "$line" ] || { echo "main() never calls: $probe" >&2; exit 1; }
     [ "$line" -lt "$build_line" ] || {
@@ -146,10 +185,15 @@ pkgs.runCommand "nixarchy-reinstall-iso" { } ''
   # and a bare grep stayed green with the printed line deleted. Found by
   # breaking it.
   # ------------------------------------------------------------------------
+  # The last two are #483's: the network image must say when the caches
+  # cannot supply this machine, and an unanswered question must never be
+  # presented as a fetchable closure.
   for claim in \
     'red "It is NOT a backup.' \
     'echo "  It carries no /home, no service state, no secrets' \
-    'ERASES the disk it installs to.'; do
+    'ERASES the disk it installs to.' \
+    'red "Some of this system is in NO cache.' \
+    'red "Whether the target could fetch this system could not be answered.'; do
     grep -qF "$claim" ${reinstallScript} || {
       echo "the script no longer says: $claim" >&2
       echo "#478 makes that honesty non-negotiable -- the image carries the" >&2


### PR DESCRIPTION
Closes #483 (child of #478).

## What this changes, and why

The `offline = false` twin of the reinstall image: ~1.5 GB instead of 6–10, carrying the configuration and fetching the system from the caches as it installs. The generated flake (`installer/template/flake.nix`) grows `reinstall-iso-net` and per-host `<name>-net` outputs through the `offline` switch `mkUserIso` already had, and `nixarchy-reinstall-iso` grows `--net` to build them.

The issue says the honest failure mode IS the scope — `nixarchy.cachix.org` holds the reference closure, `cache.nixos.org` holds **no unfree packages by policy**, and anything built locally is in no cache anywhere — so the prediction lands at both seams:

- **Build machine** (`nixarchy-reinstall-iso --net`, preflight 4): runs `installer/substitutable.sh` (#515) over the evaluated toplevel before offering the build. The script is found *inside the flake's own pinned nixarchy input* via `nix flake archive --json --dry-run`, so there is no second copy to drift and no new shipped bin. `substitutable_verdict` maps its exit code to `fetchable | build | unknown`; a must-build closure and an unanswered question both refuse by default, in sentences pointing at the offline image. Only a real exit 0 ever reads as fetchable — "nothing to build" is the answer that strands a target.
- **Target** (`install.sh`, before `format_disk`): `preflight_build` used to throw away its *successful* dry-run plan. `preflight_report_builds` now reads the plan's "will be built" section, filters it with the same `PLAN_TRIVIA` list the offline failure report already carried inline (extracted so the two readers cannot disagree), names what no reachable cache could supply, and asks — interactive only, so the reference `install-iso-net` check and any unattended install print rather than hang. The wizard predicts, from the user's closure, before anything is formatted.

Verified by hand that the new template output evaluates end-to-end: `mkUserIso { flake = self; host = "reference-unencrypted"; offline = false; }` instantiates to `nixarchy-4.0.3-net-e8ccaec-x86_64.iso.drv` (the `-net` variant suffix carried through `cd.nix`).

## How I proved the check fails

**`checks.reinstall-iso`** — reintroduced the dangerous bug: verdict mapping `*) echo fetchable` (an unanswered question read as a clean bill):

```
  ok      every path in a cache -> fetchable
  ok      something must be built -> build
  FAILED  the question was not answered: wanted unknown, got 'fetchable'
  FAILED  the script itself broke: wanted unknown, got 'fetchable'
```

**`checks.installer-store-space`** — deleted the prediction (`preflight_report_builds` returning 0 before the report):

```
  ok      real build in the plan, unattended (proceed)
  FAILED  the report does not name vscode
  FAILED  real build in the plan, declined: wanted refuse, got proceed
```

Both restored and green. The fixture plan also carries a *fetched* firefox path and the test asserts it is **not** reported as a build, and a trivia-only plan (etc fragments, units) produces no warning at all — the cry-wolf failure the three-class design in #515 exists to avoid.

## Checks run locally

- `nix build .#checks.x86_64-linux.reinstall-iso` — green (and red under the broken verdict above)
- `nix build .#checks.x86_64-linux.installer-store-space` — green (and red under the deleted report above)
- `nix build .#checks.x86_64-linux.installer-lock` — green (the template flake still assembles and locks; needs a committed tree per §5)
- `nix-instantiate` of the `-net` user image expression — evaluates, see above
- shellcheck clean on `install.sh` and `nixarchy-reinstall-iso`; `nix fmt` / statix / deadnix clean

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [ ] If this adds an option: `tests/options.nix` covers both states — no option added
- [x] If this adds a `checks.*` entry: no new `checks.*` entry — both new tables live in existing PR-triggered checks

## What this cost, and where it is written down

- [x] A general lesson is recorded in `AGENTS.md`, or nothing general came up

`tests/AGENTS.md` gains the documented hole this feature cannot close (§3): every store CI touches is warm and every closure it installs is cached, so no layer here can produce the event the prediction predicts — a real network image failing to fetch a real unfree package. The prediction's classification, wiring and target-side report are all tested against real `nix path-info` / dry-run shapes; the event itself needs a human with vscode in their closure. `docs/manual/reinstall-image.md` says the same to users and asks for the report if the prediction is ever wrong.

Nothing else general came up (the near-miss was the known Nix indented-string minimal-indent trap while editing a heredoc-bearing test, already the file's own style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5
