### PR TITLE
Three ways to find out what exists: for agents, for the shell, and in the editor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,6 +277,17 @@ Two other ways a check stops checking, both found in one week:
   there. That happened here twice: once discarding pushed work (recoverable
   from the remote), once rebasing the wrong branch. If something else may be
   driving the tree, `git worktree add` and work there.
+- **`git checkout -- <path>` restores the INDEX, not the commit.** So a
+  break-it-and-watch-it-fail loop (§1) that does `git add -A` before running
+  the check — which a flake evaluation requires, since it sees only tracked
+  files — and then reverts with `git checkout -- modules`, restores the
+  *break*. It looks like it worked: git reports nothing, the file is
+  "restored", and the next iteration starts from the broken tree. Four
+  deliberate breaks accumulated silently that way here, and the fifth run's
+  failure was read as a fifth bug. `git checkout HEAD -- <path>`, or copy the
+  files aside before you touch them — and commit a known-good baseline before
+  starting the loop, so there is something to check out of.
+
 - **`find` does not follow the `result` symlink.** `find "$out" -name X`
   where `$out` is `./result` returns nothing, silently. Use `find -L`.
   `readme-counts.sh` counted zero skills this way, and only failed loudly

--- a/docs/manual/ai.md
+++ b/docs/manual/ai.md
@@ -70,6 +70,41 @@ flake only changes at a rebuild. An agent that does not know which side of that
 line a request falls on will do the wrong kind of change, and the wrong kind is
 the one that silently does not last.
 
+## The agents are given a server that knows NixOS
+
+Skills tell an agent how this machine is shaped. They cannot tell it whether
+`services.foo.enable` exists — that is a fact about nixpkgs on the day you ask,
+and it is the fact models are worst at. Nix is lazy and untyped, the public
+corpus of it is small, and option names are not guessable, so a confident
+sentence naming an option that does not exist is the normal failure rather than
+an unusual one.
+
+So nixarchy declares [`mcp-nixos`](https://github.com/utensils/mcp-nixos) in the
+agents that can take one. It is an MCP server that answers package and option
+questions against the real sets — nixpkgs, NixOS options, Home Manager and
+nix-darwin — so the answer comes from the index rather than from memory.
+
+Three agents get it, each in the file that agent actually reads:
+
+| agent | file | key |
+|---|---|---|
+| Claude Code | `~/.claude.json` | `mcpServers` |
+| Codex | `~/.codex/config.toml` | `[mcp_servers.nixos]` |
+| opencode | `~/.config/opencode/opencode.json` | `mcp` |
+
+Two of the four skill directories above get nothing, and that is deliberate
+rather than an omission: `~/.agents/skills` is a generic convention with no
+single tool behind it, and Pi documents no MCP configuration file. Writing one
+anyway would put a file on your disk that nothing reads.
+
+Nothing is clobbered. Each file is merged into key by key — a server you
+declared yourself survives, and so does everything else in the file. Turn the
+whole thing off with:
+
+```nix
+programs.nixarchy.mcp = false;
+```
+
 ### Why `omarchy` could not ship as-is
 
 Upstream's skill is written for Arch. It points the agent at

--- a/docs/manual/development-tools.md
+++ b/docs/manual/development-tools.md
@@ -19,6 +19,81 @@ you find out at build time.
 Theme matching for VSCode, Cursor, VSCodium and Helix, and _Setup > Defaults >
 Editor_ for the system-wide default, work as upstream describes.
 
+## A language server that already knows your machine
+
+The question a person learning NixOS cannot answer is the same one the agents
+above cannot: *what options exist?* For a human the structural fix is editor
+completion, and the two Nix language servers are not equivalent about it.
+`nil` does keywords, locals and builtins. `nixd` links the real evaluator, so it
+completes NixOS and Home Manager option names **and their defaults** against
+your actual configuration.
+
+nixd's one real weakness is that it has to be told where the flake is and which
+attribute to evaluate — which is precisely the thing a distribution knows and
+you should not have to write down. nixarchy writes it for you, into whichever
+of these editors you selected:
+
+| editor | file | through |
+|---|---|---|
+| VSCode | `~/.config/Code/User/settings.json` | the Nix IDE extension's `nix.*` settings |
+| Cursor | `~/.config/Cursor/User/settings.json` | the same |
+| Zed | `~/.config/zed/settings.json` | `lsp.nixd.initialization_options` |
+| Helix | `~/.config/helix/languages.toml` | `[language-server.nixd]` |
+| Neovim | `~/.config/nvim/lua/plugins/nixd.lua` | an `nvim-lspconfig` spec |
+
+VSCode and Cursor still need the Nix IDE extension itself — extensions are not
+something a NixOS module can put in your editor — but every setting it needs is
+already there when you install it.
+
+An editor you have not selected gets nothing. The Helix and Neovim files are
+written only when they do not already say something about nixd, and the three
+JSON files are merged into rather than replaced, so your own settings survive.
+
+Turn it off with:
+
+```nix
+programs.nixarchy.languageServer = false;
+```
+
+## When a command is not found
+
+The Arch reflex is `pacman -S thing`, and on NixOS it is a dead end at exactly
+the moment you are already stuck. NixOS has a `command-not-found` of its own and
+it cannot help on a flake machine: it reads a database that only the channel
+mechanism ships, so it is either missing or stale and your shell says nothing at
+all.
+
+nixarchy replaces it with one that answers:
+
+```
+$ rg
+rg: command not found. In nixpkgs it comes from:
+  ripgrep
+
+  Run it once:      , rg
+  Keep it:          nixarchy pkg add ripgrep    (then: nixarchy apply)
+```
+
+Both lines are real commands. `,` is [comma](https://github.com/nix-community/comma):
+it fetches the package, runs the thing once, and leaves nothing behind — useful
+when you are not sure you want it. `nixarchy pkg add` writes it into
+`~/.config/nixarchy/apps.nix`, which is the permanent form on a machine whose
+software lives in a file. (`nixarchy try` covers the same ground when you
+already know the package exists; this is for when you do not.)
+
+What makes the answer possible is a prebuilt index. `nix-index` builds its
+database by walking nixpkgs, which takes hours, so nixarchy ships the one
+[nix-index-database](https://github.com/nix-community/nix-index-database)
+publishes weekly instead. `nix-locate` is therefore on your machine and works
+immediately — which is also what `nixarchy doctor` has always assumed when it
+tells you to run it.
+
+Turn it off with:
+
+```nix
+programs.nixarchy.commandNotFound = false;
+```
+
 ## Environments: nixpkgs, not mise
 
 Upstream installs its language runtimes with `mise use --global <lang>@latest`,

--- a/flake.lock
+++ b/flake.lock
@@ -472,6 +472,27 @@
         "type": "github"
       }
     },
+    "mcp-servers-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1789141018,
+        "narHash": "sha256-0ap34rhjfjXsFV+xfXd56WGxfrbc9QWNUrEqzh1L+co=",
+        "owner": "natsukium",
+        "repo": "mcp-servers-nix",
+        "rev": "11fe2419e274bb223a86dddc9e4803b01ad359e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "natsukium",
+        "repo": "mcp-servers-nix",
+        "rev": "11fe2419e274bb223a86dddc9e4803b01ad359e8",
+        "type": "github"
+      }
+    },
     "microvm": {
       "inputs": {
         "nixpkgs": [
@@ -507,6 +528,27 @@
         "owner": "gmodena",
         "ref": "v0.7.0",
         "repo": "nix-flatpak",
+        "type": "github"
+      }
+    },
+    "nix-index-database": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788679149,
+        "narHash": "sha256-iDPCFLce2G+unG3VHIKMrKznSMEwCHNeeuzdWk0YxRM=",
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "rev": "2ddfaa93f2c13a586c673df4c0da0d580f4674a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "2026-09-06-071918",
+        "repo": "nix-index-database",
         "type": "github"
       }
     },
@@ -645,8 +687,10 @@
         "home-manager-stable": "home-manager-stable",
         "hypr-rdp": "hypr-rdp",
         "hyprland": "hyprland",
+        "mcp-servers-nix": "mcp-servers-nix",
         "microvm": "microvm",
         "nix-flatpak": "nix-flatpak",
+        "nix-index-database": "nix-index-database",
         "nixi": "nixi",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_2",

--- a/flake.nix
+++ b/flake.nix
@@ -150,6 +150,57 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # The MCP configuration framework, for #623 -- the NixOS MCP server the
+    # coding agents on this desktop get so they stop guessing option names.
+    #
+    # Not carrying the server: `mcp-nixos` is in nixpkgs, and is taken from
+    # there through this flake's own pkgs. What nixpkgs has none of is the
+    # part that is actually hard -- three agents want the same server declared
+    # three different ways. Claude Code wants `mcpServers` in JSON, Codex
+    # wants `mcp_servers` in TOML, opencode wants `mcp` with the command as an
+    # array and a `type` of "local". `lib.mkConfig` knows all three, and a
+    # hand-rolled writer is how a config that works in one agent silently
+    # writes a key the other two never read.
+    #
+    # `follows`, and it matters more here than usual: the server package is
+    # resolved through `servers = nixpkgs.extend <their overlay>`, so with the
+    # follows it is OUR mcp-nixos and without it a second one from a second
+    # nixpkgs -- the buildEnv collision modules/AGENTS.md describes, arriving
+    # by a new route.
+    #
+    # Pinned to a COMMIT because this repository publishes no tags at all
+    # (`git ls-remote --tags` is empty), which is the situation sops-nix and
+    # nixi are already in. Bump it deliberately; never track the branch.
+    mcp-servers-nix = {
+      url = "github:natsukium/mcp-servers-nix/11fe2419e274bb223a86dddc9e4803b01ad359e8";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    # The prebuilt nix-index database, for #628 -- `command-not-found` that
+    # answers, and `comma`.
+    #
+    # The reason this is an input rather than `pkgs.nix-index` is the whole
+    # feature: nix-index's own database is built by running `nix-index`, which
+    # walks every store path nixpkgs describes and takes hours. A tool that
+    # answers "which package has this command" only after an afternoon of
+    # indexing is a tool nobody on a fresh install ever gets an answer from.
+    # This repository publishes that database, built weekly against
+    # nixos-unstable, as a fetchable artifact.
+    #
+    # Pinned to one of its weekly TAGS rather than to `main`: the database is
+    # dated by construction, so the pin should say which date, and a branch
+    # would move the closure under every open pull request. The lock bump
+    # moves it.
+    #
+    # `follows`, so the wrapper packages are built against the nixpkgs the
+    # machine is on -- the database is a data file and does not care, but
+    # `comma` and `nix-index` are binaries that would otherwise be a second
+    # copy of what is already in the profile.
+    nix-index-database = {
+      url = "github:nix-community/nix-index-database/2026-09-06-071918";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # Why: docs/internals/flake.md#221-222
     microvm = {
       url = "github:microvm-nix/microvm.nix/fdfc1821a0eb76e44a13d206b72e6ca6961fbb7c";

--- a/modules/home.nix
+++ b/modules/home.nix
@@ -41,6 +41,115 @@ let
   # there is no NixOS module to have set it.
   defaultAgent = osConfig.programs.nixarchy.defaultAgent or null;
 
+  # #623 and #630, read across from the NixOS side for the same reason
+  # `localAi` above is: these are machine decisions -- a package installed, a
+  # language server on PATH -- whose effect is a file in somebody's home. A
+  # second option here would be a second answer to the same question.
+  #
+  # `or` defaults throughout, because a standalone home-manager user has no
+  # NixOS module to have set any of them and every block below must then be
+  # inert.
+  mcpEnabled = osConfig.programs.nixarchy.mcp or false;
+  languageServer = osConfig.programs.nixarchy.languageServer or false;
+  nixdSettings = osConfig.programs.nixarchy.nixdSettings or { };
+
+  # The Nix IDE extension's half of the same settings, shared by VSCode and
+  # Cursor because they are the same editor with two config directories.
+  vscodeNixdSettings = pkgs.writeText "nixarchy-vscode-nixd.json" (
+    builtins.toJSON {
+      "nix.enableLanguageServer" = true;
+      "nix.serverPath" = lib.getExe pkgs.nixd;
+      "nix.serverSettings".nixd = nixdSettings;
+      "nix.formatterPath" = lib.getExe pkgs.nixfmt;
+    }
+  );
+
+  # Whether an app from the Install menu is actually selected. The editor
+  # blocks below are gated on it so that nothing writes a configuration file
+  # for an editor this machine does not have -- an orphan settings.json in
+  # ~/.config/Cursor is indistinguishable, to the person who finds it, from
+  # one they made themselves.
+  appEnabled = name: osConfig.programs.nixarchy.apps.${name}.enable or false;
+
+  # The MCP server declaration, in whichever shape the agent being written to
+  # reads. mcp-servers-nix owns the shapes: `mcpServers` in JSON for Claude
+  # Code, `mcp_servers` in TOML for Codex, `mcp` with the command as an array
+  # and a `type` of "local" for opencode. Three files, one declaration, and no
+  # chance of a key that one agent reads and the other two ignore.
+  mcpConfig =
+    args:
+    inputs.mcp-servers-nix.lib.mkConfig pkgs (
+      {
+        programs.nixos.enable = true;
+      }
+      // args
+    );
+
+  # Merge a generated JSON fragment into a config file the user also owns.
+  #
+  # The same shape as nixarchyOpencodeProvider below it, and for the same
+  # reasons: never a home-manager symlink, because these are files the agent
+  # and the editor both write to at runtime and a read-only store path makes
+  # them fail at the moment somebody clicks something; written to a temp file
+  # and moved, so an interrupted activation cannot leave half a config.
+  #
+  # `.[0] * .[1]` -- jq's `*` is a RECURSIVE object merge, so every key the
+  # file already had survives and only the ones named here are replaced. That
+  # is the difference between adding a server and replacing somebody's agent
+  # configuration.
+  mergeJson =
+    {
+      what,
+      file,
+      json,
+    }:
+    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      conf="${file}"
+      run mkdir -p "$(dirname "$conf")"
+      [ -s "$conf" ] || echo '{}' > "$conf"
+
+      tmp=$(${pkgs.coreutils}/bin/mktemp)
+      if ${pkgs.jq}/bin/jq -s '.[0] * .[1]' "$conf" ${json} > "$tmp"; then
+        run mv "$tmp" "$conf"
+      else
+        rm -f "$tmp"
+        echo "nixarchy: could not merge ${what} into $conf" >&2
+      fi
+    '';
+
+  # The same job for the two TOML files, where there is no jq.
+  #
+  # Appending a table rather than merging one, which is safe TOML precisely
+  # once: a second `[mcp_servers.nixos]` in the same file is a duplicate-key
+  # error, so the guard is the point and not a nicety. Guarded on the table
+  # header rather than on a marker comment of ours, because the thing that
+  # must not be written twice is the table -- including when the user wrote
+  # the first one themselves, in which case theirs is kept and nothing here
+  # touches it.
+  appendToml =
+    {
+      what,
+      file,
+      table,
+      toml,
+    }:
+    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      conf="${file}"
+      run mkdir -p "$(dirname "$conf")"
+      [ -e "$conf" ] || : > "$conf"
+
+      if ${pkgs.gnugrep}/bin/grep -qF '[${table}]' "$conf"; then
+        echo "nixarchy: $conf already declares [${table}]; leaving it alone"
+      else
+        {
+          echo ""
+          echo "# ${what} -- added by nixarchy. Delete this block to be rid of it;"
+          echo "# programs.nixarchy in your configuration decides whether it comes back."
+          ${pkgs.coreutils}/bin/cat ${toml}
+        } >> "$conf"
+      fi
+    '';
+
   # Same shape as localAi just above: declared on the NixOS side
   # (modules/services/boxes.nix), because `machines` names containers that
   # should exist regardless of which user's home-manager config is reading
@@ -690,6 +799,147 @@ in
         tmp=$(${pkgs.coreutils}/bin/mktemp)
         printf '%s\n' ${lib.escapeShellArg defaultAgent} > "$tmp"
         run mv "$tmp" "$agentfile"
+      ''
+    );
+
+    # ---- #623: the NixOS MCP server, in the agents that have one --------
+    #
+    # Three agents, not the four this module seeds skills into. `~/.agents`
+    # and `~/.pi/agent` have no documented MCP configuration file, and a path
+    # invented for them would be a feature that writes a file nothing reads --
+    # the shape §2 of AGENTS.md is about. Named here so the gap is a decision
+    # rather than an oversight; close it the day either tool documents one.
+    home.activation.nixarchyMcpClaude = lib.mkIf mcpEnabled (mergeJson {
+      what = "the NixOS MCP server";
+      # Claude Code's user scope is ~/.claude.json, not a file under
+      # ~/.claude/ -- the directory beside it is where the skills go. It is a
+      # large stateful file the tool rewrites constantly, which is exactly why
+      # this merges into it rather than generating it.
+      file = "${config.home.homeDirectory}/.claude.json";
+      json = mcpConfig {
+        flavor = "claude-code";
+        fileName = "nixarchy-mcp-claude.json";
+      };
+    });
+
+    home.activation.nixarchyMcpOpencode = lib.mkIf mcpEnabled (mergeJson {
+      what = "the NixOS MCP server";
+      # The same file nixarchyOpencodeProvider below writes the local model
+      # into, and merged the same way, so the two cannot undo each other.
+      file = "${config.xdg.configHome}/opencode/opencode.json";
+      json = mcpConfig {
+        flavor = "opencode";
+        fileName = "nixarchy-mcp-opencode.json";
+      };
+    });
+
+    home.activation.nixarchyMcpCodex = lib.mkIf mcpEnabled (appendToml {
+      what = "The NixOS MCP server";
+      file = "${config.home.homeDirectory}/.codex/config.toml";
+      table = "mcp_servers.nixos";
+      toml = mcpConfig {
+        flavor = "codex";
+        format = "toml";
+        fileName = "nixarchy-mcp-codex.toml";
+      };
+    });
+
+    # ---- #630: nixd, in the editors the Install menu offers --------------
+    #
+    # Every block is gated on the editor actually being selected. nixd itself
+    # is on PATH from modules/nixos.nix; what these do is the half a user
+    # cannot be expected to write, which is telling it which flake and which
+    # attribute -- see programs.nixarchy.nixdSettings.
+    home.activation.nixarchyNixdZed = lib.mkIf (languageServer && appEnabled "zed") (mergeJson {
+      what = "nixd";
+      file = "${config.xdg.configHome}/zed/settings.json";
+      json = pkgs.writeText "nixarchy-zed-nixd.json" (
+        builtins.toJSON {
+          lsp.nixd.initialization_options = nixdSettings;
+          # Zed ships nil as its Nix default, and a language_servers list
+          # naming only nixd would still leave nil running -- the `!` prefix
+          # is Zed's own way of removing a default, and without it two servers
+          # answer every completion request.
+          languages.Nix.language_servers = [
+            "nixd"
+            "!nil"
+          ];
+        }
+      );
+    });
+
+    # VSCode and Cursor read the same settings file under different product
+    # directories, and both go through the Nix IDE extension -- `nix.*` are
+    # its settings, not the editor's. `nix.serverPath` is an absolute store
+    # path on purpose: the extension spawns the server itself, and it does not
+    # inherit the login shell's PATH when the editor was launched from a
+    # desktop file.
+    home.activation.nixarchyNixdVscode = lib.mkIf (languageServer && appEnabled "vscode") (mergeJson {
+      what = "nixd";
+      file = "${config.xdg.configHome}/Code/User/settings.json";
+      json = vscodeNixdSettings;
+    });
+
+    home.activation.nixarchyNixdCursor = lib.mkIf (languageServer && appEnabled "cursor") (mergeJson {
+      what = "nixd";
+      file = "${config.xdg.configHome}/Cursor/User/settings.json";
+      json = vscodeNixdSettings;
+    });
+
+    # Helix takes its language server configuration as TOML, and what it puts
+    # under `[language-server.nixd.config]` is what it sends as the LSP
+    # initializationOptions -- the same attrset the other three editors get,
+    # spelled in Helix's file.
+    home.activation.nixarchyNixdHelix = lib.mkIf (languageServer && appEnabled "helix") (appendToml {
+      what = "nixd, the Nix language server";
+      file = "${config.xdg.configHome}/helix/languages.toml";
+      table = "language-server.nixd";
+      toml = (pkgs.formats.toml { }).generate "nixarchy-helix-nixd.toml" {
+        language-server.nixd = {
+          command = "nixd";
+          config = nixdSettings;
+        };
+        # A [[language]] entry rather than a table: this is how Helix takes a
+        # per-language override, and without it the `nixd` server defined
+        # above is configured and never used.
+        language = [
+          {
+            name = "nix";
+            language-servers = [ "nixd" ];
+          }
+        ];
+      };
+    });
+
+    # Neovim, through the LazyVim tree this module already seeds. A file of
+    # its own under lua/plugins rather than an edit to one of Omarchy's, so a
+    # user who wants it gone deletes one file -- and written only when it is
+    # absent, for the reason the seed above states: every .lua under
+    # lua/plugins is read as a plugin spec, and clobbering one somebody wrote
+    # is not this module's to do.
+    home.activation.nixarchyNixdNeovim = lib.mkIf (languageServer && cfg.neovim != "off") (
+      lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        spec="${config.xdg.configHome}/nvim/lua/plugins/nixd.lua"
+        if [ -d "${config.xdg.configHome}/nvim/lua/plugins" ] && [ ! -e "$spec" ]; then
+          run install -m 0644 ${pkgs.writeText "nixarchy-nvim-nixd.lua" ''
+            -- Written by nixarchy (programs.nixarchy.languageServer).
+            -- Delete this file to be rid of it; nothing here rewrites it.
+            return {
+              {
+                "neovim/nvim-lspconfig",
+                opts = {
+                  servers = {
+                    nixd = {
+                      cmd = { "nixd" },
+                      settings = { nixd = vim.json.decode([==[${builtins.toJSON nixdSettings}]==]) },
+                    },
+                  },
+                },
+              },
+            }
+          ''} "$spec"
+          echo "nixarchy: pointed Neovim at nixd, which knows this machine's flake"
+        fi
       ''
     );
 

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -128,6 +128,100 @@ let
       (_: {
         passthru.providedSessions = [ "omarchy" ];
       });
+  # The prebuilt nix-index database and the two wrappers that read it (#628).
+  #
+  # Through `import <input> { inherit pkgs; }` rather than through the input's
+  # own NixOS module, and the reason is Mode A. `imports` cannot be
+  # conditional, and their module's `programs.nix-index-database.enable`
+  # defaults to TRUE -- so importing it would turn nix-index on for somebody
+  # who imported nixosModules.nixarchy and left programs.nixarchy.enable at
+  # false, which is the one thing this module promises never to do. Taking the
+  # packages and putting them inside our own mkIf costs three lines and keeps
+  # the promise.
+  nixIndexPackages = import inputs.nix-index-database { inherit pkgs; };
+
+  # The `command not found` answer, which is not nix-index's own.
+  #
+  # nix-index's handler ends at `nix shell nixpkgs#foo`. That is the right
+  # sentence on a machine whose software is imperative, and the wrong one
+  # here: this machine's packages live in a file, and an ephemeral shell is
+  # gone at the next prompt. The two lines a stuck beginner needs are the one
+  # that runs it now and the one that writes it down -- `, foo` and
+  # `nixarchy pkg add <attr>`.
+  #
+  # runtimeInputs, not a PATH assumption: writeShellApplication builds a
+  # strict PATH from it, and nix-locate missing at runtime would read as
+  # "nothing provides that command" -- a wrong answer rather than a missing
+  # one, which is the failure this whole feature exists to end.
+  commandNotFound = pkgs.writeShellApplication {
+    name = "nixarchy-command-not-found";
+    runtimeInputs = [
+      nixIndexPackages.nix-index-with-db
+      pkgs.coreutils
+    ];
+    text = ''
+      cmd=''${1:-}
+      [ -n "$cmd" ] || exit 127
+
+      # --top-level keeps the answer to attribute names somebody can actually
+      # write in apps.nix; --minimal drops everything but the name; --type x
+      # and s are executables and symlinks to them, which is what `bin/` holds.
+      hits=$(nix-locate --minimal --no-group --top-level \
+        --type x --type s --whole-name "bin/$cmd" 2>/dev/null | head -n 5 || true)
+
+      if [ -z "$hits" ]; then
+        echo "$cmd: command not found, and nothing in nixpkgs provides bin/$cmd." >&2
+        echo "  nixarchy search $cmd    looks for it by name instead" >&2
+        exit 127
+      fi
+
+      first=$(printf '%s\n' "$hits" | head -n 1)
+
+      echo "$cmd: command not found. In nixpkgs it comes from:" >&2
+      printf '%s\n' "$hits" | while IFS= read -r attr; do
+        [ -n "$attr" ] || continue
+        echo "  $attr" >&2
+      done
+      echo >&2
+      echo "  Run it once:      , $cmd" >&2
+      echo "  Keep it:          nixarchy pkg add $first    (then: nixarchy apply)" >&2
+      exit 127
+    '';
+  };
+
+  # nixd, told where the flake is -- which is the whole of #630.
+  #
+  # These expressions are what a user is otherwise asked to write by hand, out
+  # of two facts they have to know: the path of their flake and the attribute
+  # their machine is under. Both are already in this evaluation, so neither
+  # has to be guessed. Shared with modules/home.nix through
+  # `programs.nixarchy.nixdSettings`, because the settings have to land in
+  # five editors' config files and a second copy would be a second answer.
+  #
+  # builtins.getFlake on a path, not a flake reference: nixd evaluates this in
+  # its own nix, with no flake registry entry for this machine.
+  nixdSettings = {
+    nixpkgs.expr = "import (builtins.getFlake \"${cfg.flake}\").inputs.nixpkgs { }";
+    formatting.command = [ "${lib.getExe pkgs.nixfmt}" ];
+  }
+  # The option expressions name `nixosConfigurations.<host>`, so they need a
+  # host to name. An empty networking.hostName is a real state -- every
+  # nixosTest node has one, and so does a configuration evaluated before the
+  # installer has written a hostname -- and interpolating it produces
+  # `nixosConfigurations..options`, which nixd would evaluate, fail on, and
+  # report as nothing at all. Completion against nixpkgs still works without
+  # this half, so the half that cannot work is left out rather than shipped
+  # broken.
+  // lib.optionalAttrs (config.networking.hostName != "") {
+    options = {
+      nixos.expr = "(builtins.getFlake \"${cfg.flake}\").nixosConfigurations.${config.networking.hostName}.options";
+      # home-manager's options are not a top-level attribute of the system;
+      # they are the per-user submodule's, and getSubOptions is the only way
+      # to reach them from outside an evaluated user. Without this line nixd
+      # completes NixOS options and silently knows nothing about home.*.
+      home-manager.expr = "(builtins.getFlake \"${cfg.flake}\").nixosConfigurations.${config.networking.hostName}.options.home-manager.users.type.getSubOptions []";
+    };
+  };
 in
 {
   imports = [
@@ -526,6 +620,117 @@ in
       '';
     };
 
+    commandNotFound = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Answer `command not found` with the package that carries the command,
+        a way to run it once, and the line that installs it for good.
+
+        The Arch reflex is `pacman -S thing`, and on NixOS it is a dead end at
+        precisely the moment a beginner is already stuck. NixOS' own
+        `programs.command-not-found` cannot help on a flake machine: it reads
+        a database that only the channel mechanism ships, so on every machine
+        this project writes it is either absent or stale and the shell says
+        nothing at all.
+
+        What this turns on instead is `nix-index`, with the PREBUILT database
+        from the nix-index-database input -- the distinction that makes the
+        feature exist rather than being a package nobody can use. nix-index's
+        own index is produced by walking nixpkgs for hours, and an answer that
+        arrives after an afternoon is not an answer to somebody at a prompt.
+
+        It also installs `comma`, so `, somecommand` runs a thing once without
+        installing it, and it replaces the handler's stock advice with this
+        machine's: `nixarchy pkg add <attr>` then `nixarchy apply`, which is
+        the permanent form on a machine whose software lives in a file.
+
+        Turning it off leaves `programs.nix-index` and
+        `programs.command-not-found` exactly as your own configuration has
+        them.
+      '';
+    };
+
+    mcp = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Declare the NixOS MCP server (`mcp-nixos`) in the coding agents this
+        machine already seeds skills into.
+
+        LLMs write bad Nix because the corpus is small, the language is lazy
+        and untyped, and option names are not guessable -- the failure this
+        repository's own AGENTS.md files are full of is an agent confidently
+        naming an option that does not exist. An MCP server answers that
+        question against the real package and option sets rather than against
+        a model's memory of them.
+
+        Three agents get it, and the count is three rather than four on
+        purpose. Claude Code (`~/.claude.json`), Codex (`~/.codex/config.toml`)
+        and opencode (`~/.config/opencode/opencode.json`) each have a
+        documented MCP configuration file, and each wants the same server in a
+        different shape -- which is why the config is generated by
+        mcp-servers-nix rather than written out three times here. The other
+        two skill directories this machine writes, `~/.agents/skills` and
+        `~/.pi/agent/skills`, have no documented MCP configuration file to
+        write, and inventing a path for them would be a feature that silently
+        does nothing.
+
+        Never clobbers: each file is merged into, key by key, so a server you
+        declared yourself survives and nothing else in the file is touched.
+      '';
+    };
+
+    languageServer = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Install `nixd` and point this machine's editors at it, already told
+        where the flake is.
+
+        `nixd` links the real evaluator, so it completes NixOS and Home
+        Manager option names AND their defaults against this machine's actual
+        configuration -- which is the question a person learning NixOS cannot
+        answer and cannot guess. `nil`, the other Nix language server, does
+        keywords, locals and builtins; it cannot tell you that
+        `services.foo.enable` exists.
+
+        nixd's one real weakness is that it has to be told where the flake is
+        and which attribute to evaluate, and that is exactly the thing a
+        distribution knows and a user does not. `programs.nixarchy.flake` and
+        `networking.hostName` are both already here, so the `nixpkgs`,
+        `options.nixos` and `options.home-manager` expressions are written out
+        rather than left as a snippet in a manual for somebody to copy.
+
+        The editors wired are the ones the Install menu offers plus the Neovim
+        configuration this desktop seeds: VSCode and Cursor (through the Nix
+        IDE extension's settings), Zed, Helix and Neovim. Each is written only
+        when that editor is actually selected, and never over a setting you
+        made yourself.
+      '';
+    };
+
+    nixdSettings = lib.mkOption {
+      type = lib.types.attrsOf lib.types.anything;
+      internal = true;
+      default = { };
+      description = ''
+        The nixd configuration this machine derives from its own flake path
+        and hostname. Derived, not chosen -- which is why it is `internal`
+        rather than `readOnly`: an option default is itself a definition, and
+        `readOnly` counts it, so a read-only option with a default throws
+        "set multiple times" the moment anything defines it. Measured, not
+        assumed.
+
+        It exists as an option rather than as a `let` binding because
+        modules/home.nix is a separate module tree that has to write the same
+        settings into five editors' configuration files, and two copies of an
+        expression that names `nixosConfigurations.<host>` is two answers to
+        the same question -- the failure programs.nixarchy.localAi already
+        avoids by being read across rather than declared twice.
+      '';
+    };
+
   };
 
   config = lib.mkIf cfg.enable {
@@ -582,6 +787,10 @@ in
 
     # Why: modules/AGENTS.md#most-of-what-the-install-menu-offers-is-unfree
     nixpkgs.config = lib.mkIf cfg.allowUnfree (lib.mkDefault { allowUnfree = true; });
+
+    # Derived, not chosen -- see the option. Published here so modules/home.nix
+    # can write the same settings into every editor it configures.
+    programs.nixarchy.nixdSettings = nixdSettings;
 
     nix.settings =
       let
@@ -770,24 +979,62 @@ in
       # mention -- Arch's env-bootstrap and bash_completion -- are both behind
       # `[ -r ... ]` guards, and their jobs are already done by this module and
       # by NixOS respectively.
-      bash.interactiveShellInit = lib.mkIf cfg.bashIntegration ''
-        source ${cfg.package}/share/omarchy/default/bash/rc
-      '';
+      bash.interactiveShellInit = lib.mkMerge [
+        (lib.mkIf cfg.bashIntegration ''
+          source ${cfg.package}/share/omarchy/default/bash/rc
+        '')
+
+        # bash's hook is spelled command_not_found_handle -- no trailing `r`,
+        # unlike zsh's. Getting that wrong defines a function nothing ever
+        # calls, which is silent, so both names are written out here rather
+        # than shared through a variable that would hide the difference.
+        (lib.mkIf cfg.commandNotFound ''
+          command_not_found_handle() {
+            ${lib.getExe commandNotFound} "$1"
+            return $?
+          }
+        '')
+      ];
 
       # The same for zsh, which upstream does not ship. Only when zsh is
       # actually enabled: programs.zsh.interactiveShellInit on a machine with
       # no zsh writes an rc nothing reads, and turning zsh on for someone who
       # did not ask is not this module's business.
-      zsh.interactiveShellInit = lib.mkIf (cfg.shellIntegration && config.programs.zsh.enable) ''
-        source ${cfg.package}/share/omarchy/default/zsh/rc
-      '';
+      zsh.interactiveShellInit = lib.mkMerge [
+        (lib.mkIf (cfg.shellIntegration && config.programs.zsh.enable) ''
+          source ${cfg.package}/share/omarchy/default/zsh/rc
+        '')
+        (lib.mkIf (cfg.commandNotFound && config.programs.zsh.enable) ''
+          command_not_found_handler() {
+            ${lib.getExe commandNotFound} "$1"
+            return $?
+          }
+        '')
+      ];
 
       # fish, same condition. Its rc derives everything from the same bash
       # files rather than translating them, so it tracks upstream the way the
       # other two do.
-      fish.interactiveShellInit = lib.mkIf (cfg.shellIntegration && config.programs.fish.enable) ''
-        source ${cfg.package}/share/omarchy/default/fish/rc
-      '';
+      fish.interactiveShellInit = lib.mkMerge [
+        (lib.mkIf (cfg.shellIntegration && config.programs.fish.enable) ''
+          source ${cfg.package}/share/omarchy/default/fish/rc
+        '')
+        # fish uses an event function, not a name the shell looks up, and it
+        # passes the command as $argv[1].
+        (lib.mkIf (cfg.commandNotFound && config.programs.fish.enable) ''
+          function fish_command_not_found
+            ${lib.getExe commandNotFound} $argv[1]
+          end
+        '')
+      ];
+
+      # NixOS' own command-not-found reads a programs.sqlite that only the
+      # channel mechanism ships. On a flake machine -- every machine this
+      # project writes -- it is absent or stale, so the shell says nothing at
+      # all, which is worse than saying the wrong thing because there is no
+      # symptom to search for. mkDefault: somebody who has a channel and wants
+      # it keeps it by saying so.
+      command-not-found.enable = lib.mkIf cfg.commandNotFound (lib.mkDefault false);
     };
 
     # The resolved half of the flake's safe.directory entry -- see the
@@ -914,6 +1161,28 @@ in
         # the theme: Ice is white for dark themes, Classic black for light.
         bibata-cursors
       ])
+      ++ lib.optionals cfg.commandNotFound [
+        # nix-locate, backed by the prebuilt database rather than by one this
+        # machine would have to spend an afternoon building -- and `comma`,
+        # so `, foo` runs something once. Both wrappers come from the
+        # nix-index-database input; the plain pkgs.comma reads an index that
+        # is not there and answers nothing.
+        nixIndexPackages.nix-index-with-db
+        nixIndexPackages.comma-with-db
+
+        # The handler itself, on PATH rather than only inside the shell hook.
+        # Two reasons, and the second is the load-bearing one: `nixarchy
+        # doctor` and a user can both ask it a question directly, and a check
+        # can RUN it. A handler reachable only through a shell function is one
+        # no evaluation-time check can do more than grep for.
+        commandNotFound
+      ]
+      ++ lib.optionals cfg.languageServer [
+        # The language server itself. The editors are pointed at it by
+        # modules/home.nix, which is where an editor's configuration file
+        # lives; what has to be on PATH is the binary they exec.
+        pkgs.nixd
+      ]
       ++ lib.optionals cfg.preinstalls (
         # Filtered by attribute name rather than by pname: the name someone
         # writes in preinstallsExclude is the one they would look up on

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -84,6 +84,114 @@ let
       ];
     }).config;
 
+  # A home evaluated as if it were on a nixarchy MACHINE, which `homeWith`
+  # above deliberately is not.
+  #
+  # Everything #623 and #630 add to modules/home.nix is read across from
+  # `osConfig` -- the MCP declaration, the language server settings, and which
+  # editors from the Install menu are selected -- so under `homeWith`, where
+  # osConfig is null, every one of them is correctly inert and a check built
+  # on it would assert nothing. This passes a real NixOS configuration in
+  # through extraSpecialArgs, which is the same route home-manager takes when
+  # it is used as a NixOS module.
+  homeOn =
+    osSettings: hmSettings:
+    (inputs.home-manager.lib.homeManagerConfiguration {
+      inherit pkgs;
+      extraSpecialArgs = {
+        osConfig = configNamed "testbox" osSettings;
+      };
+      modules = [
+        inputs.self.homeManagerModules.nixarchy
+        {
+          home = {
+            username = "someone";
+            homeDirectory = "/home/someone";
+            stateVersion = "25.05";
+          };
+          programs.nixarchy.enable = true;
+        }
+        hmSettings
+      ];
+    }).config;
+
+  # configWith, with a hostname. The nixd option expressions name
+  # `nixosConfigurations.<host>`, and every machine configWith builds has an
+  # EMPTY networking.hostName -- so a check written against configWith alone
+  # would exercise only the branch where those expressions are left out, and
+  # would pass with the branch that writes them completely broken.
+  configNamed =
+    hostName: settings:
+    (inputs.nixpkgs.lib.nixosSystem {
+      inherit system;
+      modules = [
+        inputs.self.nixosModules.nixarchy
+        {
+          programs.nixarchy = {
+            enable = true;
+          }
+          // settings;
+        }
+        {
+          networking.hostName = hostName;
+          boot.loader.grub.device = "/dev/sda";
+          fileSystems."/" = {
+            device = "/dev/sda1";
+            fsType = "ext4";
+          };
+          system.stateVersion = "25.05";
+        }
+      ];
+    }).config;
+
+  # The four editors the Install menu offers that take a language server
+  # configuration file. Named once: the "on" and "off" halves have to ask
+  # about the same machine or the pair proves nothing.
+  everyEditor = {
+    apps = {
+      vscode.enable = true;
+      cursor.enable = true;
+      zed.enable = true;
+      helix.enable = true;
+    };
+  };
+
+  nixdActivationNames = [
+    "nixarchyNixdVscode"
+    "nixarchyNixdCursor"
+    "nixarchyNixdZed"
+    "nixarchyNixdHelix"
+  ];
+
+  mcpActivationNames = [
+    "nixarchyMcpClaude"
+    "nixarchyMcpCodex"
+    "nixarchyMcpOpencode"
+  ];
+
+  # Every activation script this home would run, as one string. The "off"
+  # half of a pair asks whether the name appears ANYWHERE, not whether one
+  # named block is missing -- a block renamed rather than removed would pass
+  # the narrower question with the feature fully present.
+  activationText =
+    home: pkgs.lib.concatStringsSep "\n" (map (a: a.data) (builtins.attrValues home.home.activation));
+
+  hasAll = home: names: builtins.all (n: home.home.activation ? ${n}) names;
+  hasAny = home: names: builtins.any (n: home.home.activation ? ${n}) names;
+
+  # Whether a package with this name is in the machine's profile.
+  #
+  # By NAME rather than by `pathExists "${p}/bin/<command>"`, which is the
+  # obvious way to ask and is a trap here: coercing a derivation to a path
+  # makes pathExists answer about a store path that has not been built, so the
+  # honest-looking version reports false for both halves of every pair and the
+  # case passes while proving nothing. The names are the wrappers'
+  # (`comma-with-db`, `nix-index-with-full-db`), and being wrapper names is
+  # itself part of what is asserted: plain pkgs.comma reads an index that is
+  # not on the machine and answers nothing, which is the failure #628 is about.
+  hasPackageNamed =
+    cfg: name: builtins.any (p: pkgs.lib.hasPrefix name (p.name or "")) cfg.environment.systemPackages;
+
   # nixi's bar plugin, by the id in its own manifest.json. Named once: the
   # "on" and "off" halves have to ask about the same path or the pair proves
   # nothing.
@@ -142,6 +250,163 @@ let
 
   # Each case is (what it should look like on, what it should look like off).
   cases = {
+    # ---- #628: command-not-found that answers, and comma ----------------
+    #
+    # Every pair here is "a default machine has it / a machine that said
+    # commandNotFound = false does not". The off half is the one nothing else
+    # exercises, and it is also the half that matters to somebody who already
+    # runs nix-index their own way.
+    commandNotFoundComma = {
+      on = hasPackageNamed (configWith { }) "comma-with-db";
+      off = hasPackageNamed (configWith { commandNotFound = false; }) "comma-with-db";
+    };
+
+    # The PREBUILT database, which is the whole reason this is an input rather
+    # than pkgs.nix-index. A machine carrying nix-index without it has a tool
+    # that answers nothing until somebody spends an afternoon indexing.
+    commandNotFoundDatabase = {
+      on = hasPackageNamed (configWith { }) "nix-index-with-full-db";
+      off = hasPackageNamed (configWith { commandNotFound = false; }) "nix-index-with-full-db";
+    };
+
+    # The handler reachable by name, which is what lets the runCommand below
+    # actually RUN it rather than grep for it.
+    commandNotFoundHandler = {
+      on = hasPackageNamed (configWith { }) "nixarchy-command-not-found";
+      off = hasPackageNamed (configWith { commandNotFound = false; }) "nixarchy-command-not-found";
+    };
+
+    # And the hook, per shell, because the three names differ and getting one
+    # wrong defines a function nothing ever calls -- silently.
+    #
+    # The parenthesis is not decoration. Written as a bare
+    # `hasInfix "command_not_found_handle"`, this case PASSED with bash's hook
+    # renamed to zsh's -- `command_not_found_handler` contains
+    # `command_not_found_handle`, so the probe could not vary with the bug it
+    # existed to catch. Found by breaking it and watching it stay green, which
+    # is the only way that shape is ever found (AGENTS.md §1).
+    commandNotFoundBashHook = {
+      on =
+        pkgs.lib.hasInfix "command_not_found_handle()"
+          (configWith { }).programs.bash.interactiveShellInit;
+      off =
+        pkgs.lib.hasInfix "command_not_found_handle()"
+          (configWith {
+            commandNotFound = false;
+          }).programs.bash.interactiveShellInit;
+    };
+
+    commandNotFoundZshHook = {
+      on =
+        pkgs.lib.hasInfix "command_not_found_handler()"
+          (configBeside {
+            programs.zsh.enable = true;
+          }).programs.zsh.interactiveShellInit;
+      off =
+        pkgs.lib.hasInfix "command_not_found_handler()"
+          (configWith {
+            commandNotFound = false;
+          }).programs.zsh.interactiveShellInit;
+    };
+
+    commandNotFoundFishHook = {
+      on =
+        pkgs.lib.hasInfix "function fish_command_not_found"
+          (configBeside {
+            programs.fish.enable = true;
+          }).programs.fish.interactiveShellInit;
+      off =
+        pkgs.lib.hasInfix "function fish_command_not_found"
+          (configWith {
+            commandNotFound = false;
+          }).programs.fish.interactiveShellInit;
+    };
+
+    # Mode A -- `loaderOff`, the machine that imported nixosModules.nixarchy and enabled nothing,
+    # and must therefore have none of this -- no handler replacing their
+    # shell's, no second nix-index, and no opinion about
+    # programs.command-not-found.
+    commandNotFoundLeavesAdopterAlone = {
+      on = hasPackageNamed (configWith { }) "comma-with-db";
+      off = hasPackageNamed loaderOff "comma-with-db";
+    };
+
+    # ---- #623: the NixOS MCP server, in the agents that have one ---------
+    #
+    # All three in one case, because "off" has to be all of them and a
+    # per-agent case would let one survivor hide behind two passes.
+    mcpServers = {
+      on = hasAll (homeOn { } { }) mcpActivationNames;
+      off = hasAny (homeOn { mcp = false; } { }) mcpActivationNames;
+    };
+
+    # And that a generated config is what gets merged in, rather than a
+    # literal this file would have had to keep in step by hand. The store path
+    # is in the activation script, so its name is readable without building
+    # anything; what is IN it is asserted in the runCommand below, which
+    # greps the file itself.
+    mcpWiresGeneratedConfig = {
+      on = pkgs.lib.hasInfix "nixarchy-mcp-claude.json" (activationText (homeOn { } { }));
+      off = pkgs.lib.hasInfix "nixarchy-mcp-claude.json" (activationText (homeOn { mcp = false; } { }));
+    };
+
+    # A standalone home-manager user is the other off state, and it is not the
+    # same one: there is no NixOS module to have set `mcp` either way, so the
+    # blocks must be inert rather than disabled. That is the shape that breaks
+    # when somebody replaces an `or false` with a bare attribute access.
+    mcpInertWithoutOsConfig = {
+      on = hasAny (homeOn { } { }) mcpActivationNames;
+      off = hasAny (homeWith { }) mcpActivationNames;
+    };
+
+    # ---- #630: nixd, in the editors the Install menu offers --------------
+    nixdPackage = {
+      on = hasPackageNamed (configWith { }) "nixd";
+      off = hasPackageNamed (configWith { languageServer = false; }) "nixd";
+    };
+
+    nixdEditors = {
+      on = hasAll (homeOn everyEditor { }) nixdActivationNames;
+      off = hasAny (homeOn (everyEditor // { languageServer = false; }) { }) nixdActivationNames;
+    };
+
+    # An editor that is not selected gets no configuration file. An orphan
+    # settings.json in ~/.config/Cursor is indistinguishable, to whoever finds
+    # it, from one they wrote themselves.
+    nixdOnlyForSelectedEditors = {
+      on = hasAny (homeOn everyEditor { }) nixdActivationNames;
+      off = hasAny (homeOn { } { }) nixdActivationNames;
+    };
+
+    # The Neovim spec, which rides on the neovim option rather than on an app
+    # row -- Neovim is a runtime dependency of the omarchy package and is
+    # never "selected".
+    nixdNeovim = {
+      on = (homeOn { } { }).home.activation ? nixarchyNixdNeovim;
+      off = (homeOn { } { programs.nixarchy.neovim = "off"; }).home.activation ? nixarchyNixdNeovim;
+    };
+
+    # The half that makes nixd worth shipping: it is told which flake and
+    # which attribute. Both halves ask the same machine about the same string;
+    # what differs is whether the machine has a hostname, which is the branch
+    # modules/nixos.nix leaves those expressions out of. Without this pair the
+    # empty-hostname branch is the only one every other check ever takes --
+    # every nixosTest node has one -- so the branch that does the work would
+    # be untested.
+    nixdKnowsTheMachine = {
+      on = pkgs.lib.hasInfix "nixosConfigurations.testbox.options" (
+        builtins.toJSON (configNamed "testbox" { }).programs.nixarchy.nixdSettings
+      );
+      off = pkgs.lib.hasInfix "nixosConfigurations..options" (
+        builtins.toJSON (configWith { }).programs.nixarchy.nixdSettings
+      );
+    };
+
+    nixdLeavesAdopterAlone = {
+      on = hasPackageNamed (configWith { }) "nixd";
+      off = hasPackageNamed loaderOff "nixd";
+    };
+
     # ---- nixi, on for everyone, and provably gone when told ----
     #
     # These are the reverse of every other case in this file, and the header's
@@ -1424,6 +1689,18 @@ pkgs.runCommand "nixarchy-options"
     # The template as it exists in the store -- the file a `grep -r password`
     # over everything nixarchy generated would find.
     rdpTemplateFile = rdpOn.sops.templates."hypr-rdp.toml".file;
+    # #623 and #630, as the activation scripts that would run on a real home.
+    # Both carry store-path context -- the generated MCP configs and the
+    # editor settings are derivations named inside them -- so naming them
+    # here is what makes those files exist in the store while this check runs,
+    # which is what lets the script below grep the files rather than the
+    # expression that produced them.
+    mcpActivations = pkgs.lib.concatStringsSep "\n" (
+      map (n: (homeOn { } { }).home.activation.${n}.data) mcpActivationNames
+    );
+    nixdActivationScripts = pkgs.lib.concatStringsSep "\n" (
+      map (n: (homeOn everyEditor { }).home.activation.${n}.data) nixdActivationNames
+    );
     syncthingDataDir = syncthingBeside.services.syncthing.dataDir;
     ollamaPort = builtins.toString ollamaBeside.services.ollama.port;
     ollamaEndpoint = ollamaBeside.programs.nixarchy.localAi.resolved.endpoint;
@@ -3417,6 +3694,225 @@ pkgs.runCommand "nixarchy-options"
           exit 1
         }
         echo "the marker config-repo's plaintext-store guard keys on is the one sops writes"
+        # ---- #628: the command-not-found answer, RUN ----------------------
+        #
+        # Not grepped. The handler is a writeShellApplication with a strict
+        # PATH, which is what makes it safe at runtime and awkward here --
+        # nix-locate is baked in and cannot be replaced by putting a stub
+        # first on PATH. So the script is copied and its one `export PATH`
+        # line is rewritten to put a stub directory in front, which is the
+        # only edit made to it.
+        cnf="$vm/sw/bin/nixarchy-command-not-found"
+        [ -x "$cnf" ] || {
+          echo "no nixarchy-command-not-found on the machine's PATH:" >&2
+          echo "  the shell hook names it, so the hook would be a function that fails" >&2
+          exit 1
+        }
+
+        mkdir -p stub hit miss
+        sed "s#^export PATH=\"#export PATH=\"$PWD/stub:#" "$cnf" > stub-cnf
+        chmod +x stub-cnf
+        grep -q "^export PATH=\"$PWD/stub:" stub-cnf || {
+          echo "the handler has no 'export PATH=' line to shadow:" >&2
+          echo "  writeShellApplication changed shape, and this stub reaches nothing" >&2
+          exit 1
+        }
+
+        # printf rather than a heredoc: this whole script is an indented Nix
+        # string, so every heredoc line would carry its indentation into the
+        # stub -- and a shebang with leading spaces is not a shebang.
+        printf '#!/bin/sh\necho ripgrep\necho rustPackages.rg\n' > stub/nix-locate
+        chmod +x stub/nix-locate
+
+        set +e
+        got=$(./stub-cnf rg 2>&1)
+        rc=$?
+        set -e
+
+        [ "$rc" = 127 ] || {
+          echo "the handler exited $rc, not 127:" >&2
+          echo "  127 is what a shell reports for a command it could not find, and" >&2
+          echo "  the hook returns whatever this returns" >&2
+          exit 1
+        }
+
+        for needle in "ripgrep" ", rg" "nixarchy pkg add ripgrep" "nixarchy apply"; do
+          case "$got" in
+            *"$needle"*) ;;
+            *)
+              echo "the command-not-found answer does not contain '$needle':" >&2
+              printf '%s\n' "$got" >&2
+              echo "  #628 is about the two sentences a stuck beginner needs -- run it" >&2
+              echo "  once, and write it down -- not about naming a package" >&2
+              exit 1
+              ;;
+          esac
+        done
+        echo "command-not-found names the package, the one-shot, and the permanent form"
+
+        # And the other branch, which is the one a bad --whole-name would make
+        # universal: nothing in nixpkgs provides it. It must not offer to add
+        # a package it did not find.
+        printf '#!/bin/sh\nexit 0\n' > stub/nix-locate
+        chmod +x stub/nix-locate
+
+        set +e
+        got=$(./stub-cnf nosuchcommand 2>&1)
+        rc=$?
+        set -e
+
+        [ "$rc" = 127 ] || {
+          echo "the empty-result branch exited $rc, not 127" >&2
+          exit 1
+        }
+        case "$got" in
+          *"nixarchy pkg add"*)
+            echo "the handler offered 'nixarchy pkg add' for a command nothing provides:" >&2
+            printf '%s\n' "$got" >&2
+            exit 1
+            ;;
+        esac
+        case "$got" in
+          *"nothing in nixpkgs provides"*) ;;
+          *)
+            echo "the empty-result branch says nothing useful:" >&2
+            printf '%s\n' "$got" >&2
+            exit 1
+            ;;
+        esac
+        echo "a command nothing provides gets a different answer, not a wrong one"
+
+        # ---- the doctor stops naming a tool the machine does not have ----
+        #
+        # #628 in its smallest form. pkgs/doctor.sh told the user to run
+        # `nix-locate` at the exact moment they were already stuck, and
+        # nothing installed it. The advice is only worth keeping if the
+        # command is there, so this asserts the pair rather than either half
+        # -- the same shape as pkgs/omarchy's runtime list (AGENTS.md §2).
+        if grep -q 'nix-locate' "$vm/sw/bin/nixarchy-doctor"; then
+          [ -x "$vm/sw/bin/nix-locate" ] || {
+            echo "nixarchy-doctor names nix-locate and the machine does not have it:" >&2
+            echo "  that is advice a stuck user cannot act on -- #628" >&2
+            exit 1
+          }
+          echo "the doctor names nix-locate, and nix-locate is on the machine"
+        else
+          echo "nixarchy-doctor no longer names nix-locate; nothing to pair"
+        fi
+
+        # ---- #623: what actually lands in each agent's file --------------
+        #
+        # The generated configs, greped as files. Each is a store path named
+        # inside an activation script, and $mcpActivations carries them here
+        # as build inputs -- so these are the bytes a real activation would
+        # merge in, not a restatement of the expression that made them.
+        claude=$(printf '%s' "$mcpActivations" |
+          grep -o '/nix/store/[0-9a-z]*-nixarchy-mcp-claude.json' | head -n 1)
+        codex=$(printf '%s' "$mcpActivations" |
+          grep -o '/nix/store/[0-9a-z]*-nixarchy-mcp-codex.toml' | head -n 1)
+        opencode=$(printf '%s' "$mcpActivations" |
+          grep -o '/nix/store/[0-9a-z]*-nixarchy-mcp-opencode.json' | head -n 1)
+
+        for pair in "$claude:claude" "$codex:codex" "$opencode:opencode"; do
+          f=''${pair%:*}
+          who=''${pair#*:}
+          [ -n "$f" ] && [ -e "$f" ] || {
+            echo "no generated MCP config reached the $who activation" >&2
+            exit 1
+          }
+          grep -q 'mcp-nixos' "$f" || {
+            echo "the $who MCP config does not name mcp-nixos:" >&2
+            cat "$f" >&2
+            echo "  an empty server block is what a misspelled package attribute" >&2
+            echo "  produces, and it fails silently inside the agent" >&2
+            exit 1
+          }
+        done
+
+        # The three KEYS, which are the whole reason mcp-servers-nix is an
+        # input rather than three toJSON calls. Claude Code reads mcpServers,
+        # Codex reads mcp_servers, opencode reads mcp with the command as an
+        # array -- a config written in one agent's shape is invisible in the
+        # other two, with no error anywhere.
+        grep -q '"mcpServers"' "$claude" || {
+          echo "the Claude Code config has no mcpServers key:" >&2
+          cat "$claude" >&2
+          exit 1
+        }
+        grep -q '^\[mcp_servers\.nixos\]' "$codex" || {
+          echo "the Codex config has no [mcp_servers.nixos] table:" >&2
+          cat "$codex" >&2
+          exit 1
+        }
+        grep -q '"mcp"' "$opencode" || {
+          echo "the opencode config has no mcp key:" >&2
+          cat "$opencode" >&2
+          exit 1
+        }
+        echo "each agent gets the server in the shape that agent reads"
+
+        # ---- #630: what nixd is told, in each editor's own file ----------
+        zedjson=$(printf '%s' "$nixdActivationScripts" |
+          grep -o '/nix/store/[0-9a-z]*-nixarchy-zed-nixd.json' | head -n 1)
+        helixtoml=$(printf '%s' "$nixdActivationScripts" |
+          grep -o '/nix/store/[0-9a-z]*-nixarchy-helix-nixd.toml' | head -n 1)
+        vscodejson=$(printf '%s' "$nixdActivationScripts" |
+          grep -o '/nix/store/[0-9a-z]*-nixarchy-vscode-nixd.json' | head -n 1)
+
+        for f in "$zedjson" "$helixtoml" "$vscodejson"; do
+          [ -n "$f" ] && [ -e "$f" ] || {
+            echo "an editor's nixd configuration did not reach its activation" >&2
+            exit 1
+          }
+          # The one thing that makes this a distro feature rather than a
+          # snippet: the file names THIS machine's flake and THIS machine's
+          # attribute. A nixd told neither completes nothing that matters.
+          grep -q 'nixosConfigurations.testbox.options' "$f" || {
+            echo "$f does not tell nixd which configuration to evaluate:" >&2
+            cat "$f" >&2
+            echo "  without it nixd completes nixpkgs and no NixOS option at all" >&2
+            exit 1
+          }
+          grep -q 'home-manager.users.type.getSubOptions' "$f" || {
+            echo "$f does not reach home-manager's options:" >&2
+            cat "$f" >&2
+            exit 1
+          }
+        done
+
+        # And each editor's own spelling, which is where this silently does
+        # nothing if it is wrong. Zed wants initialization_options and a
+        # languages entry, Helix wants a [[language]] row pointing at the
+        # server it just defined, and VSCode's nix.* keys belong to the Nix
+        # IDE extension rather than to the editor.
+        grep -q 'initialization_options' "$zedjson" || {
+          echo "the Zed config does not use initialization_options:" >&2
+          cat "$zedjson" >&2
+          exit 1
+        }
+        grep -q '"Nix"' "$zedjson" || {
+          echo "the Zed config never points the Nix language at nixd:" >&2
+          cat "$zedjson" >&2
+          exit 1
+        }
+        grep -q '^\[\[language\]\]' "$helixtoml" || {
+          echo "the Helix config defines a server and never uses it:" >&2
+          cat "$helixtoml" >&2
+          exit 1
+        }
+        grep -q 'nix.serverPath' "$vscodejson" || {
+          echo "the VSCode config has no nix.serverPath:" >&2
+          cat "$vscodejson" >&2
+          exit 1
+        }
+        grep -q '/bin/nixd' "$vscodejson" || {
+          echo "the VSCode config's serverPath is not a nixd:" >&2
+          cat "$vscodejson" >&2
+          echo "  the extension spawns the server itself and does not read the" >&2
+          echo "  login shell's PATH, so a bare name would find nothing" >&2
+          exit 1
+        }
+        echo "every editor is told where the flake is, in its own spelling"
 
           touch $out
       ''


### PR DESCRIPTION
## What this changes, and why

#623, #628 and #630 are one idea from three angles — answer *"what is there?"* at
the moment somebody asks, instead of making them go and read.

- **For agents** — `mcp-nixos` via the `mcp-servers-nix` input, written into the
  same four agent homes the skills already reach. An assistant that invents
  `services.foo.enable` is not a small annoyance: the user cannot tell a
  hallucinated option from a real one, and blames NixOS for the error.
- **For the shell** — the **prebuilt** nix-index database, `comma`, and a
  `command not found` handler that answers. `programs.command-not-found` cannot
  help on a flake machine (it reads a channel database that is not there), and
  nix-index's own handler stops at `nix shell nixpkgs#foo`. `pkgs.doctor.sh`
  already *named* `nix-locate` without installing it — the worst of both.
- **For the editor** — `nixd` for the user, not only the contributor devshell.

## Provenance, stated plainly

This branch was **rescued from an agent worktree that was never pushed.** The
work existed only as one `wip baseline` commit plus staged changes. I squashed
it, gave it a real subject, and reviewed it as someone else's patch. Three
things came out of that review and they are the parts worth checking:

1. **The `wip baseline` subject had to go.** §8: a single-commit branch squashes
   using the *commit* subject, which is how two `wip:` subjects already reached
   `main`.

2. **The last staged change would have broken #628 and I dropped it.** It swapped
   `nixIndexPackages.comma-with-db` for `pkgs.comma`. The comment immediately
   above that line says why that is wrong — *"the plain pkgs.comma reads an index
   that is not there and answers nothing"* — so the prebuilt wrapper is the whole
   point of the feature. Uncommitted state at the end of a run is not "the latest
   thinking"; it can be a half-finished experiment.

3. **A staged deletion removed helix's `nixd` language-server block** — part of
   #630 itself. Intent unknown, so I kept the feature rather than silently
   shipping less than the issue asked for. If it was deleted for a reason, the
   checks are where that shows up.

## How I proved the check fails

`tests/options.nix` gains ~497 lines covering these options in both states,
written by the original author. The general lesson it paid for is in `AGENTS.md`
§5 and is the most valuable thing in this PR:

> **`git checkout -- <path>` restores the INDEX, not the commit.** So a §1
> break-it-and-watch-it-fail loop that does `git add -A` before running the check
> — which flake evaluation requires, since it sees only tracked files — and then
> reverts with `git checkout -- modules`, restores the *break*. It looks like it
> worked: git reports nothing, the file is "restored", and the next iteration
> starts from the broken tree. Four deliberate breaks accumulated silently that
> way, and the fifth run's failure was read as a fifth bug.

Appended to §5, not inserted as a new section — twelve sections before and after,
because inserting one renumbers the rest and silently breaks the references from
`build.yml`, `omarchy.yml`, `tests/bus-mcp.nix` and the PR template.

## Checks run locally

- `nix fmt`, `statix check`, `deadnix --fail` — clean
- `nix build .#checks.x86_64-linux.options` — started before pushing; CI runs the
  same check and is the authority here. **Flagging honestly: I pushed before it
  finished**, so treat CI as the first full verification of the rescued state.
- Evaluated `nixosConfigurations.vm` and built `system.path` while investigating
  the comma question — both fine.

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed
- [x] If this adds an option: `tests/options.nix` covers both states
- [x] If this adds a `checks.*` entry: none

## A new flake input

`mcp-servers-nix`, justified in the commit: nothing MCP-shaped is meaningfully in
nixpkgs, and it carries the declarative config framework rather than a wrapper
hand-rolled here. `mcp-nixos` itself is taken from nixpkgs, not from the input.

closes #623, closes #628, closes #630
