### PR TITLE
Two ML devshell presets, and a sandbox whose agent reaches only the hosts you name

### DIFF
--- a/data/devenv-presets.nix
+++ b/data/devenv-presets.nix
@@ -26,6 +26,22 @@
 # Anything that needs custom Nix does not qualify. That is what devenv's
 # examples repository is for, and `nixarchy dev init` says so on the way out.
 #
+# ## A preset may not set `packages`
+#
+# Not a style rule -- a hard one, and it is the scaffold's doing rather than
+# devenv's. `devenv init` writes `packages = [ pkgs.git ];` into the file
+# these lines are spliced into, and `lines` lands in the SAME attrset
+# literal. A second `packages = ...` is therefore not a module merge that
+# `lib.mkAfter` could order; it is
+#
+#   error: attribute 'packages' already defined at devenv.nix:8:3
+#
+# with no mention of a preset anywhere in it. The `ml` preset below was
+# written with `packages = [ pkgs.uv ];` and died exactly this way. Reach for
+# the `languages.*` option that installs the tool instead -- which is the
+# better line regardless, since it is the one devenv's own documentation
+# shows.
+#
 # ## What is checked, and what is not
 #
 # Nothing here validates itself: `lines` is a string, so a typo in an option
@@ -108,6 +124,92 @@
       };
     '';
     note = "Python with uv and a virtualenv devenv creates and enters for you, so `uv pip install` and `pip install` land in the project rather than in your home directory.";
+  };
+
+  # The two machine-learning presets, and the reason they look nothing like a
+  # nixpkgs answer to the same question.
+  #
+  # ## `ml`: uv's own CPython, deliberately
+  #
+  # The wheels an ML project actually installs -- torch, jax, onnxruntime --
+  # ship their own CUDA or ROCm runtime INSIDE the wheel. The one thing they
+  # cannot bundle is the driver, and on NixOS `libcuda.so.1` lives in
+  # /run/opengl-driver/lib, which is on no default search path. That is the
+  # whole of the machine-specific problem; nixpkgs' own cudaPackages solve a
+  # different one (building CUDA software from source) at the cost of an
+  # unfree rebuild of the world.
+  #
+  # And the correction that belongs with it, because it is the most common
+  # "I did what the wiki said and it still fails": **nix-ld does not help a
+  # nixpkgs Python.** nix-ld works by supplying a loader at the path a foreign
+  # binary expects one, and reading NIX_LD/NIX_LD_LIBRARY_PATH from the
+  # environment. A python3 out of nixpkgs is patched to use Nix's own loader
+  # and never consults either variable. Only an UNPATCHED interpreter -- the
+  # CPython uv downloads for itself -- is in a position to read them. Hence
+  # `UV_PYTHON_PREFERENCE = "only-managed"` below, and no
+  # `languages.python.enable` at all: this preset is the case where uv's
+  # interpreter is the point, not an implementation detail.
+  #
+  # Not poetry2nix. It is legacy, and its own README points at uv2nix, which
+  # self-describes as experimental with breaking API changes -- fine for a
+  # template somebody opts into with their eyes open, not for the preset a
+  # first ML project gets scaffolded from.
+  ml = {
+    label = "Machine learning (uv, CUDA/ROCm)";
+    lines = ''
+      languages.python = {
+        enable = true;
+        uv.enable = true;
+      };
+
+      # The line that makes this preset different from `python`. uv will
+      # otherwise reuse the nixpkgs interpreter the line above puts on PATH,
+      # and a nixpkgs python3 is patched to use Nix's own loader -- it never
+      # reads NIX_LD, so nix-ld cannot help a wheel it imports. uv's own
+      # downloaded CPython is an ordinary Linux binary, and is the one
+      # interpreter here that can.
+      env.UV_PYTHON_PREFERENCE = "only-managed";
+
+      # The driver is the one piece no wheel can ship. On NixOS it is here.
+      env.LD_LIBRARY_PATH = "/run/opengl-driver/lib:" + lib.makeLibraryPath [
+        pkgs.stdenv.cc.cc.lib
+        pkgs.zlib
+      ];
+    '';
+    note = "uv, with the driver on LD_LIBRARY_PATH so PyPI's CUDA and ROCm wheels load. Start with `uv venv` then `uv pip install torch` (CUDA) or `uv pip install torch --index-url https://download.pytorch.org/whl/rocm6.3` (ROCm). Deliberately uses uv's own Python: a nixpkgs python3 ignores nix-ld entirely.";
+  };
+
+  # ## `jupyter`: an ordinary devshell, which is the sharp part
+  #
+  # Search for Jupyter on Nix and the first answer is jupyenv (formerly
+  # jupyterWith). It is unmaintained and does not track current nixpkgs, so
+  # the evening goes: find it, fight its flake inputs, fail, conclude that
+  # Jupyter on NixOS is hard. It is not hard. `python3.withPackages` with
+  # jupyterlab in it is the entire answer, and `languages.python.package` is
+  # where devenv takes one.
+  #
+  # `processes.jupyter` rather than an `enterShell` that launches it: devenv's
+  # process manager is what upstream's own documentation reaches for, it means
+  # `devenv up` starts the server and `cd` does not, and it is one more option
+  # the user can read about at devenv.sh rather than here.
+  jupyter = {
+    label = "Jupyter";
+    lines = ''
+      languages.python = {
+        enable = true;
+        package = pkgs.python3.withPackages (ps: [
+          ps.jupyterlab
+          ps.ipykernel
+          ps.ipywidgets
+          ps.numpy
+          ps.pandas
+          ps.matplotlib
+        ]);
+      };
+
+      processes.jupyter.exec = "jupyter lab --no-browser";
+    '';
+    note = "JupyterLab from nixpkgs, pinned by devenv.lock -- `devenv up` starts the server. Not jupyenv (formerly jupyterWith): that project is unmaintained and does not track current nixpkgs, and this is the working path it is usually mistaken for.";
   };
 
   go = {

--- a/data/microvm-templates.nix
+++ b/data/microvm-templates.nix
@@ -67,6 +67,14 @@
     note = "Rootless-capable podman with Docker compatibility. /var/lib/containers is a 20 GiB volume that survives a restart; the rest of the root filesystem does not.";
   };
 
+  # The one template whose point is what it CANNOT do. Note says so in the
+  # same register as every other note here: what you get, and what it costs.
+  agent = {
+    label = "Agent";
+    module = ../modules/microvm/templates/agent.nix;
+    note = "Shell plus git and curl, and an egress allowlist: nothing in the guest can reach the network except through a local proxy, which only permits the hosts named one per line in the VM's own 'allow-hosts' file. HTTPS only -- an ssh:// git remote does not pass.";
+  };
+
   persistent = {
     label = "Persistent";
     module = ../modules/microvm/templates/persistent.nix;

--- a/docs/manual/ai.md
+++ b/docs/manual/ai.md
@@ -206,6 +206,33 @@ It is offered once as a notification after an agent is set up, and a
 configuration that is already committed and pushed marks itself done rather than
 asking again.
 
+## Giving an agent less than the whole machine
+
+Two things this desktop has that are worth knowing before you hand an agent a
+terminal, because neither is advertised and both are free.
+
+**An agent's damage to the system is one command to undo.**
+
+```sh
+sudo nixos-rebuild --rollback switch
+```
+
+or the previous generation in the boot menu. Whatever it added, removed or
+reconfigured *through the system's configuration* is gone, atomically. It
+does not touch your home directory, your working tree, or anything installed
+imperatively — but it is why "let it edit my configuration" is a much smaller
+bet here than on a distribution where the change is not reversible.
+
+**And it can be given a machine instead of yours.** `nixarchy vm create
+review-bot --template agent` boots a MicroVM whose only view of this machine
+is the read-only `/nix/store` and one shared directory — and whose network
+reaches nothing but the hosts you list, one per line, in the VM's own
+`allow-hosts` file. Your model endpoint and your git remote, and nothing
+else; not even DNS for anything else.
+
+[Sandboxes ▸ Running an agent that cannot phone home](sandboxes#running-an-agent-that-cannot-phone-home)
+is the page for it, including an honest list of what it does not contain.
+
 ## Pointing your own AI at nixarchy
 
 Ask any assistant about nixarchy cold and it answers from what it absorbed

--- a/docs/manual/per-project-environments.md
+++ b/docs/manual/per-project-environments.md
@@ -58,7 +58,7 @@ not trust that cache; the environments still work, they are just built locally.
 ## What `nixarchy dev init` writes
 
 `nixarchy dev init` with no argument lists the presets — `react`, `node`,
-`typescript`, `python`, `go`, `rust`. With one, it runs devenv's own
+`typescript`, `python`, `ml`, `jupyter`, `go`, `rust`. With one, it runs devenv's own
 `devenv init`, replaces the commented example language line in the scaffold
 with the preset's options, and runs `devenv allow` for you.
 
@@ -82,6 +82,76 @@ The first activation needs the network and takes a while: the inputs
 `devenv.nix`; it only scaffolds. Against a file you have been working in it
 prints the preset's two or three lines for you to paste, because there is no
 honest way to guess where in your file they belong.
+
+## The two machine-learning presets
+
+`ml` and `jupyter` are both Python and are deliberately not the same preset,
+because the two questions have different right answers on NixOS.
+
+### `nixarchy dev init ml`
+
+uv, and the GPU driver on `LD_LIBRARY_PATH`. The wheels an ML project
+installs — torch, jax, onnxruntime — ship their own CUDA or ROCm runtime
+*inside the wheel*; the one thing they cannot bundle is the driver, and on
+NixOS `libcuda.so.1` lives in `/run/opengl-driver/lib`, which is on no
+default search path. That is the whole of the machine-specific problem.
+
+```sh
+nixarchy dev init ml
+cd .                       # or re-enter the directory
+uv venv
+uv pip install torch       # CUDA wheels, from PyPI
+```
+
+For AMD, the same command against ROCm's index:
+
+```sh
+uv pip install torch --index-url https://download.pytorch.org/whl/rocm6.3
+```
+
+**The correction this preset exists to carry: `nix-ld` does not help a
+nixpkgs Python.** This is the most common "I did what the wiki said and it
+still fails" report, and the reason is mechanical. nix-ld works by putting a
+loader where a foreign binary expects one and reading `NIX_LD` and
+`NIX_LD_LIBRARY_PATH` out of the environment. A `python3` from nixpkgs is
+patched to use Nix's own loader and never consults either variable — so
+enabling nix-ld, or growing `programs.nix-ld.libraries`, changes nothing
+about what it can import. Only an **unpatched** interpreter is in a position
+to read them, and the one you have is the CPython uv downloads for itself.
+That is why the preset sets
+
+```nix
+env.UV_PYTHON_PREFERENCE = "only-managed";
+```
+
+rather than letting uv reuse the nixpkgs interpreter sitting next to it.
+
+Two things the preset deliberately does not do. It does not pull in nixpkgs'
+`cudaPackages`: those exist to *build* CUDA software from source and cost an
+unfree rebuild of a large part of the world, which is not what installing a
+wheel needs. And it does not use **poetry2nix**, which is legacy — its own
+README points at uv2nix, which self-describes as experimental with breaking
+API changes. Reach for uv2nix when something must consume the project as a
+Nix package; not for a project you are starting.
+
+### `nixarchy dev init jupyter`
+
+JupyterLab, and nothing clever:
+
+```nix
+languages.python.package = pkgs.python3.withPackages (ps: [ ps.jupyterlab ... ]);
+processes.jupyter.exec = "jupyter lab --no-browser";
+```
+
+`devenv up` starts the server; `devenv.lock` pins it.
+
+The sharp part is what this is *not*. Search for Jupyter on Nix and the first
+answer is **jupyenv** (formerly jupyterWith). It is unmaintained and does not
+track current nixpkgs, so the evening goes: find it, fight its flake inputs,
+fail, and conclude that Jupyter on NixOS is hard. It is not hard.
+`python3.withPackages` with `jupyterlab` in it is the entire answer, and
+`languages.python.package` is where devenv takes one. Add kernels by adding
+packages to that list.
 
 ## What is promised, and what is not
 

--- a/docs/manual/python.md
+++ b/docs/manual/python.md
@@ -66,13 +66,44 @@ NixOS's answer to loose prebuilt binaries is
 binaries expect the loader at, which supplies a configured set of libraries.
 It is already enabled on every nixarchy machine, and nixarchy curates
 `programs.nix-ld.libraries` beyond the NixOS default -- `libGL`, `zlib`,
-`libstdc++` and the rest of what common wheels load are in the shipped set,
-so the import above works out of the box.
+`libstdc++` and the rest of what common wheels load are in the shipped set.
+
+**Which interpreter you are running decides whether that helps you**, and the
+distinction is worth thirty seconds because getting it wrong costs a rebuild
+and a logout for nothing. nix-ld works by *being* the loader at
+`/lib64/ld-linux-x86-64.so.2`; only a binary whose ELF interpreter is that
+path reaches the shim, and only the shim reads `NIX_LD_LIBRARY_PATH`. One
+command tells you which you have:
+
+```sh
+patchelf --print-interpreter "$(readlink -f "$(command -v python3)")"
+```
+
+- `/lib64/ld-linux-x86-64.so.2` -- a foreign interpreter (the CPython **uv**
+  downloads for itself is the one you are most likely to meet). nix-ld
+  applies, and the shipped library set is what makes the import above work.
+- `/nix/store/...-glibc-.../ld-linux-x86-64.so.2` -- a **nixpkgs** python3,
+  which is what `python3` on this machine is. It uses the store's own loader
+  and never consults `NIX_LD_LIBRARY_PATH`, so growing
+  `programs.nix-ld.libraries` changes nothing about what it can import, no
+  matter how long that list gets.
+
+For the second case, hand the same libraries over for the one command that
+needs them:
+
+```sh
+LD_LIBRARY_PATH="$NIX_LD_LIBRARY_PATH${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" python3 app.py
+```
+
+Per command, not exported globally -- a global `LD_LIBRARY_PATH` is how
+unrelated Nix programs start failing. The durable answers are a devenv (below),
+an FHS environment, or simply running the venv on uv's own Python.
 [Prebuilt binaries](prebuilt-binaries) is the full story of that set.
 
-When a wheel wants a library the set does not carry, the error names it,
-and the fix is one option in your own configuration -- your entries merge
-with nixarchy's rather than replacing them:
+When a wheel wants a library the set does not carry -- on an interpreter
+nix-ld can actually reach -- the error names it, and the fix is one option in
+your own configuration; your entries merge with nixarchy's rather than
+replacing them:
 
 ```nix
 programs.nix-ld.libraries = with pkgs; [ libpulseaudio ];
@@ -107,6 +138,37 @@ current answer -- `uv.lock` as the source of truth. And when you need Nix to
 whose own documentation says to skip it for day-to-day development and just
 use uv. That is a useful signal, not a criticism: reach for uv2nix when
 something must consume the project as a Nix package, not before.
+
+## Machine learning, CUDA, and the one thing nix-ld cannot do
+
+PyTorch and friends are the hardest case of everything above, and they are
+also the case where the advice above stops applying — so it is worth being
+precise rather than general.
+
+A CUDA or ROCm wheel from PyPI already contains its own CUDA runtime. The
+only thing it needs from the machine is the *driver*, `libcuda.so.1`, which
+on NixOS is in `/run/opengl-driver/lib`. That is a `LD_LIBRARY_PATH` problem,
+not a nix-ld one.
+
+And the distinction that trips most people:
+
+> nix-ld helps an **unpatched** binary — one built on an ordinary distro,
+> which asks for the loader at `/lib64/ld-linux-x86-64.so.2` and reads
+> `NIX_LD_LIBRARY_PATH` from its environment. A `python3` out of nixpkgs is
+> not such a binary. It is patched to use Nix's own loader and consults
+> neither variable, so growing `programs.nix-ld.libraries` does nothing for
+> what *it* imports.
+
+The interpreter that does read them is the one **uv** downloads for itself.
+So the working answer for an ML project is uv's own Python, and
+[`nixarchy dev init ml`](per-project-environments#nixarchy-dev-init-ml) is
+that in one command — uv, `UV_PYTHON_PREFERENCE = "only-managed"`, and the
+driver path already set.
+
+For notebooks, [`nixarchy dev init jupyter`](per-project-environments#nixarchy-dev-init-jupyter)
+is an ordinary devshell built from `python3.withPackages`. Do not reach for
+**jupyenv** (formerly jupyterWith), which every search puts first: it is
+unmaintained and does not track current nixpkgs.
 
 ## What still will not work, and why
 

--- a/docs/manual/sandboxes.md
+++ b/docs/manual/sandboxes.md
@@ -66,6 +66,7 @@ is the same catalogue, `data/microvm-templates.nix`.
 | `shell` | nothing beyond the base guest | the fastest way to a throwaway prompt, and the template every other one starts from |
 | `python` | `python3`, `uv`, 3 GiB RAM | ephemeral — `uv venv /mnt/host/.venv` if the venv should outlive the VM |
 | `podman` | rootless-capable podman, Docker-compatible | `/var/lib/containers` is a 20 GiB volume that survives a restart; the rest of the root filesystem does not |
+| `agent` | `shell` plus git, curl, and an egress allowlist | nothing in the guest reaches the network except through a local proxy that only permits hosts you name — see [Running an agent that cannot phone home](#running-an-agent-that-cannot-phone-home) |
 | `persistent` | `shell` plus `/home` on its own volume | the volume goes when the VM does; the root filesystem is still thrown away every boot |
 
 Every template is a plain NixOS module — nothing here invents nixarchy
@@ -86,12 +87,97 @@ Every guest, regardless of template, gets the same four things from
 - **The network is NAT out, nothing in.** User-mode (SLiRP) networking:
   `curl`, `git clone`, a package fetch all work; nothing on the host, and
   nothing on your LAN, can reach in. No bridge, no tap device, no firewall
-  rule to write.
+  rule to write. The `agent` template is the one that restricts the *outbound*
+  half of this.
 - **A root filesystem on tmpfs.** Gone at every boot, along with anything
   you installed imperatively with `nix-env` or wrote outside a path a
   template explicitly persists. `shell` and `python` persist nothing at
   all; `podman` persists `/var/lib/containers`; `persistent` persists
   `/home`.
+
+## Running an agent that cannot phone home
+
+The `agent` template exists for one job: running an AI coding agent — or any
+program you are willing to let loose on a checkout but not on your network —
+where the filesystem boundary is not the only boundary.
+
+The filesystem half is the same one every template gets, and it is the strong
+half: the guest sees your host `/nix/store` read-only and one directory at
+`/mnt/host`, and nothing else. That is worth saying plainly, because the
+common alternatives are weaker. A bubblewrap wrapper maps *your* user into
+the sandbox, so a process that gets out of it reads `~/.ssh` and every API
+key on the machine. A guest kernel does not have that shape.
+
+What `agent` adds is the network. Every other template inherits "NAT out,
+nothing in", which is no constraint at all on a process you are running
+*because* you do not fully trust it. Here, the guest's own firewall drops
+everything outbound except the local proxy's traffic, and the proxy refuses
+any host you did not name.
+
+You name them one per line, in the VM's own directory, before you start it:
+
+```sh
+nixarchy vm create review-bot --template agent
+cat > ~/.local/state/nixarchy/microvm/review-bot/allow-hosts <<'EOF'
+api.anthropic.com
+github.com
+EOF
+nixarchy vm run review-bot
+```
+
+Subdomains of a listed host are allowed (`github.com` covers
+`api.github.com`), nothing else is, and `#` starts a comment. Inside the
+guest, `http_proxy` and `https_proxy` are already set, so `curl`, `git`,
+`pip`, `uv`, `npm` and every model SDK route through the proxy without being
+told.
+
+**No file, or an empty one, means nothing is allowed.** That is the only safe
+way for this to fail, and it is the failure you will meet first: an agent
+that reports it cannot reach its own API is telling you the allowlist is not
+where it expected.
+
+### What this does and does not contain
+
+It **does** stop a process in the guest from reaching anything but the hosts
+you listed. Not by asking it politely — there is no socket to the outside
+world for any user but the proxy's, DNS included, so an agent cannot resolve
+a name, let alone open a connection. DNS tunnelling is off the table for the
+same reason.
+
+It **does not**:
+
+- **Stop data leaving through an allowed host.** You allowed your model
+  endpoint; everything you hand the agent goes there. That channel is the
+  point of the exercise, and an allowlist cannot tell a prompt from an
+  exfiltration.
+- **Work for `ssh://` git remotes.** The proxy speaks HTTP `CONNECT` and is
+  restricted to port 443. Use an `https://` remote and a token.
+- **Verify what is on the other end of an allowed name.** The allowlist
+  matches the hostname the client asks for; TLS is end to end, so nothing
+  here inspects or re-signs it. That is the right trade — a sandbox that
+  terminated your TLS would be a sandbox that could read your model traffic.
+- **Survive root inside the guest.** A process that becomes root there can
+  flush the ruleset. It still cannot leave the VM, which is the boundary that
+  matters, but treat the allowlist as a policy for an agent doing what agents
+  do, not as a cage for an attacker.
+- **Restrict the shared directory.** `/mnt/host` is read-write, as it is for
+  every template. Put the checkout there and nothing else.
+
+### And when it does get out and break something
+
+Worth saying once, because nobody markets it and it is free: on a NixOS
+machine an agent's damage to the *system* is undone by
+
+```sh
+sudo nixos-rebuild --rollback switch
+```
+
+or by picking the previous generation in the boot menu. Whatever it added,
+removed or reconfigured through the system's own configuration is gone, in
+one command, atomically. That is not a sandbox — it does not touch your home
+directory, your git working tree, or anything installed imperatively — but it
+is the reason "let an agent edit my configuration" is a much smaller bet here
+than on a distribution where it is not reversible.
 
 ## Getting back in, stopping, destroying
 

--- a/modules/microvm/templates/agent.nix
+++ b/modules/microvm/templates/agent.nix
@@ -1,0 +1,185 @@
+# The `agent` template. Every other template in this catalogue answers "give
+# me a machine"; this one answers "give me a machine that cannot phone
+# anywhere I did not name".
+#
+# The filesystem half of sandboxing an AI agent was already done and is the
+# strong half: modules/microvm/guest.nix boots a guest whose only view of the
+# host is the read-only /nix/store and one directory at /mnt/host. That is a
+# kernel boundary, and it is why a MicroVM beats the bubblewrap wrappers
+# (`agent-sandbox.nix`, `nixwrap`) that map the host user into the sandbox and
+# so leave ~/.ssh one escape away.
+#
+# The network was the half still missing. `shell`, `python` and `podman` all
+# inherit guest.nix's SLiRP interface, which is "NAT out, nothing in" -- fine
+# for a package fetch, and no constraint at all on a process you are running
+# precisely because you do not fully trust what it will do. An agent that can
+# reach only its model endpoint and your git remote is a materially different
+# risk from one that can reach anything.
+#
+# ## How the egress restriction actually works
+#
+# Two pieces, and neither is nixarchy vocabulary -- both are plain NixOS, per
+# data/microvm-templates.nix's bar:
+#
+#   1. `networking.nftables` with an OUTPUT chain whose policy is `drop`. The
+#      only uid allowed off the machine is tinyproxy's. Not the `dev` user,
+#      not root, not DNS: an agent running as `dev` has no socket to the
+#      outside world at all, so there is no direct connection to make and no
+#      DNS channel to tunnel out of.
+#   2. `services.tinyproxy` on 127.0.0.1:8888 with `FilterDefaultDeny`, which
+#      is what turns "tinyproxy may egress" back into "only these hosts may".
+#      It filters the host in a CONNECT line, so HTTPS is allowed or refused
+#      by name without anything terminating the TLS.
+#
+# `environment.variables` then points http_proxy/https_proxy at it, which is
+# the interface curl, git-over-https, pip, uv, npm and every model SDK already
+# speak. Nothing in the guest has to know a proxy exists.
+#
+# ## The allowlist is per-VM, and so cannot be in the closure
+#
+# The hosts one person allows are not the hosts the next person allows, and
+# data/microvm-templates.nix's first rule is that nothing in a template may
+# depend on a per-VM value -- one closure serves every VM of a template. So
+# the allowlist arrives exactly the way the hostname does in
+# modules/microvm/guest.nix: a plain-text file the caller drops in the VM's
+# own directory, read at boot from the /mnt/host share, by a oneshot that
+# runs inside the VM that actually has it mounted.
+#
+# `/mnt/host/allow-hosts`, one hostname per line, `#` comments allowed. No
+# file, or an empty one, means an empty filter -- which under
+# `FilterDefaultDeny` is deny-everything, the only safe way for this to fail.
+{ pkgs, ... }:
+let
+  proxy = "http://127.0.0.1:8888";
+
+  # A fixed uid rather than the dynamic one the tinyproxy module would
+  # otherwise allocate, because `networking.nftables.checkRuleset` runs
+  # `nft --check` in the build sandbox, where /etc/passwd has no `tinyproxy`
+  # line and `meta skuid tinyproxy` therefore fails to parse. Numeric here is
+  # the same rule nixpkgs' own `preCheckRuleset` example exists to work
+  # around, without the workaround.
+  proxyUid = 399;
+
+  filterFile = "/run/nixarchy-agent/allow.filter";
+in
+{
+  environment.systemPackages = [
+    pkgs.git
+    pkgs.curl
+  ];
+
+  services.tinyproxy = {
+    enable = true;
+    settings = {
+      Listen = "127.0.0.1";
+      Port = 8888;
+      Allow = "127.0.0.1";
+      Timeout = 600;
+      # Filter is typed `nullOr path` upstream, and this string is an
+      # absolute path that is deliberately NOT a Nix path literal: a path
+      # literal would be copied into the store at build time, and the whole
+      # point is that this file is written at boot from the per-VM share.
+      Filter = filterFile;
+      # The line that makes this an allowlist rather than a blocklist. Without
+      # it a filter file matches hosts to REFUSE and everything else goes
+      # through, which is the opposite of what this template promises.
+      FilterDefaultDeny = true;
+      FilterExtended = true;
+      FilterCaseSensitive = false;
+      # CONNECT to 443 and nothing else. Without this, an allowed hostname is
+      # a tunnel to any port on that host, ssh included.
+      ConnectPort = 443;
+      LogLevel = "Connect";
+    };
+  };
+
+  users.users.tinyproxy.uid = proxyUid;
+
+  systemd.services.nixarchy-agent-allowlist = {
+    description = "Build this guest's egress allowlist from the host directory share";
+    wantedBy = [ "multi-user.target" ];
+    # Ordered and required, both: tinyproxy reads its filter file once, at
+    # start, so a tinyproxy that came up first would be running an allowlist
+    # that no longer describes this VM.
+    before = [ "tinyproxy.service" ];
+    requiredBy = [ "tinyproxy.service" ];
+    unitConfig.RequiresMountsFor = [ "/mnt/host" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    # Truncate first, unconditionally. A leftover filter from a previous boot
+    # is impossible on a tmpfs root, but an early `exit` on a missing
+    # allow-hosts would leave tinyproxy pointed at a file that does not exist
+    # -- and tinyproxy treats an unreadable filter as no filter, which under
+    # FilterDefaultDeny is not obviously fail-closed. An empty file is.
+    script = ''
+      install -d -m 0755 /run/nixarchy-agent
+      : > ${filterFile}
+      if [ -r /mnt/host/allow-hosts ]; then
+        while read -r host; do
+          case "$host" in
+            "" | \#*) continue ;;
+          esac
+          # Anchored, with the dots escaped and one optional subdomain label
+          # group: `github.com` allows api.github.com and refuses
+          # notgithub.com. An unescaped dot would make `.` match any
+          # character, which is how an allowlist silently becomes wider than
+          # it reads.
+          printf '^(.*\.)?%s$\n' "$(printf '%s' "$host" | sed 's/\./\\./g')" >> ${filterFile}
+        done < /mnt/host/allow-hosts
+      fi
+      chmod 0444 ${filterFile}
+    '';
+  };
+
+  # The one thing the guest's own processes have to be told. Both spellings:
+  # curl and git read the lowercase ones, a good deal of Python and Node reads
+  # the uppercase ones, and a tool that reads neither simply gets no network
+  # rather than an unfiltered one.
+  environment.variables = {
+    http_proxy = proxy;
+    https_proxy = proxy;
+    HTTP_PROXY = proxy;
+    HTTPS_PROXY = proxy;
+    no_proxy = "localhost,127.0.0.1";
+    NO_PROXY = "localhost,127.0.0.1";
+  };
+
+  networking.nftables = {
+    enable = true;
+    # Only an output chain. Inbound is already answered twice over -- SLiRP
+    # user networking has nothing to forward in, and networking.firewall's own
+    # `inet nixos-fw` table is still here -- and a second input base chain
+    # would only make the ruleset harder to read for no gain.
+    ruleset = ''
+      table inet nixarchy-agent {
+        chain output {
+          type filter hook output priority filter; policy drop;
+
+          ct state established,related accept
+          oifname "lo" accept
+
+          # DHCP, from whatever uid the guest's dhcp client runs as: SLiRP
+          # hands out the lease this guest's only interface needs, and
+          # without it there is no network for the proxy to use either.
+          udp dport 67 accept
+
+          # The proxy, and nothing else on this machine, may resolve a name
+          # or open a connection. Dropping DNS for every other uid is not
+          # incidental -- a 53/udp socket is an exfiltration channel that
+          # needs no allowed host at all.
+          meta skuid ${toString proxyUid} udp dport 53 accept
+          meta skuid ${toString proxyUid} tcp dport 53 accept
+          meta skuid ${toString proxyUid} tcp dport { 80, 443 } accept
+        }
+      }
+    '';
+  };
+
+  # Enough for an agent, a checkout and a language server. Above the 512 MiB
+  # microvm.nix default for the same reason modules/microvm/templates/python.nix
+  # raises it, and below that template's 3072 because nothing here resolves a
+  # dependency-heavy lockfile.
+  microvm.mem = 2560;
+}

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -190,3 +190,17 @@ Two branches only these can reach, as illustration:
   reporting `action timed out after 120s` two minutes after the guest had
   printed the reason. Wait for `TAG-\d+-X`, then read the code out of
   `get_console_log()`.
+- **A single column-zero line changes the indentation of a whole `''` string,
+  and the failure lands somewhere else entirely.** Nix strips the *common*
+  leading whitespace off an indented string at parse time. Adding one literal
+  line at column zero — an `${lib.optionalString ...}` opener written flush
+  left is the easy way to do it — drops that common indent to nothing, so
+  every other line in the script keeps the four spaces it used to lose. The
+  script still runs; what breaks is an indented heredoc terminator, because
+  `<<STUB` (unlike `<<-`) only matches a terminator at column zero. In
+  `tests/microvm-template.nix` the result was the stub-`nix` heredoc running to
+  end of file and bash reporting `nixarchy: command not found` on a line five
+  hundred away from the edit. If a `runCommand` script starts failing in a
+  region you did not touch, diff `nix eval --raw .#checks.<system>.<name>.buildCommand`
+  before reading the shell — and indent interpolation openers to match their
+  surroundings. `nix fmt` does not catch this; it happily formats both.

--- a/tests/microvm-template.nix
+++ b/tests/microvm-template.nix
@@ -59,6 +59,7 @@ pkgs.runCommand "nixarchy-microvm-template"
       coreutils
       util-linux # flock, for the CLI half below
       bash
+      jq # reads the guest's users-groups.json, for the uid cross-check below
     ];
   }
   ''
@@ -191,6 +192,135 @@ pkgs.runCommand "nixarchy-microvm-template"
         fi
       done
     '') names}
+
+    echo "== every template is in the manual's table =="
+
+    # A hand-maintained list naming things that exist elsewhere (CLAUDE.md #4):
+    # docs/manual/sandboxes.md's template table is written by hand and the
+    # catalogue is not, so the table fails OPEN -- a template added without a
+    # row still works, still ships, and is documented nowhere. This names the
+    # missing template rather than comparing a count, because a count only
+    # says a number moved.
+    # A backtick built with printf rather than written here: the table cells
+    # are `name` in code ticks, and a literal backtick inside double quotes is
+    # command substitution to bash.
+    bt=$(printf '\140')
+    for name in ${lib.concatStringsSep " " names}; do
+      if ! grep -qF "| $bt$name$bt |" ${../docs/manual/sandboxes.md}; then
+        echo "data/microvm-templates.nix has '$name' and docs/manual/sandboxes.md has no row for it" >&2
+        fail=1
+      fi
+    done
+
+    ${lib.optionalString (templates ? agent) ''
+      echo "== the agent template cannot reach what it was not allowed =="
+
+      # Everything below reads the guest CLOSURE rather than the qemu command
+      # line: an egress policy lives inside the guest, so the assertions the
+      # rest of this file makes against bin/microvm-run cannot see any of it.
+      # Nothing here boots -- see the header for why that matters.
+      sys=$(readlink -f ${templates.agent.kvm}/share/microvm/system)
+      units=$sys/etc/systemd/system
+
+      for unit in nftables.service tinyproxy.service nixarchy-agent-allowlist.service; do
+        if [ ! -e "$units/$unit" ]; then
+          echo "agent: $unit is not in the guest closure -- the egress restriction is not there" >&2
+          fail=1
+        fi
+      done
+
+      # The allowlist generator runs BEFORE tinyproxy, and tinyproxy does not
+      # start without it. tinyproxy reads its filter file once, at start: a
+      # tinyproxy that came up first would be enforcing the previous boot's
+      # allowlist, or none.
+      if [ ! -e "$units/tinyproxy.service.requires/nixarchy-agent-allowlist.service" ]; then
+        echo "agent: tinyproxy does not require nixarchy-agent-allowlist -- it can start without an allowlist" >&2
+        fail=1
+      fi
+
+      rules=$(grep -oE '/nix/store/[a-z0-9]+-nftables-rules' "$units/nftables.service" | head -1)
+      if [ -z "$rules" ] || [ ! -r "$rules" ]; then
+        echo "agent: could not find the nftables ruleset the guest loads at boot" >&2
+        fail=1
+      else
+        if ! grep -q 'table inet nixarchy-agent' "$rules"; then
+          echo "agent: the guest's ruleset has no nixarchy-agent table" >&2
+          fail=1
+        fi
+        # The whole restriction in one line. Without `policy drop` this is an
+        # ordinary machine with some accept rules on it.
+        if ! grep -qE 'hook output .*policy drop' "$rules"; then
+          echo "agent: the output chain does not default to drop -- egress is unrestricted" >&2
+          fail=1
+        fi
+
+        # And the accepts are all uid-qualified. An unqualified `dport 53
+        # accept` would hand every process in the guest a DNS socket, which is
+        # an exfiltration channel needing no allowed host at all -- and it
+        # would still LOOK like a locked-down ruleset.
+        bare=$(grep -vE '^[[:space:]]*#' "$rules" \
+          | grep -E 'dport[^#]*(53|80|443)' \
+          | grep -v skuid || true)
+        if [ -n "$bare" ]; then
+          echo "agent: these ruleset lines accept traffic from any uid, not just the proxy's:" >&2
+          echo "$bare" >&2
+          fail=1
+        fi
+
+        # The uid in the ruleset is the uid tinyproxy actually gets. Dropping
+        # `users.users.tinyproxy.uid` is the quiet version of this bug: the
+        # rules still read correctly and permit a uid nothing runs as.
+        ruleUid=$(grep -oE 'skuid [0-9]+' "$rules" | head -1 | cut -d' ' -f2)
+        usersJson=$(grep -oE '/nix/store/[a-z0-9]+-users-groups.json' "$sys/activate" | head -1)
+        realUid=$(jq -r '.users[] | select(.name == "tinyproxy") | .uid' "$usersJson")
+        if [ "$ruleUid" != "$realUid" ]; then
+          echo "agent: the ruleset permits uid '$ruleUid' and tinyproxy runs as uid '$realUid'" >&2
+          echo "-- the proxy cannot egress, so nothing in this guest can" >&2
+          fail=1
+        fi
+      fi
+
+      conf=$(grep -oE '\-c /nix/store/[^ ]+' "$units/tinyproxy.service" | head -1 | cut -d' ' -f2)
+      if [ -z "$conf" ] || [ ! -r "$conf" ]; then
+        echo "agent: could not find tinyproxy's generated configuration" >&2
+        fail=1
+      else
+        # FilterDefaultDeny is what makes the filter file an ALLOWlist. Without
+        # it the same file names hosts to refuse and everything else goes
+        # through -- the exact inversion of what this template promises, with
+        # no other visible difference.
+        if ! grep -q '^FilterDefaultDeny yes' "$conf"; then
+          echo "agent: tinyproxy has no FilterDefaultDeny -- the allowlist is a blocklist" >&2
+          fail=1
+        fi
+        # The filter is a runtime path, not a store path: the allowlist is
+        # per-VM (data/microvm-templates.nix's rule -- one closure serves every
+        # VM of a template), written at boot from /mnt/host/allow-hosts.
+        if ! grep -q '^Filter "/run/nixarchy-agent/allow.filter"' "$conf"; then
+          echo "agent: tinyproxy's Filter is not the per-VM file written at boot:" >&2
+          grep '^Filter' "$conf" >&2 || echo "  (no Filter line at all)" >&2
+          fail=1
+        fi
+        if ! grep -q '^ConnectPort 443' "$conf"; then
+          echo "agent: tinyproxy does not restrict CONNECT to 443 -- an allowed host is a tunnel to any port on it" >&2
+          fail=1
+        fi
+        if ! grep -q '^Listen 127.0.0.1' "$conf"; then
+          echo "agent: tinyproxy does not listen on loopback only" >&2
+          fail=1
+        fi
+      fi
+
+      # And the guest tells its own processes where the proxy is, in both
+      # spellings -- a tool reading only the uppercase pair would otherwise get
+      # a dropped connection and no explanation.
+      for var in http_proxy https_proxy HTTP_PROXY HTTPS_PROXY; do
+        if ! grep -q "^export $var=\"http://127.0.0.1:8888\"" "$sys/etc/set-environment"; then
+          echo "agent: the guest does not export $var -- nothing in it will find the proxy" >&2
+          fail=1
+        fi
+      done
+    ''}
 
     echo "== nixarchy vm: launch and locking =="
 


### PR DESCRIPTION
## What this changes, and why

Two issues, one surface each, both under the **AI and GPU work** milestone.

**#626 — ML devshell presets.** `nixarchy dev init` gains `ml` and `jupyter`.
They carry corrections as much as they carry option lines:

- **`ml`** is uv, with the driver on `LD_LIBRARY_PATH`. CUDA and ROCm wheels
  from PyPI bundle their own runtime; the one thing they cannot bundle is
  `libcuda.so.1`, which on NixOS is in `/run/opengl-driver/lib` and on no
  default search path. It sets `UV_PYTHON_PREFERENCE = "only-managed"`
  deliberately, because **nix-ld does not help a nixpkgs Python** — nix-ld
  works by *being* the loader at `/lib64/ld-linux-x86-64.so.2` and reading
  `NIX_LD_LIBRARY_PATH`, and a nixpkgs `python3` is patched to the store's own
  loader and consults neither. Only an unpatched interpreter — uv's downloaded
  CPython — can. No `cudaPackages` (those build CUDA software from source, at
  the cost of an unfree rebuild) and no poetry2nix (legacy; its own README
  points at uv2nix, which self-describes as experimental).
- **`jupyter`** is an ordinary devshell: `languages.python.package =
  pkgs.python3.withPackages (...)` plus `processes.jupyter.exec`. The sharp
  part is what it is not — **jupyenv (formerly jupyterWith) is unmaintained and
  does not track current nixpkgs**, and it is the first thing a search returns,
  so people lose an evening to it before finding the six-line answer.

**#627 — a network-restricted agent profile.** `nixarchy vm` gains an `agent`
template. The filesystem half was already the strong half (a guest kernel, the
host store read-only, one shared directory — unlike the bubblewrap wrappers
that map the host user in and leave `~/.ssh` one escape away). This adds the
missing half, in plain NixOS:

- `networking.nftables` with an **output chain whose policy is `drop`**. The
  only uid permitted off the machine is tinyproxy's — DNS included, so an
  agent cannot resolve a name, let alone tunnel out of one.
- `services.tinyproxy` on loopback with **`FilterDefaultDeny`**, `ConnectPort
  443`, and a filter file that is a *runtime* path, not a store path.
- The allowlist is per-VM and therefore cannot live in the closure (one runner
  serves every VM of a template). It arrives exactly the way the hostname
  already does in `modules/microvm/guest.nix`: `/mnt/host/allow-hosts`, one
  host per line, read at boot by a oneshot ordered before tinyproxy. **No file
  means deny everything** — the only safe way for this to fail.

`docs/manual/sandboxes.md` says what it does and does not contain, at length:
it does not stop data leaving through an allowed host, does not pass `ssh://`
git remotes, does not verify what is behind an allowed name, and does not
survive root inside the guest. It also finally writes down that
`nixos-rebuild --rollback` is atomic undo of an agent's damage to the system,
which #627 asked for and which `docs/manual/ai.md` now says too.

**One thing taken from the bus.** `#nixarchy-agents` carries a measured finding
from the #632 author: `docs/manual/python.md` states the opposite of the nix-ld
correction above ("so the import above works out of the box"), with the note
*"whoever owns those pages next: that sentence needs qualifying by which
interpreter, not deleting."* That page is in this PR's territory, so it is
qualified here — with the `patchelf --print-interpreter` one-liner that decides
it, and the per-command `LD_LIBRARY_PATH="$NIX_LD_LIBRARY_PATH..."` escape for
the nixpkgs case.

## How I proved the check fails

**`checks.microvm-template`** — five guarantees broken at once (`policy drop` →
`policy accept`; `users.users.tinyproxy.uid` deleted; the DNS rule's `meta
skuid` removed; `FilterDefaultDeny` removed; the `agent` row deleted from
`docs/manual/sandboxes.md`), each firing its own assertion:

```
> == template: agent ==
> == every template is in the manual's table ==
> data/microvm-templates.nix has 'agent' and docs/manual/sandboxes.md has no row for it
> == the agent template cannot reach what it was not allowed ==
> agent: the output chain does not default to drop -- egress is unrestricted
> agent: these ruleset lines accept traffic from any uid, not just the proxy's:
>     udp dport 53 accept
> agent: the ruleset permits uid '399' and tinyproxy runs as uid 'null'
> -- the proxy cannot egress, so nothing in this guest can
> agent: tinyproxy has no FilterDefaultDeny -- the allowlist is a blocklist
error: Cannot build '/nix/store/r8l4a4plv4rr05fcw8knfwwbi1j2bzqs-nixarchy-microvm-template.drv'.
       Reason: builder failed with exit code 1.
```

Restored, same command, exit 0:

```
> == the agent template cannot reach what it was not allowed ==
> every template's runner is qemu, shares the host store read-only, uses user
> networking, and the KVM/-tcg pair share one guest -- and nixarchy-vm launches
> it with an out-link, under a flock.
```

**`nix run .#devenv-presets`** (the presets' check, a `build.yml` job) — `ml`'s
`languages.python.uv.enable` misspelt to `uv.enabel`:

```
== ml
   does not evaluate:
       error: The option `languages.python.uv.enabel' does not exist. Definition values:
```

and restored:

```
== go
   ok
== jupyter
   ok
== ml
   ok
...
all 8 presets evaluate
```

That check also caught a real defect in the first draft of `ml`, before any
deliberate break — see "What this cost" below.

Both runs were `set -o pipefail`'d and executed as commands, not pasted into a
shell (AGENTS.md §1's two mechanical traps).

## Checks run locally

- `nix build .#checks.x86_64-linux.microvm-template` — **green** (and red on
  demand, above). It builds five guest closures now rather than four.
- `nix build .#checks.x86_64-linux.options` — **green**. No option is added
  here, so Mode A is untouched by construction; run anyway because the off
  state is the one a refactor breaks quietly.
- `nix run .#devenv-presets` — **green**, all 8.
- `nix build .#packages.x86_64-linux.microvm-agent` — the new guest closure
  builds; `networking.nftables.checkRuleset` runs `nft --check` inside it, so
  a ruleset syntax error is a build failure rather than a boot failure.

No VM check (`microvm-boot`, `session`, `install`, …) was built locally —
`gh run list` was checked first and CI was idle, but a guest-side timeout under
contention fails somebody else's PR (§6), so the boot-class evidence for this
template is CI's to produce.

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [x] If this adds an option: `tests/options.nix` covers both states — *n/a, no
      `programs.nixarchy` option is added*
- [x] If this adds a `checks.*` entry: a PR-triggered workflow builds it —
      *n/a, deliberately: the new assertions were added to the existing
      `checks.microvm-template` rather than to a new entry, so no workflow edit
      (and no maintainer sign-off, §4/§11) is needed to make them run*

## What this cost, and where it is written down

Two general lessons, both recorded here:

1. **`data/devenv-presets.nix`** now states that a preset may not set
   `packages`. `devenv init` already writes `packages = [ pkgs.git ];` into the
   file a preset's lines are spliced into, and both land in the *same attrset
   literal* — so a second one is not a module merge `lib.mkAfter` could order,
   it is `error: attribute 'packages' already defined at devenv.nix:8:3`, with
   no mention of a preset anywhere in the message. The first draft of `ml` died
   exactly this way and `nix run .#devenv-presets` is what caught it.

2. **`tests/AGENTS.md`** now carries the indented-string trap. One literal line
   at column zero — an `${lib.optionalString ...}` opener written flush left —
   drops the *common* leading whitespace Nix strips from a `''` string to
   nothing, so every other line keeps four spaces it used to lose. The script
   still runs; what breaks is an indented heredoc terminator, because `<<STUB`
   only matches at column zero. The visible failure was
   `nixarchy: command not found` five hundred lines from the edit, and
   `nix eval --raw .#checks.<system>.<name>.buildCommand` is what identified it.
   `nix fmt` formats both versions happily.

- [x] A general lesson is recorded in `AGENTS.md`, or nothing general came up

## One thing for a human

`docs/manual/prebuilt-binaries.md` implies the same nix-ld claim for wheels
that `python.md` made, per the #632 author's note. It is outside this PR's
territory and outside both issues, so it is untouched — flagging rather than
widening scope (§10).

closes #626, closes #627
