### PR TITLE
Name the X libraries as nixpkgs names them now

### DIFF
--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -665,12 +665,12 @@ in
           # The X client stack, for everything that runs under XWayland:
           # Electron, Java AWT, SDL/GLFW games. libX11 is the core protocol;
           # the rest are the extensions Chromium's own sandbox probes for.
-          xorg.libX11
-          xorg.libxcb
-          xorg.libXcursor
-          xorg.libXrandr
-          xorg.libXi
-          xorg.libXext
+          libx11
+          libxcb
+          libxcursor
+          libxrandr
+          libxi
+          libxext
           # Text on screen: fontconfig finds the fonts, freetype rasterises
           # them. A GUI binary without them renders blank labels or aborts.
           fontconfig


### PR DESCRIPTION
nixpkgs flattened the xorg package set, so the six X entries in the nix-ld
library list each print a deprecation warning on **every evaluation of every
host** that imports `modules/nixos.nix`:

```
evaluation warning: The xorg package set has been deprecated, 'xorg.libX11' has been renamed to 'libx11'
evaluation warning: The xorg package set has been deprecated, 'xorg.libxcb' has been renamed to 'libxcb'
... four more
```

Six lines of noise per build, for a rename that changes nothing else.

## Nothing rebuilds

Checked pairwise before making the change, rather than assuming:

```nix
with pkgs.xorg; [ libX11 libxcb libXcursor libXrandr libXi libXext ]
  ==
with pkgs; [ libx11 libxcb libxcursor libxrandr libxi libxext ]   # → true, identical outPaths
```

Same derivations, so no closure moves.

## Standalone use is unaffected

The flat attributes exist in this flake's **own pinned nixpkgs**, not just in the
one a consumer following it would supply — checked against both. Otherwise this
would look fine from a consumer repo and break anyone using nixarchy on its own
lock.

## What stays

The comment above the block still says "libX11 is the core protocol". That is
naming the X11 protocol library, not the attribute, so it is left alone.

Verified end to end: a host config that previously printed six of these
evaluates with zero.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T