### PR TITLE
The Roadmap names the two new epics: agent skills (#606) and secrets (#611)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1926,11 +1926,9 @@ with a changelog: what was added, what changed, and what is coming. This
 section says what is PLANNED; a merged pull request announces nothing to
 somebody who only uses nixarchy, and that is the gap those posts fill.
 
-**Nothing is in flight right now.** The three epics that were here — the
-escape hatches, the reinstall image and the package picker — all finished, and
-the table below is where they went. That is a real state rather than an
-oversight: the next one gets a row here when it is filed, and this section is
-CI-enforced, so an epic opened without one turns the build red.
+| epic | what it is for | |
+| --- | --- | --- |
+| [#606](https://github.com/olafkfreund/nixarchy/issues/606) | **The skills that cover what nixarchy actually does** — an agent asked why a downloaded binary will not run has nothing to reach for today. Three skills: the loader ladder, gaming, and one flake across several machines | 3 filed |
 
 **Recently finished:**
 [the package picker, remade](https://github.com/olafkfreund/nixarchy/issues/491)

--- a/README.md
+++ b/README.md
@@ -1929,6 +1929,7 @@ somebody who only uses nixarchy, and that is the gap those posts fill.
 | epic | what it is for | |
 | --- | --- | --- |
 | [#606](https://github.com/olafkfreund/nixarchy/issues/606) | **The skills that cover what nixarchy actually does** — an agent asked why a downloaded binary will not run has nothing to reach for today. Three skills: the loader ladder, gaming, and one flake across several machines | 3 filed |
+| [#611](https://github.com/olafkfreund/nixarchy/issues/611) | **Secrets you can actually use** — adding one is five manual steps today and neither `sops` nor `ssh-to-age` is on PATH. A menu row and an editor instead; a machine that can say what secrets exist and what uses them; a personal key you can copy without a terminal | 4 filed |
 
 **Recently finished:**
 [the package picker, remade](https://github.com/olafkfreund/nixarchy/issues/491)


### PR DESCRIPTION
**Stacks on #604**, which carries the three finished epics' row moves. Retarget to `main` once that lands.

Part one of three for filing #606, in the order §12 requires.

## The gap, measured rather than asserted

Thirteen skills ship and they are all **system-administration** shaped. The desktop grew features none of them covers — found by grepping the skills themselves:

| feature | manual page | skills mentioning it |
|---|---|---|
| Prebuilt binaries / `nix-ld` | yes | **0** |
| Gaming | yes | 3 passing lines |
| Boxes, sandboxes, many-machines, channels, remote desktop, `pkg new` | yes | **0** |

## Three, not nine

A skill per feature dilutes the index. The ones that earn a skill have a **decision tree**, where picking the wrong route costs the user an afternoon:

- **#607 `nixos-binaries`** — the ladder out of *"why won't this binary run"*: `nix-ld` → `envfs` → FHS shell → box → `pkg new`
- **#608 `nixos-gaming`** — Steam, Proton, the 32-bit stack, controllers, RetroArch's store-resolved cores
- **#609 `nixos-fleet`** — one flake, several machines

The rest are a paragraph in an existing skill. **"Review this config" is deliberately not one** — it belongs in `nixos-doctor`, which already owns "what is wrong with this machine".

## Why the row comes first

§12's guard fails a PR when an open epic has no Roadmap row — that has turned `main` red **five times**, every time because the label went on first. Its other half only complains about a roadmap number that is a **closed** epic, so a row naming an unlabelled issue is safe. **#606 carries no `epic` label yet**; it gets one once this is on `main`.

Simulated against the live issue list:

```
open epics:   (none)
roadmap:      606
HALF 1 PASS · HALF 2 PASS
```

This also refills the table the three finished epics emptied, so the "nothing is in flight" paragraph goes with them.

Docs only. Thirteen README-targeted `readme-counts.sh` patterns still match exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5