### PR TITLE
A GPU machine downloads its CUDA closure, keeps its models off the root disk, and can have a chat window over them

### DIFF
--- a/data/services.nix
+++ b/data/services.nix
@@ -166,6 +166,19 @@
     note = "For software nixpkgs does not carry. Then: flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo";
   };
 
+  open-webui = {
+    label = "Open WebUI (local chat)";
+    category = "Desktop";
+    kind = "bundled";
+    # Bundled because the UI has to be told where this machine's Ollama
+    # actually listens -- its own default is localhost:11434, and a host that
+    # moved the port gets a working UI with an empty model list and no error.
+    # The second half is smaller and worse: upstream keeps its telemetry-off
+    # settings in the option DEFAULT of `environment`, which any definition
+    # replaces wholesale.
+    note = "A browser chat window over the models this machine already runs. Needs an Ollama -- programs.nixarchy.localAi.enable is the one that puts a model on the machine -- and refuses to build without one rather than showing you an empty model list. Stays on loopback: the first visitor to reach it becomes the administrator, so open the firewall only after you have logged in once.";
+  };
+
   syncthing = {
     label = "Syncthing";
     category = "Desktop";

--- a/docs/manual/ai.md
+++ b/docs/manual/ai.md
@@ -185,6 +185,90 @@ one question through an agent took five round trips and twenty-five minutes and
 still did not finish. Nothing was misconfigured — an agent simply needs several
 turns and each turn is minutes. Set `allowCpu = true` if you want it anyway.
 
+### The CUDA cache, on a machine with an NVIDIA card
+
+`cache.nixos.org` carries no `cudaSupport` build — the NixOS Foundation does not
+redistribute CUDA binaries — so a machine that turns CUDA on compiles PyTorch
+from source, and `magma-cuda-static` alone is around a 10GB closure. nixarchy
+adds the community cache for you, on a machine whose configuration declares an
+NVIDIA card and nowhere else:
+
+```
+https://cache.nixos-cuda.org
+```
+
+`programs.nixarchy.cudaCache = false` declines it and builds locally instead. It
+follows `programs.nixarchy.binaryCaches`, so somebody who turned all the caches
+off does not have to find this one separately. Note that the URL moved off
+Cachix in November 2025 — any guide naming `cuda-maintainers.cachix.org` is
+pointing at a stale cache.
+
+**And the trap, which costs more than the cache saves.** Narrowing
+`cudaCapabilities` to your own card, usually with `cudaForwardCompat = false`,
+is real advice that genuinely cuts closure size and compile time — and it takes
+you **off** this cache, because what the cache holds is the *default* capability
+set. It is a source-build optimisation, and on a machine that could have
+substituted everything it makes the rebuild strictly slower. Leave the
+capabilities alone unless you have already decided to build locally.
+
+There is no ROCm equivalent: `rocmSupport` means local builds, full stop. The
+vulkan Ollama build is how an AMD machine sidesteps that, and `acceleration =
+"vulkan"` is how you ask for it.
+
+### Models on the big disk
+
+Weights are multi-gigabyte mutable blobs, and the defaults put them on `/` —
+`/var/lib/ollama/models` for Ollama, `~/.cache/huggingface` for everything
+else. A laptop with a small root and a big second disk fills the root quietly,
+and a full `/` on NixOS is also a machine that cannot rebuild its way out.
+
+```nix
+programs.nixarchy.localAi = {
+  enable = true;
+  modelsDir = "/mnt/data/ollama/models";
+  hfHome = "/mnt/data/huggingface";
+};
+```
+
+`modelsDir` writes `services.ollama.modelsDir` on unstable and
+`services.ollama.models` on nixos-26.05 — nixpkgs renamed it, and nixarchy uses
+whichever name your nixpkgs declares, because on stable the new name does not
+exist and on unstable the old one is an alias that warns. The unit's `OLLAMA_MODELS` is derived from it, so the server and
+anything reading its environment cannot disagree. Setting it also asks for a
+static `ollama` user and creates the directory owned by it: the service runs
+under `DynamicUser` by default, whose uid is allocated at start, so a directory
+outside its state directory has no owner to be given to — and a path in
+`ReadWritePaths` that does not exist fails the unit's mount namespace outright.
+
+`hfHome` is a session variable, for `huggingface-cli`, a transformers script,
+anything you start from a shell. Open WebUI has its own `HF_HOME` under
+`services.open-webui.stateDir`, which is the option to move for that one. If you
+add systemd hardening or impermanence of your own, both paths need naming there
+too — people hit this with `InaccessiblePaths` derived from `/var/lib/*`.
+
+### A chat window over it
+
+```nix
+programs.nixarchy.services.open-webui.enable = true;
+```
+
+Then <http://localhost:8080>. It is off by default like everything else in the
+services catalogue, and it is a thin layer over `services.open-webui`: port,
+host, `stateDir` and `openFirewall` stay upstream's options, because those are
+the names every wiki page uses. What nixarchy adds is the part that goes wrong
+unattended — the UI is pointed at the Ollama this machine actually runs, rather
+than at its own built-in guess of `localhost:11434`, which on a host that moved
+the port produces a working UI with an empty model list and no error anywhere.
+
+It refuses to build with no Ollama on the machine, and it keeps Open WebUI's
+telemetry-off settings, which are easy to lose: upstream keeps them in the
+*default* of `services.open-webui.environment`, and an option default is
+replaced wholesale the moment anything defines the option.
+
+**The first visitor becomes the administrator.** Leave it on loopback and reach
+it over Tailscale; if you do open the firewall, log in once first. nixarchy warns
+at build time when `openFirewall` is on.
+
 `nixarchy local-ai` pulls the model, reads the actual VRAM, recommends a size
 and tells you the measured tokens per second, which is a better basis for
 expectation than a table. It will not recommend anything below 4b: `qwen3:1.7b`

--- a/modules/AGENTS.md
+++ b/modules/AGENTS.md
@@ -40,6 +40,16 @@ working:
   finished.
 - `writeShellApplication` builds a strict PATH from `runtimeInputs`. A command
   a script calls and does not declare is a runtime failure no build catches.
+- **`lib.mkIf false` does not hide a definition from the option tree.** Setting
+  an option nixpkgs-unstable has and nixos-26.05 does not — `services.ollama
+  .modelsDir`, renamed from `models` — fails `checks.stable-eval` with "The
+  option ... does not exist", *with the condition printed as `false`*. The
+  module system attaches the definition to the path before any condition is
+  evaluated, so the guard has to be on the NAME: pick it off the `options`
+  argument (`if options.services.ollama ? modelsDir then … else …`) the way
+  `modules/nixos.nix` guards `hyprland-preview-share-picker` on `pkgs ?`. And
+  do not "fix" it by writing the old name on unstable — a rename shim accepts
+  the definition and warns, which `checks.config-warnings` fails on.
 - The rest of this file is the reasoning that used to sit in the code, moved
   here so the modules read as code. Each one is reachable from a `# Why:`
   pointer at the line it explains — follow the anchor, and if you change the

--- a/modules/local-ai.nix
+++ b/modules/local-ai.nix
@@ -1,12 +1,25 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
 let
   cfg = config.programs.nixarchy;
   aiCfg = cfg.localAi;
+
+  # What this nixpkgs calls the models directory, asked rather than written
+  # down. nixos-26.05 calls it `services.ollama.models`; unstable renamed it to
+  # `modelsDir` and keeps `models` only as a rename shim. Writing either name
+  # breaks one of the two, and in opposite ways: `modelsDir` is an eval error
+  # on stable ("The option ... does not exist", which is what checks.stable-eval
+  # caught), and `models` on unstable is accepted and WARNS, which
+  # checks.config-warnings fails on -- so the working name is the one that is
+  # there. Same shape as the hyprland-preview-share-picker guard in
+  # modules/nixos.nix: prefer what unstable has, so nothing changes for the
+  # people on it.
+  modelsAttr = if options.services.ollama ? modelsDir then "modelsDir" else "models";
 
   # Which Ollama to build against, decided from what this machine has ALREADY
   # declared about its GPU rather than by probing for one.
@@ -196,6 +209,59 @@ in
       description = "Port the Ollama server listens on.";
     };
 
+    modelsDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "/mnt/data/ollama/models";
+      description = ''
+        Where Ollama keeps model weights, or null for the NixOS default
+        (`/var/lib/ollama/models`, under the service's StateDirectory).
+
+        Set this when `/` is small and the disk with room is somewhere else.
+        Weights are multi-gigabyte mutable blobs -- one 70b model is larger
+        than many root filesystems -- and a full root on NixOS is also a
+        machine that cannot rebuild its way out of being full.
+
+        Underneath it is `services.ollama.modelsDir` on unstable and
+        `services.ollama.models` on nixos-26.05 -- the option was renamed, and
+        this writes whichever name your nixpkgs declares, because on stable the
+        new name is an evaluation error and on unstable the old one is an
+        alias that warns. The unit's `OLLAMA_MODELS` is derived from it by the
+        NixOS module either way, so the server and anything reading its
+        environment agree by construction.
+
+        Two things happen with it that are worth knowing before you look for
+        them. The Ollama service runs under `DynamicUser` by default, whose uid
+        is not stable, so a directory outside its StateDirectory cannot be
+        owned by it -- setting this therefore also asks for a static `ollama`
+        user (at mkDefault) and a tmpfiles rule that creates the directory
+        owned by it. And the path is a systemd mount-namespace exception:
+        upstream puts it in `ReadWritePaths`, so anyone adding hardening or
+        impermanence of their own has to grant it there too.
+      '';
+    };
+
+    hfHome = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "/mnt/data/huggingface";
+      description = ''
+        `HF_HOME` for this machine's interactive users, or null to leave the
+        Hugging Face default (`~/.cache/huggingface`) alone.
+
+        The other half of the same disk problem as modelsDir, for everything
+        that is not Ollama: `huggingface-cli download`, a transformers script,
+        a diffusers pipeline. That cache grows in the background of a workflow
+        nobody is watching, inside a home directory that is usually on the
+        root filesystem.
+
+        A session variable, so it reaches a shell, a Python process started
+        from one, and anything they launch -- it is not the Open WebUI
+        service's `HF_HOME`, which upstream puts under
+        `services.open-webui.stateDir` and which moves with that option.
+      '';
+    };
+
     pullModel = lib.mkOption {
       type = lib.types.bool;
       default = false;
@@ -271,6 +337,7 @@ in
       package = lib.mkDefault ollamaPackage;
       host = lib.mkDefault aiCfg.host;
       port = lib.mkDefault aiCfg.port;
+
       loadModels = lib.optional aiCfg.pullModel aiCfg.model;
 
       environmentVariables = {
@@ -290,6 +357,42 @@ in
       // lib.optionalAttrs (aiCfg.contextWindow != null) {
         OLLAMA_CONTEXT_LENGTH = toString aiCfg.contextWindow;
       };
+    }
+    # Relocation, only when asked for -- and under whichever name this nixpkgs
+    # declares, see modelsAttr above. optionalAttrs rather than mkIf on the
+    # value, because an absent DEFINITION is what leaves upstream's own default
+    # (`${config.services.ollama.home}/models`) computing itself, and because a
+    # dynamic attribute name cannot be written inside the literal above.
+    #
+    # The user is named for the same reason: Ollama runs under DynamicUser,
+    # whose uid is allocated at start -- fine for a StateDirectory systemd
+    # creates and chowns, impossible for a path on another filesystem that has
+    # to exist first. mkDefault, so a machine that already runs Ollama as its
+    # own user keeps that user and the tmpfiles rule below follows whoever won.
+    // lib.optionalAttrs (aiCfg.modelsDir != null) {
+      ${modelsAttr} = lib.mkDefault aiCfg.modelsDir;
+      user = lib.mkDefault "ollama";
+    };
+
+    # The directory itself. Not systemd.tmpfiles.settings: `rules` is what the
+    # rest of this repo writes and they merge identically. A list, so plain
+    # assignment -- mkDefault on a merging type drops our contribution the
+    # moment the machine has a rule of its own.
+    #
+    # The owner is read back off services.ollama rather than hardcoded, so a
+    # host that set its own user gets a directory that user can write. Without
+    # this the unit does not start at all: ReadWritePaths on a path that does
+    # not exist fails the mount namespace, and the journal says "No such file
+    # or directory" about a path the configuration plainly names.
+    systemd.tmpfiles.rules = lib.optional (
+      aiCfg.modelsDir != null
+    ) "d ${aiCfg.modelsDir} 0750 ${ollamaCfg.user} ${ollamaCfg.group} -";
+
+    # For the user's own tools, not for the service -- the Ollama unit gets
+    # OLLAMA_MODELS from modelsDir, and Open WebUI has its own HF_HOME under
+    # its stateDir. attrset, so plain assignment for the reason above.
+    environment.sessionVariables = lib.optionalAttrs (aiCfg.hfHome != null) {
+      HF_HOME = aiCfg.hfHome;
     };
 
     environment.systemPackages =
@@ -297,6 +400,25 @@ in
       ++ lib.optional (builtins.elem "pi" aiCfg.agents) pkgs.pi-coding-agent;
 
     assertions = [
+      # Both paths reach systemd, which resolves nothing relative: a tmpfiles
+      # rule with a relative path is rejected at activation, and a relative
+      # OLLAMA_MODELS is resolved against the unit's WorkingDirectory, which
+      # is the state directory somebody was trying to move off. Caught at
+      # evaluation instead, where it is one line to fix.
+      {
+        assertion = aiCfg.modelsDir == null || lib.hasPrefix "/" aiCfg.modelsDir;
+        message = ''
+          programs.nixarchy.localAi.modelsDir must be an absolute path, and is
+          "${aiCfg.modelsDir}".
+        '';
+      }
+      {
+        assertion = aiCfg.hfHome == null || lib.hasPrefix "/" aiCfg.hfHome;
+        message = ''
+          programs.nixarchy.localAi.hfHome must be an absolute path, and is
+          "${aiCfg.hfHome}".
+        '';
+      }
       {
         assertion = acceleration != "cpu" || aiCfg.allowCpu;
         message = ''

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -344,6 +344,39 @@ in
       '';
     };
 
+    cudaCache = lib.mkOption {
+      type = lib.types.bool;
+      default = cfg.binaryCaches;
+      defaultText = lib.literalExpression "config.programs.nixarchy.binaryCaches";
+      description = ''
+        Add the community CUDA cache, `cache.nixos-cuda.org`, on a machine that
+        declares an NVIDIA card. Nothing on any other machine: the substituter
+        appears only when `hardware.nvidia.enabled` is true, so an AMD or a VM
+        host pays nothing for this option existing.
+
+        Why it needs to exist at all: `cache.nixos.org` does not carry
+        `cudaSupport` builds -- the NixOS Foundation does not redistribute
+        CUDA binaries -- so a machine that turns CUDA on compiles PyTorch,
+        and `magma-cuda-static` alone is around a 10GB closure.
+
+        Follows programs.nixarchy.binaryCaches, because somebody who turned
+        that off said something about trust rather than about Hyprland. Its own
+        option so the decision can still be made per cache -- this one is a
+        community cache rather than one Cachix runs for a named project.
+
+        **The trap, which costs more than this option saves.** Narrowing
+        `cudaCapabilities` to your own card, with `cudaForwardCompat = false`,
+        genuinely cuts closure size and compile time -- and it takes you OFF
+        this cache, because what the cache holds is the DEFAULT capability set.
+        It is a source-build optimisation, and on a machine that could have
+        substituted everything it makes the rebuild strictly slower. Leave the
+        capabilities alone unless you have decided to build locally anyway.
+
+        There is no ROCm equivalent. `rocmSupport` means local builds, full
+        stop; the vulkan Ollama build is how an AMD machine sidesteps that.
+      '';
+    };
+
     preinstalls = lib.mkOption {
       type = lib.types.bool;
       default = true;
@@ -550,31 +583,54 @@ in
     # Why: modules/AGENTS.md#most-of-what-the-install-menu-offers-is-unfree
     nixpkgs.config = lib.mkIf cfg.allowUnfree (lib.mkDefault { allowUnfree = true; });
 
-    nix.settings = {
-      # nixarchy-apply runs `nh os switch <flake>`, so flakes are not
-      # optional here. mkDefault leaves a user free to manage this themselves.
-      experimental-features = lib.mkDefault [
-        "nix-command"
-        "flakes"
-      ];
+    nix.settings =
+      let
+        # The declared NVIDIA path, which is the same signal
+        # modules/local-ai.nix reads to pick an Ollama build: a machine with an
+        # NVIDIA card has said so, and `hardware.nvidia.enabled` is the
+        # read-only option computed from having said it. Nothing probes.
+        cudaCache = cfg.cudaCache && config.hardware.nvidia.enabled;
+      in
+      {
+        # nixarchy-apply runs `nh os switch <flake>`, so flakes are not
+        # optional here. mkDefault leaves a user free to manage this themselves.
+        experimental-features = lib.mkDefault [
+          "nix-command"
+          "flakes"
+        ];
 
-      # hyprland.cachix.org covers Hyprland when the pinned commit is one
-      # hyprwm built; nixarchy.cachix.org covers it when it is not, plus the
-      # vendored Omarchy tree and the packages this flake builds itself.
-      #
-      # Behind an option rather than mkForce: these are lists, so they merge
-      # into a user's existing trust with no conflict and no warning, which
-      # makes them the only thing in this module that can change a machine
-      # silently. See programs.nixarchy.binaryCaches.
-      substituters = lib.mkIf cfg.binaryCaches [
-        "https://nixarchy.cachix.org"
-        "https://hyprland.cachix.org"
-      ];
-      trusted-public-keys = lib.mkIf cfg.binaryCaches [
-        "nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM="
-        "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE="
-      ];
-    };
+        # hyprland.cachix.org covers Hyprland when the pinned commit is one
+        # hyprwm built; nixarchy.cachix.org covers it when it is not, plus the
+        # vendored Omarchy tree and the packages this flake builds itself.
+        #
+        # Behind an option rather than mkForce: these are lists, so they merge
+        # into a user's existing trust with no conflict and no warning, which
+        # makes them the only thing in this module that can change a machine
+        # silently. See programs.nixarchy.binaryCaches.
+        # Two lists rather than two mkIfs, because there are now two caches with
+        # two different gates. An empty list contributes nothing to a merging
+        # option, so `optionals false` and a removed definition are the same
+        # thing here.
+        #
+        # The CUDA cache is gated on the NVIDIA path as well as on its own
+        # toggle -- see programs.nixarchy.cudaCache, and the cudaCapabilities
+        # trap written out there. Substituter and key are written from the same
+        # condition on purpose: a machine that trusts a cache it cannot reach
+        # still works, and a machine that reaches one it does not trust silently
+        # builds everything, which is the failure nobody notices.
+        substituters =
+          lib.optionals cfg.binaryCaches [
+            "https://nixarchy.cachix.org"
+            "https://hyprland.cachix.org"
+          ]
+          ++ lib.optional cudaCache "https://cache.nixos-cuda.org";
+        trusted-public-keys =
+          lib.optionals cfg.binaryCaches [
+            "nixarchy.cachix.org-1:05JOuIlsQOWY2/5DQMq7JEA1hwlhgvmMWowMfka8mMM="
+            "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIITemDosxrE9/Kb+PfYvE="
+          ]
+          ++ lib.optional cudaCache "cache.nixos-cuda.org:74DUi4Ye579gUqzH4ziL9IyiJBlDpMRn9MBN8oNan9M=";
+      };
 
     # One `programs` block rather than three scattered assignments: statix
     # flags a repeated top-level key, and it is right that they read better

--- a/modules/services/default.nix
+++ b/modules/services/default.nix
@@ -73,6 +73,7 @@ inputs: {
     ./devenv.nix
     (import ./hypr-rdp.nix inputs)
     (import ./microvm.nix inputs)
+    ./open-webui.nix
     ./syncthing.nix
     ./tailscale.nix
   ];

--- a/modules/services/open-webui.nix
+++ b/modules/services/open-webui.nix
@@ -1,0 +1,119 @@
+# Open WebUI: a browser chat window over the models this machine already runs.
+#
+# Bundled rather than plain for one reason, and it is the reason somebody
+# reports as a bug: Open WebUI's own default for OLLAMA_BASE_URL is
+# localhost:11434, and nixarchy's Ollama is wherever services.ollama actually
+# listens. Those agree until they do not -- a host that set its own port, or
+# bound Ollama to a tailnet address -- and the symptom is a working UI with an
+# empty model list and nothing on screen about why.
+#
+# The second reason is smaller and sharper: services.open-webui.environment
+# carries upstream's telemetry-off defaults IN THE OPTION DEFAULT, and an
+# option default is replaced rather than merged the moment anything defines
+# the option. So a module that adds one variable there silently turns
+# ANONYMIZED_TELEMETRY back on. They are restated below.
+#
+# Everything else stays upstream's. There is no nixarchy port, host, stateDir
+# or openFirewall option here: those are one line each in services.open-webui,
+# which is the vocabulary every wiki page and forum answer will use, and RFC 42
+# is right that a copied option goes stale. See data/services.nix on the bar
+# for "bundled".
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.nixarchy;
+  svc = cfg.services.open-webui;
+
+  ollama = config.services.ollama;
+
+  # The address the UI dials, read off the server rather than off our own
+  # options -- the same rule modules/local-ai.nix follows for the agents: a
+  # host that already set services.ollama.port keeps it, and the client has to
+  # follow the server to wherever it actually listens.
+  #
+  # A wildcard bind is not an address to connect TO. Ollama listening on
+  # 0.0.0.0 or [::] is reachable at loopback, and a URL containing 0.0.0.0
+  # fails in some HTTP clients and resolves to something unintended in others.
+  ollamaHost =
+    if
+      builtins.elem ollama.host [
+        "0.0.0.0"
+        "[::]"
+        "::"
+      ]
+    then
+      "127.0.0.1"
+    else
+      ollama.host;
+  ollamaUrl = "http://${ollamaHost}:${toString ollama.port}";
+in
+{
+  options.programs.nixarchy.services.open-webui = {
+    enable = lib.mkEnableOption ''
+      Open WebUI, a browser chat interface pointed at this machine's Ollama.
+
+      Off by default like everything else here. Enabling it starts a service on
+      port 8080 whose first visitor creates the administrator account, so it
+      stays on loopback until you say otherwise -- `services.open-webui.host`
+      and `.openFirewall` are upstream's and this module does not touch them.
+
+      Useful beside `programs.nixarchy.localAi`, which is what puts a model on
+      the machine in the first place. It works without it, pointed at an Ollama
+      you run yourself; it does not work with no Ollama at all, and says so at
+      evaluation rather than showing you an empty model list
+    '';
+  };
+
+  config = lib.mkIf (cfg.enable && svc.enable) {
+    services.open-webui = {
+      # Scalar, so mkDefault -- see the header of modules/services.
+      enable = lib.mkDefault true;
+
+      # An attrset, so plain assignment: mkDefault on a merging type is
+      # dropped before the merge, and a user adding one variable of their own
+      # would take the base URL with it.
+      #
+      # The three telemetry keys are upstream's option DEFAULT, restated
+      # because defining this option replaces that default outright. Dropping
+      # them here would be nixarchy turning analytics on for somebody.
+      environment = {
+        OLLAMA_API_BASE_URL = ollamaUrl;
+        SCARF_NO_ANALYTICS = "True";
+        DO_NOT_TRACK = "True";
+        ANONYMIZED_TELEMETRY = "False";
+      };
+    };
+
+    assertions = [
+      {
+        assertion = ollama.enable;
+        message = ''
+          programs.nixarchy.services.open-webui is on and this machine runs no
+          Ollama, so the UI would start with nothing to talk to.
+
+          Either let nixarchy run one, which also picks the build from the GPU
+          this configuration declares:
+
+            programs.nixarchy.localAi.enable = true;
+
+          or enable services.ollama yourself. To point the UI at a model server
+          on another machine instead, set the base URL by hand and this module
+          is not what you want:
+
+            services.open-webui.environment.OLLAMA_API_BASE_URL = "http://host:11434";
+        '';
+      }
+    ];
+
+    warnings = lib.optional config.services.open-webui.openFirewall ''
+      programs.nixarchy.services.open-webui: the firewall is open on port
+      ${toString config.services.open-webui.port}, so anyone who can reach this
+      machine can reach the UI. Open WebUI has accounts, and the FIRST visitor
+      to an empty instance becomes the administrator -- so open this only after
+      you have logged in once, or leave it closed and reach it over Tailscale.
+    '';
+  };
+}

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -468,6 +468,71 @@ let
           (configWith { browserThemeUser = null; }).systemd.tmpfiles.rules;
     };
 
+    # ---- #622: the cache appears on the NVIDIA path and nowhere else ----
+    cudaCacheSubstituter = {
+      on = builtins.elem cudaUrl nvidiaHost.nix.settings.substituters;
+      # A machine with no NVIDIA card declared. Same option, same default --
+      # the gate is the hardware the configuration claims.
+      off = builtins.elem cudaUrl (configWith { }).nix.settings.substituters;
+    };
+    cudaCacheKey = {
+      on = builtins.elem cudaKey nvidiaHost.nix.settings.trusted-public-keys;
+      off = builtins.elem cudaKey nvidiaDeclined.nix.settings.trusted-public-keys;
+    };
+    # binaryCaches = false has to take this one with it, or "trust neither"
+    # quietly became "trust one of the three".
+    cudaCacheFollowsBinaryCaches = {
+      on = builtins.elem cudaUrl nvidiaHost.nix.settings.substituters;
+      off = builtins.elem cudaUrl cachesDeclined.nix.settings.substituters;
+    };
+
+    # ---- #624: the weights move, and everything that has to move with them --
+    ollamaModelsDir = {
+      on = aiModels.services.ollama.modelsDir == "/mnt/big/ollama/models";
+      off = aiPlain.services.ollama.modelsDir == "/mnt/big/ollama/models";
+    };
+    # The variable the server actually reads, derived by the NixOS module from
+    # the option above. Asserted separately because "the option is set" and
+    # "the process is told" are two claims, and the rename shim between
+    # `models` and `modelsDir` is exactly where they came apart for people.
+    ollamaModelsEnv = {
+      on = (aiModels.systemd.services.ollama.environment.OLLAMA_MODELS or "") == "/mnt/big/ollama/models";
+      off = (aiPlain.systemd.services.ollama.environment.OLLAMA_MODELS or "") == "/mnt/big/ollama/models";
+    };
+    # Without this the unit does not start: ReadWritePaths on a path that does
+    # not exist fails the mount namespace, and the journal blames a path the
+    # configuration plainly names.
+    ollamaModelsDirCreated = {
+      on = hasModelsRule aiModels;
+      off = hasModelsRule aiPlain;
+    };
+    # And the rule needs an owner that exists. A DynamicUser's uid is
+    # allocated at start, so a directory outside the StateDirectory cannot
+    # belong to it.
+    ollamaStaticUser = {
+      on = aiModels.services.ollama.user != null;
+      off = aiPlain.services.ollama.user != null;
+    };
+    hfHomeSessionVar = {
+      on = (aiModels.environment.sessionVariables.HF_HOME or "") == "/mnt/big/huggingface";
+      off = aiPlain.environment.sessionVariables ? HF_HOME;
+    };
+
+    # ---- #625: Open WebUI, opt-in, and inert until it is asked for ----
+    webuiUnit = {
+      on = webuiOn.systemd.services ? open-webui;
+      off = webuiOff.systemd.services ? open-webui;
+    };
+    # Upstream keeps its telemetry-off settings in the option DEFAULT of
+    # `environment`, and an option default is replaced wholesale the moment
+    # anything defines the option. So a module that adds one variable there
+    # turns analytics back on unless it restates them -- silently, which is
+    # why this is a case rather than a comment.
+    webuiTelemetryOff = {
+      on = (webuiOn.services.open-webui.environment.ANONYMIZED_TELEMETRY or "") == "False";
+      off = webuiOff.services.open-webui.environment ? OLLAMA_API_BASE_URL;
+    };
+
     # sops-nix is imported by every nixarchy machine and must do nothing
     # until a secret is declared. See sopsOff/sopsOn below for why this is
     # asserted rather than assumed.
@@ -1048,6 +1113,85 @@ let
     services.ollama.port = 21434;
   };
 
+  # ---- the CUDA cache, and the two things that must stay tied (#622) ----
+  #
+  # `cache.nixos.org` carries no cudaSupport build, so a machine that turns
+  # CUDA on compiles PyTorch. The community cache fixes that and must appear
+  # ONLY where it was asked for: substituters are a merging list, so a cache
+  # that leaks onto every machine leaks silently.
+  #
+  # The NVIDIA signal is `services.xserver.videoDrivers`, because
+  # `hardware.nvidia.enabled` is readOnly and computed from exactly that --
+  # which is also the line the local-ai assertion tells a user to write, so
+  # this asserts the same shape a real machine has.
+  cudaUrl = "https://cache.nixos-cuda.org";
+  cudaKey = "cache.nixos-cuda.org:74DUi4Ye579gUqzH4ziL9IyiJBlDpMRn9MBN8oNan9M=";
+  nvidiaHost = configBeside { services.xserver.videoDrivers = [ "nvidia" ]; };
+  nvidiaDeclined = configBeside {
+    services.xserver.videoDrivers = [ "nvidia" ];
+    programs.nixarchy.cudaCache = false;
+  };
+  # Somebody who declined every cache: cudaCache follows binaryCaches, so this
+  # is the state where a second option would have had to be found and turned
+  # off by hand for the promise to hold.
+  cachesDeclined = configBeside {
+    services.xserver.videoDrivers = [ "nvidia" ];
+    programs.nixarchy.binaryCaches = false;
+  };
+
+  # ---- models off the root filesystem (#624) ----
+  #
+  # The failure this prevents is a full `/`, which on NixOS is also a machine
+  # that cannot rebuild its way out. Four mechanisms, because relocating the
+  # weights takes all four and three of them are invisible: the option
+  # upstream renamed (`modelsDir`, not `models`), the OLLAMA_MODELS the unit
+  # derives from it, the tmpfiles rule without which the unit cannot start at
+  # all, and the static user without which that rule has no owner to name.
+  aiModels = configWith {
+    localAi = {
+      enable = true;
+      allowCpu = true;
+      modelsDir = "/mnt/big/ollama/models";
+      hfHome = "/mnt/big/huggingface";
+    };
+  };
+  aiPlain = configWith {
+    localAi = {
+      enable = true;
+      allowCpu = true;
+    };
+  };
+  # Mode A: a host that had already moved its own models keeps them. modelsDir
+  # is a scalar, so ours is mkDefault and theirs must win.
+  aiModelsBeside = configBeside {
+    programs.nixarchy.localAi = {
+      enable = true;
+      allowCpu = true;
+      modelsDir = "/mnt/big/ollama/models";
+    };
+    services.ollama.modelsDir = "/srv/models";
+  };
+  hasModelsRule =
+    cfg: builtins.any (r: pkgs.lib.hasInfix "/mnt/big/ollama/models" r) cfg.systemd.tmpfiles.rules;
+
+  # ---- Open WebUI over the Ollama that is actually running (#625) ----
+  #
+  # The port is moved on purpose. Open WebUI's own default base URL is
+  # localhost:11434 and this machine's Ollama is not there, which is the whole
+  # reason the row is "bundled" -- the symptom otherwise is a working UI with
+  # an empty model list and nothing on screen about why.
+  webuiOn = configBeside {
+    programs.nixarchy = {
+      localAi = {
+        enable = true;
+        allowCpu = true;
+      };
+      services.open-webui.enable = true;
+    };
+    services.ollama.port = 21434;
+  };
+  webuiOff = configWith { };
+
   # And the group the desktop user gets. This check used to assert the user WAS
   # in `docker`, which was right while the rooted daemon was the default: the
   # group was the only way `docker ps` worked without sudo. The default is now
@@ -1283,6 +1427,25 @@ pkgs.runCommand "nixarchy-options"
     syncthingDataDir = syncthingBeside.services.syncthing.dataDir;
     ollamaPort = builtins.toString ollamaBeside.services.ollama.port;
     ollamaEndpoint = ollamaBeside.programs.nixarchy.localAi.resolved.endpoint;
+    # The two halves of trusting a cache, counted rather than spot-checked: a
+    # machine that trusts a cache it cannot reach still works, and one that
+    # reaches a cache it does not trust builds everything and says nothing.
+    cudaSubstituters = pkgs.lib.concatStringsSep " " nvidiaHost.nix.settings.substituters;
+    cudaKeys = pkgs.lib.concatStringsSep " " nvidiaHost.nix.settings.trusted-public-keys;
+    cudaKeyWanted = cudaKey;
+    # A machine with no NVIDIA card, whose keys nothing else reads. The
+    # substituter half of this is a case above; the KEY half is only visible
+    # here, and it is the quieter failure -- a trusted key for a cache you
+    # never reach changes nothing you can see, and is still this machine
+    # trusting a third party nobody asked it to trust.
+    plainSubstituters = pkgs.lib.concatStringsSep " " (configWith { }).nix.settings.substituters;
+    plainKeys = pkgs.lib.concatStringsSep " " (configWith { }).nix.settings.trusted-public-keys;
+    # The other two caches must survive the change that added a third.
+    modelsDirMine = aiModels.services.ollama.modelsDir;
+    modelsDirTheirs = aiModelsBeside.services.ollama.modelsDir;
+    modelsRule = pkgs.lib.concatStringsSep " | " aiModels.systemd.tmpfiles.rules;
+    modelsOwner = aiModels.services.ollama.user;
+    webuiBaseUrl = webuiOn.services.open-webui.environment.OLLAMA_API_BASE_URL or "";
     dockerGroups = pkgs.lib.concatStringsSep " " dockerGroups;
     dockerRootedGroups = pkgs.lib.concatStringsSep " " dockerRootedGroups;
     dockerRootlessDefault = pkgs.lib.boolToString dockerRootlessDefault;
@@ -1526,6 +1689,64 @@ pkgs.runCommand "nixarchy-options"
             exit 1
           }
           echo "local-ai yields the Ollama port and the agents follow it"
+
+          # ---- the CUDA cache: substituter and key, or neither -----------
+          case " $cudaSubstituters " in
+            *" https://nixarchy.cachix.org "*) ;;
+            *) echo "adding the CUDA cache dropped the ones that were there:" >&2
+               echo "  substituters = $cudaSubstituters" >&2
+               exit 1 ;;
+          esac
+          case " $cudaKeys " in
+            *" $cudaKeyWanted "*) ;;
+            *) echo "the CUDA substituter is trusted by no key:" >&2
+               echo "  keys = $cudaKeys" >&2
+               echo "an untrusted substituter is silently skipped, so this is" >&2
+               echo "a machine that compiles CUDA while looking configured." >&2
+               exit 1 ;;
+          esac
+          echo "the CUDA cache arrives with its key and beside the other two"
+
+          case " $plainSubstituters $plainKeys " in
+            *cache.nixos-cuda.org*)
+               echo "a machine with no NVIDIA card was given the CUDA cache:" >&2
+               echo "  substituters = $plainSubstituters" >&2
+               echo "  keys         = $plainKeys" >&2
+               echo "substituters and keys are merging lists, so this arrives" >&2
+               echo "with no conflict and nothing on screen to say it did." >&2
+               exit 1 ;;
+          esac
+          echo "a machine with no NVIDIA card is given neither half of it"
+
+          # ---- the weights, where they were asked for --------------------
+          [ "$modelsDirMine" = "/mnt/big/ollama/models" ] || {
+            echo "modelsDir did not reach services.ollama: $modelsDirMine" >&2
+            exit 1
+          }
+          [ "$modelsDirTheirs" = "/srv/models" ] || {
+            echo "local-ai overrode a models directory the user had set:" >&2
+            echo "  services.ollama.modelsDir is $modelsDirTheirs, not /srv/models" >&2
+            echo "modelsDir is a scalar and must be lib.mkDefault." >&2
+            exit 1
+          }
+          case "$modelsRule" in
+            *"d /mnt/big/ollama/models "*"$modelsOwner"*) ;;
+            *) echo "the models directory is created for nobody in particular:" >&2
+               echo "  rules = $modelsRule" >&2
+               echo "  ollama runs as $modelsOwner" >&2
+               exit 1 ;;
+          esac
+          echo "the models directory is relocated, created, and owned by the server"
+
+          # ---- Open WebUI dials the Ollama that is actually running ------
+          [ "$webuiBaseUrl" = "http://127.0.0.1:21434" ] || {
+            echo "Open WebUI was pointed somewhere Ollama is not:" >&2
+            echo "  OLLAMA_API_BASE_URL is $webuiBaseUrl, not http://127.0.0.1:21434" >&2
+            echo "its own default is localhost:11434, which is why this module" >&2
+            echo "exists: the symptom otherwise is an empty model list." >&2
+            exit 1
+          }
+          echo "Open WebUI follows the Ollama port the machine actually uses"
 
           case " $dockerGroups " in
             *" docker "*)


### PR DESCRIPTION
## What this changes, and why

Three things a machine that runs a local model needs, in the order they bite.

**#622 — the CUDA cache.** `cache.nixos.org` carries no `cudaSupport` build (the
NixOS Foundation does not redistribute CUDA binaries), so a machine that turns
CUDA on compiles PyTorch from source and `magma-cuda-static` alone is a ~10GB
closure. `programs.nixarchy.cudaCache` adds `https://cache.nixos-cuda.org` with
the key `cache.nixos-cuda.org:74DUi4Ye579gUqzH4ziL9IyiJBlDpMRn9MBN8oNan9M=`,
gated on the declared NVIDIA path — `hardware.nvidia.enabled`, the same signal
`modules/local-ai.nix` already reads to pick an Ollama build — and defaulting to
`programs.nixarchy.binaryCaches`, the way `devenv` gates `devenv.cachix.org`. An
AMD or VM host gets neither the substituter nor the key. Both values are the ones
the [CUDA wiki page](https://wiki.nixos.org/wiki/CUDA) names since the cache moved
off Cachix in November 2025; `cuda-maintainers.cachix.org` is stale. The option's
description carries the trap that undoes it: narrowing `cudaCapabilities` (with
`cudaForwardCompat = false`) takes you **off** this cache, because the cache
builds the default capability set — a source-build optimisation that makes a
cached machine strictly slower. No ROCm equivalent exists; the vulkan Ollama build
stays the AMD answer.

**#624 — models on the big disk.** `localAi.modelsDir` and `localAi.hfHome`. The
first is `services.ollama.modelsDir` underneath — not `models`, which nixpkgs
renamed and still resolves through a shim, which is why half the guides say the
old name — and the unit's `OLLAMA_MODELS` is derived from it by the NixOS module,
so server and environment cannot disagree. Setting it also asks for a static
`ollama` user at `mkDefault` and creates the directory owned by whoever won:
Ollama runs under `DynamicUser`, whose uid is allocated at start, so a path
outside its `StateDirectory` has no owner to be given to, and a `ReadWritePaths`
entry that does not exist fails the unit's mount namespace outright. `hfHome` is
a session variable, for the tools that are not Ollama; Open WebUI's own `HF_HOME`
lives under `services.open-webui.stateDir` and the docs say so. Both are asserted
absolute at evaluation, because systemd resolves neither relative.

**#625 — Open WebUI.** A catalogue row (`kind = "bundled"`, so
`modules/services/open-webui.nix` exists as the catalogue check requires) that
declares only `enable`. Port, host, `stateDir` and `openFirewall` stay upstream's
options — RFC 42's argument, and those are the names every wiki page uses. What
earns the module is the part that fails unattended: the UI is pointed at the
Ollama this machine actually listens on rather than at its own built-in guess of
`localhost:11434`, which on a host that moved the port is a working UI with an
empty model list and no error anywhere. It also restates upstream's three
telemetry-off settings, which live in the **default** of
`services.open-webui.environment` and are therefore replaced wholesale the moment
anything defines that option — so a module adding one variable there silently
turns analytics back on. It asserts an Ollama exists rather than showing an empty
list, and warns when `openFirewall` is on, because the first visitor to an empty
instance becomes the administrator.

Mode A throughout: every scalar is `lib.mkDefault`, every list and attrset is
plain assignment, nothing is `mkForce`, and all ten new cases are asserted in both
states.

## How I proved the check fails

Six runs, each breaking one thing and watching `checks.options` go red, then green
again with the fix. Bash, not zsh; full logs kept.

**1. The NVIDIA gate removed (`cudaCache = cfg.cudaCache`), the `modelsDir`/`user`
wiring and the tmpfiles rule deleted, the telemetry keys dropped** — six cases
fail, including the cache leaking onto a machine with no NVIDIA card:

```
  cudaCacheSubstituter: on=1 off=1
  ollamaModelsDir: on= off=
  ollamaModelsDirCreated: on= off=
  ollamaModelsEnv: on= off=
  ollamaStaticUser: on= off=
  webuiTelemetryOff: on= off=
these options do not take effect both ways: cudaCacheSubstituter ollamaModelsDir ollamaModelsDirCreated ollamaModelsEnv ollamaStaticUser webuiTelemetryOff
an option that cannot be turned off is not an option.
```

**2. The substituter added with no key** (`lib.optional false "cache.nixos-cuda…"`):

```
  cudaCacheKey: on= off=
these options do not take effect both ways: cudaCacheKey
```

**3. The refactor of the cache block losing a cache that was there** (dropped
`https://nixarchy.cachix.org` while adding the third) — caught by the existing
`binaryCaches` case, which is the answer to "did rewriting that block break the
two that were already in it":

```
these options do not take effect both ways: binaryCaches
```

**4. The key gated on the toggle alone rather than on the NVIDIA path** — no case
sees this (a trusted key for a cache you never reach changes nothing visible), so
this is what the script assertion is for:

```
a machine with no NVIDIA card was given the CUDA cache:
  substituters = https://nixarchy.cachix.org https://hyprland.cachix.org https://cache.nixos.org/
  keys         = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nixarchy.cachix.org-1:05JOu… hyprland.cachix.org-1:a7pgx… cache.nixos-cuda.org:74DUi4Ye579gUqzH4ziL9IyiJBlDpMRn9MBN8oNan9M=
substituters and keys are merging lists, so this arrives
with no conflict and nothing on screen to say it did.
```

**5. `modelsDir` at `mkForce` instead of `mkDefault`** (Mode A: a host that had
already moved its own models):

```
local-ai overrode a models directory the user had set:
  services.ollama.modelsDir is /mnt/big/ollama/models, not /srv/models
modelsDir is a scalar and must be lib.mkDefault.
```

**6. The base URL hardcoded to `http://127.0.0.1:11434`** — the exact bug the
module exists to prevent, against an Ollama moved to 21434:

```
Open WebUI was pointed somewhere Ollama is not:
  OLLAMA_API_BASE_URL is http://127.0.0.1:11434, not http://127.0.0.1:21434
its own default is localhost:11434, which is why this module
exists: the symptom otherwise is an empty model list.
```

Green with everything restored:

```
the CUDA cache arrives with its key and beside the other two
a machine with no NVIDIA card is given neither half of it
the models directory is relocated, created, and owned by the server
Open WebUI follows the Ollama port the machine actually uses
the services catalogue is well formed (12 entries)
```

## Checks run locally

- `nix build .#checks.x86_64-linux.options` — green on the final tree, and red in
  each of the six broken states above (evaluation only, ~2 min a run).
- `nix eval .#nixosConfigurations.vm.config.system.build.toplevel.drvPath` — the
  new module is in the import list of a machine that still evaluates.
- No VM check was built locally, deliberately: install jobs share this box and a
  guest-side timeout would fail somebody else's PR.

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [x] If this adds an option: `tests/options.nix` covers both states
- [x] If this adds a `checks.*` entry: no new `checks.*` entry

## What this cost, and where it is written down

Nothing general beyond what the code now says at the line it protects: an option
**default** (upstream's `services.open-webui.environment`) is replaced rather than
merged by any definition, which is a different rule from the priority merging
`AGENTS.md` §7 already covers, and it is written where somebody editing that
attrset will read it. The `DynamicUser`/`ReadWritePaths` mechanic behind the
tmpfiles rule is likewise at the line. Posted both to `#nixarchy-agents`.

- [x] A general lesson is recorded in `AGENTS.md`, or nothing general came up

closes #622, closes #625, closes #624
