### PR TITLE
The Roadmap empties: the reinstall image and the package picker are finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -1926,11 +1926,24 @@ with a changelog: what was added, what changed, and what is coming. This
 section says what is PLANNED; a merged pull request announces nothing to
 somebody who only uses nixarchy, and that is the gap those posts fill.
 
-| epic | what it is for | |
-| --- | --- | --- |
-| [#491](https://github.com/olafkfreund/nixarchy/issues/491) | **The package picker, remade** — a miss opens the picker instead of a URL, rows say what they cost, and packages can be removed as well as added | 6 filed |
+**Nothing is in flight right now.** The three epics that were here — the
+escape hatches, the reinstall image and the package picker — all finished, and
+the table below is where they went. That is a real state rather than an
+oversight: the next one gets a row here when it is filed, and this section is
+CI-enforced, so an epic opened without one turns the build red.
 
 **Recently finished:**
+[the package picker, remade](https://github.com/olafkfreund/nixarchy/issues/491)
+— a miss opens the picker instead of printing a URL, rows say what they cost
+(licence, homepage, unfree, broken, and whether you already have it), a dry run
+shows the diff before anything is written, and Remove means remove. The last
+child was the interesting one: adding several packages ran one nixpkgs
+evaluation per name, and on a non-interactive shell the first unresolvable name
+aborted the loop — so `nixarchy pkg add ripgrep typo fd` wrote `ripgrep` and
+**silently dropped `fd`**. One evaluation for all of them fixed the speed
+(1.06s to 0.21s for five, flat in the count) and the data loss together. Six
+children closed.
+Also
 [a reinstall image of this machine](https://github.com/olafkfreund/nixarchy/issues/478)
 — `nixarchy reinstall iso` builds a bootable image from this machine's own
 configuration, so it can be rebuilt on new hardware after the disk is gone. The

--- a/README.md
+++ b/README.md
@@ -1928,10 +1928,23 @@ somebody who only uses nixarchy, and that is the gap those posts fill.
 
 | epic | what it is for | |
 | --- | --- | --- |
-| [#478](https://github.com/olafkfreund/nixarchy/issues/478) | **A reinstall image** — build a bootable image from this machine's own configuration, so it can be rebuilt on new hardware. Not a backup: it carries no `/home` and booting it erases the target | 6 filed |
 | [#491](https://github.com/olafkfreund/nixarchy/issues/491) | **The package picker, remade** — a miss opens the picker instead of a URL, rows say what they cost, and packages can be removed as well as added | 6 filed |
 
 **Recently finished:**
+[a reinstall image of this machine](https://github.com/olafkfreund/nixarchy/issues/478)
+— `nixarchy reinstall iso` builds a bootable image from this machine's own
+configuration, so it can be rebuilt on new hardware after the disk is gone. The
+fifth way back, and the only one that survives losing the disk: generations
+cover a bad change, snapshots cover a deleted file, the home backup covers
+dotfiles, the config repo covers the configuration, and this covers the whole
+system. It is not a backup and does not pretend to be — it carries no `/home`,
+and booting it erases the target. A `--net` variant trades ~1.5 GB for fetching
+the closure, and **predicts what it cannot fetch** twice over: on the build
+machine before a stick is burned, and on the target before anything is
+formatted, where only a literal exit 0 reads as "all fetchable". The check that
+keeps it honest asserts #436's property — not that the install succeeded, but
+that nothing was built and nothing was fetched. Six children closed.
+Also
 [the escape hatches](https://github.com/olafkfreund/nixarchy/issues/566)
 — the moment that breaks NixOS is running a binary somebody else compiled, and
 `pip install` succeeding then dying on `libGL.so.1` is the shape of it. `nix-ld`


### PR DESCRIPTION
**Stacks on #604** (base `docs/roadmap-566-finished`) — all three edit the same README region, so they go in sequence. Retarget to `main` once #604 lands.

Moves the rows for **#478** (reinstall image) and **#491** (package picker) to *Recently finished*. With #604's #566 row, that is all three epics, and **the Roadmap table is now empty.**

Every child verified **against the tree**, not against the PRs that claimed them.

### #478 — a reinstall image

| child | evidence |
|---|---|
| `lib.mkUserIso` over a foreign flake | `flake.nix` |
| embed the repo, autostart via `nixarchy.from=` | `installer/cd.nix` |
| `nixarchy-reinstall-iso` + menu row | command ships, 10 menu references |
| free-space and config-drift preflights | both in the command |
| a network variant (#483) | `--net`, merged as #600 |
| a VM check (#484) | green in nightly 34557396063 |

### #491 — the package picker

Miss opens the picker, richer rows, `pkg-remove` with Remove coverage, dry-run diff, `allowUnfreePredicate` help, and batch verification (#496).

**#496 read as performance and was data loss.** Adding several packages ran one nixpkgs evaluation per name, and a non-interactive shell aborted on the first unresolvable one — so `nixarchy pkg add ripgrep typo fd` wrote `ripgrep` and **silently dropped `fd`**. One evaluation fixed both; the check puts the bad name **first**, the ordering the old loop died on.

## An empty table needed a sentence, not nothing

A section titled *"what is being worked on, and what is planned"* rendering as a bare header row reads like a mistake. It isn't one — so it says so, says where the three went, and names the property that makes the emptiness trustworthy: **the section is CI-enforced**, so an epic opened without a row turns the build red. A reader can therefore conclude from an empty table that nothing is in flight, rather than that somebody forgot.

## Guard

```
open epics:   (none)
roadmap rows: (none)
HALF 1 PASS · HALF 2 PASS
```

Thirteen README-targeted `readme-counts.sh` patterns still match exactly once. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5