### PR TITLE
The dozen Nix failures a desktop user actually hits get named in their own vocabulary

### DIFF
--- a/docs/manual/getting-started.md
+++ b/docs/manual/getting-started.md
@@ -305,7 +305,21 @@ sudo nixos-rebuild switch --flake /home/you/nixos-config
 ```
 
 Every remaining conflict shows up here as an evaluation error, not as a broken
-machine. Then log out and choose the **Omarchy** session at the login screen.
+machine. If one of them is unreadable — and the trace for a conflicting option
+lands in nixpkgs' own `lib/modules.nix`, naming no file of yours — pipe it
+through the explainer rather than reading the trace:
+
+```sh
+sudo nixos-rebuild switch --flake /home/you/nixos-config 2>&1 |
+  nix run github:olafkfreund/nixarchy#explain
+```
+
+It covers the failures that actually stop this step, including the one that
+reads as `path '...' does not exist` about a file you can `ls` — that is a
+file you have not `git add`ed, and a flake cannot see it. There is a table of
+what it recognises in [troubleshooting](troubleshooting).
+
+Then log out and choose the **Omarchy** session at the login screen.
 On SDDM the login screen is Omarchy's own branded greeter; on greetd, GDM or
 LightDM you keep your greeter and it offers the Omarchy entry like any other
 session.

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -25,6 +25,51 @@ actual problem on a NixOS host:
 | Boot splash | Whether Omarchy's Plymouth theme is the one in use, or stylix's |
 | TLP | TLP is on, so power-profiles-daemon is off and `omarchy powerprofiles` cannot work |
 
+### A rebuild failed and the error is unreadable
+
+```sh
+sudo nixos-rebuild switch --flake . 2>&1 | nixarchy explain
+```
+
+Or, if you would rather it ran the command for you, or you have a saved log:
+
+```sh
+nixarchy explain -- nixos-rebuild build --flake .
+nixarchy explain /tmp/that-log.txt
+```
+
+Only 4.0% of respondents to the [2025 Nix community
+survey](https://nixos.org/surveys/community/2025/) say they understand every
+Nix error message, and error messages were the second-highest thing people
+wanted improved. Upstream's have to be general. This one only has to be right
+about the configuration nixarchy shipped, so it can name the file you wrote
+rather than the frame in `lib/modules.nix` the trace stops at.
+
+What it recognises:
+
+| What Nix says | What it means |
+|---|---|
+| `path '...' does not exist`, about a file you can `ls` | The file is not `git add`ed. A flake evaluates from its git tree, so an untracked file does not exist as far as evaluation is concerned |
+| `infinite recursion encountered` | Something is defined in terms of itself -- and the frame shown is where Nix gave up, not where the loop was closed |
+| `attribute 'x' missing`, with a trace naming only `lib/modules.nix` | A module wants an argument nothing passes it. A module argument cannot have a `?` default; pass it from the call site |
+| `The option 'x' does not exist` | A typo, or an option from a module set this configuration does not import -- a home-manager option written into the system config reads exactly like a typo |
+| `has conflicting definition values` | Two places define one option. `lib.mkDefault` on one of them, or remove it |
+| `collision between`, `conflicting subpath` | Two packages ship the same file. `lib.lowPrio` on the one that should yield |
+| an unfree or `marked as insecure` refusal | A policy refusal, not a failure. One line of opt-in -- and nixarchy already sets the unfree one, so seeing it means a second nixpkgs |
+
+It rebuilds nothing and edits nothing: it reads the text and says what it is,
+then prints the lines to paste. If it does not recognise your error it says so
+rather than guessing, and that is worth
+[reporting](https://github.com/olafkfreund/nixarchy/issues) -- the list grows
+by people saying which one it missed.
+
+It runs without nixarchy installed too, which is the state your machine is in
+when the rebuild that would have installed it has just failed:
+
+```sh
+nix run github:olafkfreund/nixarchy#explain -- /tmp/that-log.txt
+```
+
 ### `libGL.so.1: cannot open shared object file: No such file or directory`
 
 Or `libstdc++.so.6`, or any other `.so` -- from a pip wheel at `import`, a

--- a/flake.nix
+++ b/flake.nix
@@ -375,6 +375,25 @@
               (builtins.readFile ./pkgs/doctor.sh);
         };
 
+        # `nixarchy explain` -- reads a Nix failure and says what it is in the
+        # vocabulary of the files the user wrote. In the overlay rather than
+        # only under `packages` for the same reason the doctor is: the module
+        # installs it, and a module cannot take a package from
+        # inputs.self.packages without mixing nixpkgs instances.
+        nixarchy-explain = final.writeShellApplication {
+          name = "nixarchy-explain";
+          runtimeInputs = with final; [
+            coreutils
+            # grep and sed do all of the recognising. Undeclared, every family
+            # would read as "not recognised" rather than as a missing command
+            # -- the vainfo trap in pkgs/AGENTS.md, and worse here, because
+            # "nothing matched" is a legitimate answer this tool gives.
+            gnugrep
+            gnused
+          ];
+          text = builtins.readFile ./pkgs/explain.sh;
+        };
+
         nixarchy-verify = final.writeShellApplication {
           name = "nixarchy-verify";
           runtimeInputs = with final; [
@@ -772,6 +791,12 @@
           # nixarchy is an input anywhere, which is the only entry point someone
           # deciding whether to adopt it actually has.
           doctor = pkgsFor.${system}.nixarchy-doctor;
+
+          # `nix run github:olafkfreund/nixarchy#explain` -- pipe a failing
+          # rebuild into it. Runnable without nixarchy installed on purpose:
+          # the moment someone needs it is the moment their rebuild will not
+          # complete.
+          explain = pkgsFor.${system}.nixarchy-explain;
 
           # Why: docs/internals/flake.md#nix-run-devenv-presets-scaffolds-every-preset-in
           devenv-presets =
@@ -1534,6 +1559,16 @@
           doctor-ldd = import ./tests/doctor-ldd.nix {
             pkgs = pkgsFor.${system};
             inherit (self.packages.${system}) doctor;
+          };
+
+          # The error explainer, against errors produced in the check rather
+          # than pasted into it -- nixpkgs has reworded two of these families
+          # inside a year, and a pasted trace would keep the check green while
+          # the explainer stopped recognising what a user's machine prints.
+          # See tests/explain.nix.
+          explain = import ./tests/explain.nix {
+            pkgs = pkgsFor.${system};
+            inherit (self.packages.${system}) explain;
           };
 
           # nixarchy-channel edits a file the user owns, so the check is mostly

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -994,6 +994,7 @@ in
             # Why: modules/AGENTS.md#the-doctor-and-verify-which-until-now-were-flake-a
             (pkgs.extend inputs.self.overlays.default).nixarchy-doctor
             (pkgs.extend inputs.self.overlays.default).nixarchy-verify
+            (pkgs.extend inputs.self.overlays.default).nixarchy-explain
 
           ]
           # The default agent's own package, when the configuration names one.
@@ -2819,6 +2820,7 @@ in
                   # actually has. Route to the command that works rather than to
                   # a binary that is not there.
                   verify)   shift; exec nixarchy-verify "$@" ;;
+                  explain)  shift; exec nixarchy-explain "$@" ;;
                   doctor)
                     if command -v nixarchy-doctor >/dev/null 2>&1; then
                       shift; exec nixarchy-doctor "$@"
@@ -2931,6 +2933,7 @@ in
                   nixarchy vm <subcommand>    Disposable NixOS MicroVMs -- 'nixarchy vm help'
                   nixarchy box <subcommand>   distrobox, for software NixOS will not run -- 'nixarchy box help'
                   nixarchy doctor             What this machine needs to run nixarchy
+                  nixarchy explain            What a Nix error means -- pipe a failure into it
 
                 This machine:
 

--- a/pkgs/AGENTS.md
+++ b/pkgs/AGENTS.md
@@ -17,6 +17,7 @@ re-port, and that property is worth more than any individual fix.
 | `omarchy/skills/` | what an agent on a nixarchy machine reads |
 | `apps/` | packages with no nixpkgs equivalent |
 | `doctor.sh`, `verify.sh`, `review.sh` | scripts spliced into derivations at build time |
+| `explain.sh` | reads a Nix failure and says what it is, in the user's vocabulary |
 | `box.nix`, `microvm.nix` | the container and guest runners |
 
 ## The trap that has cost the most here
@@ -35,6 +36,26 @@ Before adding a command to any script here, add it to that derivation's
 `runtimeInputs`. If the script parses JSON, that means `jq` — reaching for `sed`
 on JSON is how a check starts confidently reporting wrong things the first time
 nix reformats a file.
+
+## `writeShellApplication` also sets `errexit`
+
+The `runtimeInputs` trap above is the expensive one. This is its sibling, and
+it cost an hour here: the wrapper is `set -o errexit -o nounset -o pipefail`,
+so a script that runs fine as `bash pkgs/thing.sh` can die at the first
+command substitution once it is packaged.
+
+`nixarchy explain -- <command>` did exactly that. `err=$("$@" 2>&1)` captures
+the output of a command that is failing — that is the entire point of the
+form — and under `errexit` the script exited there, before printing anything,
+with the wrapped command's status. Which reads as the tool never having run.
+`err=$("$@" 2>&1) || status=$?` is the fix; a script's own `set -uo pipefail`
+does **not** turn `errexit` back off.
+
+The general shape: **anything that deliberately runs a failing command has to
+say so at the call site.** And a script whose whole job is to be handed
+failures is one where every path is that path — so exercise the packaged
+binary, not the source file. The bug survived a green check suite because
+every assertion fed the script on stdin, and stdin never fails.
 
 ## Patching upstream
 
@@ -57,3 +78,4 @@ purpose; a fenced block is what an agent copies.
 | `doctor-graphics` | the doctor's GPU rules, against fixture machines |
 | `doctor-ldd` | the doctor's dynamic-link check, against binaries built broken |
 | `dashboard-clock` | the install dashboard against a rewound clock |
+| `explain` | the error explainer, against errors produced inside the check |

--- a/pkgs/explain.sh
+++ b/pkgs/explain.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# What a Nix failure means, in the vocabulary of the files you wrote.
+#
+# Only 4.0% of respondents to the 2025 Nix community survey say they
+# understand every Nix error message, and error messages were the
+# second-highest improvement priority at 47.6%. Upstream's messages have to
+# be general, which is a hard problem. This one only has to be right about
+# the configuration nixarchy shipped, which is a much easier one.
+#
+# Reads an error -- from stdin, from a file, or from a command it runs -- and
+# recognises it. It never rebuilds and never edits a file: the whole value is
+# turning a trace that lands in lib/modules.nix into a sentence naming
+# something the user typed, plus a snippet to paste. Same register as
+# pkgs/doctor.sh, deliberately: one line of finding, then the paste-able
+# block at the end.
+#
+# Exit 0 when it recognised something in reading mode, 2 when it did not --
+# so a caller can tell whether the explainer had anything to add rather than
+# printing an empty heading.
+set -uo pipefail
+
+bold=$(printf '\033[1m')
+dim=$(printf '\033[2m')
+warn=$(printf '\033[33m')
+off=$(printf '\033[0m')
+
+say() { printf '%s\n' "$*"; }
+finding() { printf '  %s%s%s %s\n' "$2" "$1" "$off" "$3"; }
+detail() { printf '    %s%s%s\n' "$dim" "$*" "$off"; }
+
+# Every line that has to go into their configuration, collected as we go and
+# printed together at the end -- a snippet to paste beats a list of prose
+# instructions to translate. Same contract as doctor.sh's.
+declare -a snippet=()
+declare -a notes=()
+found=0
+
+usage() {
+  cat <<'USAGE'
+nixarchy explain -- what a Nix failure means
+
+  nixarchy explain                     read the error from stdin
+  nixarchy explain <file>              read it from a file
+  nixarchy explain -- <command>...     run the command, explain what it printed
+
+For example:
+
+  sudo nixos-rebuild switch --flake . 2>&1 | nixarchy explain
+  nixarchy explain -- nixos-rebuild build --flake .
+USAGE
+}
+
+# ---- reading the error ---------------------------------------------------
+# Three entry points because there are three moments someone reaches for
+# this: mid-failure with the text still on screen, afterwards with a log, and
+# ahead of time wrapping the command. The wrapper form passes the output
+# through unchanged first -- swallowing the real error and replacing it with
+# an interpretation is how an explainer becomes a thing to work around.
+status=0
+case "${1:-}" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  --)
+    shift
+    if [ $# -eq 0 ]; then
+      usage >&2
+      exit 64
+    fi
+    # `|| status=$?` rather than a bare assignment: writeShellApplication
+    # wraps this in `set -o errexit`, so capturing the output of a command
+    # that fails -- the only kind this form is ever given -- killed the
+    # script before it printed anything at all. Silently, with the exit
+    # status of the wrapped command, which reads as the tool not being run.
+    err=$("$@" 2>&1) || status=$?
+    printf '%s\n' "$err"
+    # A command that worked has nothing to explain, and a heading saying so
+    # is noise on every successful rebuild someone wraps out of habit.
+    if [ "$status" -eq 0 ]; then exit 0; fi
+    say ""
+    ;;
+  "" | -)
+    err=$(cat)
+    ;;
+  *)
+    if [ ! -r "$1" ]; then
+      say "nixarchy explain: cannot read $1" >&2
+      exit 64
+    fi
+    err=$(cat -- "$1")
+    ;;
+esac
+
+if [ -z "${err//[[:space:]]/}" ]; then
+  say "nixarchy explain: nothing on the input to explain" >&2
+  exit 64
+fi
+
+# Nix quotes a name four ways depending on version and on which subsystem is
+# speaking: `foo' in the old spelling, 'foo' plainly, "foo", and the curly
+# pair the module system uses. Two of those turn up in a single trace today.
+# Every one is folded to a plain apostrophe here, once, rather than every
+# pattern below carrying a four-way alternation -- and folded by literal byte
+# substitution rather than a bracket expression, because a bracket expression
+# over a three-byte character matches per byte under the C locale a build
+# sandbox runs in, which is a silent wrong answer rather than an error.
+err=$(
+  printf '%s' "$err" |
+    sed -e "s/$(printf '\342\200\230')/'/g" \
+      -e "s/$(printf '\342\200\231')/'/g" \
+      -e "s/\`/'/g"
+)
+
+has() { printf '%s' "$err" | grep -qF -- "$1"; }
+hasre() { printf '%s' "$err" | grep -qE -- "$1"; }
+
+between() { # <before> <after> -- the first quoted name after the marker
+  printf '%s' "$err" | sed -n "s/.*$1'\([^']*\)'$2.*/\1/p" | head -1
+}
+
+say ""
+say "${bold}What this error is${off}"
+say ""
+
+# ---- a file you have not git added --------------------------------------
+# The single highest-value entry in the file. A flake sees only tracked or
+# staged files, and an untracked one is reported as "does not exist" -- not
+# as "untracked". Contributors to this repository lost three separate
+# debugging sessions to it in one day, with the file plainly there in `ls`
+# (AGENTS.md section 5). Newer Nix says "is not tracked by Git" and prints
+# the fix; older Nix, and any path reaching evaluation through a store copy
+# of the flake, still says "does not exist". Both spellings are matched
+# because both are on machines running nixarchy today.
+if
+  has "is not tracked by Git" ||
+    hasre "path '[^']*\.nix' does not exist"
+then
+  found=1
+  missing=$(between "path " " does not exist")
+  if [ -z "$missing" ]; then missing=$(between "Path " " in the repository"); fi
+  finding "A file your flake imports is not in git" "$warn" "${missing:-the path the error names}"
+  detail "Nix evaluates a flake from its git tree, so a file that is on disk and"
+  detail "untracked does not exist as far as evaluation is concerned. That is why"
+  detail "the error says 'does not exist' about a file you can ls."
+  detail "Nothing is wrong with the file. It has never been added."
+  snippet+=(
+    "  # in your flake's directory:"
+    "  git add ${missing:-<the file the error names>}"
+    ""
+    "  # 'git add', not 'git commit' -- staged is enough for evaluation."
+  )
+  notes+=("nixarchy-apply writes nixarchy-apps.nix into your flake root. If that is a git repo, the file needs adding the first time.")
+fi
+
+# ---- infinite recursion --------------------------------------------------
+if has "infinite recursion encountered"; then
+  found=1
+  finding "Something is defined in terms of itself" "$warn" "infinite recursion"
+  detail "Nix stopped following a definition that comes back round to itself. The"
+  detail "trace points at where it gave up, which is rarely where the loop was"
+  detail "closed -- look at what you most recently added, not at the frame shown."
+  detail ""
+  detail "Three shapes cause nearly all of them in a NixOS configuration:"
+  detail "  - config.<option> read inside the definition of that same option"
+  detail "  - a let binding that names itself: let pkgs = pkgs.foo; in ..."
+  detail "  - an overlay using 'final' where it meant 'prev'"
+  snippet+=(
+    "  # An overlay reading final where it meant prev is the usual one:"
+    "  nixpkgs.overlays = [ (final: prev: { foo = prev.foo.override { }; }) ];"
+    "  #                                          ^^^^ prev, not final"
+  )
+fi
+
+# ---- a module argument that is not there --------------------------------
+# The distinguishing feature is that the trace names lib/modules.nix and
+# nothing the user wrote, which is exactly the complaint in
+# docs/manual/getting-started.md. A NixOS module argument cannot have a ?
+# default: an argument absent from specialArgs resolves through _module.args
+# rather than by the function default, so the module reads as correct and
+# fails with 'attribute missing' two frames down.
+if hasre "attribute '[^']*' missing"; then
+  found=1
+  attr=$(between "attribute " " missing")
+  if has "_module.args" || has "modules.nix"; then
+    finding "A module asked for an argument nothing passes it" "$warn" "${attr:-the attribute the error names}"
+    detail "The trace lands in nixpkgs' own lib/modules.nix and names no file of"
+    detail "yours, which is what makes this one unreadable. A module's arguments"
+    detail "come from specialArgs and _module.args, never from the function's own"
+    detail "default -- so { ${attr:-x} ? {} }: reads as correct and still fails here."
+    snippet+=(
+      "  # Pass it from the call site rather than defaulting it in the module:"
+      "  _module.args.${attr:-yourArgument} = <value>;"
+      ""
+      "  # 'inputs' is the one people hit first. The flake nixarchy writes"
+      "  # passes it already: specialArgs = { inherit inputs; };"
+    )
+  else
+    finding "An attribute the configuration reads is not there" "$warn" "${attr:-the attribute the error names}"
+    detail "Usually a package name that is not in this nixpkgs, or a spelling that"
+    detail "changed between releases."
+    snippet+=(
+      "  # Check the name against the nixpkgs this machine actually follows:"
+      "  nixarchy search ${attr:-<name>}"
+    )
+  fi
+fi
+
+# ---- an option that does not exist --------------------------------------
+# Ordered after the untracked-file family on purpose: this message also
+# contains the words "does not exist", and matching that loosely swallows
+# the other one.
+if hasre "The option '[^']*' does not exist"; then
+  found=1
+  opt=$(between "The option " " does not exist")
+  finding "That option does not exist" "$warn" "${opt:-the option the error names}"
+  detail "Either the name is misspelt, or it belongs to a module set this"
+  detail "configuration does not import -- a home-manager option written into the"
+  detail "system configuration is the common one, and it reads exactly like a"
+  detail "typo. An option's own module has to be imported before its name is"
+  detail "defined anywhere."
+  snippet+=(
+    "  # Every NixOS option, and every nixarchy one, in one picker:"
+    "  nixarchy search ${opt:-<option>}"
+  )
+  case "$opt" in
+    programs.nixarchy.*)
+      notes+=("$opt is spelt like a nixarchy option and is not one -- 'nixarchy search programs.nixarchy' lists the whole surface.")
+      ;;
+    home | home.* | home-manager.*)
+      notes+=("That name is home-manager's. It exists inside home-manager.users.<you> = { ... }, not in the system configuration.")
+      ;;
+    *) ;;
+  esac
+fi
+
+# ---- two definitions of one option --------------------------------------
+if hasre "has conflicting definition|conflicting definitions|has conflicting value"; then
+  found=1
+  opt=$(between "The option " " has conflicting")
+  finding "Two places define the same option" "$warn" "${opt:-the option the error names}"
+  detail "Nix will not guess which you meant, and the trace lands in"
+  detail "lib/modules.nix rather than in either of the two files. Nixarchy sets"
+  detail "its own defaults with lib.mkDefault, so a plain assignment of yours"
+  detail "already wins over anything nixarchy ships -- if you are seeing this"
+  detail "against a nixarchy option, the other definition is yours too."
+  snippet+=(
+    "  # Make one of the two yield, rather than raising both:"
+    "  ${opt:-the.option} = lib.mkDefault <value>;   # this one gives way"
+    "  ${opt:-the.option} = lib.mkForce   <value>;   # this one wins outright"
+    ""
+    "  # nixpkgs.config is NOT resolved by priority -- it is a free-form"
+    "  # attribute set. Use programs.nixarchy.allowUnfree rather than writing"
+    "  # nixpkgs.config.allowUnfree in two places."
+  )
+fi
+
+# ---- two packages shipping the same file --------------------------------
+# buildEnv's wording has changed across nixpkgs releases -- "collision
+# between" in the spelling most people have seen, "conflicting subpath" in
+# current nixpkgs -- and both are live on machines running nixarchy.
+if hasre "collision between|conflicting subpath|colliding subpath"; then
+  found=1
+  finding "Two packages want to install the same file" "$warn" "a profile collision"
+  detail "Nothing is broken. NixOS builds your packages into one directory of"
+  detail "symlinks and two of them claim the same path -- almost always the same"
+  detail "program twice, once from your systemPackages and once pulled in by"
+  detail "something else, or one from nixpkgs and one from an overlay. The two"
+  detail "store paths in the message name the culprits."
+  snippet+=(
+    "  # Keep both, and give the loser a worse priority:"
+    "  environment.systemPackages = [ (lib.lowPrio pkgs.<the-one-to-yield>) ];"
+    ""
+    "  # Better where you can: install it once. Nixarchy does not install a"
+    "  # second copy of something you already declare, and 'nixarchy doctor'"
+    "  # lists what overlaps."
+  )
+fi
+
+# ---- unfree, and insecure -----------------------------------------------
+# Reads as a hard refusal and is a one-line opt-in. Nixarchy sets allowUnfree
+# itself, so seeing it at all on a nixarchy machine usually means a second
+# nixpkgs instance -- worth saying, because the obvious fix then goes in the
+# wrong file and appears not to work.
+# Both refusals now share the sentence "Refusing to evaluate package x in
+# <file> because ..."; only the tail tells them apart, so matching the shared
+# opening reports every insecure package as unfree.
+if has "has an unfree license"; then
+  found=1
+  pkg=$(between "Refusing to evaluate package " " in ")
+  finding "Nix is refusing an unfree package, and asking permission" "$warn" "${pkg:-the package the error names}"
+  detail "A policy refusal, not a failure: the package is fine and the build never"
+  detail "started. Nixarchy already sets nixpkgs.config.allowUnfree, so if you are"
+  detail "seeing this on a nixarchy machine the package is coming from a second"
+  detail "nixpkgs -- another flake input with its own instance, which your setting"
+  detail "does not reach."
+  snippet+=(
+    "  programs.nixarchy.allowUnfree = true;   # this is the nixarchy default"
+    ""
+    "  # Set it there rather than writing nixpkgs.config.allowUnfree yourself:"
+    "  # nixpkgs.config is a free-form attribute set, so two definitions of one"
+    "  # key do not resolve by priority and yours may not be the one used."
+  )
+fi
+
+if has "is marked as insecure"; then
+  found=1
+  pkg=$(between "Refusing to evaluate package " " in ")
+  if [ -z "$pkg" ]; then pkg=$(between "Package " " in "); fi
+  finding "Nix is refusing a package with a known vulnerability" "$warn" "${pkg:-the package the error names}"
+  detail "Also a policy refusal. Someone recorded a CVE against this version and"
+  detail "nixpkgs will not build it silently. The permitted list is by exact"
+  detail "version string, so it stops applying the moment the package is updated"
+  detail "-- which is the point of it."
+  snippet+=(
+    "  nixpkgs.config.permittedInsecurePackages = [ \"${pkg:-<name-version>}\" ];"
+    ""
+    "  # Copy the name and version exactly as the error printed them."
+  )
+fi
+
+# ---- nothing matched -----------------------------------------------------
+if [ "$found" -eq 0 ]; then
+  say "  Nothing here matches a failure this explainer knows about."
+  say ""
+  detail "That is a gap worth reporting. It covers the failures a desktop user"
+  detail "actually hits, and the list grows by people saying which one it missed:"
+  detail "  https://github.com/olafkfreund/nixarchy/issues"
+  say ""
+  exit 2
+fi
+
+say ""
+say "${bold}What to do${off}"
+say ""
+printf '%s\n' "${snippet[@]}"
+say ""
+
+if [ ${#notes[@]} -gt 0 ]; then
+  say "${bold}Worth knowing${off}"
+  for n in "${notes[@]}"; do
+    say "  - $n"
+  done
+  say ""
+fi
+
+# The wrapper form reports the command's status, not the explainer's: a
+# caller that ran a rebuild through this still needs to know the rebuild
+# failed. Reading mode reports whether anything was recognised.
+if [ "$status" -ne 0 ]; then exit "$status"; fi
+exit 0

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -132,11 +132,52 @@ image, booted against real caches, missing a real unfree package. That run
 needs a human with vscode in their closure and a machine to lose; until one
 reports back, the prediction is tested and the event it predicts is not.
 
+## A fixture that quotes an error is a fixture that goes stale
+
+`explain` recognises Nix error messages, and the obvious way to test that is a
+directory of captured traces. It is the wrong way, and the reason generalises
+past this check.
+
+An error message is not ours. nixpkgs reworded the buildEnv collision from
+``collision between `a' and `b'`` to `two given paths contain a conflicting
+subpath` — same failure, different words — and Nix reworded the untracked-file
+error from `path '…' does not exist` to `Path '…' is not tracked by Git`, which
+is a better message and matches nothing the old matcher looked for. A captured
+trace keeps passing through both rewordings, because the fixture and the
+matcher agree with each other while both have stopped describing the machine in
+front of the user. That is §1's green light with a different coat on.
+
+So `tests/explain.nix` produces every error inside the check, from the real
+producer: a real git repository with a real untracked file, `lib.evalModules`
+with two definitions of one option, nixpkgs' own `buildenv/builder.pl` against
+two colliding trees, `stdenvNoCC.mkDerivation` with an unfree licence. Nothing
+is quoted. If nixpkgs rewords one again, the fixture changes under the check
+and the check goes red — which is the whole point.
+
+Two mechanics that make this possible, and one that nearly stopped it:
+
+- **Nested `nix` evaluation works in a build sandbox.** Point `NIX_STORE_DIR`,
+  `NIX_STATE_DIR` and `NIX_LOG_DIR` at `$PWD`, and `nix-instantiate --eval`
+  and `nix eval` both run. Full nixpkgs evaluation is available offline
+  because `${pkgs.path}` is already an input. Nothing is built, so this stays
+  a seconds-long check.
+- **A failing derivation cannot be a check's dependency**, so a build-time
+  error has to be produced by running the builder rather than by building.
+  `buildenv/builder.pl` reads its arguments from `NIX_ATTRS_JSON_FILE`; hand
+  it a JSON file naming two trees and it prints the real collision.
+- **`NIXPKGS_ALLOW_UNFREE` is read through `builtins.getEnv`.** A nixarchy
+  desktop exports it, so the unfree fixtures succeed when you run them by hand
+  and fail correctly in the sandbox. Every fixture that depends on nixpkgs
+  policy asserts the raw Nix message before asserting anything about our
+  output — a fixture that quietly starts succeeding otherwise leaves the thing
+  under test reading an empty string, and "recognised nothing" is
+  indistinguishable from "there was nothing to recognise".
+
 ## The cheap ones, which is where new checks usually belong
 
 `installer-ui`, `installer-wizard`, `installer-refusal`, `installer-lock`,
 `installer-store-space`, `try-preflight`, `doctor-graphics`, `dashboard-clock`,
-`options`, `review-pins`, `patched-files`, `doc-options`.
+`options`, `review-pins`, `patched-files`, `doc-options`, `explain`.
 
 These are `runCommand`s that finish in seconds and drive one decision with a
 stubbed environment. Prefer one of these over extending a VM test: they are the

--- a/tests/explain.nix
+++ b/tests/explain.nix
@@ -1,0 +1,252 @@
+{ pkgs, explain }:
+# The error explainer, against errors Nix actually emits in this check.
+#
+# Not one fixture is a pasted string. Every family below is produced here, by
+# making Nix fail the way a user makes it fail, and the explainer is fed
+# whatever comes out. A pasted trace goes stale silently -- nixpkgs reworded
+# the buildEnv collision from "collision between" to "conflicting subpath"
+# and reworded the untracked-file error entirely, and a fixture file would
+# have kept both checks green while the explainer stopped recognising what
+# the machine in front of the user prints.
+#
+# Each family is asserted twice, and the first assertion is the one that
+# matters: `raw` checks that the fixture STILL produces the Nix message it
+# was written for. Without it, a fixture that quietly starts succeeding
+# leaves the explainer reading an empty string, and "nothing recognised" is
+# indistinguishable from "nothing to recognise". Then `want` checks that the
+# explainer said the nixarchy-specific thing.
+#
+# Nested nix: eval only, into a private store and state dir. Nothing is
+# built and nothing is fetched -- ${pkgs.path} is already an input, so full
+# nixpkgs evaluation is available offline in the sandbox.
+pkgs.runCommand "nixarchy-explain"
+  {
+    nativeBuildInputs = [
+      pkgs.nix
+      pkgs.git
+      pkgs.perl
+      pkgs.gnugrep
+      pkgs.gnused
+    ];
+  }
+  ''
+    # NIXPKGS_ALLOW_UNFREE and NIXPKGS_ALLOW_INSECURE are read by check-meta
+    # through builtins.getEnv, so an interactive shell that exports them (a
+    # nixarchy desktop does) makes the unfree fixtures silently succeed. The
+    # sandbox does not carry them; setting them to 0 says so out loud, and is
+    # what makes this check reproduce outside one.
+    export HOME=$PWD/home
+    export NIX_STORE_DIR=$PWD/nix-store NIX_STATE_DIR=$PWD/nix-state NIX_LOG_DIR=$PWD/nix-log
+    export NIXPKGS_ALLOW_UNFREE=0 NIXPKGS_ALLOW_INSECURE=0
+    export NIX_CONFIG="experimental-features = nix-command flakes"
+    mkdir -p "$HOME"
+
+    lib=${pkgs.path}/lib
+    nixpkgs=${pkgs.path}
+
+    fails=0
+    # Short variable names here, and none of them called `out`: a shell
+    # variable named out clobbers the derivation's own $out, and the build
+    # then fails with "failed to produce output path" long after every
+    # assertion has printed green, which reads as a store problem.
+    want() { # <name> <text> <pattern>
+      if printf '%s' "$2" | grep -qF -- "$3"; then echo "  ok       $1"
+      else echo "  FAILED   $1: no '$3' in the explanation"; fails=$((fails + 1)); fi
+    }
+    wantnot() {
+      if printf '%s' "$2" | grep -qF -- "$3"; then
+        echo "  FAILED   $1: '$3' present and should not be"; fails=$((fails + 1))
+      else echo "  ok       $1"; fi
+    }
+    raw() { # the fixture still produces the Nix message it was written for
+      if printf '%s' "$2" | grep -qF -- "$3"; then echo "  fixture  $1"
+      else
+        echo "  FAILED   $1: the fixture no longer produces '$3' -- it printed:"
+        printf '%s\n' "$2" | sed 's/^/           /' | tail -20
+        fails=$((fails + 1))
+      fi
+    }
+    explain() { printf '%s' "$1" | ${explain}/bin/nixarchy-explain 2>&1 || true; }
+    evalfail() { nix-instantiate --eval --strict -E "$1" 2>&1 || true; }
+
+    echo "== a file that is not git added =========================="
+    # Two spellings, both current on machines running nixarchy: a working
+    # tree says "is not tracked by Git", and a pinned rev -- what CI and a
+    # `nixos-rebuild` against a locked flake evaluate -- copies only the
+    # committed files into the store and says "does not exist" about a file
+    # that is plainly there in ls. The second is the one that cost this
+    # repository three debugging sessions in a day (AGENTS.md section 5).
+    mkdir -p flake && (
+      cd flake
+      git init -q .
+      git config user.email a@example.invalid
+      git config user.name fixture
+      printf '{ outputs = _: { x = import ./untracked.nix; }; }\n' > flake.nix
+      echo 42 > untracked.nix
+      git add flake.nix
+      git commit -qm fixture
+    )
+    tree=$(cd flake && nix eval .#x 2>&1 || true)
+    raw     "working tree: Nix still says 'not tracked'" "$tree" "is not tracked by Git"
+    e=$(explain "$tree")
+    want    "working tree: recognised"                   "$e" "not in git"
+    want    "working tree: names the file"               "$e" "untracked.nix"
+    want    "working tree: git add is the fix"           "$e" "git add"
+    want    "working tree: staged is enough"             "$e" "staged is enough"
+
+    rev=$(cd flake && git rev-parse HEAD)
+    pinned=$(cd flake && nix eval "git+file://$PWD?rev=$rev"#x 2>&1 || true)
+    raw     "pinned rev: the older spelling is produced" "$pinned" "does not exist"
+    e=$(explain "$pinned")
+    want    "pinned rev: recognised as the same thing"   "$e" "not in git"
+    want    "pinned rev: says the file is fine"          "$e" "Nothing is wrong with the file"
+
+    echo "== infinite recursion ===================================="
+    r=$(evalfail 'let a = a + 1; in a')
+    raw     "the fixture recurses"                       "$r" "infinite recursion encountered"
+    e=$(explain "$r")
+    want    "recognised"                                 "$e" "defined in terms of itself"
+    want    "warns the trace is not the place"           "$e" "rarely where the loop was"
+    want    "names the overlay shape"                    "$e" "prev, not final"
+
+    echo "== a module argument nothing passes ======================"
+    # The AGENTS.md section 5 trap exactly: a module argument cannot have a ?
+    # default, because an absent argument resolves through _module.args
+    # rather than by the function default. The trace names lib/modules.nix
+    # and nothing the user wrote, which is the whole complaint.
+    r=$(evalfail "((import $lib).evalModules { modules = [
+          ({ lib, ... }: { options.probe = lib.mkOption { type = lib.types.attrs; default = {}; }; })
+          ({ source ? {}, ... }: { probe = source; })
+        ]; }).config")
+    raw     "the fixture loses the argument"             "$r" "attribute 'source' missing"
+    raw     "and the trace names only nixpkgs"           "$r" "lib/modules.nix"
+    e=$(explain "$r")
+    want    "recognised as a module argument"            "$e" "argument nothing passes it"
+    want    "names the argument"                         "$e" "source"
+    want    "the fix is the call site"                   "$e" "_module.args.source"
+    wantnot "not mistaken for a missing package"         "$e" "not in this nixpkgs"
+
+    echo "== an option that does not exist ========================="
+    r=$(evalfail "((import $lib).evalModules { modules = [ { services.nope.enable = true; } ]; }).config")
+    raw     "the fixture refuses the option"             "$r" "does not exist"
+    e=$(explain "$r")
+    want    "recognised"                                 "$e" "That option does not exist"
+    want    "names the option"                           "$e" "services"
+    want    "offers the picker"                          "$e" "nixarchy search"
+    # The ordering guard: this message contains the words "does not exist"
+    # too, and a loose pattern for the untracked-file family swallows it.
+    wantnot "not mistaken for an untracked file"         "$e" "not in git"
+
+    echo "== a home-manager option in the system config ============"
+    r=$(evalfail "((import $lib).evalModules { modules = [ { home.packages = []; } ]; }).config")
+    raw     "the fixture refuses it"                     "$r" "does not exist"
+    e=$(explain "$r")
+    want    "says whose option it really is"             "$e" "home-manager.users"
+
+    echo "== two definitions of one option ========================="
+    r=$(evalfail "((import $lib).evalModules { modules = [
+          ({ lib, ... }: { options.probe = lib.mkOption { type = lib.types.int; }; })
+          { probe = 1; }
+          { probe = 2; }
+        ]; }).config")
+    raw     "the fixture collides"                       "$r" "conflicting definition"
+    e=$(explain "$r")
+    want    "recognised"                                 "$e" "Two places define the same option"
+    want    "names the option"                           "$e" "probe"
+    want    "explains that nixarchy already yields"      "$e" "lib.mkDefault"
+    want    "warns about nixpkgs.config"                 "$e" "free-form"
+
+    echo "== two packages shipping the same file ==================="
+    # Driven through nixpkgs' own buildenv builder rather than a pasted
+    # message, because the wording has changed inside nixpkgs at least once.
+    # Building a real buildEnv here would need a whole stdenv in the nested
+    # store; running the real builder against two fixture trees produces the
+    # real message for the price of a perl invocation.
+    mkdir -p pkgA/bin pkgB/bin env-res
+    echo A > pkgA/bin/hello
+    echo B > pkgB/bin/hello
+    sed 's|@storeDir@|/nix/store|g' "$nixpkgs/pkgs/build-support/buildenv/builder.pl" > builder.pl
+    cat > attrs.json <<JSON
+    {"outputs":{"out":"$PWD/env-res"},"extraPrefix":"","pathsToLink":["/"],
+     "ignoreCollisions":false,"checkCollisionContents":true,"ignoreSingleFileOutputs":false,
+     "chosenOutputs":[{"paths":["$PWD/pkgA"],"priority":5},{"paths":["$PWD/pkgB"],"priority":5}],
+     "extraPathsFrom":"","manifest":""}
+    JSON
+    r=$(NIX_ATTRS_JSON_FILE=$PWD/attrs.json perl builder.pl 2>&1 || true)
+    raw     "the real builder collides"                  "$r" "conflicting subpath"
+    e=$(explain "$r")
+    want    "recognised"                                 "$e" "the same file"
+    want    "says nothing is broken"                     "$e" "Nothing is broken"
+    want    "offers lowPrio"                             "$e" "lib.lowPrio"
+    # The spelling this nixpkgs no longer emits, and every older one still
+    # does. Produced by hand precisely because no fixture here can produce
+    # it any more -- an unproduceable spelling with no assertion is how a
+    # matcher rots unnoticed (AGENTS.md section 3).
+    e=$(explain "error: collision between \`/nix/store/a-1/bin/hello' and \`/nix/store/b-1/bin/hello'")
+    want    "the older buildEnv wording too"             "$e" "the same file"
+
+    echo "== unfree, and insecure =================================="
+    # Hermetic on purpose: a package of our own with an unfree licence,
+    # rather than naming a real one whose licence could be relicensed out
+    # from under the check.
+    r=$(evalfail "let p = import $nixpkgs { system = \"${pkgs.stdenv.hostPlatform.system}\"; config = {}; };
+        in (p.stdenvNoCC.mkDerivation { name = \"probe-1.0\"; meta.license = p.lib.licenses.unfree; }).outPath")
+    raw     "the fixture is refused"                     "$r" "has an unfree license"
+    e=$(explain "$r")
+    want    "recognised"                                 "$e" "refusing an unfree package"
+    want    "says it is not a failure"                   "$e" "policy refusal, not a failure"
+    want    "names the nixarchy option"                  "$e" "programs.nixarchy.allowUnfree = true"
+    want    "names the package"                          "$e" "probe-1.0"
+
+    r=$(evalfail "let p = import $nixpkgs { system = \"${pkgs.stdenv.hostPlatform.system}\"; config = {}; };
+        in (p.stdenvNoCC.mkDerivation { pname = \"probe\"; version = \"1.0\"; meta.knownVulnerabilities = [ \"probe CVE\" ]; }).outPath")
+    raw     "the fixture is marked insecure"             "$r" "is marked as insecure"
+    e=$(explain "$r")
+    want    "recognised"                                 "$e" "known vulnerability"
+    # Both refusals now open with the same sentence, so a matcher keyed on
+    # that opening calls every insecure package unfree.
+    wantnot "not reported as an unfree package"          "$e" "unfree"
+    want    "gives the exact list entry"                 "$e" "permittedInsecurePackages = [ \"probe-1.0\" ]"
+
+    echo "== the wrapper form ======================================"
+    # `nixarchy explain -- <command>` is the form that never gets exercised by
+    # feeding text to stdin, and it was broken on the first real run: the
+    # package is built by writeShellApplication, which wraps the script in
+    # `set -o errexit`, so capturing the output of a command that fails --
+    # the only kind this form is ever handed -- killed the script before it
+    # printed anything. It exited with the wrapped command's status, so it
+    # looked exactly like the tool had not run.
+    w=$(${explain}/bin/nixarchy-explain -- nix-instantiate --eval -E 'let a = a + 1; in a' 2>&1 || true)
+    want    "the command's own output is passed through" "$w" "infinite recursion encountered"
+    want    "and then explained"                         "$w" "defined in terms of itself"
+    ${explain}/bin/nixarchy-explain -- true > /dev/null 2>&1
+    echo "  ok       a command that succeeds is not an error"
+    if ${explain}/bin/nixarchy-explain -- nix-instantiate --eval -E 'let a = a + 1; in a' >/dev/null 2>&1; then
+      echo "  FAILED   the wrapper must report the command's failure"; fails=$((fails + 1))
+    else
+      echo "  ok       the wrapper reports the command's failure"
+    fi
+
+    echo "== what it does with something it cannot place ==========="
+    # A recogniser that recognises everything is a horoscope. This asserts
+    # the explainer keeps quiet, and reports it in its exit status, on text
+    # it has nothing to say about.
+    clean=$(evalfail '1 + 1')
+    e=$(explain "no space left on device while building /nix/store/x.drv")
+    want    "says so rather than guessing"               "$e" "Nothing here matches"
+    wantnot "invents no finding"                         "$e" "What to do"
+    if printf '%s' "no space left on device" | ${explain}/bin/nixarchy-explain >/dev/null 2>&1; then
+      echo "  FAILED   unrecognised input must not exit 0"; fails=$((fails + 1))
+    else
+      echo "  ok       unrecognised input exits non-zero"
+    fi
+    raw     "the control fixture really succeeded"       "$clean" "2"
+
+    echo ""
+    if [ "$fails" -gt 0 ]; then
+      echo "$fails assertion(s) failed"
+      exit 1
+    fi
+    echo "all assertions passed"
+    touch $out
+  ''


### PR DESCRIPTION
## What this changes, and why

Only **4.0%** of respondents to the [2025 Nix community survey](https://nixos.org/surveys/community/2025/) say they understand every Nix error message, and error messages were the second-highest improvement priority at 47.6%. `docs/manual/getting-started.md:307` answered a failed rebuild by telling the user to read the evaluation trace — a trace that lands in nixpkgs' `lib/modules.nix` and names no file they wrote.

Upstream's messages have to be general. Nixarchy's only have to be right about the configuration it shipped, which is a far easier problem. `nixarchy explain` reads a failure — from stdin, from a file, or from a command it wraps — and recognises the families that actually stop a desktop, in `pkgs/doctor.sh`'s register: one line of finding, then the paste-able block.

| family | what it says instead |
|---|---|
| `path '…' does not exist` / `is not tracked by Git` | the file is not `git add`ed; a flake evaluates from its git tree. **Both** spellings, because Nix reworded it and both are live |
| `infinite recursion encountered` | the frame shown is where Nix gave up, not where the loop closed; the three shapes that cause nearly all of them |
| `attribute 'x' missing` with a trace naming only `lib/modules.nix` | a module argument nothing passes. A module argument cannot have a `?` default — pass it from the call site |
| `The option 'x' does not exist` | typo, or an option from a module set that is not imported; home-manager options get named as home-manager's |
| `has conflicting definition values` | two definitions of one option; nixarchy already yields with `mkDefault`, so the other one is yours too |
| `collision between` / `conflicting subpath` | two packages ship one file; `lib.lowPrio`. Both wordings, because nixpkgs reworded this one too |
| unfree / `marked as insecure` | a policy refusal, not a failure — and nixarchy already sets `allowUnfree`, so seeing it means a second nixpkgs |

It rebuilds nothing and edits nothing. Given something it cannot place it says so and exits non-zero rather than guessing.

Reachable as `nixarchy explain`, and as `nix run github:olafkfreund/nixarchy#explain` without nixarchy installed — which is the state the machine is in when the rebuild that would have installed it has just failed.

**No pasted fixtures.** `tests/explain.nix` produces every error inside the check, from the real producer: a real git repository with a real untracked file (and a pinned rev for the store-copy spelling), `lib.evalModules` for the module families, nixpkgs' own `pkgs/build-support/buildenv/builder.pl` driven through `NIX_ATTRS_JSON_FILE` for the collision, and `stdenvNoCC.mkDerivation` with an unfree licence and with `knownVulnerabilities`. Nested `nix` evaluation works in a build sandbox with `NIX_STORE_DIR`/`NIX_STATE_DIR` pointed at `$PWD`; nothing is built and nothing is fetched, and the whole check runs in about 40 seconds.

Every family also asserts the **raw** Nix message first. A fixture that quietly stops failing otherwise leaves the explainer reading an empty string, and "recognised nothing" is indistinguishable from "there was nothing to recognise".

## How I proved the check fails

Break-and-restore, one detector at a time, run as a bash script (never pasted into zsh). Each mutation replaces exactly one matcher with `zz-no-such-message`, `git add`s it, and builds `checks.explain`; the last run restores and shows green.

```
----- untracked file (part 1: the modern spelling) -----
  fixture  working tree: Nix still says 'not tracked'
  FAILED   working tree: recognised: no 'not in git' in the explanation
  FAILED   working tree: names the file: no 'untracked.nix' in the explanation
  FAILED   working tree: git add is the fix: no 'git add' in the explanation
  FAILED   working tree: staged is enough: no 'staged is enough' in the explanation
  fixture  pinned rev: the older spelling is produced
  ok       pinned rev: recognised as the same thing        <- the other spelling still green
  ok       pinned rev: says the file is fine
4 assertion(s) failed

----- untracked file (part 2: the store-copy spelling) -----
  ok       working tree: recognised                        <- and now the other way round
  ok       working tree: names the file
  fixture  pinned rev: the older spelling is produced
  FAILED   pinned rev: recognised as the same thing: no 'not in git' in the explanation
  FAILED   pinned rev: says the file is fine: no 'Nothing is wrong with the file' in the explanation
2 assertion(s) failed

----- infinite recursion -----
  FAILED   recognised: no 'defined in terms of itself' in the explanation
  FAILED   warns the trace is not the place: no 'rarely where the loop was' in the explanation
  FAILED   names the overlay shape: no 'prev, not final' in the explanation
3 assertion(s) failed

----- module argument missing -----
  FAILED   recognised as a module argument: no 'argument nothing passes it' in the explanation
  FAILED   names the argument: no 'source' in the explanation
  FAILED   the fix is the call site: no '_module.args.source' in the explanation
3 assertion(s) failed

----- option does not exist -----
  FAILED   recognised: no 'That option does not exist' in the explanation
  FAILED   names the option: no 'services' in the explanation
  FAILED   offers the picker: no 'nixarchy search' in the explanation
  FAILED   says whose option it really is: no 'home-manager.users' in the explanation
4 assertion(s) failed

----- conflicting definitions -----
  FAILED   recognised: no 'Two places define the same option' in the explanation
  FAILED   names the option: no 'probe' in the explanation
  FAILED   explains that nixarchy already yields: no 'lib.mkDefault' in the explanation
  FAILED   warns about nixpkgs.config: no 'free-form' in the explanation
4 assertion(s) failed

----- file collision -----
  FAILED   recognised: no 'the same file' in the explanation
  FAILED   says nothing is broken: no 'Nothing is broken' in the explanation
  FAILED   offers lowPrio: no 'lib.lowPrio' in the explanation
  FAILED   the older buildEnv wording too: no 'the same file' in the explanation
4 assertion(s) failed

----- unfree refusal -----
  FAILED   recognised: no 'refusing an unfree package' in the explanation
  FAILED   says it is not a failure: no 'policy refusal, not a failure' in the explanation
  FAILED   names the nixarchy option: no 'programs.nixarchy.allowUnfree = true' in the explanation
  FAILED   names the package: no 'probe-1.0' in the explanation
4 assertion(s) failed

----- insecure refusal -----
  FAILED   recognised: no 'known vulnerability' in the explanation
  FAILED   gives the exact list entry: no 'permittedInsecurePackages = [ "probe-1.0" ]' in the explanation
2 assertion(s) failed

----- the honesty guard: recognising everything (found=0 -> found=1) -----
  FAILED   says so rather than guessing: no 'Nothing here matches' in the explanation
  FAILED   invents no finding: 'What to do' present and should not be
  FAILED   unrecognised input must not exit 0
3 assertion(s) failed

----- restored: everything passes again -----
exit status: 0
```

### The one it caught for real

The wrapper form (`nixarchy explain -- <command>`) shipped broken for an hour and I found it by running the built binary, not by reading it. `writeShellApplication` wraps the script in `set -o errexit`, so `err=$("$@" 2>&1)` — capturing the output of a command that is failing, which is the *only* kind this form is ever handed — killed the script before it printed anything, exiting with the wrapped command's status. It looked exactly like the tool had not run. The script's own `set -uo pipefail` does not turn `errexit` back off; `|| status=$?` is the fix.

Every stdin assertion stayed green throughout, because stdin never fails. So the check grew a wrapper-form section, and here it is failing against the real bug reintroduced verbatim:

```
----- err=$("$@" 2>&1) without the || status=$? -----
  FAILED   the command's own output is passed through: no 'infinite recursion encountered' in the explanation
  FAILED   and then explained: no 'defined in terms of itself' in the explanation
  ok       a command that succeeds is not an error
  ok       the wrapper reports the command's failure
2 assertion(s) failed
```

Green with the fix:

```
== the wrapper form ======================================
  ok       the command's own output is passed through
  ok       and then explained
  ok       a command that succeeds is not an error
  ok       the wrapper reports the command's failure
...
all assertions passed
```

## Checks run locally

- `nix build .#checks.x86_64-linux.explain` — green, ~40s (and red eleven times on purpose, above)
- `nix build .#checks.x86_64-linux.options` — green (the dispatcher and `systemPackages` hunks in `modules/apps.nix`)
- `nix build .#explain` — the package itself, then exercised end to end by hand
- No VM check was built locally: install jobs share this machine.

- [x] `nix fmt` / statix / deadnix are clean (`nix fmt -- --ci`: 0 changed; `shellcheck pkgs/explain.sh`: clean)
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [ ] If this adds an option: `tests/options.nix` covers both states — no new option
- [x] If this adds a `checks.*` entry: a PR-triggered workflow builds it

**On that last box — no workflow edit is needed, and I want a reviewer to confirm I read this right.** `build.yml`'s coverage guard is an opt-*out*: `claimed`, `exempt` and `nightly_only` name the checks another job owns, and the generated step derives its targets from `nix eval .#checks.x86_64-linux` and builds everything else. `explain` is on none of those three lists, so the generated step picks it up on every pull request with no YAML written. That is the inversion the guard's own comment describes ("adding a check now runs it, with no YAML to write and nothing to forget"). If a reviewer disagrees, the line to add is `nix build .#checks.x86_64-linux.explain` in `build.yml`'s check step — but adding it would also mean claiming the name, and I have not touched a CI gate.

## What this cost, and where it is written down

Two general lessons, both in this PR:

- **`pkgs/AGENTS.md`** — `writeShellApplication` also sets `errexit`, and what that does to a capture. The `runtimeInputs` trap already documented there has a sibling: a script that is fine as `bash pkgs/thing.sh` can die at the first command substitution once packaged, and a script whose whole job is being handed failures is one where every path is that path. Exercise the packaged binary, not the source file.
- **`tests/AGENTS.md`** — a fixture that quotes an error is a fixture that goes stale. nixpkgs reworded the buildEnv collision and Nix reworded the untracked-file error; a captured trace keeps passing through both, because the fixture and the matcher agree with each other while neither describes the machine in front of the user. Plus the three mechanics that let a check produce real errors instead: nested `nix` eval works in a sandbox, a failing derivation cannot be a dependency so build-time errors are produced by running the builder, and `NIXPKGS_ALLOW_UNFREE` is read through `builtins.getEnv` so a nixarchy desktop makes the unfree fixtures pass by hand and the sandbox does not.

Closes #629
