### PR TITLE
Four finished epics leave the Roadmap, and a milestone stops outliving its work

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -648,6 +648,60 @@ jobs:
           done
           echo "the roadmap names every open epic and no closed one"
 
+      # The same argument as the roadmap check above, one level out. Milestones
+      # answer "how far has each feature got", and a milestone whose issues are
+      # all closed answers it wrongly: it says in progress about something that
+      # shipped. Nobody had ever closed one -- six features were complete and
+      # still open when this was written -- because nothing asked.
+      #
+      # Discipline is what this replaces. AGENTS.md §4: any list naming things
+      # that exist elsewhere wants a comparison, not a habit, and the comparison
+      # has to NAME the item rather than print a count, because a count only
+      # says a number moved.
+      #
+      # Same trigger as the roadmap check and for the same reason: it reads the
+      # live issue list, which a pull request from a fork cannot be trusted to
+      # do, and closing happens after the merge anyway.
+      - name: A milestone whose work is done is closed
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          # The same argument as the roadmap check above, one level out.
+          # Milestones answer "how far has each feature got", and a milestone
+          # whose issues are all closed answers it wrongly: it says in progress
+          # about something that shipped. Nobody had ever closed one -- six
+          # features were complete and still open when this was written --
+          # because nothing ever asked.
+          #
+          # AGENTS.md §4: any list naming things that exist elsewhere wants a
+          # comparison, not a habit, and the comparison must NAME the item,
+          # because a count only says a number moved.
+          #
+          # "Keeping the lights on" is exempt BY DESIGN, not by oversight: §12
+          # says it is where CI, docs and small fixes go, that it has no end,
+          # and that this "is not a failure to plan". It sits at zero open
+          # issues every time the queue is briefly clear.
+          #
+          # jq does the selecting and the exemption, so the shell never splits
+          # a title on spaces -- every milestone title here contains them.
+          mapfile -t stale < <(
+            gh api "repos/$GH_REPO/milestones?state=open&per_page=100" --jq '
+              .[]
+              | select(.open_issues == 0 and .closed_issues > 0)
+              | select(.title != "Keeping the lights on")
+              | .title'
+          )
+
+          if [ "${#stale[@]}" -gt 0 ]; then
+            for title in "${stale[@]}"; do
+              echo "::error::milestone \"$title\" has no open issues left and is still open -- close it, or the milestone list stops meaning what is in flight"
+            done
+            exit 1
+          fi
+          echo "every milestone with work left is open, and none outlives its work"
+
       # Every number in the README that is derived from this repository --
       # command counts, app counts, the size of the pacman surface -- checked
       # by one script instead of six hand-written assertions. They went stale

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -548,19 +548,14 @@ It fails **both** ways: an open epic with no row, and a row whose epic has
 since closed.
 
 **Where it fails changed, and this paragraph used to say otherwise.** The step
-now carries `if: github.event_name != 'pull_request'`, so it runs on pushes to
-`main` and weekly — never on a pull request. The sentence here said it failed
-"on every subsequent PR", which sent at least one reader looking through PR
-runs for a failure that was only ever in main's push build. Look at the push
-run for the merge, or the weekly one.
+carries `if: github.event_name != 'pull_request'`, so it runs on pushes to
+`main` and weekly — never on a pull request. The sentence here used to say it
+failed "on every subsequent PR", which sends a reader through PR runs looking
+for a failure that only ever appears in main's push build.
 
-That gating is also what makes an epic retirable at all. There is no state
-where both halves are true at once — closing the epic leaves the row lying,
-removing the row leaves the epic unlisted — so the only safe order is: get the
-row-removal PR green (the guard never runs on it), close the epic (no push, so
-nothing evaluates), then merge immediately (one push, landing in the good
-state). Anything merging to `main` in that window fails, so do not do it while
-other pull requests are landing.
+It reads the **live issue list**, not the diff, so a red clears on a re-run once
+the state is consistent — no new commit needed. `docs/internals/workflows.md`
+has the filing and retirement orders and why each one avoids the red.
 
 The same shape now guards milestones: "A milestone whose work is done is
 closed" names any milestone with no open issues left. `Keeping the lights on`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -542,10 +542,30 @@ by a stranger, because it may have been.
 
 First establish that it *is* unrelated: is `main` red too? One standing trap —
 opening an issue with the `epic` label without adding a row to README's
-Roadmap table fails CI **on every subsequent PR**, related or not (four times
-in one day: #105, #148, #159, #174; the guard is the "roadmap still matches
-the open epics" step in `build.yml`, and it fails the other way when an epic
-closes and the row remains).
+Roadmap table breaks the roadmap guard, the "roadmap still matches the open
+epics" step in `build.yml` (four times in one day: #105, #148, #159, #174).
+It fails **both** ways: an open epic with no row, and a row whose epic has
+since closed.
+
+**Where it fails changed, and this paragraph used to say otherwise.** The step
+now carries `if: github.event_name != 'pull_request'`, so it runs on pushes to
+`main` and weekly — never on a pull request. The sentence here said it failed
+"on every subsequent PR", which sent at least one reader looking through PR
+runs for a failure that was only ever in main's push build. Look at the push
+run for the merge, or the weekly one.
+
+That gating is also what makes an epic retirable at all. There is no state
+where both halves are true at once — closing the epic leaves the row lying,
+removing the row leaves the epic unlisted — so the only safe order is: get the
+row-removal PR green (the guard never runs on it), close the epic (no push, so
+nothing evaluates), then merge immediately (one push, landing in the good
+state). Anything merging to `main` in that window fails, so do not do it while
+other pull requests are landing.
+
+The same shape now guards milestones: "A milestone whose work is done is
+closed" names any milestone with no open issues left. `Keeping the lights on`
+is exempt by design (§12) — it sits at zero open issues whenever the queue is
+briefly clear.
 
 If the failure is unrelated: do not "fix" it inside your PR — that is scope
 the reviewer did not ask for and a second thing to review. Say in the PR what

--- a/README.md
+++ b/README.md
@@ -1932,9 +1932,7 @@ somebody who only uses nixarchy, and that is the gap those posts fill.
 | epic | what it is for | |
 | --- | --- | --- |
 
-*Nothing in flight at the moment.* The last four epics landed together and are
-written up below; the next one is picked in
-[Discussions](https://github.com/olafkfreund/nixarchy/discussions).
+| [#640](https://github.com/olafkfreund/nixarchy/issues/640) | **What upstream adds must be classified, not absorbed** — the ledger says whether a vendored script changed, not what it does; upstream's 40-file `/etc` overlay is carried and inert; its own SKILL.md is replaced with no comparison. Three manifests that fail until a human classifies what arrived | 3 filed |
 
 **Recently finished:**
 [the skills that cover what nixarchy actually does](https://github.com/olafkfreund/nixarchy/issues/606)

--- a/README.md
+++ b/README.md
@@ -1931,12 +1931,67 @@ somebody who only uses nixarchy, and that is the gap those posts fill.
 
 | epic | what it is for | |
 | --- | --- | --- |
-| [#606](https://github.com/olafkfreund/nixarchy/issues/606) | **The skills that cover what nixarchy actually does** — an agent asked why a downloaded binary will not run has nothing to reach for today. Three skills: the loader ladder, gaming, and one flake across several machines | 3 filed |
-| [#611](https://github.com/olafkfreund/nixarchy/issues/611) | **Secrets you can actually use** — adding one is five manual steps today and neither `sops` nor `ssh-to-age` is on PATH. A menu row and an editor instead; a machine that can say what secrets exist and what uses them; a personal key you can copy without a terminal | 4 filed |
-| [#620](https://github.com/olafkfreund/nixarchy/issues/620) | **AI and GPU work that does not compile for two hours** — `cache.nixos.org` does not cache CUDA, so a GPU machine builds PyTorch from source. Plus agents grounded in real option names instead of guessed ones, and models that do not silently fill the root disk | 6 filed |
-| [#621](https://github.com/olafkfreund/nixarchy/issues/621) | **Making Nix answerable** — 4% of Nix users say they understand every error message. The three cliffs a distribution can fix rather than document: which package has this binary, what this error means, and what options exist | 3 filed |
+
+*Nothing in flight at the moment.* The last four epics landed together and are
+written up below; the next one is picked in
+[Discussions](https://github.com/olafkfreund/nixarchy/discussions).
 
 **Recently finished:**
+[the skills that cover what nixarchy actually does](https://github.com/olafkfreund/nixarchy/issues/606)
+— an agent asked why a downloaded binary will not run had nothing to reach for,
+and answered from whatever it had absorbed about Arch. Three skills close that:
+the loader ladder, gaming, and one flake across several machines. The most
+valuable line in any of them is a correction — **`nix-ld` does not help a
+nixpkgs Python.** Only an unpatched interpreter reads `NIX_LD`, which is why a
+`uv`-managed CPython works and the system `python3` does not, and guidance
+elsewhere including the wiki says the opposite. That single fact is the most
+common "I did exactly what the docs said and it still failed" report there is.
+Sixteen skills ship now, and the count is derived from the shipped files rather
+than written down, because the three lists that name them had already drifted
+apart once. Three children closed.
+Also
+[secrets you can actually use](https://github.com/olafkfreund/nixarchy/issues/611)
+— adding one was five manual steps ending in a hand-written `.sops.yaml`, and
+neither `sops` nor `ssh-to-age` was on `PATH` at all. It is a menu row and an
+editor now, the machine can say what secrets exist and what references them, and
+a personal key can be copied without a terminal. sops-nix rather than agenix,
+for the reason the design record already gave: agenix delivers raw files with no
+templating, so composing one into a config would need a hand-rolled
+`ExecStartPre` shim per service. The mechanism was always there — exactly one
+service used it. What changed is that a person can now reach it. Four children
+closed.
+Also
+[AI and GPU work that does not compile for two hours](https://github.com/olafkfreund/nixarchy/issues/620)
+— `cache.nixos.org` deliberately does not cache CUDA, because the NixOS
+Foundation does not redistribute NVIDIA binaries. So every machine with CUDA
+enabled built PyTorch from source, and `magma-cuda-static` alone is a ~10 GB
+closure. The community cache that fixes it **moved off Cachix to
+`cache.nixos-cuda.org` in November 2025**, so every guide still naming
+`cuda-maintainers.cachix.org` points somewhere stale. It is configured here now,
+gated on the declared NVIDIA path. The trap documented beside it is the one a
+blog post will hand you: narrowing `cudaCapabilities` cuts closure size and
+takes you **off** the cache, making a cached machine strictly slower. Also
+models that no longer silently fill `/`, a chat UI over the Ollama already
+running, ML and Jupyter devshells — `jupyenv` is unmaintained and is what people
+find first — and agents grounded in real option names instead of guessed ones.
+Six children closed.
+Also
+[making Nix answerable](https://github.com/olafkfreund/nixarchy/issues/621)
+— **4.0%** of respondents to the 2025 Nix community survey say they understand
+every error message, and 62.5% are tutorial-dependent, including 57% of people
+who call themselves *intermediate*. That is a discoverability failure rather
+than a reading failure, which is why more prose does not fix it and a
+distribution has leverage a manual does not: it can answer at the instant the
+question is asked. Three answers, for the three cliffs. `command-not-found` now
+answers instead of dead-ending, with `comma` for a one-shot run — the doctor
+used to *name* `nix-locate` without installing it, which is the worst of both.
+An explainer covers the dozen failures a desktop user actually meets, including
+the unstaged-file-in-a-flake trap that reports as `path does not exist` and has
+cost contributors here three debugging sessions in one day. And `nixd` is
+configured for the user's editor rather than only the contributor shell, because
+knowing where the flake is is exactly what a distribution knows and a user does
+not. Three children closed.
+Also
 [the package picker, remade](https://github.com/olafkfreund/nixarchy/issues/491)
 — a miss opens the picker instead of printing a URL, rows say what they cost
 (licence, homepage, unfree, broken, and whether you already have it), a dry run

--- a/docs/internals/workflows.md
+++ b/docs/internals/workflows.md
@@ -379,3 +379,42 @@ merged first is not always possible — if another pull request is already armed
 with auto-merge it will land ahead of yours — in which case the red is
 expected, harmless, and clears on a re-run once the row exists. No new commit
 is needed, because the check reads live state.
+
+### Retiring a finished epic: close the issue *before* the row leaves
+
+The mirror of the above, and the direction that comes up once an epic's
+children have all shipped. The guard fails both ways, so there is no state
+where a half-done retirement passes:
+
+| epic | Roadmap row | guard |
+|---|---|---|
+| open | present | pass |
+| open | absent | fails — "open and not in the README's Roadmap" |
+| closed | present | fails — "closed but the Roadmap still lists it as planned" |
+| closed | absent | pass |
+
+Every single-step transition crosses a failing state. The order that avoids
+the red:
+
+1. open the pull request that moves the row into *Recently finished* prose
+2. **close the epic** — closing an issue pushes nothing, so nothing evaluates
+3. merge
+
+The row must not leave `main` while the epic is open, so do not merge before
+closing. And as above, a red here is recoverable: the check reads live state,
+so once the epic is closed and the row is gone, a re-run is green without a new
+commit.
+
+The prose under *Recently finished* is invisible to the guard — it matches only
+table rows (`^| [#`). That is deliberate, and the comment in `build.yml` records
+why: reading every link in the section flagged the finished one as a lie the
+first time it ran.
+
+### A milestone whose work is done is closed
+
+The same argument one level out. Milestones answer "how far has each feature
+got", and a milestone whose issues are all closed answers it wrongly. Nobody
+had ever closed one — six features were complete and still open, some for
+weeks — because nothing asked. The check names each one rather than counting
+them, and exempts `Keeping the lights on`, which sits at zero open issues
+whenever the queue is briefly clear and has no end by design (`AGENTS.md` §12).


### PR DESCRIPTION
> [!IMPORTANT]
> **Do not merge until every team PR has landed and the four epics are closed.**
> The order is not stylistic — see below. Between closing the epics and merging
> this, any *other* push to `main` fails the roadmap guard.

## What this changes, and why

The Roadmap listed #606, #611, #620 and #621 as planned after all sixteen of
their children had shipped. They move to *Recently finished*, written in the
register the entries above them already use — the interesting finding rather
than a restatement of the issue.

It also adds a check, because closing ten milestones by hand fixes today and
drifts again next month.

## The part that matters: there is no safe intermediate state

The guard at `build.yml:605-649` checks **both** directions:

| epics | rows | guard |
|---|---|---|
| open | present | pass ← before |
| open | absent | **fail** — "epic #N is open and not in the README's Roadmap" |
| closed | present | **fail** — "epic #N is closed but the Roadmap still lists it as planned" |
| closed | absent | pass ← after |

Every single-step transition passes through a failure. What makes it survivable
is `if: github.event_name != 'pull_request'` — the guard only ever speaks on a
push to `main`. So: get this PR green (the guard never runs on it), **close the
four epics** (closing an issue triggers no push, so nothing evaluates), **then
merge** (one push, landing directly in the good state).

Doing it the other way round fails the merge push itself.

## How I proved the check fails

The new milestone check was **already red** against the live API, so it needed
no manufactured failure:

```
::error::milestone "Reinstall image" has no open issues left and is still open -- close it, or the milestone list stops meaning what is in flight
::error::milestone "Preview changes" has no open issues left and is still open -- ...
::error::milestone "The package picker" has no open issues left and is still open -- ...
::error::milestone "Try without installing" has no open issues left and is still open -- ...
::error::milestone "Choose a channel" has no open issues left and is still open -- ...
::error::milestone "Escape hatches" has no open issues left and is still open -- ...
EXIT=1
```

Six features complete and still open, some since August, because nothing ever
asked. After closing them:

```
every milestone with work left is open, and none outlives its work
EXIT=0
```

**The exemption is load-bearing, not decorative.** `Keeping the lights on` is
`open=0 closed=20` right now — without the `jq` exclusion the check would have
been wrong on its very first run. §12 says that milestone "has no end and is
not a failure to plan".

It names each milestone rather than printing a count, per §4: *a count only says
a number moved*.

## Checks run locally

- `actionlint .github/workflows/build.yml` — no findings in the new block; the
  four remaining are pre-existing `info`-level and on a green `main`
- The milestone check, red then green, above
- Roadmap table parses to **0** rows; each epic now appears only as a prose link
- `AGENTS.md` still has **12** sections — inserting one renumbers the rest and
  silently breaks references from `build.yml`, `omarchy.yml`,
  `tests/bus-mcp.nix` and the PR template

One honest note on `readme-counts.sh`: I first ran it against another branch's
built tree and got six convincing-looking failures that were purely an artefact
of mixing a `result` from a different branch with this branch's README. The
script has no roadmap, epic or "N filed" assertions, and this PR touches no
skills, apps or commands, so it is unaffected by construction. CI is the real
answer.

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (none)
- [x] If this adds an option: n/a
- [x] If this adds a `checks.*` entry: none — this is a workflow step, not a check

## A workflow edit, flagged rather than slipped in

This touches `.github/workflows/build.yml`, and §11 says CI-gate changes need a
human. I believe this one is in the spirit of the rule rather than against it —
it adds a new report step alongside the existing roadmap guard, with the same
trigger and the same rationale, and changes no trigger, required check, coverage
guard or timeout. Flagging it explicitly so that is your call and not mine.

## What this cost, and where it is written down

`AGENTS.md` §10 said the roadmap guard "fails CI **on every subsequent PR**".
That stopped being true when the step was gated to non-PR events, and the
sentence sends a reader through PR runs looking for a failure that only ever
appears in `main`'s push build. §10 now says where it actually fails, and
records the retirement ordering above — which is the non-obvious part and was
not written down anywhere.

Refs #606, Refs #611, Refs #620, Refs #621
