### PR TITLE
Docker runs rootless, so no group grants the desktop user passwordless root

### DIFF
--- a/data/services.nix
+++ b/data/services.nix
@@ -42,7 +42,9 @@
 # modules/nixos.nix enables these for every nixarchy machine, at mkDefault, so
 # a catalogue entry would be an option that changes nothing:
 #
-#   virtualisation.docker.enable        nixos.nix:705
+#   virtualisation.docker.rootless      nixos.nix (the ROOTED daemon is off by
+#                                       default: its socket needs the `docker`
+#                                       group, which is passwordless root)
 #   services.printing.enable            nixos.nix:634
 #   services.avahi.{enable,nssmdns4}    nixos.nix:635-639
 #

--- a/docs/manual/boxes.md
+++ b/docs/manual/boxes.md
@@ -67,8 +67,8 @@ This turns on rootless [podman](https://podman.io) (`virtualisation.docker`,
 if you already use it, is untouched -- boxes only need podman) and installs
 `distrobox` itself. Rootless means `--userns keep-id`: files a box writes in
 `$HOME` stay yours, there is no daemon, and no root-equivalent group -- the
-same thing this desktop's own `nixos-security` skill already flags about
-plain Docker.
+same property nixarchy's own rootless Docker default has, for the same
+reason.
 
 ## Making one
 

--- a/docs/manual/development-tools.md
+++ b/docs/manual/development-tools.md
@@ -136,21 +136,93 @@ If what you want is a project with a pinned interpreter, use
 `pip install` to work at all, [Python](python) is the page that explains why
 it sometimes does not.
 
-## Docker
+## Docker, rootless
 
-Docker and Docker Compose are enabled by `virtualisation.docker.enable`,
-which nixarchy sets by default, and Lazydocker is on `Super + Shift + D`.
+Docker and Docker Compose are enabled by default and Lazydocker is on
+`Super + Shift + D`, as upstream. What differs is **whose** daemon it is:
+nixarchy runs Docker **rootless**, as a systemd user service under your own
+account, rather than the usual root-owned daemon.
 
-As upstream, your user is not in the `docker` group, for the reason upstream
-gives: the group is effectively passwordless root. Use `sudo docker`, and the
-Docker TUI asks for authorisation through polkit when it needs the socket.
-_Setup > Security > Sudoless Docker_ (`omarchy-setup-security-sudoless-docker`)
-adds you to the group after its warning. To make that choice part of your
-configuration rather than a one-off, the declarative form is:
+`docker build`, `docker run`, `docker compose` all work unprivileged, with no
+`sudo` and no group.
+
+The reason is the group that arrangement otherwise requires. A root-owned
+socket means `docker ps` without `sudo` needs you in the `docker` group, and
+**that group is equivalent to passwordless root** -- `docker run -v /:/host` is
+the whole exploit. It is not that it grants something you lack; you are in
+`wheel` already. It removes **the prompt**, for everything running as you: a
+browser, an `npm install` postinstall script, a dependency in a shell you
+opened for one afternoon. Rootless keeps the convenience and drops that.
+
+An escape from a rootless container gets your user account, not the machine.
+
+### What rootless costs
+
+Not nothing, so it is worth knowing before you meet it:
+
+| | |
+|---|---|
+| ports below 1024 | need `net.ipv4.ip_unprivileged_port_start` lowered, or a higher port |
+| bind mounts | file ownership maps through user namespaces, which surprises people once |
+| devcontainers, testcontainers | some assume a root-owned socket and fail to find one |
+| containers after logout | it is a *user* service -- `loginctl enable-linger $USER` to keep them running |
+| images you already had | live in root's `/var/lib/docker` and are not visible to your own daemon |
+
+That last row is the one that bites on upgrade. If you were running nixarchy
+before this changed, your existing images and containers are still there, under
+the root daemon -- `sudo docker images` shows them. Re-pull or `docker save` /
+`docker load` across, or turn the rooted daemon back on.
+
+### Turning the rooted daemon back on
+
+It is your machine. One line puts the classic arrangement back, group included:
 
 ```nix
-users.users.<you>.extraGroups = [ "docker" ];
+virtualisation.docker.enable = true;
 ```
+
+Rootless switches off when you do that, so `DOCKER_HOST` is not left pointing
+at a second daemon. **You are then in the `docker` group, with the
+root-equivalence described above** -- that is the trade you are making, and it
+is a reasonable one to make deliberately for devcontainers or a low port.
+
+To keep the rooted daemon and *not* the group, use `sudo docker` and say which
+groups you keep:
+
+```nix
+virtualisation.docker.enable = true;
+users.users.<you>.extraGroups = lib.mkForce [ "wheel" "video" "input" "i2c" ];
+```
+
+`mkForce`, because a plain assignment merges with what is there instead of
+replacing it. **List the groups you keep** -- `mkForce [ ]` would take `wheel`
+with it and leave you unable to `sudo`.
+
+Upstream offers _Setup > Security > Sudoless Docker_
+(`omarchy-setup-security-sudoless-docker`) for the same opt-in. It still works;
+on a rootless machine there is no root socket for it to grant access to.
+
+### Podman
+
+Rootless [podman](https://podman.io) solves the same problem a different way --
+no daemon at all. nixarchy already uses it: [boxes](boxes) are rootless podman
+underneath, though podman is only switched on when you enable boxes.
+
+If you prefer it as your container runtime, note that nixpkgs refuses to build
+a machine where both `dockerCompat` and the rooted Docker daemon exist
+(*"Option dockerCompat conflicts with docker"*). With nixarchy's default that
+daemon is already off, so this is enough:
+
+```nix
+virtualisation.podman = {
+  enable = true;
+  dockerCompat = true;                      # provides a `docker` command
+  defaultNetwork.settings.dns_enabled = true;
+};
+```
+
+You will then want `virtualisation.docker.rootless.enable = false;` as well, so
+only one thing is answering to the name `docker`.
 
 Upstream's [Docker section](https://omarchy.org/manual/development-tools/)
 covers the rest — including _Install > Development > Docker DB_ for local

--- a/installer/host.nix
+++ b/installer/host.nix
@@ -198,11 +198,15 @@
 
   users.users.${username} = {
     isNormalUser = true;
+    # No "docker" here. modules/nixos.nix adds it if and only if the rooted
+    # daemon is enabled, which by default it is not; listing it outright left
+    # the group on every installed machine even with Docker off -- a group
+    # granting root to whatever installs a socket there later, which is the
+    # exact outcome that conditional exists to prevent.
     extraGroups = [
       "wheel"
       "video"
       "input"
-      "docker"
       "i2c"
     ];
     # The password is a FILE, not an evaluation input, and that is what makes

--- a/modules/AGENTS.md
+++ b/modules/AGENTS.md
@@ -543,24 +543,39 @@ the alternative is guessing which of a machine's users logs into the
 desktop.
 
 <a id="docker-is-enabled-above-at-mkdefault-for-every-mac"></a>
-### Docker is enabled above, at mkDefault, for every machine
+### Docker runs rootless, and that is why there is no group
 
 ```nix
-++ lib.optional config.virtualisation.docker.enable "docker";
+virtualisation.docker.enable = lib.mkDefault false;
+virtualisation.docker.rootless.enable = lib.mkDefault (!config.virtualisation.docker.enable);
 ```
 
-Docker is enabled above, at mkDefault, for every machine. Enabled and
-unusable, until now: without this group every command wants sudo, and
-`docker ps` answers "permission denied while trying to connect to the
-Docker daemon socket" -- which reads like a broken install rather than
-a missing group.
+The rooted daemon's socket is owned by root, so the only way `docker ps`
+works without sudo is the `docker` group -- and that group is
+passwordless root for anything running as the user, which on a desktop
+means a browser, a postinstall script, any dependency in any shell.
+`docker run -v /:/host` is the whole exploit. It grants no capability
+the user lacks (they are in `wheel`); what it removes is the prompt.
 
-The installer has always put its user in `docker` directly
-(installer/host.nix), so this was only ever wrong for someone adding
-nixarchy to a machine they already run: they got the daemon and not
-the access. Conditioned on the option rather than set unconditionally,
-so turning Docker off does not leave a group behind that grants root
-to whatever installs a socket there later.
+This was the arrangement here until #617/#618. The group was added
+conditionally in this file *and* listed outright in
+`installer/host.nix` -- so the conditional, whose entire purpose was
+that "turning Docker off does not leave a group behind that grants root
+to whatever installs a socket there later", was defeated on every
+machine the installer built. Both halves are fixed together: the
+default is rootless, and `host.nix` no longer names the group.
+
+Rootless is gated on the rooted daemon being off rather than set flat.
+Somebody who turns Docker back on -- devcontainers, a port below 1024 --
+gets the classic arrangement and the group with it, because Docker
+enabled and unusable reads as a broken install. They must not get both:
+`setSocketVariable` would otherwise point their `DOCKER_HOST` at a
+second daemon they never asked for.
+
+`tests/options.nix` asserts both states. The check that lived here
+previously asserted the user *was* in the group; it was correct for the
+old default and was retargeted rather than satisfied, which is the
+distinction CLAUDE.md §1 draws.
 
 <a id="default-fontconfig-conf-avail-50-omarchy-conf-whic"></a>
 ### default/fontconfig/conf.avail/50-omarchy.conf, which upstream symlinks

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -1027,8 +1027,24 @@ in
       "${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}"
     ];
 
-    # install/config/docker.sh
-    virtualisation.docker.enable = lib.mkDefault true;
+    # install/config/docker.sh, but rootless.
+    #
+    # The rooted daemon's socket is owned by root, so making `docker ps` work
+    # without sudo means the `docker` group -- and that group is passwordless
+    # root for anything running as the user. Rootless runs the daemon AS the
+    # user instead: same `docker` command, no group, and an escape gets the
+    # account rather than the machine.
+    #
+    # Why: modules/AGENTS.md#docker-is-enabled-above-at-mkdefault-for-every-mac
+    virtualisation.docker.enable = lib.mkDefault false;
+    virtualisation.docker.rootless = {
+      # Gated on the rooted daemon being off rather than set flat, so somebody
+      # who turns Docker back on gets the classic arrangement and not both --
+      # setSocketVariable would otherwise point their DOCKER_HOST at a daemon
+      # they did not ask for.
+      enable = lib.mkDefault (!config.virtualisation.docker.enable);
+      setSocketVariable = lib.mkDefault (!config.virtualisation.docker.enable);
+    };
 
     networking = {
       # install/config/firewall.sh (upstream uses ufw)

--- a/pkgs/doctor.sh
+++ b/pkgs/doctor.sh
@@ -1186,6 +1186,13 @@ fi
 say ""
 
 for unit in docker.service NetworkManager.service; do
+  # Docker's default here is ROOTLESS, so the system docker.service is off on a
+  # stock machine and its absence says nothing. The daemon is a *user* unit of
+  # the same name; without this arm the doctor reported "docker is off here" on
+  # every correctly configured desktop.
+  if [ "$unit" = docker.service ] && systemctl --user is-enabled docker.service >/dev/null 2>&1; then
+    continue
+  fi
   if ! systemctl is-enabled "$unit" >/dev/null 2>&1; then
     say "  ${dim}${unit%.service} is off here; nixarchy defaults it on but defers to you.${off}"
   fi

--- a/pkgs/doctor.sh
+++ b/pkgs/doctor.sh
@@ -1190,7 +1190,13 @@ for unit in docker.service NetworkManager.service; do
   # stock machine and its absence says nothing. The daemon is a *user* unit of
   # the same name; without this arm the doctor reported "docker is off here" on
   # every correctly configured desktop.
-  if [ "$unit" = docker.service ] && systemctl --user is-enabled docker.service >/dev/null 2>&1; then
+  # XDG_RUNTIME_DIR first, and it is not belt-and-braces: `systemctl --user`
+  # with no user bus to talk to is a host-environment read whose answer depends
+  # on whether a session exists, which is exactly the kind of thing that makes
+  # a check pass on one runner and fail on the next. A rootless daemon only
+  # means anything where there IS a user session.
+  if [ "$unit" = docker.service ] && [ -n "${XDG_RUNTIME_DIR:-}" ] \
+     && systemctl --user is-enabled docker.service >/dev/null 2>&1; then
     continue
   fi
   if ! systemctl is-enabled "$unit" >/dev/null 2>&1; then

--- a/pkgs/omarchy/skills/nixos-services/SKILL.md
+++ b/pkgs/omarchy/skills/nixos-services/SKILL.md
@@ -171,7 +171,9 @@ agenix, sops-nix, rotation, leak handling — use the **`nixos-secrets` skill**.
 
 ```nix
 virtualisation.docker.enable = true;          # or virtualisation.podman
-users.users.<name>.extraGroups = [ "docker" ];  # docker group == root. Say so.
+# The docker group == passwordless root. Say so, and prefer rootless, which is
+# nixarchy's default and needs no group at all:
+virtualisation.docker.rootless = { enable = true; setSocketVariable = true; };
 
 virtualisation.oci-containers.containers.myapp = {
   image = "myapp:1.2.3";                      # pin a tag; :latest is not reproducible

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -1048,11 +1048,22 @@ let
     services.ollama.port = 21434;
   };
 
-  # And the group the desktop user gets, which is the other half of #92: docker
-  # is enabled for every machine at nixos.nix:705 and was usable only on
-  # machines the installer built.
-  dockerGroups =
-    (configBeside { programs.nixarchy.user = "someone"; }).users.users.someone.extraGroups;
+  # And the group the desktop user gets. This check used to assert the user WAS
+  # in `docker`, which was right while the rooted daemon was the default: the
+  # group was the only way `docker ps` worked without sudo. The default is now
+  # rootless, so the property flipped -- the group is passwordless root, and
+  # nothing should be handing it out by default. Both states, because the off
+  # state is the one a refactor breaks quietly: somebody who turns the rooted
+  # daemon back on must still get the group, or Docker is enabled and unusable.
+  dockerDefault = configBeside { programs.nixarchy.user = "someone"; };
+  dockerRooted = configBeside {
+    programs.nixarchy.user = "someone";
+    virtualisation.docker.enable = true;
+  };
+  dockerGroups = dockerDefault.users.users.someone.extraGroups;
+  dockerRootedGroups = dockerRooted.users.users.someone.extraGroups;
+  dockerRootlessDefault = dockerDefault.virtualisation.docker.rootless.enable;
+  dockerRootlessRooted = dockerRooted.virtualisation.docker.rootless.enable;
 
   # ---- "nixarchy wrote this machine", both ways -------------------------
   #
@@ -1273,6 +1284,9 @@ pkgs.runCommand "nixarchy-options"
     ollamaPort = builtins.toString ollamaBeside.services.ollama.port;
     ollamaEndpoint = ollamaBeside.programs.nixarchy.localAi.resolved.endpoint;
     dockerGroups = pkgs.lib.concatStringsSep " " dockerGroups;
+    dockerRootedGroups = pkgs.lib.concatStringsSep " " dockerRootedGroups;
+    dockerRootlessDefault = pkgs.lib.boolToString dockerRootlessDefault;
+    dockerRootlessRooted = pkgs.lib.boolToString dockerRootlessRooted;
     managedModeA = pkgs.lib.boolToString managedModeA;
     factoryUnitModeA = pkgs.lib.boolToString factoryUnitModeA;
     # The factory-reset script, run rather than read. Every branch of it is
@@ -1514,11 +1528,31 @@ pkgs.runCommand "nixarchy-options"
           echo "local-ai yields the Ollama port and the agents follow it"
 
           case " $dockerGroups " in
-            *" docker "*) echo "the desktop user can reach the docker socket" ;;
-            *) echo "docker is enabled but the desktop user is not in its group" >&2
-               echo "groups: $dockerGroups" >&2
+            *" docker "*)
+               echo "the default machine puts the desktop user in the docker group," >&2
+               echo "which is passwordless root: groups: $dockerGroups" >&2
+               exit 1 ;;
+            *) echo "no docker group by default" ;;
+          esac
+          [ "$dockerRootlessDefault" = "true" ] || {
+            echo "no docker group AND no rootless daemon: docker is simply gone" >&2
+            exit 1
+          }
+          echo "rootless docker is what gives the default machine containers"
+
+          # The other state. Turning the rooted daemon back on has to restore
+          # the group, or docker is enabled and every command wants sudo -- and
+          # rootless must go, so DOCKER_HOST is not pointed at a second daemon.
+          case " $dockerRootedGroups " in
+            *" docker "*) echo "opting back in to the rooted daemon restores the group" ;;
+            *) echo "rooted docker is enabled but the user is not in its group" >&2
+               echo "groups: $dockerRootedGroups" >&2
                exit 1 ;;
           esac
+          [ "$dockerRootlessRooted" = "false" ] || {
+            echo "rooted docker is on and rootless came with it" >&2
+            exit 1
+          }
 
           # ---- no Omarchy artwork on either boot splash -------------------
           #


### PR DESCRIPTION
## What this changes, and why

The desktop user was in the `docker` group, which is equivalent to passwordless
root: `docker run -v /:/host` is the whole exploit. It granted nothing a `wheel`
user lacks — what it removed was **the prompt**, for everything running as the
user: a browser, an `npm install` postinstall script, a dependency in a shell
opened for one afternoon.

Docker now runs **rootless** by default — the daemon is a systemd *user*
service under the user's own account. `docker build`, `docker run` and
`docker compose` still work with no `sudo`, and there is no group to hand out.
A container escape gets the account rather than the machine.

Two halves, because either alone is ineffective:

- `modules/nixos.nix` defaults `virtualisation.docker.enable` to `false` and
  `virtualisation.docker.rootless` to on. Rootless is gated on the rooted
  daemon being off rather than set flat, so someone who turns Docker back on
  gets the classic arrangement and the group with it — Docker enabled and
  unusable reads as a broken install — and never both, since
  `setSocketVariable` would otherwise point their `DOCKER_HOST` at a second
  daemon they did not ask for.
- `installer/host.nix` no longer lists `docker` in `extraGroups`. The module's
  line was already conditional, and `modules/AGENTS.md` says why: *"so turning
  Docker off does not leave a group behind that grants root to whatever
  installs a socket there later"*. The installer listed it outright, which
  defeated that on every machine the installer built.

Not Arch-specific and not upstream's bug: upstream leaves the user out of the
group and offers _Setup > Security > Sudoless Docker_ as an explicit opt-in.
This was nixarchy's own divergence.

## How I proved the check fails

`tests/options.nix` asserted the user **was** in the group — correct while the
rooted daemon was the default. Retargeted rather than satisfied (§1: ask what
the check asserts before asking what broke), and it now covers both states.

Restoring the old default (`virtualisation.docker.enable = lib.mkDefault true`)
with the new check in place:

```
a bundled service yields to configuration the user already had
local-ai yields the Ollama port and the agents follow it
the default machine puts the desktop user in the docker group,
which is passwordless root: groups: input docker
```

Green with the fix — output in the run below.

## Checks run locally

- `nix build .#checks.x86_64-linux.options` — red then green, above
- `shellcheck -S warning pkgs/doctor.sh` — clean

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (no new files)
- [x] If this adds an option: `tests/options.nix` covers both states
- [x] If this adds a `checks.*` entry: none added

## Collateral this turned up

Four places encoded the old default and would have gone stale silently:

- `pkgs/doctor.sh` checked the **system** `docker.service`. Under rootless it
  is correctly off, so the doctor would have printed *"docker is off here"* on
  every properly configured desktop. It now checks the user unit first.
- `data/services.nix` listed `virtualisation.docker.enable` under "already on
  for every machine".
- `docs/manual/boxes.md` contrasted boxes' rootless podman with "plain Docker"
  having a root-equivalent group — no longer the contrast it was.
- `pkgs/omarchy/skills/nixos-services/SKILL.md` advised adding the group.

## What this cost, and where it is written down

Nothing general beyond what is already in §1 — but this PR *is* a §1 case worth
noting: the check that failed here was correct for months and encoded the old
default. The design record at `modules/AGENTS.md#docker-is-enabled-above-at-mkdefault-for-every-mac`
is rewritten in this PR rather than left describing the old arrangement.

Refs #617, Refs #618
