### PR TITLE
Three skills for the features the desktop grew: prebuilt binaries, gaming, and a fleet

### DIFF
--- a/.github/scripts/readme-counts.sh
+++ b/.github/scripts/readme-counts.sh
@@ -173,6 +173,8 @@ word_for() {
     5) echo Five ;; 6) echo Six ;; 7) echo Seven ;; 8) echo Eight ;;
     9) echo Nine ;; 10) echo Ten ;; 11) echo Eleven ;; 12) echo Twelve ;;
     13) echo Thirteen ;; 14) echo Fourteen ;; 15) echo Fifteen ;;
+    16) echo Sixteen ;; 17) echo Seventeen ;; 18) echo Eighteen ;;
+    19) echo Nineteen ;; 20) echo Twenty ;;
     *) echo "" ;;
   esac
 }
@@ -227,8 +229,8 @@ quantity "pacman-replaced" "$repl_word" \
   '^(Six|Seven|Eight|Nine|Ten|Eleven|Twelve) of those are replaced.*' \
   's/^(Six|Seven|Eight|Nine|Ten|Eleven|Twelve) of those are replaced/'"$repl_word"' of those are replaced/'
 quantity "skills" "$skills_word" \
-  '^So (twelve|thirteen|fourteen|fifteen) skills ship here instead:$' \
-  's/^So (twelve|thirteen|fourteen|fifteen) skills ship here instead:$/So '"$skills_word"' skills ship here instead:/'
+  '^So (twelve|thirteen|fourteen|fifteen|sixteen|seventeen) skills ship here instead:$' \
+  's/^So (twelve|thirteen|fourteen|fifteen|sixteen|seventeen) skills ship here instead:$/So '"$skills_word"' skills ship here instead:/'
 quantity "apps-total" "$a_total" \
   '.*\| ([0-9]+) apps in the selection \|.*' \
   "s/\| [0-9]+ apps in the selection \| [0-9]+ from nixpkgs, [0-9]+ as NixOS modules, [0-9]+ built here, [0-9]+ with no equivalent \|/| $a_total apps in the selection | $a_nixpkgs from nixpkgs, $a_mod as NixOS modules, $a_ours built here, $a_un with no equivalent |/"
@@ -272,15 +274,15 @@ quantity "installer-questions-iso" "$questions_word" \
 readme_saved=$readme
 readme="$root/docs/llms.txt"
 quantity "skills-llms" "$skills_cap" \
-  '^- (Ten|Eleven|Twelve|Thirteen|Fourteen|Fifteen) AI agent skills written.*' \
-  's/^- (Ten|Eleven|Twelve|Thirteen|Fourteen|Fifteen) AI agent skills written/- '"$skills_cap"' AI agent skills written/'
+  '^- (Ten|Eleven|Twelve|Thirteen|Fourteen|Fifteen|Sixteen|Seventeen) AI agent skills written.*' \
+  's/^- (Ten|Eleven|Twelve|Thirteen|Fourteen|Fifteen|Sixteen|Seventeen) AI agent skills written/- '"$skills_cap"' AI agent skills written/'
 quantity "skills-llms-manual" "$skills_word" \
-  '.*the (ten|eleven|twelve|thirteen|fourteen|fifteen) NixOS agent skills.*' \
-  's/the (ten|eleven|twelve|thirteen|fourteen|fifteen) NixOS agent skills/the '"$skills_word"' NixOS agent skills/'
+  '.*the (ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen) NixOS agent skills.*' \
+  's/the (ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen) NixOS agent skills/the '"$skills_word"' NixOS agent skills/'
 readme="$root/docs/manual/ai.md"
 quantity "skills-manual-ai" "$skills_word" \
-  '^(ten|eleven|twelve|thirteen|fourteen|fifteen) skills instead of one:$' \
-  's/^(ten|eleven|twelve|thirteen|fourteen|fifteen) skills instead of one:$/'"$skills_word"' skills instead of one:/'
+  '^(ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen) skills instead of one:$' \
+  's/^(ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen) skills instead of one:$/'"$skills_word"' skills instead of one:/'
 readme=$readme_saved
 
 # The count says a number moved; this says which skill a table forgot. Every

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -780,7 +780,7 @@ jobs:
           skills=result/share/omarchy/default/agents/skills
 
           have=$(ls "$skills" | sort | tr '\n' ' ')
-          [ "$have" = "devenv diagnose-crash nixarchy nixos nixos-ai nixos-android nixos-config-repo nixos-doctor nixos-gpu nixos-performance nixos-secrets nixos-security nixos-services " ] || {
+          [ "$have" = "devenv diagnose-crash nixarchy nixos nixos-ai nixos-android nixos-binaries nixos-config-repo nixos-doctor nixos-fleet nixos-gaming nixos-gpu nixos-performance nixos-secrets nixos-security nixos-services " ] || {
             echo "::error::unexpected skill set: $have"
             exit 1
           }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,15 @@ Two other ways a check stops checking, both found in one week:
   **Any list naming things that exist elsewhere wants a comparison, not
   discipline** — and the comparison should name the missing item, because a
   count only says a number moved.
+- **A guard can also fail CLOSED, and then it looks like your change.**
+  `readme-counts.sh` spells its counts as words from a hand-written `word_for`
+  table and matches them with a fixed alternation (`twelve|thirteen|…`). The
+  sixteenth skill is not a drift the script reports — it is a number the script
+  cannot *say*, so it refuses with "computed as empty" or "nothing matches its
+  pattern", which reads as a broken script rather than a missing vocabulary
+  entry. That refusal is the design (§4's rule: an auto-fixer that cannot refuse
+  is worse than a check). **Teach it the new word in the same PR** — the case
+  table and every alternation that carries the old range.
 
 ## 5. Git and flake mechanics that bite
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ this repo replaced with one that deliberately refuses. Shipping them unchanged m
 an agent confidently doing imperative things the next rebuild wipes, which is the
 one failure mode that looks like success.
 
-So thirteen skills ship here instead:
+So sixteen skills ship here instead:
 
 | skill | owns |
 |---|---|
@@ -203,6 +203,9 @@ So thirteen skills ship here instead:
 | **`nixos-doctor`** | The sweep to run *before* you have a theory: failed units, `-p err`, disk, memory, and what changed between generations |
 | **`nixos-config-repo`** | Getting the configuration into git and keeping it there, and the two things that bite: untracked files are invisible to the build, and git refuses a repository owned by somebody else |
 | **`nixos-android`** | scrcpy over USB and over Wi-Fi, Waydroid and what it will not run, and the two traps: `programs.adb.enable` is inert on current nixpkgs, and `adb mdns services` cannot work because android-tools is built without an mDNS backend |
+| **`nixos-binaries`** | Why a downloaded binary, an AppImage or a pip wheel will not run, and the ladder out: nix-ld's curated library set, envfs, an FHS environment, a box, packaging it — including the correction that nix-ld cannot help an interpreter nixpkgs built |
+| **`nixos-gaming`** | Steam as a module rather than a package, Proton per title, the 32-bit graphics stack that is the usual cause, controllers, gamescope, and thirteen libretro cores that live in the package rather than `/usr/lib` |
+| **`nixos-fleet`** | One flake, several machines: the `hosts/<name>/` layout, what is shared and what is per-machine, `nixarchy-apply`'s hostname match, pulling on a timer, and where `--target-host` stops |
 | **`devenv`** | Per-project environments: `devenv.nix`, the lockfile, and the judgement call of whether a requested tool belongs to the project or to the machine |
 | **`diagnose-crash`** | Upstream's, patched. Keeps its name because `omarchy-agent-crash` reads that path literally |
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -93,7 +93,7 @@ Key facts an assistant should know before answering questions about nixarchy:
   run. nixpkgs first, always.
 - Unfree packages are allowed by default (`programs.nixarchy.allowUnfree =
   false;` restores nixpkgs' policy).
-- Thirteen AI agent skills written for NixOS ship with the desktop and are exposed
+- Sixteen AI agent skills written for NixOS ship with the desktop and are exposed
   through Menu ▸ Trigger ▸ Ask; `programs.nixarchy.localAi.enable = true`
   runs them against local models via Ollama (needs a supported GPU).
 
@@ -116,7 +116,7 @@ Key facts an assistant should know before answering questions about nixarchy:
 - [Prebuilt binaries](https://olafkfreund.github.io/nixarchy/manual/prebuilt-binaries): the three on-by-default answers to a downloaded Linux binary -- nix-ld and its curated library set, envfs for shebangs, binfmt-registered AppImages -- and where each stops
 - [Boxes](https://olafkfreund.github.io/nixarchy/manual/boxes): Arch or Debian userlands via rootless podman and distrobox, ad hoc or declared (opt-in)
 - [Sandboxes](https://olafkfreund.github.io/nixarchy/manual/sandboxes): disposable NixOS MicroVMs sharing the host store, and the declarative always-up half (opt-in)
-- [AI](https://olafkfreund.github.io/nixarchy/manual/ai): the thirteen NixOS agent skills, the Ask menu, choosing an agent, and running it all locally
+- [AI](https://olafkfreund.github.io/nixarchy/manual/ai): the sixteen NixOS agent skills, the Ask menu, choosing an agent, and running it all locally
 - [Gaming](https://olafkfreund.github.io/nixarchy/manual/gaming): Steam, RetroArch, the launchers and cloud gaming — how each Install ▸ Gaming row lands on NixOS
 - [Android](https://olafkfreund.github.io/nixarchy/manual/android): running Android apps — scrcpy mirroring a phone, and Waydroid in a container
 - [Security](https://olafkfreund.github.io/nixarchy/manual/security): the firewall, disk encryption, and what the port changes

--- a/docs/manual/ai.md
+++ b/docs/manual/ai.md
@@ -38,7 +38,7 @@ location, so most harnesses load it automatically. nixarchy keeps the
 mechanism — `omarchy-provision-user` symlinks every directory under
 `$OMARCHY_PATH/default/agents/skills/` into `~/.claude/skills`,
 `~/.agents/skills`, `~/.codex/skills` and `~/.pi/agent/skills` — but ships
-thirteen skills instead of one:
+sixteen skills instead of one:
 
 | skill | owns |
 |---|---|
@@ -53,6 +53,9 @@ thirteen skills instead of one:
 | `nixos-doctor` | the whole-machine sweep to run before forming a theory |
 | `nixos-config-repo` | getting the configuration into git, and keeping it there |
 | `nixos-android` | mirroring a phone with scrcpy over USB or Wi-Fi, and Waydroid in a container |
+| `nixos-binaries` | why a downloaded binary or a pip wheel will not run, and the ladder out: nix-ld, envfs, AppImages, an FHS environment, a box |
+| `nixos-gaming` | Steam and Proton, the 32-bit graphics stack, controllers, gamescope, RetroArch and the launchers |
+| `nixos-fleet` | one flake and several machines: the `hosts/<name>/` layout, sharing without coupling, pulling on a timer, deploying with `--target-host` |
 | `devenv` | per-project environments: `devenv.nix`, the lockfile, and whether a tool belongs to the project or the machine |
 | `diagnose-crash` | working out why a process dumped core, and where to report it if it is a distribution bug |
 

--- a/pkgs/omarchy/skills/nixos-binaries/SKILL.md
+++ b/pkgs/omarchy/skills/nixos-binaries/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: nixos-binaries
+description: >
+  REQUIRED when a program that is not built by Nix will not run on this NixOS
+  machine — a downloaded release tarball, a vendor CLI, an AppImage, a pip wheel
+  that imports and dies, a Node native module, an installer script. Use when asked
+  why a binary that plainly exists reports "No such file or directory", why an
+  import fails on a `.so`, how to add a library to nix-ld, whether something needs
+  an FHS environment or a container, or how to package software that is in no
+  repository. Triggers: nix-ld, NIX_LD, NIX_LD_LIBRARY_PATH, envfs, appimage,
+  buildFHSEnv, steam-run, patchelf, autoPatchelfHook, ld-linux, "cannot open shared
+  object file", libGL.so.1, libstdc++.so.6, "No such file or directory" on a file
+  that exists, `#!/bin/bash`, `/usr/bin/env`, ImportError, downloaded binary,
+  prebuilt, wheel, distrobox, `nixarchy pkg new`.
+  For per-project toolchains use `devenv`; for the GPU driver underneath a
+  graphics library use `nixos-gpu`.
+---
+
+# NixOS Prebuilt Binaries Skill
+
+A user downloads an ordinary Linux binary and it dies before it starts:
+
+```
+bash: ./tool: No such file or directory
+```
+
+The file exists. What does not exist is what the binary asks for first: a loader
+at `/lib64/ld-linux-x86-64.so.2`, libraries in `/usr/lib`, an interpreter at
+`/bin/bash`. NixOS keeps all of that in `/nix/store` under versioned paths, and
+only programs built by Nix know where. **The binary is asking a reasonable
+question in a filesystem that answers it for nobody.**
+
+The same defect wearing a different hat, from a pip wheel or a Node module:
+
+```
+ImportError: libGL.so.1: cannot open shared object file: No such file or directory
+```
+
+Read that error precisely before doing anything. The wheel is fine, pip is fine,
+the venv is fine. A wheel with compiled code in it is an ordinary Linux binary,
+and at import time the dynamic loader went looking in `/usr/lib`. **This is a
+loader problem, not a packaging problem**, and the two have completely different
+fixes.
+
+## The ladder — cheapest rung first
+
+This is the whole value of this skill. An agent that reaches for a container
+because one library was missing has cost the user an afternoon.
+
+| you have | reach for |
+|---|---|
+| anything in nixpkgs | nixpkgs — always first |
+| a loose prebuilt binary missing a library | `programs.nix-ld.libraries` — one line |
+| a script with `#!/bin/bash` or `/usr/bin/env` | `envfs`, already on — nothing to do |
+| a downloaded AppImage | run it; binfmt registration is already on |
+| pip compiling C against system headers | a `devenv` with the libraries, or `pkgs.buildFHSEnv` |
+| software that wants a whole distribution | a box (distrobox) |
+| software in no repository at all | `nixarchy pkg new <url>` |
+
+Three of those rungs — nix-ld, envfs, AppImage binfmt — are **already on for
+every nixarchy machine**. Most "it will not run" reports are answered by adding
+one entry to a list, not by installing anything.
+
+## Rung 1: nix-ld, the loader and its libraries
+
+[nix-ld](https://github.com/nix-community/nix-ld) puts a shim at the path foreign
+binaries expect the loader at. When one starts, the shim supplies the libraries
+in `programs.nix-ld.libraries` — and nixarchy curates that list well beyond the
+NixOS default: `libstdc++`/`libgcc_s`, `libGL`, the Wayland and X client stacks,
+fontconfig and freetype, glib, NSS/NSPR (every Electron app dlopens `libnss3.so`
+and exits without it), `libasound`, ffmpeg's libraries, zlib, openssl, libxml2.
+The entries and the reason for each are in `modules/nixos.nix`.
+
+When a binary wants something the list does not carry, the error names it. The
+fix is one line in the user's own configuration — **their entries merge with
+nixarchy's, they do not replace them**:
+
+```nix
+programs.nix-ld.libraries = with pkgs; [ libpulseaudio ];
+```
+
+Then rebuild and **log out and back in**. `NIX_LD_LIBRARY_PATH` is set at login,
+so the session they are sitting in keeps the old list — a user who rebuilds,
+retries in the same terminal and reports "it did not work" has hit this and
+nothing else.
+
+To go from a soname to the package that carries it:
+
+```sh
+nix-locate lib/libfoo.so.2          # nix-index, most direct
+```
+
+or search the file name at <https://search.nixos.org>.
+
+### The correction that matters most: nix-ld does NOT help a nixpkgs Python
+
+This is the single most common "I did exactly what the docs said and it still
+failed" report, and guidance elsewhere — including the wiki — states the
+opposite. **Say this before suggesting a `programs.nix-ld.libraries` entry for a
+Python import error.**
+
+nix-ld works by *being* the loader at `/lib64/ld-linux-x86-64.so.2`. Only a
+binary whose ELF interpreter points at that path goes through it, and only that
+loader reads `NIX_LD` and `NIX_LD_LIBRARY_PATH`. **Anything nixpkgs built is
+patched to the glibc loader in the store**, so it never consults either
+variable — no matter how long the library list is.
+
+Check which one you have, and never assume:
+
+```sh
+patchelf --print-interpreter "$(readlink -f "$(command -v python3)")"
+```
+
+- `/nix/store/…-glibc-…/lib/ld-linux-x86-64.so.2` — nixpkgs' own. nix-ld is not
+  in the picture.
+- `/lib64/ld-linux-x86-64.so.2` — a foreign binary. nix-ld applies.
+
+Measured on a nixarchy machine with `libGL` in the shipped nix-ld set:
+
+```
+$ python3 -c 'import ctypes; ctypes.CDLL("libGL.so.1")'
+OSError: libGL.so.1: cannot open shared object file: No such file or directory
+
+$ ~/.local/share/uv/python/cpython-3.12.14-.../bin/python3.12 \
+    -c 'import ctypes; ctypes.CDLL("libGL.so.1")'
+(no error)
+```
+
+Same machine, same library list, same second. The difference is entirely which
+interpreter the binary declares.
+
+So for a wheel that fails to import, there are four real fixes and one that only
+looks like one:
+
+1. **Run the venv on an unpatched interpreter.** `uv python install 3.12` fetches
+   a generic-Linux CPython whose interpreter is `/lib64/ld-linux-x86-64.so.2`, so
+   it goes through nix-ld and the curated set applies. This is why `uv`-managed
+   Pythons "just work" while the system `python3` does not.
+2. **Hand the libraries to the nixpkgs interpreter directly**, per command or per
+   shell — not globally, which breaks other Nix programs:
+   ```sh
+   LD_LIBRARY_PATH="$NIX_LD_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" python3 app.py
+   ```
+3. **A `devenv`** with the library in the environment — the right answer once the
+   code is a project. See the `devenv` skill.
+4. **`pkgs.buildFHSEnv`**, which fakes the whole `/usr` layout for anything that
+   insists on it.
+
+And the one that only looks like a fix: adding the library to
+`programs.nix-ld.libraries` and rebuilding. It changes nothing for a nixpkgs
+interpreter, costs a rebuild and a logout, and sends the user away convinced the
+documentation lied to them.
+
+**The two Python users are different people.** Someone following a tutorial has a
+loader problem: venv plus wheels plus an interpreter that can find libraries, and
+no flake is involved. Someone building a project wants `uv` with `uv.lock` as the
+source of truth — and `uv2nix` only when Nix must *build* the project, which
+uv2nix's own documentation says to skip day to day. Do not answer the first
+person with the second person's tooling.
+
+## Rung 2: envfs — shebangs and `/usr/bin`
+
+A script starting `#!/bin/bash` or `#!/usr/bin/env python` fails with "no such
+file or directory" on a bare NixOS: `/bin` holds only `sh` and `/usr/bin` only
+`env`. [envfs](https://github.com/Mic92/envfs) mounts both as a FUSE view of the
+current `PATH`, and it is **already on** — so every tutorial script and every
+downloaded installer's shebang resolves.
+
+Its limit is exact: it resolves a name to whatever that name means on the `PATH`
+*right now*. A script that execs a command the user never installed still fails,
+and the fix is installing that command, not touching the loader.
+
+## Rung 3: AppImages
+
+`programs.appimage` with `binfmt` is on, so the kernel recognises the format
+itself:
+
+```sh
+chmod +x ./Tool.AppImage
+./Tool.AppImage
+```
+
+That works from the file manager too, without knowing `appimage-run` exists.
+Underneath, the wrapper unpacks the image and runs it against the nix-ld set. An
+AppImage bundles most of what it needs by design, so this rung rarely needs
+per-app work.
+
+## Rung 4: an FHS environment
+
+When something wants a `/usr` that is really there — pip compiling C against
+system headers, a vendor installer, an old proprietary toolchain:
+
+```nix
+(pkgs.buildFHSEnv {
+  name = "fhs";
+  targetPkgs = pkgs: with pkgs; [ gcc zlib libGL ];
+  runScript = "bash";
+})
+```
+
+`steam-run` is a ready-made one from nixpkgs and is worth trying before writing
+an env: `steam-run ./installer.sh`. Note the bound: an FHS env supplies headers
+and layout at *build* time as well as run time, which is exactly what nix-ld
+cannot do.
+
+## Rung 5: a box
+
+Software that wants a whole distribution — `/opt`, postinstall scripts, a package
+manager of its own — is what distrobox is for. It is off by default and is **not
+a sandbox**: it runs privileged, with the user's entire `$HOME` read-write. Reach
+for it last, and say what it costs: a second package manager and a second update
+cadence.
+
+## Rung 6: package it
+
+Software in no repository at all gets a first draft from:
+
+```sh
+nixarchy pkg new https://github.com/someone/tool
+```
+
+For a prebuilt release specifically, the derivation wants `autoPatchelfHook`,
+which rewrites the binary's interpreter and RPATH to store paths — the permanent
+version of what nix-ld does at run time, and the right answer once something is
+worth keeping.
+
+## The machine can diagnose it
+
+```sh
+nixarchy-doctor ~/.venv/lib/python3.12/site-packages/cv2/cv2.so
+nixarchy-doctor some-downloaded-tool
+```
+
+It runs the loader's own resolution against the nix-ld set, names every missing
+library, and for the common sonames prints the `programs.nix-ld.libraries` line
+that fixes it.
+
+**State its limits when you report a clean result**, because a clean report is
+not a guarantee:
+
+- It checks only the files it is given. The no-argument scan covers `~/.local/bin`
+  and nothing else — it does not crawl venvs or `node_modules`. For a broken
+  import, name the actual `.so` inside the package; the traceback usually names
+  it.
+- It answers "is every library findable", not "is every library right". A library
+  that is present but the wrong ABI loads cleanly and misbehaves later.
+- It resolves what the binary *declares*. A library the program `dlopen`s by hand
+  is invisible until that moment, so a binary can pass and still fail with the
+  same error. Bring it the library name from *that* error and add it the same way.
+
+## Diagnosing by hand
+
+```sh
+file ./tool                                   # is it even ELF, and for this arch?
+patchelf --print-interpreter ./tool           # nixpkgs' loader, or /lib64's?
+ldd ./tool                                    # what is "not found"
+
+# Ask the question the runtime will ask, with the nix-ld set in play:
+LD_LIBRARY_PATH="$NIX_LD_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ldd ./tool
+```
+
+| Symptom | Cause |
+|---|---|
+| `No such file or directory` on a file that exists | Its interpreter is missing — foreign binary, nix-ld not reached, or a wrong-arch build |
+| `libfoo.so.2: cannot open shared object file` from a downloaded binary | Add `foo` to `programs.nix-ld.libraries`, rebuild, log out and in |
+| Same error from a `python3`/`node` that nixpkgs built | nix-ld does not apply — see the correction above |
+| Added the library, rebuilt, still failing | Still in the old session: `NIX_LD_LIBRARY_PATH` is set at login |
+| `#!/bin/bash: bad interpreter` | envfs is off, or the command genuinely is not on `PATH` |
+| Loads, then segfaults or misbehaves | Present-but-wrong-ABI library. No list entry fixes this; use an FHS env or package it |
+| `pip install` fails compiling C | Not a loader problem at all. devenv or `buildFHSEnv` |
+
+## Rules
+
+- **Read the error before choosing a rung.** "cannot open shared object file" is
+  rung 1; "bad interpreter" is rung 2; a compiler error is rung 4. They look
+  alike in a bug report and have nothing in common.
+- **Check the interpreter before promising a nix-ld fix.** One `patchelf
+  --print-interpreter` decides whether the rebuild you are about to recommend can
+  possibly work.
+- **Never suggest replacing `programs.nix-ld.libraries`** — plain assignment
+  merges with nixarchy's curated set; a user who writes `lib.mkForce` loses all
+  of it.
+- **Say "log out and back in" every time** you recommend a library addition.
+- **Do not reach past rung 1 without a reason.** A container for one missing
+  soname is the most common over-correction on this topic.
+- **`nixpkgs` first, always.** If the thing is packaged, none of this ladder
+  applies.

--- a/pkgs/omarchy/skills/nixos-config-repo/SKILL.md
+++ b/pkgs/omarchy/skills/nixos-config-repo/SKILL.md
@@ -10,7 +10,9 @@ description: >
   is ignored by the build. Triggers: git, GitHub, GitLab, repo, repository, commit,
   push, remote, .gitignore, CI, GitHub Actions, flake check, back up my config,
   version control, "untracked", "does not exist", dubious ownership, nixarchy config repo.
-  For encrypting secrets that live in that repo, use `nixos-secrets`.
+  For encrypting secrets that live in that repo, use `nixos-secrets`; for the
+  shape of a repository that holds SEVERAL machines — `hosts/<name>/`, sharing
+  without coupling, deploying and pulling — use `nixos-fleet`.
 ---
 
 # NixOS Config Repo Skill
@@ -265,6 +267,13 @@ sudo nixos-rebuild switch --flake .#laptop
 Shared modules go in `./modules`, per-machine differences in `./hosts/<name>`.
 Do not restructure someone's working single-host config into this shape unless
 they ask.
+
+**That is as far as this skill goes.** The `nixos-fleet` skill owns the multi-host
+layout itself — what a nixarchy-installed repository already looks like, what
+belongs in a shared module versus a host file, `nixarchy-apply`'s hostname match,
+pulling on a timer and deploying with `--target-host`. This skill owns git around
+it: remotes, CI, ignores, and getting the configuration in there at all. Hand a
+"several machines" question over rather than answering half of it here.
 
 ## Troubleshooting
 

--- a/pkgs/omarchy/skills/nixos-fleet/SKILL.md
+++ b/pkgs/omarchy/skills/nixos-fleet/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: nixos-fleet
+description: >
+  REQUIRED for one flake that configures several machines — the `hosts/<name>/`
+  layout, what is shared and what is per-machine, adding a second or tenth
+  machine, installing one from an existing repository, rebuilding one machine
+  from another, and machines that pull their own configuration on a timer. Use
+  when asked to add a laptop to an existing configuration, share a module between
+  hosts, stop a change for one machine landing on another, deploy to a remote
+  host, set up unattended upgrades across several machines, or work out why a
+  machine is not picking up the configuration that was pushed. Triggers: hosts/,
+  nixosConfigurations, multi-host, several machines, fleet, deploy, remote
+  rebuild, --target-host, --build-host, system.autoUpgrade,
+  programs.nixarchy.fleet, nixarchy-hardware.nix, nixarchy-apply, colmena,
+  deploy-rs, clan, comin, GitOps, "same config on both machines".
+  Git itself — remotes, CI, .gitignore, "back up my config" — belongs to
+  `nixos-config-repo`; this skill owns the shape of a multi-host flake.
+---
+
+# NixOS Fleet Skill
+
+Multi-host is where a configuration stops being a file and starts being a system.
+NixOS handles it natively, so most of this skill is a layout and a set of traps
+rather than a tool.
+
+**Where this skill stops.** `nixos-config-repo` owns git: `git init`, remotes,
+public vs private, `.gitignore`, CI on the flake, dubious ownership, and the
+"back up my configuration" question. This skill owns what is *inside* the
+repository once more than one machine lives in it. They are adjacent and must not
+overlap — if the question is about pushing, cloning or CI, hand it over and stop.
+
+**First, which machine is this?** Everything below is about a machine the
+nixarchy installer wrote. If nixarchy was added to a NixOS configuration the user
+already runs, **none of this restructures it** — their flake is theirs, and the
+one option that could rebuild their machine from somewhere else is off unless
+they turn it on. Do not convert a working single-host flake to this layout
+uninvited.
+
+## The shape
+
+```
+/etc/nixos
+├── flake.nix              finds machines by reading ./hosts
+├── flake.lock             one lock for every machine — deliberate
+├── disk-config.nix
+└── hosts/
+    ├── desk/
+    │   ├── default.nix                 username, disk, encryption
+    │   ├── configuration.nix           timezone, keymap, and whatever is added
+    │   ├── hardware-configuration.nix  generated on that machine
+    │   ├── nixarchy-hardware.nix       what that machine IS, detected
+    │   └── nixarchy-apps.nix           this machine's app selection
+    └── laptop/…
+```
+
+`flake.nix` reads the directory rather than naming machines:
+
+```nix
+hosts = lib.attrNames (lib.filterAttrs (_: kind: kind == "directory") (builtins.readDir ./hosts));
+```
+
+**Adding a machine is adding a directory.** Copy one, change what differs, `git
+add` it. There is nothing to edit in `flake.nix`, and an agent that opens it to
+add a `nixosConfigurations.laptop` entry has misread the design. Directories
+only: a stray `README` under `hosts/` would otherwise become a configuration that
+fails to evaluate for reasons nothing explains.
+
+**`git add` is not a tidiness rule.** A flake in a git worktree sees only tracked
+or staged files, so an unstaged `hosts/laptop/` does not exist as far as
+evaluation is concerned — and the error says the *path is missing*, not that it
+is untracked. This costs people an hour every time. Stage first, then debug.
+
+One `flake.lock` for the whole repository is a feature: every machine gets the
+same nixpkgs on the same day, which is what makes "it works on my desktop" mean
+anything about the laptop.
+
+## Sharing without coupling
+
+The failure to design against is **a change for one laptop landing on the
+server**. Three places to put a thing, in order of how much they couple:
+
+| put it in | who gets it |
+|---|---|
+| `hosts/<name>/configuration.nix` | that machine only |
+| a module under `modules/` (or `common/`), imported by the hosts that want it | the hosts that opt in |
+| the shared module list in `flake.nix`, applied to every host | everyone, always |
+
+The middle row is the one to reach for, and it is ordinary NixOS — a file that is
+a module, and an `imports` line in each host that wants it:
+
+```nix
+# modules/desktop.nix — no magic, just a module
+{ pkgs, ... }:
+{
+  services.printing.enable = true;
+  environment.systemPackages = with pkgs; [ firefox ];
+}
+```
+
+```nix
+# hosts/laptop/configuration.nix
+{ ... }:
+{
+  imports = [ ../../modules/desktop.nix ];
+  time.timeZone = "Europe/London";
+}
+```
+
+Two rules that keep this from rotting:
+
+- **Put a setting in the shared module only when every host that imports it
+  genuinely wants that value.** "It is probably fine on the server too" is how a
+  fleet acquires a printer daemon on a rack machine.
+- **Use `lib.mkDefault` in shared modules for anything a host might reasonably
+  override**, so the host file wins without `mkForce`. On lists and attribute
+  sets use plain assignment instead — `mkDefault` on a merging type silently
+  drops the whole contribution the moment a host adds one element.
+
+Per-machine by nature, and never to be shared: `hardware-configuration.nix`,
+`nixarchy-hardware.nix`, the disk layout, the hostname.
+
+### `nixarchy-hardware.nix` — per machine, and copying it is the one thing not to do
+
+The installer writes it from what it found: CPU vendor, GPU vendor, whether there
+is a battery, whether the disk spins. Each line is a
+[nixos-hardware](https://github.com/NixOS/nixos-hardware) module:
+
+```nix
+{ inputs, ... }:
+{
+  imports = [
+    inputs.nixos-hardware.nixosModules.common-cpu-intel-cpu-only
+    inputs.nixos-hardware.nixosModules.common-gpu-intel
+    inputs.nixos-hardware.nixosModules.common-pc-laptop-ssd
+  ];
+}
+```
+
+That is microcode, the media stack and `fstrim` — things otherwise discovered one
+at a time. Everything they set is `lib.mkDefault`, so anything written elsewhere
+wins, and the file is the user's to edit; nothing regenerates it behind them.
+
+**Only the generic `common-*` modules are chosen automatically**, deliberately:
+the machine-specific ones key on DMI product strings with no machine-readable
+table anywhere, so matching them would be guessing, and importing
+`dell-xps-13-9310` onto a 9315 is a machine that boots wrong in a way nobody
+traces back to us. `nixarchy doctor` prints what the machine calls itself so the
+user can search for a match and add it by hand. Plenty of machines have no module
+at all.
+
+**NVIDIA is never chosen automatically either** — open kernel modules versus the
+legacy series, plus PRIME bus ids in decimal on a hybrid laptop. Get it wrong and
+the machine has no screen. The doctor computes it and prints the lines; see the
+`nixos-gpu` skill.
+
+## Adding the second machine
+
+```sh
+nixarchy config repo                                      # 1. first machine into git
+nixarchy-install --from github:you/config --host laptop   # 2. install the second from it
+nixarchy config repo                                      # 3. on the new machine, push its hardware back
+```
+
+If `hosts/laptop/` already exists, the repository decides the disk, the username
+and the rest, and only a password is asked for. If it does not, the usual
+questions are asked and the machine is written into the repository beside the
+others.
+
+Step 3 is not optional bookkeeping: `hardware-configuration.nix` and
+`nixarchy-hardware.nix` are generated *on* the machine, because hardware is the
+one thing a repository written elsewhere cannot know.
+
+Using somebody else's configuration is the same command with a machine name it
+has never heard of — there is no template mechanism and there does not need to
+be one. That is only safe to offer because the login hash is **not** in the
+repository: it lives at `/var/lib/nixarchy/password.hash`, outside git, so a
+configuration is safe to push and safe to hand to somebody.
+
+> **`--from` runs their Nix as root.** Their `disk-config.nix` formats the disk.
+> Same trust as `nix run github:...`, and worth saying out loud.
+
+## `nixarchy-apply` on a fleet — know this before touching anything
+
+`nixarchy-apply` copies `~/.config/nixarchy/apps.nix` into the flake and rebuilds.
+**Where it copies to depends on the hostname:**
+
+```sh
+base="$flake"
+[ -d "$flake/hosts/$(uname -n)" ] && base="$flake/hosts/$(uname -n)"
+# → $base/nixarchy-apps.nix
+```
+
+So on a multi-host repository each machine's app selection lands in its own
+`hosts/<name>/nixarchy-apps.nix` and affects nobody else — which is right, and
+which also means:
+
+- **The match is on `uname -n`.** A machine whose hostname does not equal its
+  host directory name writes to the repository *root* instead, where the shared
+  configuration is, and its app selection leaks to every host. Check
+  `uname -n` against `ls hosts/` before debugging anything stranger.
+- The Install menu's "enabled" versus "queued" status comes from that same copy,
+  so a selection that has not been applied reads as queued on that machine only.
+- Do not hand-edit another machine's `nixarchy-apps.nix` expecting that machine's
+  menu to agree; it reads its own file.
+
+## Pulling on a timer
+
+```nix
+programs.nixarchy.fleet = {
+  enable = true;
+  url = "github:you/config";
+  dates = "daily";            # a systemd calendar expression
+};
+```
+
+`nixos-rebuild` resolves the attribute from the hostname, so **one value serves
+every machine** — no machine list anywhere. Underneath it is
+`system.autoUpgrade` with `--refresh` (without it a flakeref naming a branch is
+resolved from the evaluation cache and the machine "upgrades" to what it already
+has, indefinitely) and a 45-minute randomised delay so fifty machines do not wake
+at 03:00 to hammer the same remote.
+
+> **The running system comes from the remote flake.** Local edits under
+> `/etc/nixos` that were never pushed are reverted at the next pull, silently.
+> That is the point of a fleet and it is also the way to lose an afternoon.
+> Say this before enabling it for somebody.
+
+Two consequences to state up front:
+
+- **Secrets.** The machine pulls a public-ish repository and rebuilds as root, so
+  nothing decryptable may be in it. agenix or sops-nix, with the private key
+  placed on the machine out of band — the `nixos-secrets` skill owns this.
+- **A machine that is off** misses its window. `persistent` is on (nixpkgs'
+  default), so it catches up at the next boot rather than waiting a day — which
+  is exactly what a laptop needs.
+
+The failure this wrapper exists for: an unattended upgrade that starts failing
+stops delivering configuration and **nothing says so** — a fleet that has quietly
+stopped converging looks exactly like one that is up to date. So a failure
+appends a timestamped line to a file that survives journal rotation:
+
+```sh
+cat /var/lib/nixarchy/upgrade-failed
+systemctl status nixos-upgrade.service
+journalctl -u nixos-upgrade.service -b
+```
+
+**Check that file first** when a machine is "not picking up" configuration. The
+usual answers are: it was never pushed, the hostname does not match any host
+directory, the file was never `git add`ed, or the upgrade has been failing for a
+week.
+
+## Pushing instead of pulling
+
+Nothing in nixarchy is involved, and nothing needs to be:
+
+```sh
+nixos-rebuild switch --flake github:you/config#laptop --target-host root@laptop
+nixos-rebuild switch --flake .#laptop --target-host root@laptop --build-host localhost
+```
+
+Where it stops, so nobody discovers it mid-deploy:
+
+- **It needs root over SSH** on the target — a key for `root@`, or
+  `--use-remote-sudo` with a user that has passwordless sudo.
+- **It is one machine per invocation.** No roles, no tags, no parallelism, no
+  ordering, no health check, no rollback on failure. A shell loop over hostnames
+  is the honest version of "deploy the fleet" here.
+- **A closure for a different architecture needs a builder for it.** Deploying to
+  an aarch64 machine from x86_64 means `--build-host` on the target itself, or a
+  configured remote builder, or binfmt emulation.
+- The target must be reachable *and* have the disk space; a failed copy leaves
+  the running system untouched, which is the good news.
+
+For more than a handful of machines, or anything with roles and tags, point at a
+tool built for it: [colmena](https://github.com/zhaofengli/colmena),
+[deploy-rs](https://github.com/serokell/deploy-rs) or
+[clan](https://clan.lol/). **nixarchy does not reimplement them and will not.**
+The repository is an ordinary NixOS flake and all three take one, so adopting one
+is additive and costs nothing here.
+
+That is a settled decision, not an open question: `modules/fleet.nix` says so in
+its header — `system.autoUpgrade` with a flake URL already *is* pull-based GitOps,
+so the module is an opt-in wrapper that fixes the two things it gets wrong when
+nobody is watching, and otherwise gets out of the way. No comin, no colmena, no
+clan built in. **Do not propose adding one to nixarchy**; propose using one
+alongside, if the user's fleet has outgrown a loop.
+
+## Diagnosing
+
+```sh
+uname -n && ls /etc/nixos/hosts          # does this machine have a directory?
+nix flake show /etc/nixos                # which nixosConfigurations actually exist
+cd /etc/nixos && git status --short      # untracked = invisible to evaluation
+nixos-rebuild build --flake /etc/nixos#laptop   # evaluate another host from here
+nix eval /etc/nixos#nixosConfigurations.laptop.config.system.build.toplevel.drvPath
+```
+
+| Symptom | Cause |
+|---|---|
+| `path '…/hosts/laptop' does not exist`, but it is right there | Not `git add`ed. The flake sees tracked files only |
+| `attribute 'laptop' missing` | No `hosts/laptop/` directory, or it is a file rather than a directory |
+| A machine rebuilds to the wrong configuration | `uname -n` does not match its host directory name |
+| An app selection appears on every machine | Same cause: `nixarchy-apply` fell back to the repository root |
+| A pushed change never arrives | Timer never ran, or has been failing — `/var/lib/nixarchy/upgrade-failed` |
+| Local edits keep disappearing | `fleet.enable` is on; the remote flake is the system of record |
+| One machine gets a different nixpkgs | Its own `flake.lock`, i.e. it is not really in the same repository |
+| `--target-host` fails on permissions | No root over SSH; `--use-remote-sudo` |
+
+## Rules
+
+- **Never restructure a single-host flake into `hosts/` uninvited.** It is a
+  large diff in the one file a user cannot afford to have broken.
+- **`git add` before evaluating, every time.** More fleet debugging time goes here
+  than anywhere else.
+- **Check `uname -n` against `ls hosts/` early.** It explains a whole class of
+  "the wrong machine changed".
+- **Never copy `hardware-configuration.nix` or `nixarchy-hardware.nix` between
+  machines.** They describe the machine they were generated on.
+- **Say what `fleet.enable` costs** — unpushed local edits are reverted silently —
+  before turning it on for somebody.
+- **No plaintext secrets in a repository a fleet pulls.** Send it to
+  `nixos-secrets`.
+- **Do not propose a deploy tool as a nixarchy feature.** Suggest running one
+  alongside; the flake is an ordinary one.
+- **Git questions go to `nixos-config-repo`.**

--- a/pkgs/omarchy/skills/nixos-gaming/SKILL.md
+++ b/pkgs/omarchy/skills/nixos-gaming/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: nixos-gaming
+description: >
+  REQUIRED for gaming on this NixOS machine — Steam and Proton, the 32-bit
+  graphics stack, controllers, gamemode and gamescope, launchers, emulation and
+  cloud gaming. Use when asked to install Steam, run a Windows game, fix a game
+  that will not launch or shows no Vulkan device, choose or force a Proton
+  version, pair an Xbox or PlayStation controller, add libretro cores to
+  RetroArch, set up Lutris, Heroic, Battle.net, Minecraft, GeForce NOW or
+  Moonlight, or host game streaming with Sunshine. Triggers: steam, programs.steam,
+  proton, protontricks, PROTON_, STEAM_COMPAT, enable32Bit, lib32, vulkan, dxvk,
+  vkd3d, gamemode, gamescope, mangohud, xpadneo, xone, Steam Input, lutris, heroic,
+  bottles, umu-launcher, retroarch, libretro, emulation, prismlauncher, minecraft,
+  sunshine, moonlight, geforce now, "game won't start".
+  Drivers, CUDA/ROCm, VA-API and hybrid laptops belong to `nixos-gpu` — send
+  driver questions there and stop.
+---
+
+# NixOS Gaming Skill
+
+Gaming works well here, and nearly every "it does not work" report is one of
+three things: the 32-bit half of the graphics stack is missing, Steam was
+installed as a package instead of enabled as a module, or the driver underneath
+was never set up at all.
+
+**Where this skill stops.** Drivers — NVIDIA/CUDA, AMD/ROCm, Intel, VA-API,
+hybrid/Optimus laptops — belong to the `nixos-gpu` skill. If `vulkaninfo` finds no
+device, or the question is which driver branch or which bus id, go there and stop;
+do not diagnose a driver from here. This skill owns everything from a working GPU
+upwards.
+
+Everything below is route 2 in the `nixos` skill: edit the configuration, then
+rebuild. The Install ▸ Gaming rows in the Omarchy menu (`Super + Space`) write
+the same lines into `~/.config/nixarchy/apps.nix`, and _Install ▸ Apply changes_
+rebuilds with them.
+
+## The thing people miss: the 32-bit graphics stack
+
+Steam's runtime, most Proton builds and a great many older games are 32-bit. The
+64-bit driver stack alone gives a game that starts and then dies with no Vulkan
+device, or a black window — which reads as a broken game, not a missing option.
+
+```nix
+hardware.graphics = {
+  enable = true;
+  enable32Bit = true;        # this line
+};
+```
+
+On NixOS this is one option for every driver. On Arch it is a per-driver lib32
+package (`omarchy-install-gaming-gpu-lib32` upstream), which is why guides written
+for Arch send people looking for packages that do not exist here.
+
+Check before assuming:
+
+```sh
+vulkaninfo --summary | head -20            # does the 64-bit stack see the GPU?
+nix shell nixpkgs#pkgsi686Linux.mesa-demos -c glxinfo | head   # and the 32-bit one
+```
+
+## Steam
+
+**Steam is a NixOS module, not a package, and installing `pkgs.steam` by hand
+does not run.** Steam's own binaries and every game it downloads expect `/lib`,
+`/usr/lib` and the rest of an ordinary Linux layout. `programs.steam.enable`
+builds an FHS environment — a private root with that layout — and runs Steam
+inside it.
+
+```nix
+{
+  programs.steam = {
+    enable = true;
+    remotePlay.openFirewall = true;       # Steam Remote Play
+    dedicatedServer.openFirewall = false; # only if hosting
+    localNetworkGameTransfers.openFirewall = true;
+    gamescopeSession.enable = true;       # a Steam Deck-style session, optional
+  };
+  hardware.graphics.enable32Bit = true;
+}
+```
+
+Steam is unfree; nixarchy sets `allowUnfree` by default, so the row works as-is.
+On a machine where that default was turned back off, `nixpkgs.config.allowUnfree
+= true` is needed or the rebuild aborts.
+
+**Steam takes 10–20 seconds to start with no feedback on the first run.** Say so
+before someone concludes it is broken.
+
+Extra packages go inside the FHS environment rather than into
+`environment.systemPackages`, or Steam cannot see them:
+
+```nix
+programs.steam.extraPackages = with pkgs; [ gamemode mangohud ];
+```
+
+## Proton
+
+Proton is Valve's Wine fork and it is **per title, not global**. Set it in Steam:
+right-click the game ▸ _Properties_ ▸ _Compatibility_ ▸ force a specific tool.
+There is no NixOS option for a game's Proton version, and there should not be —
+the choice differs per title and lives in Steam's own config.
+
+- **Proton Experimental** first for a title that fails on stable; it carries fixes
+  before they are released.
+- **Proton-GE** for titles needing media codecs or anti-cheat workarounds:
+  `programs.steam.extraCompatPackages = [ pkgs.proton-ge-bin ];`, then pick it in
+  the same menu. Do not hand-copy builds into `~/.steam/`; the option exists.
+- Check <https://www.protondb.com> for a title before debugging it. Most
+  "unplayable" reports there come with the exact launch option that fixes them.
+
+Where the state lives, which matters when something is wedged:
+
+| path | what |
+|---|---|
+| `~/.steam/steam/steamapps/compatdata/<appid>/` | the game's wine prefix |
+| `~/.steam/steam/steamapps/shadercache/` | compiled shaders |
+| `~/.steam/steam/steamapps/common/` | the games themselves |
+
+Deleting a title's `compatdata` directory resets its prefix and is the standard
+first move for a game that broke after an update. It loses in-prefix
+configuration, not saves held in the game's own directory — say which before
+recommending it.
+
+Launch options go in the same Properties dialog, and the common ones are
+environment variables:
+
+```
+PROTON_LOG=1 %command%              # writes ~/steam-<appid>.log
+PROTON_USE_WINED3D=1 %command%      # fall back from DXVK, for a driver bug
+PROTON_NO_ESYNC=1 %command%         # if the game dies on file-descriptor limits
+DXVK_HUD=fps %command%              # a quick frame counter
+MANGOHUD=1 %command%                # richer overlay, needs mangohud installed
+gamemoderun %command%               # CPU governor and scheduling for this process
+```
+
+`protontricks` runs `winetricks` against a Steam prefix. It has its own option
+inside the module — `programs.steam.protontricks.enable = true;` — which is the
+one to use, because it lands inside Steam's FHS environment where the prefixes
+are. Reach for it only when a title's ProtonDB page names a specific verb.
+
+## Controllers
+
+| controller | what it needs |
+|---|---|
+| Xbox, USB cable | nothing — `xpad` is in the kernel |
+| Xbox, Bluetooth | `hardware.xpadneo.enable = true;` |
+| Xbox, official wireless dongle | `hardware.xone.enable = true;` |
+| PlayStation DualShock/DualSense | nothing — `hid-playstation` is in the kernel |
+| Nintendo Pro / Joy-Con | nothing for the kernel; Steam Input for mapping |
+| anything else, wrong or no mapping | Steam Input, or a udev rule |
+
+`xpadneo` is an out-of-tree kernel module, so it has to be built against the
+running kernel and loaded — that is why the Install ▸ Gaming row enables a
+hardware option rather than adding a package, and why a kernel change rebuilds
+it. Pair afterwards with `Super + Ctrl + B`.
+
+Steam Input handles remapping, gyro and per-title profiles for everything above
+and is almost always the right answer before writing udev rules. For a pad only
+non-Steam software sees:
+
+```nix
+hardware.steam-hardware.enable = true;   # Valve's udev rules, also needed for the Steam Controller and Index
+services.udev.packages = [ pkgs.game-devices-udev-rules ];
+```
+
+Diagnose before configuring:
+
+```sh
+ls /dev/input/js* /dev/input/event*
+nix shell nixpkgs#evtest -c evtest      # does the kernel see button presses at all?
+```
+
+If `evtest` sees the buttons, the kernel side is done and the problem is mapping —
+Steam Input, not a module.
+
+## gamemode and gamescope
+
+```nix
+programs.gamemode.enable = true;    # governor, scheduling and I/O priority while a game runs
+programs.gamescope = {
+  enable = true;
+  capSysNice = true;                # lets it raise its own priority
+};
+```
+
+`gamemode` does nothing until a game asks for it: `gamemoderun %command%` as a
+launch option, or a launcher that calls it. `gamescope` is a micro-compositor —
+use it for a game that insists on changing the display mode, that scales badly on
+a HiDPI screen, or that behaves poorly under a tiling Wayland compositor:
+
+```
+gamescope -W 2560 -H 1440 -r 144 -f -- %command%
+```
+
+`programs.steam.gamescopeSession.enable` gives a Steam Deck-style
+big-picture session as a separate login option.
+
+## Launchers, and what each Install ▸ Gaming row lands on
+
+| Row | What it does here |
+|---|---|
+| Steam | enables `programs.steam` |
+| RetroArch | nixarchy's own `retroarch`, 13 free cores |
+| Xbox Controllers | enables `hardware.xpadneo` |
+| Lutris | `pkgs.lutris` |
+| Heroic (Epic Games) | `pkgs.heroic` |
+| Minecraft | `pkgs.prismlauncher` |
+| Xbox Cloud Gaming | a web app — no package at all |
+| Battle.net | needs `pkgs.umu-launcher` in the configuration first |
+| NVIDIA GeForce NOW | needs `services.flatpak.enable` first |
+
+Two of those run upstream install scripts that begin by asking for a package,
+which prints the declarative route and stops. The route is one line each:
+
+```nix
+environment.systemPackages = [ pkgs.umu-launcher ];   # Battle.net
+services.flatpak.enable = true;                       # GeForce NOW
+```
+
+Then `flatpak install flathub com.nvidia.geforcenow` after the rebuild — GeForce
+NOW ships only as a Flatpak, and Flatpak here is a service rather than a package,
+so without it there is nowhere for the app to be installed.
+
+Lutris and Heroic are plain packages. Both look like nothing is happening while a
+game installs; give them time. Lutris wants `wine`, `winetricks` and
+`gamemode` available to be useful — add them beside it rather than expecting the
+launcher to fetch them.
+
+## RetroArch and emulation
+
+nixpkgs' `retroarch` is `retroarch-with-cores` built with an **empty core list**:
+it installs cleanly and emulates nothing. `retroarch-full` pulls in unfree cores,
+and an unfree package aborts the whole rebuild rather than failing on its own for
+anyone who turned `allowUnfree` back off.
+
+So nixarchy builds its own `retroarch` with thirteen free cores: bsnes (SNES),
+mesen (NES), gambatte and mgba (Game Boy), blastem (Mega Drive),
+beetle-pce-fast, beetle-psx-hw, parallel-n64, desmume, flycast, ppsspp, puae
+(Amiga) and vice-x64 (C64). snes9x and genesis-plus-gx are unfree in nixpkgs,
+which is why bsnes and blastem cover those systems.
+
+For the unfree ones, override the package rather than switching to
+`retroarch-full`:
+
+```nix
+programs.nixarchy.apps.retroarch.package =
+  pkgs.retroarch.withCores (c: [ c.snes9x c.mame c.dolphin ]);
+```
+
+**That replaces the core list rather than adding to it** — name everything you
+want, including the ones you were happy with.
+
+Two differences from every guide written for Arch:
+
+- Cores are **inside the package**, not in `/usr/lib/libretro`. Nothing to copy,
+  nothing to point at; `omarchy-retroarch-cores` prints the current directory if
+  something asks for a path.
+- `~/Games/roms`, `~/Games/bios` and the CRT Royale shader preset are written by
+  an upstream install script whose first step is a package install that stops
+  here. Set the ROM and BIOS directories in RetroArch's own settings after the
+  first launch.
+
+Standalone emulators are ordinary packages: `dolphin-emu`, `pcsx2`, `rpcs3`,
+`duckstation`, `cemu`, `ryujinx`. Most want `enable32Bit` and a Vulkan-capable
+driver, which is the first section of this skill again.
+
+## Streaming
+
+Moonlight is preinstalled and streams *from* a Windows PC running Sunshine with
+no configuration here.
+
+Hosting *from* this machine needs the package and the ports, and there is no ufw:
+
+```nix
+environment.systemPackages = [ pkgs.sunshine ];
+networking.firewall.allowedTCPPorts = [ 47984 47989 48010 ];
+networking.firewall.allowedUDPPorts = [ 47998 47999 48000 48002 48010 ];
+```
+
+Those are the ports upstream's script opens, minus 5353, which `services.avahi`
+already has. `networking.firewall.interfaces.<name>` restricts them to a LAN or a
+Tailscale interface if that is wanted — see the `nixos-security` skill.
+
+## Troubleshooting
+
+```sh
+vulkaninfo --summary | head -20             # a GPU here, or a driver problem (-> nixos-gpu)
+glxinfo -B | grep -i 'renderer\|opengl'     # llvmpipe means software rendering
+journalctl --user -b | grep -i steam
+cat ~/steam-<appid>.log                     # with PROTON_LOG=1 %command%
+```
+
+| Symptom | Cause |
+|---|---|
+| Steam installed but will not run | Installed as `pkgs.steam`. It has to be `programs.steam.enable` |
+| Game starts, then exits instantly, no window | Missing 32-bit stack: `hardware.graphics.enable32Bit` |
+| "No Vulkan device" / "failed to create device" | Driver layer, not gaming — `nixos-gpu` |
+| Renderer says `llvmpipe` | Software rendering: the driver is not loaded at all — `nixos-gpu` |
+| Works on the iGPU, not the dGPU, on a laptop | PRIME offload — `nixos-gpu` |
+| Game ran last week, not today | Proton version moved, or a wedged prefix. Force the old Proton, or reset `compatdata` |
+| Anti-cheat kicks the player | Usually unsupported by the publisher on Linux. Check ProtonDB before spending a rebuild |
+| Controller seen by `evtest`, not by the game | Mapping, not kernel: Steam Input |
+| Bluetooth Xbox pad will not pair | `hardware.xpadneo.enable`, and reboot into the new kernel module |
+| RetroArch lists no cores | Plain `pkgs.retroarch` somewhere in the config, shadowing nixarchy's |
+| Unfree licence error on a rebuild | `nixpkgs.config.allowUnfree = true;` |
+
+## Rules
+
+- **Check `enable32Bit` before anything else.** It is one line and it is the
+  cause more often than everything below it combined.
+- **Never install `pkgs.steam`.** It is a module here for a reason that cannot be
+  worked around with a package.
+- **Send driver questions to `nixos-gpu` and stop.** Two skills answering "the
+  GPU does not work" is how a user gets two contradictory diagnoses.
+- **Proton version is per title.** Do not write configuration for it.
+- **Read ProtonDB before debugging a specific title.** The fix is usually a
+  documented launch option, not a system change.
+- **A kernel module change — `xpadneo`, `xone` — needs a reboot**, not just
+  `switch`. Say so before claiming the change did not work.
+- **Warn before deleting a prefix.** `compatdata` removal is routine and it is
+  still destruction of the user's in-game settings.

--- a/pkgs/omarchy/skills/nixos-gpu/SKILL.md
+++ b/pkgs/omarchy/skills/nixos-gpu/SKILL.md
@@ -10,7 +10,8 @@ description: >
   rocminfo, HSA_OVERRIDE_GFX_VERSION, amdgpu, hardware.graphics, OpenCL, Vulkan,
   VA-API, nvidia-container-toolkit, PRIME, offload, "GPU not detected".
   For running models on that GPU use `nixos-ai`; for thermals, power and
-  throttling use `nixos-performance`.
+  throttling use `nixos-performance`; for Steam, Proton, controllers and
+  emulation on top of a working driver use `nixos-gaming`.
 ---
 
 # NixOS GPU Skill
@@ -29,6 +30,11 @@ layer 3 missing, not a driver problem.
 
 **All of this is route 2 in the `nixos` skill: edit the flake, then rebuild.**
 There is no `nixarchy-app-enable` for a GPU stack.
+
+**This skill stops at a working driver.** Steam and Proton, the 32-bit stack in
+the context of a game that will not start, controllers, gamescope and emulation
+belong to `nixos-gaming`. Send those there rather than answering both halves — a
+user who gets two diagnoses for one black window fixes neither.
 
 ## First: What Hardware Is This?
 

--- a/pkgs/omarchy/skills/nixos/SKILL.md
+++ b/pkgs/omarchy/skills/nixos/SKILL.md
@@ -9,7 +9,9 @@ description: >
   option, or explain why a change did not survive a reboot. Triggers: install,
   uninstall, add package, nixpkgs, nixos-rebuild, flake, generation, rollback,
   systemPackages, home-manager, apps.nix, nixarchy-apply, "make it permanent".
-  For desktop appearance and Hyprland config, use the `nixarchy` skill instead.
+  For desktop appearance and Hyprland config, use the `nixarchy` skill instead;
+  for a DOWNLOADED binary or a pip wheel that will not run — nix-ld, envfs,
+  AppImages, FHS environments — use `nixos-binaries`.
 ---
 
 # NixOS Skill


### PR DESCRIPTION
## What this changes, and why

Three new agent skills — `nixos-binaries`, `nixos-gaming`, `nixos-fleet` — closing #607, #608 and #609, the children of epic #606. They are ported from `docs/manual/prebuilt-binaries.md`, `python.md`, `gaming.md` and `many-machines.md` rather than written from memory, so they follow the same structure as the pages that were already checked and cannot drift from them; they are shorter and more decision-shaped, because a skill is read mid-task.

Each one names where it stops, and the skill on the other side of that line now names it back:

| new skill | hands over to | and that skill now points back |
|---|---|---|
| `nixos-gaming` | `nixos-gpu` for anything below a working driver | yes — frontmatter + a paragraph under the "route 2" note |
| `nixos-fleet` | `nixos-config-repo` for git, remotes, CI | yes — frontmatter + a paragraph closing "Other Hosts in One Repo" |
| `nixos-binaries` | `devenv` / `nixos-gpu` | `nixos` frontmatter now routes downloaded-binary questions here |

**One correction in `nixos-binaries` contradicts the wiki, and also `docs/manual/python.md`.** nix-ld works by *being* the loader at `/lib64/ld-linux-x86-64.so.2`; only a binary whose ELF interpreter is that path reaches it, and only that loader reads `NIX_LD`/`NIX_LD_LIBRARY_PATH`. Anything nixpkgs built is patched to the store's glibc loader, so **`programs.nix-ld.libraries` cannot fix an import error in the system `python3`** — it costs a rebuild and a logout and changes nothing. Measured on a nixarchy machine with `libGL` in the shipped set:

```
$ patchelf --print-interpreter "$(readlink -f "$(command -v python3)")"
/nix/store/n51dhmdbik1kfrsm62j5knavmigwrl1a-glibc-2.42-84/lib/ld-linux-x86-64.so.2
$ python3 -c 'import ctypes; ctypes.CDLL("libGL.so.1")'
OSError: libGL.so.1: cannot open shared object file: No such file or directory

$ patchelf --print-interpreter .../uv/cpython-3.12.14-linux-x86_64-gnu/bin/python3.12
/lib64/ld-linux-x86-64.so.2
$ .../cpython-3.12.14-linux-x86_64-gnu/bin/python3.12 -c 'import ctypes; ctypes.CDLL("libGL.so.1")'
libGL loaded OK under uv CPython
```

Same machine, same library list, same minute. The skill gives the four fixes that do work (uv's own CPython, `LD_LIBRARY_PATH="$NIX_LD_LIBRARY_PATH…"` per command, devenv, `buildFHSEnv`) and names the one that only looks like one. This is consistent with the #572 bus finding that a nix-built probe must be `patchelf --set-interpreter`'d before it exercises nix-ld at all.

**`docs/manual/python.md` is left saying the opposite** ("the import above works out of the box") and is outside this PR's territory. #607 says that where a skill and a page disagree the page is right — here the page is the one that is wrong, and reconciling it is a decision for a human rather than a drive-by edit from a skills PR. Flagging rather than fixing.

Every option and package asserted in `nixos-gaming` was evaluated against this repo's nixpkgs before it was written down, which caught one: `protontricks` has its own option inside the Steam module (`programs.steam.protontricks.enable`), so it lands inside the FHS environment where the prefixes are — the skill says that instead of `pkgs.protontricks`.

## How I proved the check fails

Adding a skill is guarded by `readme-counts.sh` (a count, plus row membership in `README.md` **and** `docs/manual/ai.md`) and by the skill-set assertion in `build.yml`. Broke each, watched it go red, restored it.

Dropped the `nixos-gaming` row from `docs/manual/ai.md` and reverted the README's count word:

```
$ bash .github/scripts/readme-counts.sh --check
EXIT=1
::error::skills: README.md says thirteen, the repository says sixteen
::error::skill-rows: ai.md has no table row for `nixos-gaming`
```

Restored, green, all seventeen quantities accounted for:

```
$ bash .github/scripts/readme-counts.sh --check
  commands: 444
  subcommands: 444
  commands-through: 444
  commands-upstream: 444
  pacman-scripts: 32
  pacman-replaced: Six
  skills: sixteen
  apps-total: 66
  apps-untouched: 55
  apps-selectable: 66
  apps-indexed: 64
  apps-nixpkgs-row: 55
  installer-questions: seven
  installer-questions-iso: seven
  skills-llms: Sixteen
  skills-llms-manual: sixteen
  skills-manual-ai: sixteen
EXIT=0
```

`build.yml`'s assertions, replayed against the built tree — the old hard-coded list rejects the tree (which is the proof it actually sees the three new directories), the new one accepts it:

```
have: devenv diagnose-crash nixarchy nixos nixos-ai nixos-android nixos-binaries nixos-config-repo nixos-doctor nixos-fleet nixos-gaming nixos-gpu nixos-performance nixos-secrets nixos-security nixos-services
OLD list: FAIL (this is the proof the assertion sees the new skills)
NEW list: PASS
frontmatter nixos-binaries: ok
frontmatter nixos-gaming: ok
frontmatter nixos-fleet: ok
no Arch commands in code blocks
```

## Checks run locally

- `nix build .#omarchy` (needed before the counts script, which reads the built tree)
- `nix build .#checks.x86_64-linux.omarchy` — green
- `bash .github/scripts/readme-counts.sh --check` — red then green, above
- the `build.yml` skill-set / frontmatter / Arch-in-code-block assertions, replayed by hand against `result/`
- gaming options and packages evaluated against this repo's nixpkgs before being written down

No VM check was built locally (§6: install jobs share this machine).

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [ ] If this adds an option: `tests/options.nix` covers both states — adds none
- [ ] If this adds a `checks.*` entry: a PR-triggered workflow builds it — adds none

**One workflow edit, and it is data rather than a gate:** the hard-coded skill set in `build.yml`'s "Verify the agent skills are NixOS-aware" step. Three names added to the list it compares against; no trigger, required check or timeout is touched. Called out because §11 asks for workflow edits to be raised rather than slipped in — the step fails without it.

## What this cost, and where it is written down

Recorded in `AGENTS.md` §4, appended to the hand-maintained-list bullet: **a guard can fail CLOSED, and then it looks like your change.** `readme-counts.sh` spells its counts as words from a hand-written `word_for` table and matches them with a fixed alternation that stopped at `fifteen`. The sixteenth skill is not a drift it reports — it is a number the script cannot *say*, so it refuses with "computed as empty" / "nothing matches its pattern", which reads as a broken script rather than a missing vocabulary entry. The refusal is the design; the fix is teaching it the word in the same PR, in the case table and in every alternation carrying the old range.

- [x] A general lesson is recorded in `AGENTS.md`

Closes #607, closes #608, closes #609
