### PR TITLE
nixarchy secret puts the five manual steps behind one command, and the machine can say what it has

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,15 @@ Two other ways a check stops checking, both found in one week:
   where `$out` is `./result` returns nothing, silently. Use `find -L`.
   `readme-counts.sh` counted zero skills this way, and only failed loudly
   because it refuses on an implausible count.
+- **`builtins.tryEval` does not catch a missing attribute.** It catches
+  `throw` and `assert`, and nothing else — so `tryEval (v.${n})` around an
+  attribute access reads as a guard and is not one. A walk over
+  `config.programs.nixarchy` aborted with `attribute 'allowUnfreePredicate'
+  missing`, thrown from an *option default*
+  (`{ inherit (pkgs.config) allowUnfree allowUnfreePredicate; }`), with every
+  access already wrapped. If you are walking evaluated configuration, bound
+  the root to a subtree you know rather than trusting `tryEval` to make an
+  unbounded walk safe.
 
 ## 6. How to run the checks, and what each one costs
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -56,6 +56,7 @@ nav:
   - { path: /manual/gaming,                   title: Gaming }
   - { path: /manual/android,                  title: Android }
   - { path: /manual/security,                 title: Security }
+  - { path: /manual/secrets,                  title: Secrets }
   - { path: /manual/remote-desktop,           title: Remote Desktop }
   - { path: /manual/system-snapshots,         title: System Snapshots }
   - { path: /manual/many-machines,            title: Many Machines }

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -120,6 +120,7 @@ Key facts an assistant should know before answering questions about nixarchy:
 - [Gaming](https://olafkfreund.github.io/nixarchy/manual/gaming): Steam, RetroArch, the launchers and cloud gaming — how each Install ▸ Gaming row lands on NixOS
 - [Android](https://olafkfreund.github.io/nixarchy/manual/android): running Android apps — scrcpy mirroring a phone, and Waydroid in a container
 - [Security](https://olafkfreund.github.io/nixarchy/manual/security): the firewall, disk encryption, and what the port changes
+- [Secrets](https://olafkfreund.github.io/nixarchy/manual/secrets): `nixarchy secret` over sops-nix — system secrets root-only for services, user secrets to the clipboard, and what reads each one
 - [Remote Desktop](https://olafkfreund.github.io/nixarchy/manual/remote-desktop): serving the running Hyprland session over RDP (opt-in)
 - [System Snapshots](https://olafkfreund.github.io/nixarchy/manual/system-snapshots): generations replace snapper for the system; snapper covers /home on installer-built machines
 - [Many machines, one repo](https://olafkfreund.github.io/nixarchy/manual/many-machines): one flake for a fleet, and machines that pull their configuration on a timer

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -89,6 +89,7 @@ the documentation as much as the code.
 | Faq | same as Omarchy — [read there](https://omarchy.org/manual/faq/) |
 | **System snapshots** | **differs on NixOS** — [read here](system-snapshots) |
 | **Security** | **differs on NixOS** — [read here](security) |
+| **Secrets** | **nixarchy only** — [read here](secrets) |
 | **Remote desktop** | **nixarchy only** — [read here](remote-desktop) |
 | Omarchy on | same as Omarchy — [read there](https://omarchy.org/manual/omarchy-on/) |
 | **Dual boot install** | **differs on NixOS** — [read here](dual-boot-install) |

--- a/docs/manual/remote-desktop.md
+++ b/docs/manual/remote-desktop.md
@@ -69,55 +69,33 @@ you, under `/run` — never in the store and never in git.
 
 ### Getting the password there
 
-You need `services.openssh.enable = true` first, and one rebuild after it. The
-secret is encrypted to the machine's own SSH host key, and that key is
-generated on first boot — so on a machine installed from the ISO this is
-always the second rebuild, not the first. Without sshd there is no key at all
-and sops-nix says so rather than guessing.
-
-**1. Read this host's public key as an age recipient.**
+One command does all of it:
 
 ```sh
-nix-shell -p ssh-to-age --run 'ssh-keyscan localhost 2>/dev/null | ssh-to-age'
+nixarchy secret new hypr-rdp-password
 ```
 
-**2. Name it in `.sops.yaml` at the root of your flake repository.** Create the
-file if it is not there:
-
-```yaml
-keys:
-  - &desk age1qz...           # the key from step 1
-creation_rules:
-  - path_regex: hosts/desk/secrets\.yaml$
-    key_groups:
-      - age:
-          - *desk
-```
-
-Add your own age key as a second recipient here if you have one. Encrypted to
-the host alone, the file can only ever be decrypted on that host, as root —
-which is fine until you want to change the password from your laptop.
-
-**3. Write the password in.**
-
-```sh
-nix-shell -p sops --run 'sops edit hosts/desk/secrets.yaml'
-```
-
-The file's content is plain YAML before sops encrypts it, and the key is the
-name you are about to declare:
+That derives this host's age recipient, writes `.sops.yaml` at the root of your
+flake if there is not one, and opens `hosts/<host>/secrets.yaml` in your
+editor. The file is plain YAML while you edit it and encrypted when you save:
 
 ```yaml
 hypr-rdp-password: something-long
 ```
 
-Avoid a double quote, a backslash or a newline in it. The value is written
-into a TOML string, and one that breaks the quoting makes hypr-rdp fail to
-parse its config — a safe failure, since it exits rather than starting, but a
-confusing way to find out.
+Avoid a double quote, a backslash or a newline in the value. It is written into
+a TOML string, and one that breaks the quoting makes hypr-rdp fail to parse its
+config -- a safe failure, since it exits rather than starting, but a confusing
+way to find out.
 
-**4. Declare the secret and point the service at it,** in
-`hosts/desk/configuration.nix`:
+You need sshd enabled first, and one rebuild after it. The secret is encrypted
+to the machine's own SSH host key, and that key is generated on first boot --
+so on a machine installed from the ISO this is always the second rebuild, not
+the first. Without sshd there is no key at all, and `nixarchy secret` says so
+rather than letting you meet it as a build error.
+
+Then **declare the secret and point the service at it**, in
+`hosts/<host>/configuration.nix`:
 
 ```nix
 sops.secrets.hypr-rdp-password.sopsFile = ./secrets.yaml;
@@ -128,23 +106,27 @@ programs.nixarchy.services.hypr-rdp = {
 };
 ```
 
-`passwordSecret` is the attribute name under `sops.secrets` — not the password
+`passwordSecret` is the attribute name under `sops.secrets` -- not the password
 and not a path to it.
 
 Put this in `configuration.nix` rather than in `~/.config/nixarchy/services.nix`.
-The menu's file is copied into `hosts/<host>/nixarchy/` by `nixarchy-apply`, so
+The menu's file is copied into `hosts/<host>/nixarchy/` by `nixarchy apply`, so
 a relative `./secrets.yaml` written there would resolve one directory too deep.
 Enabling from the menu is fine; the secret's two lines belong beside the file
 they name.
 
-**5. `git add` the encrypted file, then rebuild.** A flake in a git worktree
+Finally `git add` the encrypted file and rebuild. A flake in a git worktree
 sees only tracked files, so an unstaged `secrets.yaml` does not exist as far as
 evaluation is concerned, and the error says the path is missing rather than
 that it is untracked.
 
-Changing the password later means editing the encrypted file, rebuilding, and
-then `systemctl --user restart hypr-rdp`. sops-nix restarts system units and
-this is a user unit, so nothing restarts it for you.
+Changing the password later means `nixarchy secret edit`, a rebuild, and then
+`systemctl --user restart hypr-rdp`. sops-nix restarts system units and this is
+a user unit, so nothing restarts it for you.
+
+[The Secrets page](secrets) covers the rest of the command -- what exists on
+this machine, what reads it, and the second kind of secret, which goes to your
+clipboard rather than to a service.
 
 ## Reaching it: three shapes
 

--- a/docs/manual/secrets.md
+++ b/docs/manual/secrets.md
@@ -1,0 +1,221 @@
+---
+title: Secrets
+---
+
+# Secrets
+
+A password, an API key, a token, a certificate. Something the machine needs and
+nobody else should have.
+
+The rule everything here follows from is that **`/nix/store` is world-readable,
+and every build input ends up in it**. Writing the value into your
+configuration puts it in a store path any user on the machine can read, in the
+closure, in every binary cache the machine pushes to, and — if the flake is a
+git repository — in the history forever. Deleting the line afterwards undoes
+none of that.
+
+So the value is kept encrypted, in the repository, and decrypted on the machine
+at the moment something needs it. nixarchy uses
+[sops-nix](https://github.com/Mic92/sops-nix) for that, and
+`nixarchy secret` is the command in front of it.
+
+```sh
+nixarchy secret new <name>      # create one, and open your editor
+nixarchy secret list            # what exists, and what reads each one
+nixarchy secret copy            # put one on the clipboard
+nixarchy secret where <name>    # what names this one
+nixarchy secret edit            # change them
+nixarchy secret remove <name>
+```
+
+Everything below is also in the menu, under **Setup ▸ Secrets**.
+
+## Two kinds, and why they are not one
+
+This is the whole design, and it is worth thirty seconds before you use it.
+
+| | **system** | **user** (`--user`) |
+|---|---|---|
+| decrypted by | root, at activation | you, when you ask |
+| lands in | `/run/secrets/<name>`, mode `0400` | the clipboard, and nowhere else |
+| encrypted to | this machine's SSH host key | an age identity of your own |
+| for | a **service** to read | a **person** to paste |
+| lives in | `hosts/<host>/secrets.yaml`, in your flake | `~/.local/share/nixarchy/secrets/` |
+
+A system secret is `root:root 0400` on purpose. That is exactly right for a
+daemon and useless for a person, and the tempting fix — making them readable by
+your own user instead — would mean every process running as you can read every
+secret on the machine. A browser. A dependency in a dev shell. An agent. So
+there are two kinds: one the machine can use without you, and one you can use
+without the machine.
+
+`nixarchy secret copy` reads both. Copying a system secret asks for sudo, and
+the picker says which kind each row is.
+
+## A system secret, start to finish
+
+### You need sshd first, and one reboot after it
+
+A system secret is encrypted to `/etc/ssh/ssh_host_ed25519_key`, and NixOS
+generates that key only when sshd is enabled — and only on the **first boot
+after** that. On a machine installed from the ISO this is always the second
+rebuild, never the first.
+
+```nix
+# hosts/<host>/configuration.nix
+services.openssh.enable = true;
+```
+
+Rebuild, then carry on. Without it, `nixarchy secret` says so plainly, and
+declaring a secret anyway fails the rebuild at evaluation time — loudly, before
+anything starts.
+
+If you would rather not run sshd, `nixarchy secret new --user <name>` needs
+none of it. The trade is that a user secret cannot be handed to a system
+service.
+
+### Make it
+
+```sh
+nixarchy secret new hypr-rdp-password
+```
+
+That derives this host's age recipient, writes `.sops.yaml` at the root of your
+flake if there is not one, and opens `hosts/<host>/secrets.yaml` in your
+editor. The file is plain YAML while you are editing it and encrypted the
+moment you save:
+
+```yaml
+hypr-rdp-password: something-long
+```
+
+### Declare it — this part is yours
+
+The command prints the line and does not write it, because **where** it goes
+matters:
+
+```nix
+# hosts/<host>/configuration.nix
+sops.secrets.hypr-rdp-password.sopsFile = ./secrets.yaml;
+```
+
+Not in `~/.config/nixarchy/*.nix`. `nixarchy apply` copies those into
+`hosts/<host>/nixarchy/`, so a relative `./secrets.yaml` written there resolves
+one directory too deep, and the error you get names a missing path rather than
+the reason.
+
+### Stage it, and rebuild
+
+```sh
+sudo git -C /etc/nixos add hosts/<host>/secrets.yaml
+nixarchy apply
+```
+
+A flake in a git worktree sees only tracked files. An unstaged `secrets.yaml`
+does not exist as far as evaluation is concerned — the error says the path is
+missing, not that it is untracked.
+
+### Point something at it
+
+A nixarchy service that takes a secret takes the **name**, not the value and
+not a path:
+
+```nix
+programs.nixarchy.services.hypr-rdp = {
+  enable = true;
+  passwordSecret = "hypr-rdp-password";
+};
+```
+
+Anything else that wants a file gets the path sops-nix decrypts it to:
+
+```nix
+services.something.passwordFile = config.sops.secrets.hypr-rdp-password.path;
+```
+
+## A user secret
+
+```sh
+nixarchy secret new --user openai-key
+nixarchy secret copy openai-key
+```
+
+The first call makes an age identity at
+`~/.local/share/nixarchy/secrets/identity.txt` if you have none, and encrypts a
+store beside it. Nothing about a user secret touches your flake, so nothing
+about it is committed, pushed, or visible to anyone with the repository.
+
+**That identity file is the only thing that can read your user secrets.** It is
+deliberately outside the configuration repository and outside
+`nixarchy home backup`'s allowlist, because both of those get pushed to a git
+remote. Copy it somewhere safe yourself. If you lose it, the store is
+unreadable and there is no recovery.
+
+### The clipboard is not private
+
+`nixarchy secret copy` never writes the value to disk — it goes straight from
+sops into the clipboard through a pipe, and the clipboard clears itself after
+one paste.
+
+Omarchy's own clipboard history does write it down. Every string you copy lands
+in `~/.local/state/omarchy/clipboard-history.json` in plaintext, and a
+clipboard watcher in the shell is not something this command can opt out of.
+The command says so each time. Clear the history when you are done with a
+secret, and treat that file as sensitive — `nixarchy home backup` already
+excludes it for the same reason.
+
+## What do I have, and what reads it?
+
+```sh
+nixarchy secret list
+```
+
+Two answers, kept apart because they can disagree:
+
+- **Declared** comes from evaluating this machine's own configuration, so it
+  cannot drift from what the machine actually does. For each secret it names
+  what reads it — an option that names it, or a config file sops renders it
+  into.
+- **Present** comes from reading the encrypted files. sops encrypts *values*
+  and leaves the *keys* in plaintext, so this works with no identity at all —
+  and it is why a secret's **name** should not itself be sensitive.
+
+A name declared and not present fails activation. A name present and not
+declared is dead weight nothing reads. Neither is visible from one list alone,
+so `list` calls out the difference.
+
+`nixarchy secret where <name>` does the same for one secret, and adds a
+straight text search of your configuration — that second answer catches a
+reference you wrote yourself, which the derived one cannot see.
+
+## One machine
+
+`nixarchy secret` is deliberately about **this machine**. A system secret is
+encrypted to this host's key and can be decrypted on this host and nowhere
+else, which is the right default and an inconvenience the first time you want
+to edit it from your laptop.
+
+Sharing is sops' own job, and its sharpest edge. Add the other recipient to
+`.sops.yaml` and rekey:
+
+```sh
+sops updatekeys hosts/<host>/secrets.yaml
+```
+
+See [sops on adding and removing keys](https://github.com/getsops/sops#adding-and-removing-keys).
+nixarchy does not wrap this, because a half-implemented fleet story is worse
+than none.
+
+## Before you push
+
+`nixarchy config repo` scans for secrets before it commits anything: values
+that look like passwords written straight into `.nix` files, and a
+`secrets.yaml` that sops never encrypted. It asks before committing either.
+
+Once a secret is in git history, deleting it later does not remove it.
+
+## See also
+
+- [Remote Desktop](remote-desktop) — the service this mechanism was built for
+- [Security](security) — the firewall, disk encryption, and what is exposed
+- The `nixos-secrets` agent skill: *"how do I store an API key here?"*

--- a/flake.nix
+++ b/flake.nix
@@ -747,6 +747,11 @@
           # `nixarchy box` execs.
           nixarchy-box = pkgsFor.${system}.callPackage ./pkgs/box.nix { };
 
+          # Same reason again: tests/menu-verbs.nix reads the verbs out of the
+          # command the Secrets menu rows exec, and it can only do that if the
+          # command is a package it can build.
+          nixarchy-secret = pkgsFor.${system}.callPackage ./pkgs/secret.nix { };
+
           verify = pkgsFor.${system}.nixarchy-verify;
 
           # `nix run .#review` -- what needs updating, and what is quietly

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -325,6 +325,53 @@ let
           description = "Every package, NixOS option and Omarchy app, in one picker";
         };
 
+        # The Secrets group (#611). A new parent with no action of its own,
+        # which is legitimate for a submenu -- Menu.qml renders the children.
+        # Every row here is a new id upstream does not ship, so every one of
+        # them carries its own `label` and `icon`: the generator fails on a
+        # row it cannot name, and a row that omits `label` renders the raw id
+        # rather than inheriting one.
+        #
+        # `secret new` and not `secret add`: tests/menu-verbs.nix checks each
+        # of these actions against the verbs nixarchy-secret's own case block
+        # accepts, because the last row written to match a menu KEY rather
+        # than a CLI shipped broken and was found by a tester.
+        "setup.secret" = {
+          icon = "󰌾";
+          label = "Secrets";
+          aliases = [
+            "password"
+            "key"
+            "token"
+            "sops"
+            "credential"
+          ];
+        };
+        "setup.secret.new" = {
+          icon = "󰷖";
+          label = "New secret";
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-secret new";
+          description = "A password or key a service on this machine can read. Encrypted to this machine";
+        };
+        "setup.secret.copy" = {
+          icon = "󰅍";
+          label = "Copy a secret";
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-secret copy";
+          description = "Put one on the clipboard. Never written to disk";
+        };
+        "setup.secret.list" = {
+          icon = "󰈙";
+          label = "What secrets exist";
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-secret list";
+          description = "Everything this machine declares, and what reads each one";
+        };
+        "setup.secret.edit" = {
+          icon = "󰏫";
+          label = "Edit secrets";
+          action = "omarchy-launch-floating-terminal-with-presentation nixarchy-secret edit";
+          description = "Open the encrypted store in your editor";
+        };
+
         # Why: modules/AGENTS.md#backup-and-recovery-one-menu-542
         "system.recovery" = {
           icon = "󰁯";
@@ -2798,6 +2845,13 @@ in
             # a /nix/store path.
             (pkgs.callPackage ../pkgs/box.nix { })
 
+            # `nixarchy secret <subcommand>`. Its own file for the same reason
+            # as the three above: tests/menu-verbs.nix reads the verbs out of
+            # the command the Secrets rows exec. See pkgs/secret.nix for why
+            # the host's age identity never leaves root, and why the
+            # declaration line is printed rather than written.
+            (pkgs.callPackage ../pkgs/secret.nix { })
+
             # Why: modules/AGENTS.md#one-name-for-the-commands-this-repo-adds-and-a-way
             (pkgs.writeShellApplication {
               name = "nixarchy";
@@ -2865,6 +2919,7 @@ in
                   try) shift; exec nixarchy-try "$@" ;;
                   vm) shift; exec nixarchy-vm "$@" ;;
                   box) shift; exec nixarchy-box "$@" ;;
+                  secret) shift; exec nixarchy-secret "$@" ;;
 
                   # The rest of them (#538). Every one of these was shipped,
                   # documented, and unreachable: without a row here the command
@@ -2942,6 +2997,7 @@ in
                   nixarchy rollback           Go back to an earlier system generation
                   nixarchy unfreeze           Let this machine receive updates again
                   nixarchy config repo        Put /etc/nixos in git, with a remote and CI
+                  nixarchy secret <subcommand> Passwords and keys, encrypted -- 'nixarchy secret help'
                   nixarchy home backup        Back up the desktop configuration in your home
                   nixarchy reinstall iso      Build an image that reinstalls this machine
                   nixarchy android            Connect an Android phone over Wi-Fi, for scrcpy

--- a/modules/secrets.md
+++ b/modules/secrets.md
@@ -3,10 +3,31 @@
 This is the contributor-facing note. The copy-pasteable user instructions
 belong in `docs/manual/`, which is not this file.
 
-nixarchy carries a declarative secrets mechanism — sops-nix, imported by
-`modules/nixos.nix` — and it is deliberately the smallest thing that works.
-It exists so the services nixarchy *bundles* can consume a secret. It is not
-a user-facing secrets product and there is no wizard.
+nixarchy carries a declarative secrets mechanism -- sops-nix, imported by
+`modules/nixos.nix` -- and the mechanism itself is deliberately the smallest
+thing that works. It exists so the services nixarchy *bundles* can consume a
+secret.
+
+**This file used to end that paragraph with "it is not a user-facing secrets
+product and there is no wizard". #611 made that false, deliberately, and the
+sentence is replaced rather than left standing.** The reasoning for the change
+is worth as much as the reasoning for the original position:
+
+- The mechanism has now proved itself on a real service. hypr-rdp consumes a
+  secret through `sops.templates` and has done since #154, which is the
+  evidence the original scope cut was waiting for.
+- The cost of using it was five manual steps in
+  `docs/manual/remote-desktop.md`, of which two -- `ssh-keyscan | ssh-to-age`
+  and hand-writing a `.sops.yaml` creation rule -- are ceremony a command can
+  do exactly as well and more reliably. Neither `sops` nor `ssh-to-age` was
+  even on PATH; the manual shelled them in with `nix-shell -p`.
+- Five steps on a desktop is not a scope decision, it is a wall.
+
+What #611 did NOT change: nixarchy still sets no sops option of its own, the
+module is still imported inertly, and the mechanism underneath is exactly the
+one described below. `nixarchy secret` (`pkgs/secret.nix`) is a command in
+front of sops; it is not a second mechanism, and nothing in the module system
+depends on it existing.
 
 ## Why there is one at all
 
@@ -140,3 +161,81 @@ The lock cost is one node: sops-nix declares exactly one input, `nixpkgs`,
 which follows ours. Its `nixConfig` asks for `cache.thalheim.io`, which does
 not apply to us — `nixConfig` is honoured only from the flake you invoke, not
 from its inputs — so taking this input grants no substituter and no trust.
+
+## The two kinds, which is the whole of #611's design
+
+`nixarchy secret` adds a second kind of secret beside the one above, and the
+separation is the design rather than an implementation detail.
+
+**System secrets** are what everything above describes: encrypted to the host's
+SSH host key, decrypted by sops-nix into `/run/secrets` as `root:root 0400`,
+declared in `hosts/<host>/configuration.nix`, and read by a *service*.
+
+**User secrets** are new. They have their own age identity, live in
+`~/.local/share/nixarchy/secrets/`, and are decrypted **to the clipboard**.
+
+The reason they are separate rather than one kind made convenient: `0400
+root:root` is correct for a daemon and useless for a person, and the obvious
+fix — `sops.secrets.<n>.owner = "you"` on everything — would mean **every
+process running as you can read every secret on the machine**. A browser. A
+dependency in a dev shell. An agent with a shell tool. The two kinds exist so
+that "a service can use it without me" and "I can use it without the service"
+are different grants.
+
+Three consequences worth writing down, because each is a place a later change
+could quietly undo the design:
+
+- **A user secret can never be handed to a system service.** That is not a
+  gap to close; it is the property.
+- **The user identity is outside the config repo and outside
+  `nixarchy-home-backup`'s allowlist**, because both of those are pushed to a
+  git remote. The command says so when it creates one, and the manual says so
+  again. It also means losing it loses the store, which is the honest trade.
+- **Plaintext reaches the clipboard through a pipe and nothing else.** No temp
+  file, no shell variable, no argument. `tests/options.nix` asserts this
+  against the built script, because it is a security property and a comment is
+  not an assertion.
+
+### The hole this leaves, named rather than papered over
+
+Omarchy's shell records the clipboard in
+`~/.local/state/omarchy/clipboard-history.json`, in plaintext. `nixarchy secret
+copy` cannot opt out of that — the recorder is a Wayland clipboard watcher in
+the shell, and `wl-copy` has no "do not record me" protocol that it honours.
+`--paste-once` limits the clipboard to a single paste and does nothing about
+the history file.
+
+So the command warns every time, and `docs/manual/secrets.md` says it where a
+user will read it. §3's rule applies: a documented hole gets tested by a human,
+an undocumented one gets tested by a user. If Omarchy ever grows a sensitive
+-content hint, honouring it is the fix.
+
+## Discovery is derived, never declared
+
+`nixarchy secret list` and `nixarchy secret where` answer "what exists" and
+"what reads it" by evaluating `nixosConfigurations.<host>.config` and reading
+`config.sops.secrets` out of it. Not from a list, and not from a grep — §4 is
+this repository's own history of hand-maintained lists failing open.
+
+Two things about how that is implemented, both of which cost time to find:
+
+- **The walk is rooted at `programs.nixarchy.services`, not
+  `programs.nixarchy`.** Walking the whole option tree forces
+  `apps.nixpkgsConfig`, whose default is
+  `{ inherit (pkgs.config) allowUnfree allowUnfreePredicate; }`, and that
+  throws `attribute 'allowUnfreePredicate' missing` on a pkgs that sets no
+  predicate. **`builtins.tryEval` does not catch that** — it catches `throw`
+  and `assert`, not a missing attribute — so wrapping the access in `tryEval`
+  is no protection at all. The expression aborted rather than returning
+  anything, which is worth knowing before writing the next such walk.
+- **A template reference is found by the placeholder, not by the name.**
+  `sops.templates.<t>.content` carries `config.sops.placeholder.<name>`, which
+  is a hash of the name and not the name, so a grep for the name finds
+  nothing. Matching uses `builtins.split` rather than `builtins.match`, because
+  a template's content is a whole config file and whether `.` matches a newline
+  is not worth betting on.
+
+What is deliberately **out of scope** is suggesting where a secret *could* go.
+Scanning the options index for things that want a credential and proposing
+wiring is the part most likely to be confidently wrong, and a wrong suggestion
+about a secret is worse than no suggestion.

--- a/pkgs/omarchy/nix-bin/nixarchy-config-repo
+++ b/pkgs/omarchy/nix-bin/nixarchy-config-repo
@@ -370,6 +370,31 @@ secret_scan() {
     | grep -vE 'File[[:space:]]*=|hashedPasswordFile|\.path|placeholder|config\.(age|sops)' \
     | head -20)
 
+  # The path `nixarchy secret` opens (#611). The grep above reads *.nix only,
+  # and a secret store is YAML -- so a hosts/<host>/secrets.yaml that sops
+  # never encrypted (an interrupted `sops edit`, or a file written by hand
+  # before reading the manual) is invisible to it, and this command would
+  # commit and push it. sops writes `ENC[AES256_GCM,...]` around every value
+  # it encrypts, so its absence in a file named for secrets is the signal.
+  local plain=""
+  while IFS= read -r f; do
+    [[ -f $f ]] || continue
+    grep -q 'ENC\[AES256_GCM' "$f" || plain+="    ''${f#"$FLAKE"/}"$'\n'
+  done < <(find "$FLAKE" -name 'secrets.yaml' -o -name 'secrets.yml' 2>/dev/null)
+
+  if [[ -n $plain ]]; then
+    warn "These are named as secret stores and are NOT encrypted:\n"
+    printf '%s' "$plain"
+    say "\n  sops wraps every value it encrypts in \033[1mENC[AES256_GCM...]\033[0m, and"
+    say "  none of these has one. Committing the file puts the value in the"
+    say "  history permanently, where a later edit does not remove it."
+    say "  Encrypt it first: \033[1mnixarchy secret edit\033[0m\n"
+
+    gum confirm --default=false "Commit anyway?" && return 0
+    abort_on_quit $?
+    return 1
+  fi
+
   [[ -z $hits ]] && { ok "nothing obvious found"; return 0; }
 
   warn "Found values that look like secrets written directly into Nix files:\n"

--- a/pkgs/omarchy/skills/nixos-secrets/SKILL.md
+++ b/pkgs/omarchy/skills/nixos-secrets/SKILL.md
@@ -5,7 +5,7 @@ description: >
   other secret has to reach this NixOS machine's configuration. Use when asked to
   store a secret, add an API key, set a service password, encrypt something in the
   config repo, set up sops-nix or agenix, rotate or share a key, give a systemd
-  service a credential, or review a config for leaked secrets. Triggers: secret,
+  service a credential, or review a config for leaked secrets. Triggers: nixarchy secret, secret,
   password, API key, token, credential, agenix, sops, sops-nix, age, .age, SOPS,
   ssh key, private key, .env, environmentFile, hashedPasswordFile, "world-readable
   store", "don't commit the password", encrypt, decrypt, rotate, GPG, ACME key.
@@ -37,9 +37,18 @@ Stop at the first one that fits.
 |---|---|
 | It is a password *hash* for a user account | `users.users.<n>.hashedPasswordFile` |
 | A single machine, secret never needs to be in the repo | A file in `/var/lib/...`, referenced by path |
-| Secrets live in the config repo, one or two machines, SSH-key based | **agenix** |
-| Many machines/users, key rotation, partial-file encryption, non-Nix consumers too | **sops-nix** |
+| **Anything that has to be encrypted, on a nixarchy machine** | **`nixarchy secret`** — see below |
+| Secrets in the config repo, on a machine that is not nixarchy | **sops-nix**, or agenix if that repo already uses it |
 | A secret only one systemd service needs, at runtime | `LoadCredential=` |
+
+**On a nixarchy machine there is no agenix choice to make.** nixarchy ships
+sops-nix, imported by `modules/nixos.nix`, and `modules/secrets.md` records why
+agenix was rejected: agenix delivers files containing raw secrets and has no
+templating, so composing one into a config file would need a hand-rolled
+`ExecStartPre` shim per service — the exact hack the mechanism exists to avoid.
+Reaching for agenix here means installing a second framework to do what the
+first one already does. The agenix section further down is kept for machines
+that are not nixarchy; **do not follow it on this one**.
 
 Do not reach for an encryption framework for a single secret on a single laptop
 that is never committed. A `0400` file in `/var/lib` and a `*File` option is a
@@ -67,7 +76,71 @@ inlining the secret. The honest workarounds are, in order: a systemd
 `LoadCredential` + a wrapper, an `environmentFile` on the generated unit, or
 patching the module. Never "just this once" in a `.nix` file.
 
-## agenix
+## nixarchy secret — the command on this machine
+
+`nixarchy secret` is sops-nix with the ceremony removed. Prefer it to every
+raw `sops` invocation below when the machine is nixarchy.
+
+```bash
+nixarchy secret new <name>      # bootstrap if needed, then $EDITOR, then encrypt
+nixarchy secret new --user <n>  # a secret for the PERSON, not for a service
+nixarchy secret list            # what exists, and what reads each one
+nixarchy secret where <name>    # what names this one
+nixarchy secret copy [<name>]   # to the clipboard, never to disk
+nixarchy secret edit
+nixarchy secret remove <name>
+```
+
+`new` derives the host's age recipient from its SSH host key, writes
+`.sops.yaml` at the flake root if there is none, opens
+`hosts/<host>/secrets.yaml`, and then **prints the declaration for you to
+place**:
+
+```nix
+# hosts/<host>/configuration.nix   -- and nowhere else
+sops.secrets.<name>.sopsFile = ./secrets.yaml;
+```
+
+Three things to get right, each of which is a real failure someone met:
+
+- **The declaration goes in `hosts/<host>/configuration.nix`.** Not in
+  `~/.config/nixarchy/*.nix`: `nixarchy apply` copies those into
+  `hosts/<host>/nixarchy/`, so a relative `./secrets.yaml` written there
+  resolves one directory too deep, and the error names a missing path rather
+  than the cause.
+- **sshd must be enabled, with one rebuild after it.** The host's SSH key is
+  generated on first boot; without `services.openssh.enable` there is no key
+  at all and any declared secret fails evaluation with sops-nix's own "No key
+  source configured for sops". `nixarchy secret` says this before you get
+  there.
+- **`git add` the encrypted file.** A flake in a git worktree sees only tracked
+  files, so an unstaged `secrets.yaml` "does not exist" to evaluation.
+
+### Two kinds, and never conflate them
+
+| | system | `--user` |
+|---|---|---|
+| decrypted by | root, at activation, into `/run/secrets` `0400` | you, on request |
+| goes to | a **service** | the **clipboard**, never disk |
+| encrypted to | the host's SSH key | an age identity in `~/.local/share/nixarchy/secrets/` |
+
+If asked to make system secrets readable by the user, **push back**: it means
+every process running as that user — a browser, a dev-shell dependency, an
+agent — can read every secret on the machine. Use a user secret for the human
+case instead.
+
+Two limits worth stating rather than discovering: the user identity file is
+outside the config repo and outside `nixarchy home backup`, so losing it loses
+the store; and Omarchy records the clipboard in
+`~/.local/state/omarchy/clipboard-history.json` in plaintext, which
+`nixarchy secret copy` warns about and cannot prevent.
+
+User-facing instructions live in `docs/manual/secrets.md`; the design record is
+`modules/secrets.md`.
+
+## agenix — for machines that are not nixarchy
+
+**Not on a nixarchy machine.** See the note under the decision table.
 
 Encrypts each secret to a set of **age or SSH public keys**. Decryption happens at
 activation using the machine's SSH host key — so no passphrase, no unlock step,

--- a/pkgs/secret.nix
+++ b/pkgs/secret.nix
@@ -1,0 +1,723 @@
+# `nixarchy secret <verb>` -- the five manual steps in
+# docs/manual/remote-desktop.md, as one command.
+#
+# Its own file for the same reason as pkgs/dev-init.nix, pkgs/microvm.nix and
+# pkgs/box.nix: tests/menu-verbs.nix has to read the verbs out of the command
+# the menu actually execs, which means the command has to be a package.
+#
+# WHAT THIS IS BUILT ON, AND WHY IT IS NOT agenix. modules/secrets.md has the
+# long version; the short one is that hypr-rdp reads its password only from
+# inside a TOML file, `sops.templates` is the upstreamed shim that puts it
+# there, and agenix has no templating at all. `sops edit` opens $EDITOR
+# exactly as `agenix -e` does, so nothing about the flow the user sees depends
+# on that choice.
+#
+# THREE RULES THIS FILE MUST NOT BREAK:
+#
+# 1. The declaration goes in `hosts/<host>/configuration.nix`, and this
+#    command never writes it. `nixarchy-apply` copies ~/.config/nixarchy/*.nix
+#    into the flake and `git add -A`s them, so a secret declared there is
+#    carried into a directory one level deeper than the `./secrets.yaml` it
+#    names. We print the two lines; the user places them.
+#
+# 2. The host's age identity never leaves root. Deriving it costs a read of
+#    /etc/ssh/ssh_host_ed25519_key, so every sops call that has to DECRYPT a
+#    system secret goes through `hostSops` below -- a root-side wrapper that
+#    does the conversion in its own command substitution. Writing
+#    `sudo env SOPS_AGE_KEY="$(sudo ssh-to-age ...)" sops ...` instead would
+#    put the host's private identity in argv, and /proc/*/cmdline is
+#    world-readable to every process on the machine.
+#
+# 3. A decrypted value goes to the clipboard through a PIPE. It is never
+#    assigned to a variable, written to a file, or passed as an argument.
+{
+  lib,
+  writeShellApplication,
+  writeText,
+  coreutils,
+  gnugrep,
+  gnused,
+  gawk,
+  jq,
+  fzf,
+  sops,
+  ssh-to-age,
+  age,
+  wl-clipboard,
+}:
+let
+  # sops, holding the host's own key. Root-only by construction: the
+  # conversion happens inside this script's own process, so the identity
+  # exists nowhere a non-root process can read it. See rule 2 above.
+  hostSops = writeShellApplication {
+    name = "nixarchy-secret-host-sops";
+    runtimeInputs = [
+      sops
+      ssh-to-age
+      coreutils
+    ];
+    text = ''
+      key=/etc/ssh/ssh_host_ed25519_key
+      if [ ! -r "$key" ]; then
+        echo "nixarchy secret: cannot read $key." >&2
+        echo "  This has to run as root: sops decrypts a system secret with" >&2
+        echo "  the machine's own SSH host key and with nothing else." >&2
+        exit 1
+      fi
+      # Command substitution inside a process that is already root. The value
+      # is exported to the one child and to nothing else.
+      SOPS_AGE_KEY=$(ssh-to-age -private-key -i "$key")
+      export SOPS_AGE_KEY
+      exec sops "$@"
+    '';
+  };
+
+  # What the machine actually declares, and what names it -- read out of the
+  # evaluated configuration rather than out of a list somebody maintains.
+  # §4: a hand-maintained list fails OPEN, and this repository found three
+  # doing exactly that in one day.
+  #
+  # `refs` answers "what uses this secret". hypr-rdp is the shape to match:
+  # `passwordSecret` is a string NAMING a sops.secrets attribute, so a
+  # reference is an option whose name ends in Secret and whose value is the
+  # secret's name. The other shape is a template that renders it, and that one
+  # is found by the placeholder rather than by the name -- sops.templates
+  # carry `config.sops.placeholder.<name>`, which is a hash, not the name.
+  discover = writeText "nixarchy-secret-discover.nix" ''
+    cfg:
+    let
+      tryV = f: let r = builtins.tryEval f; in if r.success then r.value else null;
+
+      secrets = builtins.attrNames (cfg.sops.secrets or { });
+      templates = cfg.sops.templates or { };
+
+      # Bounded on purpose: programs.nixarchy is the surface this repository
+      # owns and the only one whose naming convention we can rely on. A
+      # reference written in the user's OWN configuration is found textually
+      # by the caller instead, and `where` labels the two differently -- a
+      # derived answer and a grep are not the same claim.
+      walk =
+        depth: path: v:
+        if depth > 8 then
+          [ ]
+        else if builtins.isAttrs v then
+          (
+            if v ? outPath || v ? _type then
+              [ ]
+            else
+              builtins.concatMap (
+                n: walk (depth + 1) (if path == "" then n else path + "." + n) (tryV v.''${n})
+              ) (builtins.attrNames v)
+          )
+        else if builtins.isString v then
+          [ { p = path; v = v; } ]
+        else
+          [ ];
+
+      # programs.nixarchy.SERVICES, not programs.nixarchy. Two reasons, and
+      # the second is the one that bites: every *Secret option this repository
+      # has or is likely to grow belongs to a bundled service, and walking the
+      # whole of programs.nixarchy forces `apps.nixpkgsConfig`, whose default
+      # is `{ inherit (pkgs.config) allowUnfree allowUnfreePredicate; }` and
+      # throws `attribute 'allowUnfreePredicate' missing` on a pkgs that has
+      # not set one. `builtins.tryEval` does NOT catch that -- it catches
+      # `throw` and `assert`, not a missing attribute -- so tryV around the
+      # access is no protection at all. Verified live: with the root at
+      # programs.nixarchy this expression aborted rather than returning
+      # anything.
+      named = builtins.filter (e: (builtins.match ".*Secret" e.p) != null) (
+        walk 0 "programs.nixarchy.services" (tryV (cfg.programs.nixarchy.services or { }))
+      );
+
+      refsFor =
+        name:
+        (map (e: "option " + e.p) (builtins.filter (e: e.v == name) named))
+        ++ (
+          let
+            ph = tryV (cfg.sops.placeholder.''${name} or null);
+          in
+          if ph == null || !(builtins.isString ph) then
+            [ ]
+          else
+            map (t: "template " + t) (
+              builtins.filter (
+                t:
+                let
+                  c = tryV (templates.''${t}.content or "");
+                in
+                # builtins.split rather than builtins.match: a template's
+                # content is a whole config file, and whether `.` matches a
+                # newline is not something to bet a discovery tool on.
+                c != null && builtins.isString c && builtins.length (builtins.split ph c) > 1
+              ) (builtins.attrNames templates)
+            )
+        );
+    in
+    builtins.listToAttrs (
+      map (n: {
+        name = n;
+        value = {
+          path = tryV (cfg.sops.secrets.''${n}.path or null);
+          owner = tryV (cfg.sops.secrets.''${n}.owner or null);
+          refs = refsFor n;
+        };
+      }) secrets
+    )
+  '';
+in
+writeShellApplication {
+  name = "nixarchy-secret";
+
+  # §7: writeShellApplication PREPENDS this to PATH rather than replacing it,
+  # so `sudo` still resolves through /run/wrappers/bin -- the only place it
+  # can, since a sudo out of the store is not setuid. `nix` is left to the
+  # machine's own PATH for the same reason nixarchy-config-repo leaves it:
+  # the CLI and the daemon want to be the pair the system installed.
+  runtimeInputs = [
+    coreutils
+    gnugrep
+    gnused
+    gawk
+    jq
+    fzf
+    sops
+    ssh-to-age
+    age
+    wl-clipboard
+  ];
+
+  # jq programs reference their --arg bindings as $n inside single quotes,
+  # which is the documented way to pass a shell value into jq safely and
+  # exactly what SC2016 exists to warn about elsewhere.
+  excludeShellChecks = [ "SC2016" ];
+
+  text = ''
+    FLAKE=''${NIXARCHY_FLAKE:-/etc/nixos}
+    HOST=$(cat /proc/sys/kernel/hostname)
+    HOST_KEY=/etc/ssh/ssh_host_ed25519_key
+    SYS_STORE="$FLAKE/hosts/$HOST/secrets.yaml"
+    POLICY="$FLAKE/.sops.yaml"
+
+    # NOT ~/.config/nixarchy: nixarchy-apply copies that directory into the
+    # flake, and the flake gets committed and pushed. NOT anywhere on
+    # nixarchy-home-backup's allowlist either -- that list is four paths
+    # chosen not to contain secrets, and this would be the fifth.
+    USER_DIR="''${XDG_DATA_HOME:-$HOME/.local/share}/nixarchy/secrets"
+    USER_STORE="$USER_DIR/user.yaml"
+    USER_KEY="$USER_DIR/identity.txt"
+
+    HOST_SOPS=${lib.getExe hostSops}
+    DISCOVER=${discover}
+
+    bold=$(printf '\033[1m')
+    dim=$(printf '\033[2m')
+    red=$(printf '\033[31m')
+    yellow=$(printf '\033[33m')
+    green=$(printf '\033[32m')
+    off=$(printf '\033[0m')
+
+    say()  { printf '%s\n' "$*"; }
+    step() { printf '\n%s%s%s\n' "$bold" "$*" "$off"; }
+    ok()   { printf '  %s+%s %s\n' "$green" "$off" "$*"; }
+    warn() { printf '  %s!%s %s\n' "$yellow" "$off" "$*"; }
+    fail() { printf '  %sx%s %s\n' "$red" "$off" "$*" >&2; }
+
+    usage() {
+    cat <<'USAGE'
+    nixarchy secret -- passwords, keys and tokens this machine can use.
+
+      nixarchy secret new [--user] <name>     create one, and open the editor
+      nixarchy secret edit [--user]           change one
+      nixarchy secret list                    what exists, and what reads it
+      nixarchy secret where <name>            what names this one
+      nixarchy secret copy [<name>]           put one on the clipboard
+      nixarchy secret remove [--user] <name>  take one out of the store
+
+    Two kinds, and the difference between them is the whole design:
+
+      system   decrypted by root into /run/secrets, mode 0400, for a SERVICE
+               to read. Encrypted to this machine's SSH host key.
+      --user   decrypted by you, to the clipboard, never to disk. Encrypted
+               to an age identity of your own.
+
+    Making system secrets readable by you instead would mean every process
+    running as you -- a browser, a dependency in a dev shell -- can read every
+    secret on the machine. That is why there are two kinds and not one.
+
+    THIS MACHINE ONLY. Sharing a secret with a second machine means adding its
+    recipient to .sops.yaml and rekeying, which is sops' own job and its
+    sharpest edge: see `sops updatekeys` and
+    https://github.com/getsops/sops#adding-and-removing-keys
+    USAGE
+    }
+
+    # ---- the ordering constraint, met once rather than discovered ----------
+    #
+    # modules/secrets.md: a machine's SSH host key is generated on FIRST BOOT,
+    # and without services.openssh there is never one at all. sops.age
+    # .sshKeyPaths then evaluates to [] and declaring any secret fails the
+    # rebuild with upstream's own message. That is a good failure -- loud,
+    # early, nothing starts -- and a terrible way to meet it, so this says it
+    # first.
+    require_host_key() {
+      [ -r "$HOST_KEY.pub" ] && return 0
+      fail "This machine has no SSH host key, so nothing can encrypt to it."
+      say  ""
+      say  "  A system secret is encrypted to $HOST_KEY,"
+      say  "  which NixOS generates only when sshd is enabled, and only on the"
+      say  "  first boot after that. Without it, declaring a secret fails the"
+      say  "  rebuild at evaluation time with sops-nix's own message:"
+      say  ""
+      say  "    ''${dim}No key source configured for sops. Either set"
+      say  "    services.openssh.enable or set sops.age.keyFile...''${off}"
+      say  ""
+      say  "  Add this to ''${bold}$FLAKE/hosts/$HOST/configuration.nix''${off},"
+      say  "  rebuild, then run this again:"
+      say  ""
+      say  "    services.openssh.enable = true;"
+      say  ""
+      say  "  Or leave sshd off and use ''${bold}nixarchy secret new --user <name>''${off},"
+      say  "  which encrypts to an identity of your own instead. A user secret"
+      say  "  cannot be handed to a system service, and that is the trade."
+      return 1
+    }
+
+    # .sops.yaml is the user's policy file, and it may already describe other
+    # hosts or name their own key as a second recipient. Written whole when it
+    # is absent; when it exists and does not cover this host, the block is
+    # PRINTED rather than spliced in -- a YAML edit made by pattern-matching
+    # is how a creation rule silently stops matching.
+    ensure_policy() {
+      local recipient
+      recipient=$(ssh-to-age -i "$HOST_KEY.pub")
+
+      if [ ! -e "$POLICY" ]; then
+        step "Writing $POLICY"
+        {
+          printf '%s\n' "# Which recipients can decrypt which file. Written by nixarchy secret."
+          printf '%s\n' "# Add your own age key as a second recipient here if you want to edit"
+          printf '%s\n' "# this host's secrets from another machine, then run"
+          printf '%s\n' "#   sops updatekeys hosts/$HOST/secrets.yaml"
+          printf '%s\n' "keys:"
+          printf '%s\n' "  - &$HOST $recipient"
+          printf '%s\n' "creation_rules:"
+          printf '%s\n' "  - path_regex: hosts/$HOST/secrets\\.yaml\$"
+          printf '%s\n' "    key_groups:"
+          printf '%s\n' "      - age:"
+          printf '%s\n' "          - *$HOST"
+        } | sudo tee "$POLICY" >/dev/null
+        ok "policy written, with this host as the only recipient"
+        return 0
+      fi
+
+      if grep -q "hosts/$HOST/secrets" "$POLICY"; then
+        ok "$POLICY already covers this host"
+        return 0
+      fi
+
+      fail "$POLICY exists and has no rule for hosts/$HOST/secrets.yaml."
+      say  ""
+      say  "  Not edited for you: this file is your policy, and a rule spliced"
+      say  "  in by pattern-matching is one that can silently stop matching."
+      say  "  Add this to it, beside the keys you already have:"
+      say  ""
+      say  "    keys:"
+      say  "      - &$HOST $recipient"
+      say  "    creation_rules:"
+      say  "      - path_regex: hosts/$HOST/secrets\\.yaml\$"
+      say  "        key_groups:"
+      say  "          - age:"
+      say  "              - *$HOST"
+      say  ""
+      return 1
+    }
+
+    # ---- the user half -----------------------------------------------------
+    #
+    # sops decrypts to /run/secrets as root:root 0400, which is right for a
+    # service and useless for a person. So: a separate identity, and a store
+    # the user owns.
+    ensure_user_identity() {
+      mkdir -p "$USER_DIR"
+      chmod 700 "$USER_DIR"
+
+      if [ ! -f "$USER_KEY" ]; then
+        step "Creating your own age identity"
+        age-keygen -o "$USER_KEY" 2>/dev/null
+        chmod 600 "$USER_KEY"
+        ok "$USER_KEY"
+        warn "This file is the ONLY thing that can read your user secrets."
+        say  "    It is deliberately outside the configuration repository and"
+        say  "    outside ''${bold}nixarchy home backup''${off}'s allowlist, because both of"
+        say  "    those are pushed to a git remote. Copy it somewhere safe"
+        say  "    yourself: if you lose it the store is unreadable, and there"
+        say  "    is no recovery."
+      fi
+
+      local recipient
+      recipient=$(age-keygen -y "$USER_KEY")
+      {
+        printf '%s\n' "# Written by nixarchy secret. sops walks up from the file it is"
+        printf '%s\n' "# editing, so this governs user.yaml beside it and nothing else."
+        printf '%s\n' "creation_rules:"
+        printf '%s\n' "  - path_regex: user\\.yaml\$"
+        printf '%s\n' "    key_groups:"
+        printf '%s\n' "      - age:"
+        printf '%s\n' "          - $recipient"
+      } > "$USER_DIR/.sops.yaml"
+    }
+
+    # ---- reading what exists -----------------------------------------------
+    #
+    # sops encrypts VALUES and leaves keys in plaintext, so the names in a
+    # store can be read with no identity at all. That is what makes `list`
+    # work on a machine whose flake will not evaluate, and it is also why
+    # modules/secrets.md says to keep anything sensitive out of a name.
+    names_in_store() {
+      [ -r "$1" ] || return 0
+      grep -oE '^[A-Za-z0-9_][A-Za-z0-9_.-]*:' "$1" 2>/dev/null \
+        | sed 's/:$//' \
+        | grep -vx sops || true
+    }
+
+    # config.sops.secrets, out of the real configuration. Empty output means
+    # "could not evaluate", which the caller reports differently from "none
+    # declared" -- those are very different answers, and reporting the first
+    # as the second is where a discovery tool starts lying.
+    declared_json() {
+      nix eval --json --apply "$(cat "$DISCOVER")" \
+        "$FLAKE#nixosConfigurations.$HOST.config" 2>/dev/null || true
+    }
+
+    # ---- verbs --------------------------------------------------------------
+
+    do_new() {
+      local kind=$1 name=$2
+      if [ "$kind" = user ]; then
+        ensure_user_identity
+        step "Opening your user secret store"
+        say  "  Add a line ''${bold}$name: your-value''${off} and save."
+        SOPS_AGE_KEY_FILE="$USER_KEY" sops edit "$USER_STORE"
+        ok "encrypted to your identity, at $USER_STORE"
+        say ""
+        say "  Read it back with: ''${bold}nixarchy secret copy $name''${off}"
+        return 0
+      fi
+
+      require_host_key || return 1
+      sudo mkdir -p "$FLAKE/hosts/$HOST"
+      ensure_policy || return 1
+
+      step "Opening $SYS_STORE"
+      say  "  Plain YAML until you save; sops encrypts it on the way out. Add:"
+      say  ""
+      say  "    ''${bold}$name: your-value''${off}"
+      say  ""
+      sudo --preserve-env=EDITOR "$HOST_SOPS" edit "$SYS_STORE"
+
+      # The one step this command deliberately does not take for you, and
+      # exactly where it has to go. See rule 1 in this file's header.
+      step "One line left, and it is yours to place"
+      say  "  In ''${bold}$FLAKE/hosts/$HOST/configuration.nix''${off}:"
+      say  ""
+      say  "    sops.secrets.$name.sopsFile = ./secrets.yaml;"
+      say  ""
+      say  "  ''${bold}Not''${off} in ~/.config/nixarchy/*.nix. nixarchy-apply copies those"
+      say  "  into $FLAKE/hosts/$HOST/nixarchy/, so a relative ./secrets.yaml"
+      say  "  written there resolves one directory too deep."
+      say  ""
+      say  "  Then stage the encrypted file and rebuild. A flake in a git"
+      say  "  worktree sees only tracked files, so an unstaged secrets.yaml"
+      say  "  does not exist as far as evaluation is concerned:"
+      say  ""
+      say  "    sudo git -C $FLAKE add hosts/$HOST/secrets.yaml"
+      say  "    nixarchy apply"
+    }
+
+    do_edit() {
+      local kind=$1
+      if [ "$kind" = user ]; then
+        [ -f "$USER_STORE" ] || {
+          fail "no user secrets yet. Make one: nixarchy secret new --user <name>"
+          return 1
+        }
+        ensure_user_identity
+        SOPS_AGE_KEY_FILE="$USER_KEY" sops edit "$USER_STORE"
+        return 0
+      fi
+      require_host_key || return 1
+      [ -f "$SYS_STORE" ] || {
+        fail "no system secrets yet. Make one: nixarchy secret new <name>"
+        return 1
+      }
+      sudo --preserve-env=EDITOR "$HOST_SOPS" edit "$SYS_STORE"
+    }
+
+    do_remove() {
+      local kind=$1 name=$2
+      if [ "$kind" = user ]; then
+        [ -f "$USER_STORE" ] || { fail "no user secrets to remove from"; return 1; }
+        ensure_user_identity
+        if SOPS_AGE_KEY_FILE="$USER_KEY" sops unset "$USER_STORE" "[\"$name\"]" 2>/dev/null; then
+          ok "removed $name"
+          return 0
+        fi
+        fail "could not remove it automatically."
+        say  "  Open the store and delete the line: ''${bold}nixarchy secret edit --user''${off}"
+        return 1
+      fi
+
+      require_host_key || return 1
+      if sudo "$HOST_SOPS" unset "$SYS_STORE" "[\"$name\"]" 2>/dev/null; then
+        ok "removed $name from $SYS_STORE"
+        warn "Anything still declaring sops.secrets.$name fails the next rebuild."
+        return 0
+      fi
+      fail "could not remove it automatically."
+      say  "  Open the store and delete the line: ''${bold}nixarchy secret edit''${off}"
+      return 1
+    }
+
+    # ---- copy: to the clipboard, never to disk ------------------------------
+    #
+    # The plaintext exists only in the pipe between sops and wl-copy. It is
+    # never assigned to a variable (which `set -x`, a crash dump or an
+    # exported environment could expose), never written to a temporary file,
+    # and never passed as an argument.
+    #
+    # THE HOLE, NAMED (§3): Omarchy's shell records what you copy in
+    # ~/.local/state/omarchy/clipboard-history.json, in plaintext. Nothing
+    # here can prevent that -- the recorder is a Wayland clipboard watcher in
+    # the shell, and a wl-copy that opts out of it does not exist.
+    # `--paste-once` narrows the clipboard itself to a single paste; the
+    # history entry is what the warning below is about, and
+    # docs/manual/secrets.md says the same thing where a user will read it.
+    copy_value() {
+      local kind=$1 name=$2
+      if [ "$kind" = user ]; then
+        ensure_user_identity
+        SOPS_AGE_KEY_FILE="$USER_KEY" sops -d --extract "[\"$name\"]" "$USER_STORE" \
+          | wl-copy --paste-once
+      else
+        require_host_key || return 1
+        sudo "$HOST_SOPS" -d --extract "[\"$name\"]" "$SYS_STORE" \
+          | wl-copy --paste-once
+      fi
+      ok "$name is on the clipboard, and clears itself after one paste."
+      warn "Omarchy records the clipboard: this value is now in plaintext in"
+      say  "    ~/.local/state/omarchy/clipboard-history.json until you clear it."
+    }
+
+    # Every row the picker can offer, as "<kind><tab><name>".
+    all_rows() {
+      local n
+      while IFS= read -r n; do
+        [ -n "$n" ] && printf 'system\t%s\n' "$n"
+      done < <(names_in_store "$SYS_STORE")
+      while IFS= read -r n; do
+        [ -n "$n" ] && printf 'user\t%s\n' "$n"
+      done < <(names_in_store "$USER_STORE")
+    }
+
+    do_copy() {
+      local name=''${1:-} kind="" rows selection answer
+
+      if [ -n "$name" ]; then
+        if names_in_store "$USER_STORE" | grep -qx "$name"; then
+          kind=user
+        elif names_in_store "$SYS_STORE" | grep -qx "$name"; then
+          kind=system
+        else
+          fail "no secret called '$name'. Try: nixarchy secret list"
+          return 1
+        fi
+        copy_value "$kind" "$name"
+        return
+      fi
+
+      rows=$(all_rows)
+      [ -n "$rows" ] || {
+        fail "no secrets on this machine yet. Make one: nixarchy secret new <name>"
+        return 1
+      }
+
+      selection=$(printf '%s\n' "$rows" \
+        | awk -F'\t' '{ printf "%-8s %s\n", $1, $2 }' \
+        | fzf --prompt='copy secret > ' \
+              --header='system = decrypted by root, asks for sudo    user = yours' \
+              --height=40% --reverse) || return 0
+      [ -n "$selection" ] || return 0
+
+      kind=$(printf '%s' "$selection" | awk '{print $1}')
+      name=$(printf '%s' "$selection" | awk '{print $2}')
+
+      # #596: a `read` reached from a picker's dispatch reads whatever the
+      # loop is feeding it, not the keyboard, and fails silently at EOF. Every
+      # prompt here names the terminal, and tests/options.nix asserts it for
+      # this command as well as for nixarchy-search.
+      if [ "$kind" = system ]; then
+        answer=""
+        read -r -p "  $name is a system secret and needs sudo. Copy it? [y/N] " answer < /dev/tty
+        case "$answer" in
+          [yY]*) ;;
+          *) say "  nothing copied."; return 0 ;;
+        esac
+      fi
+      copy_value "$kind" "$name"
+    }
+
+    do_list() {
+      local json declared sysnames usernames n refs missing
+
+      json=$(declared_json)
+
+      step "Declared in this machine's configuration"
+      if [ -z "$json" ]; then
+        warn "could not evaluate $FLAKE#nixosConfigurations.$HOST."
+        say  "    Falling back to the names in the encrypted files, which sops"
+        say  "    leaves in plaintext. That says what EXISTS and nothing about"
+        say  "    what the machine does with it."
+      else
+        declared=$(printf '%s' "$json" | jq -r 'keys[]')
+        if [ -z "$declared" ]; then
+          say "  ''${dim}none. sops-nix is imported on every nixarchy machine and does"
+          say "  nothing at all until a secret is declared: no unit, no activation"
+          say "  script, no package. That is the state this machine is in.''${off}"
+        else
+          while IFS= read -r n; do
+            [ -n "$n" ] || continue
+            printf '  %s%s%s  %s%s%s\n' "$bold" "$n" "$off" \
+              "$dim" "$(printf '%s' "$json" | jq -r --arg n "$n" '.[$n].path // ""')" "$off"
+            refs=$(printf '%s' "$json" | jq -r --arg n "$n" '.[$n].refs[]?')
+            if [ -n "$refs" ]; then
+              printf '%s\n' "$refs" | sed 's/^/      read by /'
+            else
+              printf '      %snothing in programs.nixarchy names it%s\n' "$dim" "$off"
+            fi
+          done <<< "$declared"
+        fi
+      fi
+
+      step "Present in the encrypted stores"
+      sysnames=$(names_in_store "$SYS_STORE")
+      usernames=$(names_in_store "$USER_STORE")
+
+      if [ -n "$sysnames" ]; then
+        say "  ''${dim}$SYS_STORE''${off}"
+        printf '%s\n' "$sysnames" | sed 's/^/    system  /'
+      else
+        say "  ''${dim}no system store at $SYS_STORE''${off}"
+      fi
+      if [ -n "$usernames" ]; then
+        say "  ''${dim}$USER_STORE''${off}"
+        printf '%s\n' "$usernames" | sed 's/^/    user    /'
+      else
+        say "  ''${dim}no user store at $USER_STORE''${off}"
+      fi
+
+      # The divergence is the finding. A name declared and not present fails
+      # activation; a name present and not declared is dead weight nothing
+      # reads. Neither is visible from either list on its own.
+      if [ -n "$json" ] && [ -n "$declared" ]; then
+        missing=$(comm -23 \
+          <(printf '%s\n' "$declared" | sort) \
+          <(printf '%s\n' "$sysnames" | sort))
+        if [ -n "$missing" ]; then
+          step "Declared, and not in the store"
+          printf '%s\n' "$missing" | sed 's/^/    /'
+          say  "  ''${dim}sops-nix fails activation for each of these.''${off}"
+        fi
+      fi
+
+      say ""
+      say "  ''${bold}nixarchy secret where <name>''${off}   what names one"
+      say "  ''${bold}nixarchy secret copy''${off}           put one on the clipboard"
+    }
+
+    do_where() {
+      local name=$1 json refs textual
+
+      json=$(declared_json)
+
+      step "$name"
+      if [ -n "$json" ] && [ "$(printf '%s' "$json" | jq -r --arg n "$name" 'has($n)')" = true ]; then
+        printf '  declared, at %s\n' "$(printf '%s' "$json" | jq -r --arg n "$name" '.[$n].path')"
+        refs=$(printf '%s' "$json" | jq -r --arg n "$name" '.[$n].refs[]?')
+        if [ -n "$refs" ]; then
+          say "  ''${bold}Derived from the evaluated configuration:''${off}"
+          printf '%s\n' "$refs" | sed 's/^/    /'
+        else
+          say "  ''${dim}nothing under programs.nixarchy names it, and no sops template"
+          say "  renders it.''${off}"
+        fi
+      else
+        warn "not declared in $FLAKE#nixosConfigurations.$HOST."
+      fi
+
+      # The grep is a SECOND answer, not the same one. The walk above covers
+      # programs.nixarchy, the only surface with a convention we can rely on;
+      # a reference in the user's own configuration --
+      # `services.foo.passwordFile = config.sops.secrets.<name>.path` -- is
+      # invisible to it and obvious to a grep. Labelled apart, because a
+      # derived answer and a textual one are not the same claim.
+      say ""
+      say "  ''${bold}Named in the configuration text:''${off}"
+      textual=$(grep -rn --include='*.nix' -F -- "$name" "$FLAKE" 2>/dev/null | head -20 || true)
+      if [ -n "$textual" ]; then
+        printf '%s\n' "$textual" | sed "s|$FLAKE/||" | sed 's/^/    /'
+      else
+        say "    ''${dim}nothing''${off}"
+      fi
+    }
+
+    # ---- dispatch ------------------------------------------------------------
+    #
+    # tests/menu-verbs.nix reads the verbs out of this case block, in the
+    # BUILT script, and checks every menu row that runs `nixarchy-secret
+    # <verb>` against them. The `nixarchy-vm new` row that shipped broken --
+    # a row written to match the menu key rather than the CLI -- is why.
+    kind=system
+    declare -a args=()
+    for a in "$@"; do
+      if [ "$a" = "--user" ]; then kind=user; else args+=("$a"); fi
+    done
+    set -- "''${args[@]:-}"
+
+    case "''${1:-}" in
+      new)
+        [ -n "''${2:-}" ] || { fail "which secret? nixarchy secret new <name>"; exit 1; }
+        do_new "$kind" "$2"
+        ;;
+      edit)
+        do_edit "$kind"
+        ;;
+      remove)
+        [ -n "''${2:-}" ] || { fail "which secret? nixarchy secret remove <name>"; exit 1; }
+        do_remove "$kind" "$2"
+        ;;
+      list)
+        do_list
+        ;;
+      where)
+        [ -n "''${2:-}" ] || { fail "which secret? nixarchy secret where <name>"; exit 1; }
+        do_where "$2"
+        ;;
+      copy)
+        do_copy "''${2:-}"
+        ;;
+      "" | -h | --help | help)
+        usage
+        ;;
+      *)
+        fail "nixarchy secret: unknown subcommand '$1'"
+        usage >&2
+        exit 1
+        ;;
+    esac
+  '';
+
+  meta = {
+    description = "Create, edit and read this machine's sops-nix secrets";
+    mainProgram = "nixarchy-secret";
+  };
+}

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -245,3 +245,19 @@ Two branches only these can reach, as illustration:
   region you did not touch, diff `nix eval --raw .#checks.<system>.<name>.buildCommand`
   before reading the shell — and indent interpolation openers to match their
   surroundings. `nix fmt` does not catch this; it happily formats both.
+- **Grep the spelling the script CONTAINS, not the value it resolves to.** A
+  check meant to prove every call to a root-only helper goes through `sudo`
+  greped for the helper's *store path* — which appears on exactly one line, its
+  assignment. The loop iterated once, matched the arm that skips the
+  assignment, and passed with the `sudo` deleted from every call. The script
+  spells those calls `"$HOST_SOPS"`. Same shape as the forbid-pattern note
+  above and worth stating the other way round: after writing a loop over
+  `grep` output, **count what it iterated and assert a floor**, because a loop
+  that reads zero of the right lines satisfies every case in silence.
+- **Break the product, not the assertion, and watch which assertion fires.**
+  Two of this repository's newest checks were wrong in ways only that found:
+  one matched `$(` immediately followed by `sops`, and the real bug put an
+  environment assignment in between; one counted `sops -d --extract` when half
+  the calls go through a wrapper whose name merely *ends* in `sops`. Both
+  reported green on the broken code, and both were caught because §1's
+  break-it-first contract was actually run rather than described.

--- a/tests/menu-verbs.nix
+++ b/tests/menu-verbs.nix
@@ -35,6 +35,7 @@ let
 
   vmcli = inputs.self.packages.${system}.nixarchy-vm;
   boxcli = inputs.self.packages.${system}.nixarchy-box;
+  secretcli = inputs.self.packages.${system}.nixarchy-secret;
 
   # nixarchy-channel ships in the omarchy tree rather than as its own package,
   # so it is reached through the built tree the same way the menu reaches it.
@@ -74,10 +75,12 @@ pkgs.runCommand "nixarchy-menu-verbs"
 
     verbs_of ${vmcli}/bin/nixarchy-vm   > vm-verbs
     verbs_of ${boxcli}/bin/nixarchy-box > box-verbs
+    verbs_of ${secretcli}/bin/nixarchy-secret > secret-verbs
     verbs_of ${omarchyPkg}/share/omarchy/bin/nixarchy-channel > channel-verbs
 
     echo "nixarchy-vm accepts:  $(tr '\n' ' ' < vm-verbs)"
     echo "nixarchy-box accepts: $(tr '\n' ' ' < box-verbs)"
+    echo "nixarchy-secret accepts: $(tr '\n' ' ' < secret-verbs)"
     echo "nixarchy-channel accepts: $(tr '\n' ' ' < channel-verbs)"
 
     # A floor. An empty verb list makes every row below pass, turning "the
@@ -85,6 +88,8 @@ pkgs.runCommand "nixarchy-menu-verbs"
     # this file exists to reject.
     test "$(wc -l < vm-verbs)"  -ge 5
     test "$(wc -l < box-verbs)" -ge 5
+    # new, edit, list, where, copy, remove -- plus the three help spellings.
+    test "$(wc -l < secret-verbs)" -ge 6
     # Two: stable and unstable. `rc` and `dev` are pacman repositories with no
     # NixOS meaning and stay out of the menu, so this floor is 2 and not 4.
     test "$(wc -l < channel-verbs)" -ge 2
@@ -112,6 +117,12 @@ pkgs.runCommand "nixarchy-menu-verbs"
     scan '\bnixarchy-box +[-a-z]+'     2 nixarchy-box box-verbs
     scan '\bnixarchy +box +[-a-z]+'    3 nixarchy-box box-verbs
 
+    # The Secrets group (#611/#612). Four rows, added with the rows rather
+    # than after one of them breaks -- `nixarchy-vm new`, the row this file
+    # exists about, was a verb that did not exist and a tester found it.
+    scan '\bnixarchy-secret +[-a-z]+'  2 nixarchy-secret secret-verbs
+    scan '\bnixarchy +secret +[-a-z]+' 3 nixarchy-secret secret-verbs
+
     # The channel rows (#529). Added with the rows themselves rather than
     # after the first one breaks, because the row this file was written about
     # -- `nixarchy-vm new`, a verb that does not exist -- shipped and was
@@ -122,7 +133,17 @@ pkgs.runCommand "nixarchy-menu-verbs"
     # The second floor: if the menu stopped carrying these rows, every scan
     # above would run zero times and the check would pass having read nothing.
     echo "menu verbs checked: $checked"
-    test "$checked" -ge 8
+    test "$checked" -ge 12
+
+    # And the Secrets group specifically. The floor above is a sum, so losing
+    # every secret row would drop it from 16 to 12 and still pass -- which is
+    # the "a loop that iterated nothing" shape this file already guards
+    # against for the CLIs.
+    secretrows=$(grep -coE '\bnixarchy-secret +[-a-z]+' ${menu} || true)
+    test "$secretrows" -ge 3 || {
+      echo "ERROR: the menu has $secretrows Secrets rows; the group is gone" >&2
+      exit 1
+    }
 
     test "$fail" -eq 0
     echo "every menu row names a subcommand its CLI has"

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -1355,7 +1355,14 @@ pkgs.runCommand "nixarchy-options"
     splashUpstream = "${(pkgs.extend inputs.self.overlays.default).omarchy.src}/default/plymouth";
     serviceCount = builtins.toString (builtins.length (builtins.attrNames services));
     notApps = pkgs.lib.concatStringsSep " " notApps;
-    nativeBuildInputs = [ pkgs.python3 ];
+    nativeBuildInputs = [
+      pkgs.python3
+      # For the secrets round-trip below. A throwaway identity is generated
+      # inside the check: NOTHING encrypted with a real key is committed as a
+      # fixture, even though an encrypted fixture looks harmless.
+      pkgs.sops
+      pkgs.age
+    ];
   }
   (
     if flatpakProblems != [ ] then
@@ -2093,7 +2100,7 @@ pkgs.runCommand "nixarchy-options"
         # nixarchy-apply are built by writeShellApplication in
         # modules/apps.nix rather than shipped in nix-bin -- so they cannot be
         # derived below and are named here.
-        for verb in try search apply vm box; do
+        for verb in try search apply vm box secret; do
           grep -qE "^ *$verb\)" "$vm/sw/bin/nixarchy" || {
             echo "the nixarchy dispatcher has no route for '$verb':" >&2
             echo "  it falls through to \`exec omarchy $verb\`, which knows only" >&2
@@ -2906,8 +2913,20 @@ pkgs.runCommand "nixarchy-options"
               exit 1
               ;;
           esac
-        done < <(grep -E 'read -r -p' "$vm/sw/bin/nixarchy-search")
-        echo "every prompt in the picker reads the terminal, not the loop"
+        done < <(grep -E 'read -r -p' "$vm/sw/bin/nixarchy-search" "$vm/sw/bin/nixarchy-secret")
+        echo "every prompt in the pickers reads the terminal, not the loop"
+
+        # And the loop has to have READ something. Greping two files for a
+        # pattern neither contains satisfies every case above in silence --
+        # the floor this repository keeps arriving at (#538, #596). Both
+        # pickers prompt, so both must contribute.
+        for picker in nixarchy-search nixarchy-secret; do
+          grep -qE 'read -r -p' "$vm/sw/bin/$picker" || {
+            echo "$picker has no 'read -r -p' at all, so the tty check above" >&2
+            echo "  read nothing for it and proved nothing." >&2
+            exit 1
+          }
+        done
 
         # And the ROUTE, not just the call site: #498 shipped `nixarchy try`
         # advertised and unreachable, because nothing asserted the dispatcher
@@ -2975,6 +2994,208 @@ pkgs.runCommand "nixarchy-options"
             ;;
         esac
         echo "nixarchy pkg undraft routes to nixarchy-pkg-undraft"
+
+        # ---- nixarchy secret (#611, #612, #613, #614, #615) -----------------
+        #
+        # The three properties this command cannot be allowed to lose. Each is
+        # a security property rather than a feature, so each is asserted
+        # against the BUILT script rather than trusted to a comment.
+        secretbin="$vm/sw/bin/nixarchy-secret"
+        test -x "$secretbin" || {
+          echo "nixarchy-secret is not on the system, so every row and route" >&2
+          echo "  below points at nothing." >&2
+          exit 1
+        }
+
+        # 1. The host's age identity never leaves root. Converting the SSH
+        #    host key to an age identity has to happen INSIDE a process that
+        #    is already root -- pkgs/secret.nix does it in a wrapper reached
+        #    only through sudo. The way to get this wrong is
+        #    `sudo env SOPS_AGE_KEY="$(sudo ssh-to-age -private-key ...)"`,
+        #    which puts the machine's private identity in argv, where
+        #    /proc/*/cmdline makes it readable by every process on the box.
+        if grep -q 'ssh-to-age -private-key' "$secretbin"; then
+          echo "::error::nixarchy-secret derives the host's age identity in its" >&2
+          echo "  own (unprivileged) process. That value must only ever exist" >&2
+          echo "  inside the root-side wrapper -- see rule 2 in pkgs/secret.nix." >&2
+          exit 1
+        fi
+        hostsops=$(sed -n 's/^HOST_SOPS=//p' "$secretbin")
+        test -n "$hostsops" || { echo "nixarchy-secret names no root-side sops wrapper" >&2; exit 1; }
+        grep -q 'ssh-to-age -private-key' "$hostsops" || {
+          echo "the root-side wrapper no longer derives the identity from the host key" >&2
+          exit 1
+        }
+        # The USES, which are spelled "$HOST_SOPS" -- not the store path. The
+        # first version of this loop greped for the store path, which appears
+        # on exactly one line (the assignment), so it iterated once, matched
+        # the *HOST_SOPS=* arm and passed with the sudo deleted from every
+        # call. A loop that reads the wrong lines is a green light (§1).
+        uses=0
+        while IFS= read -r line; do
+          case "$line" in
+            *HOST_SOPS=*) continue ;;
+          esac
+          uses=$((uses + 1))
+          case "$line" in
+            *sudo*'"$HOST_SOPS"'*) ;;
+            *)
+              echo "::error::nixarchy-secret reaches the root-side sops wrapper" >&2
+              echo "  without sudo. That wrapper reads /etc/ssh/ssh_host_ed25519_key," >&2
+              echo "  so unprivileged it fails at runtime -- and the temptation" >&2
+              echo "  then is to derive the identity on the user side instead," >&2
+              echo "  which is the leak rule 2 in pkgs/secret.nix exists to stop:" >&2
+              echo "  $line" >&2
+              exit 1
+              ;;
+          esac
+        done < <(grep -F -- '"$HOST_SOPS"' "$secretbin")
+        test "$uses" -ge 3 || {
+          echo "::error::only $uses calls reach the root-side wrapper; the loop" >&2
+          echo "  above is not reading the lines it thinks it is." >&2
+          exit 1
+        }
+        echo "the host's age identity is derived only inside the root-side wrapper"
+
+        # 2. A decrypted value reaches the clipboard through a PIPE and is
+        #    never captured. `v=$(sops -d ...)` would put plaintext in a shell
+        #    variable, which `set -x`, a core dump or an exported environment
+        #    can all expose, and which outlives the call.
+        #    Written as "a decrypting line must not contain a command
+        #    substitution at all", not as "must not start with $(sops": the
+        #    first version of this check matched `$(` immediately followed by
+        #    sops, and a break that put an environment assignment in between
+        #    -- `v=$(SOPS_AGE_KEY_FILE=... sops -d ...)`, the exact bug --
+        #    walked straight past it. Proving the check fails is what found
+        #    that; §1 is not a formality.
+        if grep -n -- '-d --extract' "$secretbin" | grep -F -- '$('; then
+          echo "::error::nixarchy-secret captures a decrypted value in a" >&2
+          echo "  command substitution. It must be piped straight to wl-copy:" >&2
+          echo "  plaintext never touches disk and never outlives the pipe," >&2
+          echo "  where set -x, a core dump and an exported environment cannot" >&2
+          echo "  reach it (#613)." >&2
+          exit 1
+        fi
+        # ...and each decrypting call is the head of a pipe into the clipboard.
+        # `-d --extract`, not `sops -d --extract`: the system path calls the
+        # root-side WRAPPER, whose store path ends in ...host-sops" -- so the
+        # obvious spelling matched the user path only, and reported one call
+        # where there are two. Found by breaking the sudo on the other path
+        # and watching the wrong assertion fire.
+        deccalls=$(grep -c -- '-d --extract' "$secretbin")
+        test "$deccalls" -eq 2 || {
+          echo "::error::nixarchy-secret has $deccalls decrypting calls, not the" >&2
+          echo "  two (system, user) this check knows how to reason about." >&2
+          exit 1
+        }
+        pipes=$(grep -c 'wl-copy --paste-once' "$secretbin")
+        test "$pipes" -ge 2 || {
+          echo "::error::nixarchy-secret has $pipes clipboard writes; both the" >&2
+          echo "  system and the user path must pipe to wl-copy." >&2
+          exit 1
+        }
+        echo "a decrypted value is piped to the clipboard and never captured ($pipes paths)"
+
+        # 3. The declaration goes in hosts/<host>/configuration.nix, and the
+        #    command says so. nixarchy-apply copies ~/.config/nixarchy/*.nix
+        #    into hosts/<host>/nixarchy/ and `git add -A`s them, so a
+        #    `./secrets.yaml` written there resolves one directory too deep --
+        #    a failure whose message names a missing path and not the cause.
+        for needle in 'configuration.nix' 'sops.secrets.$name.sopsFile = ./secrets.yaml;' \
+                      'one directory too deep' 'services.openssh.enable = true;'; do
+          grep -qF -- "$needle" "$secretbin" || {
+            echo "::error::nixarchy-secret no longer says '$needle'." >&2
+            echo "  Every one of these is a trap a user meets as an unexplained" >&2
+            echo "  build error if the command stops naming it (#612)." >&2
+            exit 1
+          }
+        done
+        echo "the command names the file the declaration goes in, and the sshd prerequisite"
+
+        # ---- and it works, on a store this check encrypts itself ------------
+        #
+        # NO REAL SECRET AS A FIXTURE, encrypted or otherwise. The identity is
+        # made here, used here, and thrown away with the build directory.
+        #
+        # What this proves is the property `nixarchy secret list` rests on:
+        # sops encrypts VALUES and leaves the keys in plaintext, so the names
+        # of a machine's secrets can be read with no identity at all. If that
+        # ever stopped being true, list would silently report nothing.
+        secretwork=$PWD/secret-roundtrip
+        mkdir -p "$secretwork/hosts/$(cat /proc/sys/kernel/hostname)"
+        age-keygen -o "$secretwork/id.txt" 2>/dev/null
+        recipient=$(age-keygen -y "$secretwork/id.txt")
+        printf 'demo-token: not-a-real-value-0123456789\n' > "$secretwork/plain.yaml"
+        sops --age "$recipient" --encrypt --input-type yaml --output-type yaml \
+          "$secretwork/plain.yaml" \
+          > "$secretwork/hosts/$(cat /proc/sys/kernel/hostname)/secrets.yaml"
+
+        store="$secretwork/hosts/$(cat /proc/sys/kernel/hostname)/secrets.yaml"
+        grep -q '^demo-token:' "$store" || {
+          echo "::error::sops no longer leaves the key names in plaintext." >&2
+          echo "  \`nixarchy secret list\` reads them without an identity and" >&2
+          echo "  would now report an empty machine." >&2
+          exit 1
+        }
+        if grep -q 'not-a-real-value-0123456789' "$store"; then
+          echo "::error::the value survived encryption in plaintext." >&2
+          exit 1
+        fi
+
+        # The real command, against that store. `nix` is not in this sandbox,
+        # so declared_json returns empty and the fallback path runs -- which
+        # is the path a machine whose flake will not evaluate takes, and the
+        # one whose message must not claim the machine has no secrets.
+        listout=$(NIXARCHY_FLAKE=$secretwork run "$secretbin" list 2>&1)
+        case "$listout" in
+          *demo-token*) ;;
+          *)
+            echo "::error::nixarchy secret list did not name the secret in the store:" >&2
+            printf '%s\n' "$listout" >&2
+            exit 1
+            ;;
+        esac
+        case "$listout" in
+          *"could not evaluate"*) ;;
+          *)
+            echo "::error::list reported no evaluation problem on a tree it cannot" >&2
+            echo "  evaluate. 'could not evaluate' and 'no secrets declared' are" >&2
+            echo "  different answers and must not be reported as the same one." >&2
+            printf '%s\n' "$listout" >&2
+            exit 1
+            ;;
+        esac
+        echo "nixarchy secret list reads a store it has no identity for, and says so"
+
+        # ---- and the config repo still refuses to publish a plaintext one ---
+        #
+        # nixarchy-config-repo's secret_scan reads *.nix, and a secret store is
+        # YAML -- so `nixarchy secret` opens a path the existing scan cannot
+        # see. The new guard keys on sops' own ENC[AES256_GCM marker, and THAT
+        # is the half worth checking rather than asserting: if sops ever
+        # changed how it wraps a value, the guard would quietly pass every
+        # encrypted file AND every plaintext one. The store encrypted above is
+        # real sops output, so this varies with the thing it is about.
+        repobin="$vm/sw/bin/nixarchy-config-repo"
+        grep -qF 'ENC\[AES256_GCM' "$repobin" || {
+          echo "::error::nixarchy-config-repo no longer looks for an unencrypted" >&2
+          echo "  secret store, so 'nixarchy config repo' would commit and push" >&2
+          echo "  a plaintext secrets.yaml (#611 added the path; the *.nix grep" >&2
+          echo "  cannot see it)." >&2
+          exit 1
+        }
+        grep -qF 'ENC[AES256_GCM' "$store" || {
+          echo "::error::sops no longer writes ENC[AES256_GCM into an encrypted" >&2
+          echo "  file. nixarchy-config-repo's plaintext-store guard keys on that" >&2
+          echo "  marker and would now pass a plaintext store as encrypted." >&2
+          exit 1
+        }
+        grep -qF 'ENC[AES256_GCM' "$secretwork/plain.yaml" && {
+          echo "::error::the plaintext fixture carries the encrypted marker, so" >&2
+          echo "  the guard above cannot tell the two apart." >&2
+          exit 1
+        }
+        echo "the marker config-repo's plaintext-store guard keys on is the one sops writes"
 
           touch $out
       ''


### PR DESCRIPTION
## What this changes, and why

Adding a secret to a nixarchy machine was five manual steps in
`docs/manual/remote-desktop.md`, two of which needed `nix-shell -p` because
neither `sops` nor `ssh-to-age` was on PATH at all — and nothing on the machine
could answer *"what secrets do I have"* or *"what reads this one"*. The
mechanism (sops-nix, imported inertly by `modules/nixos.nix`) was fine; the
distance between it and a person was the problem.

`nixarchy secret` (`pkgs/secret.nix`) is one command over that mechanism —
`new`, `edit`, `list`, `where`, `copy`, `remove` — plus a **Setup ▸ Secrets**
menu group and a dispatcher route. Built on sops-nix, not agenix, per the
existing decision record: agenix has no templating, so composing a secret into
a TOML would need a hand-rolled `ExecStartPre` per service. `sops edit` opens
`$EDITOR` exactly as `agenix -e` does, so the flow a user sees is unchanged.

Three decisions carried through from #611, each visible in the code:

- **Two kinds, deliberately not one.** System secrets stay `root:root 0400` in
  `/run/secrets` for a *service*; user secrets get their own age identity and
  decrypt **to the clipboard through a pipe, never to disk**. Making system
  secrets user-readable instead would mean every process running as you — a
  browser, a dev-shell dependency, an agent — can read every secret on the box.
- **Discovery is derived.** `list` and `where` evaluate
  `nixosConfigurations.<host>.config` and read `sops.secrets` out of it, so they
  cannot drift. A reference is either an option under
  `programs.nixarchy.services` whose name ends in `Secret` (hypr-rdp's shape) or
  a `sops.template` carrying the secret's *placeholder* — which is a hash, not
  the name, so a grep finds nothing. Proved on a real config: `rdp-pw` came back
  with `["option programs.nixarchy.services.hypr-rdp.passwordSecret", "template
  hypr-rdp.toml"]` and a second, unused secret came back with `[]`.
- **This machine only.** Rekeying for a second host is `sops updatekeys`, and
  the command says so rather than half-implementing a fleet story.

**The host's age identity never leaves root.** The SSH-host-key → age
conversion happens inside a root-side wrapper reached only through `sudo`,
because `sudo env SOPS_AGE_KEY="$(sudo ssh-to-age ...)"` would put the machine's
private identity in argv, and `/proc/*/cmdline` is world-readable.

**Traps handled rather than discovered:** the declaration is *printed*, never
written into `~/.config/nixarchy/*.nix` (which `nixarchy-apply` copies one
directory deeper); the missing-host-key case is explained before it becomes an
evaluation error; every prompt reads `< /dev/tty`; every new menu row carries
`label` and `icon`.

Also here: `nixarchy-config-repo`'s `secret_scan` reads `*.nix` only, so a
`secrets.yaml` sops never encrypted was invisible to it — a path this PR opens.
It now refuses on a store with no `ENC[AES256_GCM` marker. The `nixos-secrets`
skill's decision table sent *"config repo, one-two machines, SSH-key based"* to
**agenix**, which this machine does not have; it now describes the wrapper.
`modules/secrets.md`'s *"not a user-facing secrets product and there is no
wizard"* is replaced with the reasoning for the change rather than left
contradicting what ships.

Mode A is untouched: `nixarchy secret` is a command, not a module. No sops
option is set by nixarchy, and `tests/options.nix`'s inertness assertions
(`sopsOff`/`sopsOn`) are unchanged and still green.

`modules/home.nix` needed nothing: the user store is created on demand by the
command, deliberately in `~/.local/share/nixarchy/secrets/` — outside
`nixarchy-apply`'s copy and outside `nixarchy-home-backup`'s allowlist, because
both of those get pushed to a git remote.

## How I proved the check fails

Six breaks, each run under `nix build .#checks.x86_64-linux.{options,menu-verbs}`,
each restored afterwards. **Two of them found bugs in the new checks rather than
in the code** — which is the whole argument for §1.

**1. The prompt stops reading the terminal (#596's shape):**

```
> a prompt in the picker's dispatch does not read /dev/tty:
>   .../sw/bin/nixarchy-secret:    read -r -p "  $name is a system secret and needs sudo. Copy it? [y/N] " answer
>   stdin there is the selection herestring, so it reads EOF and no-ops (#596)
```

**2. The decrypted value is captured in a variable instead of piped.** First
attempt at this check matched `$(` immediately followed by `sops`, and the
break — `v=$(SOPS_AGE_KEY_FILE=... sops -d --extract ...)`, an environment
assignment in between — **walked straight past it and the check passed.**
Rewritten as "a decrypting line must not contain a command substitution at
all", it fails:

```
> 312:    v=$(SOPS_AGE_KEY_FILE="$USER_KEY" sops -d --extract "[\"$name\"]" "$USER_STORE")
> ::error::nixarchy-secret captures a decrypted value in a
>   command substitution. It must be piped straight to wl-copy:
>   plaintext never touches disk and never outlives the pipe,
>   where set -x, a core dump and an exported environment cannot
>   reach it (#613).
```

**3. The root-side sops wrapper is reached without sudo.** Same story: the
first version of this loop greped for the wrapper's *store path*, which appears
on exactly one line — its own assignment — so it iterated once, matched the
skip arm, and **passed with the `sudo` deleted from every call**. Retargeted at
the spelling the script actually contains (`"$HOST_SOPS"`) and given a floor on
how many lines it read:

```
> ::error::nixarchy-secret reaches the root-side sops wrapper
>   without sudo. That wrapper reads /etc/ssh/ssh_host_ed25519_key,
>   so unprivileged it fails at runtime -- and the temptation
>   then is to derive the identity on the user side instead,
>   which is the leak rule 2 in pkgs/secret.nix exists to stop:
>     "$HOST_SOPS" edit "$SYS_STORE"
```

**4. The dispatcher loses its route (#538's shape):**

```
> the nixarchy dispatcher has no route for 'secret':
>   it falls through to `exec omarchy secret`, which knows only
>   omarchy-* siblings, so the command dies as 'Unknown Omarchy
>   command' -- with nothing naming the real cause.
```

**5. Discovery lies — a tree it cannot evaluate reported as "no secrets
declared"** (`|| true` changed to `|| echo '{}'`):

```
> ::error::list reported no evaluation problem on a tree it cannot
>   evaluate. 'could not evaluate' and 'no secrets declared' are
>   different answers and must not be reported as the same one.
```

**6. A menu row names a verb the CLI does not have** (`nixarchy-vm new`'s
shape), and then the whole group deleted, against `checks.menu-verbs`:

```
> ERROR: a menu row runs 'nixarchy-secret add', which nixarchy-secret does not accept
>        it accepts: --help -h copy edit help list new remove where
...
> menu verbs checked: 12
> ERROR: the menu has 0 Secrets rows; the group is gone
```

Green with everything restored:

```
> every prompt in the pickers reads the terminal, not the loop
> the host's age identity is derived only inside the root-side wrapper
> a decrypted value is piped to the clipboard and never captured (2 paths)
> the command names the file the declaration goes in, and the sshd prerequisite
> nixarchy secret list reads a store it has no identity for, and says so
> the marker config-repo's plaintext-store guard keys on is the one sops writes
> every advertised nixarchy subcommand has a route (11 derived)
> nixarchy-secret accepts: --help -h copy edit help list new remove where
> menu verbs checked: 16
> every menu row names a subcommand its CLI has
```

**No real secret is committed as a fixture, encrypted or otherwise.** The
round-trip generates a throwaway age identity inside the check, encrypts a
fake value with it, and asserts what `list` depends on: sops leaves the *keys*
in plaintext and the *value* is gone. That is also what the config-repo guard's
`ENC[AES256_GCM` marker is checked against — real sops output, so the assertion
varies with the thing it is about rather than restating a constant.

## Checks run locally

- `nix build .#checks.x86_64-linux.options` — green (and red six times, above)
- `nix build .#checks.x86_64-linux.menu-verbs` — green
- `nix build .#checks.x86_64-linux.doc-options` — green
- `nix build .#checks.x86_64-linux.bin-ledger` — green
- `nix build .#checks.x86_64-linux.config-warnings` — green
- `nix build .#nixarchy-secret`, `nix build .#omarchy`
- `bash .github/scripts/readme-counts.sh --check` — 17/17, skill count untouched
  (the `nixos-secrets` skill is **edited**, not added)
- Not run locally: any VM check. CI install jobs were in flight and two of the
  four runners are on this box (§6).

**No new `checks.*` entry**, deliberately: `checks.options` and
`checks.menu-verbs` are both already named by a `pull_request` workflow, so
nothing here needs a CI-gate change (§4/§10).

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [x] If this adds an option: `tests/options.nix` covers both states — no new
      option; the sops on/off assertions are unchanged and still pass
- [x] If this adds a `checks.*` entry: none added

## What this cost, and where it is written down

Two general lessons, both in this PR:

- **`AGENTS.md` §5** — `builtins.tryEval` catches `throw` and `assert` and
  *nothing else*, so it does not catch a missing attribute. A walk over
  `config.programs.nixarchy` aborted with `attribute 'allowUnfreePredicate'
  missing`, thrown from an option *default*, with every access already wrapped
  in `tryEval`. Bound the root of such a walk; do not trust `tryEval` to make
  an unbounded one safe.
- **`tests/AGENTS.md`** — grep the spelling the script *contains*, not the value
  it resolves to (breaks 2 and 3 above), and put a floor on how many lines a
  `grep`-fed loop iterated: a loop that reads zero of the right lines satisfies
  every case inside it in silence.

Also recorded where the next reader of that subsystem will be: the clipboard-
history hole is named in `pkgs/secret.nix`, `modules/secrets.md` and
`docs/manual/secrets.md` rather than papered over — Omarchy's shell records
every copied string in `~/.local/state/omarchy/clipboard-history.json` in
plaintext, `wl-copy` has no opt-out it honours, and `--paste-once` limits the
clipboard but not the history file.

- [x] A general lesson is recorded in `AGENTS.md`

closes #612, closes #613, closes #614, closes #615
