### PR TITLE
The repository says MIT in three places and now has the file that means it

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,26 @@
+MIT License
+
+Copyright (c) 2026 Olaf Krasicki Freund and the nixarchy contributors
+
+Portions of this repository are derived from upstream Omarchy
+(<https://github.com/basecamp/omarchy>), which is vendored rather than
+reimplemented. Those portions are Copyright (c) David Heinemeier Hansson
+and the Omarchy contributors, and are also licensed under the MIT License.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2106,4 +2106,4 @@ been seen working.
 
 ## License
 
-Packaging is MIT. Vendored Omarchy is MIT, © Basecamp.
+[MIT](LICENSE). Vendored Omarchy is MIT, © Basecamp.


### PR DESCRIPTION
## What this changes, and why

GitHub reports `license: NONE` for this repository — public, 54 stars, 4 forks. With no LICENSE file the default is all rights reserved, which is the opposite of what every other statement in the tree says:

| where | what it says |
|---|---|
| `README.md:2064` | "Packaging is MIT. Vendored Omarchy is MIT, © Basecamp." |
| `pkgs/omarchy/default.nix:1868` | `license = lib.licenses.mit;` |
| upstream `basecamp/omarchy` | MIT |

So this **records an existing decision rather than making a new one**. A sentence in a README is not a grant that tooling detects, that a downstream packager can rely on, or that a contributor can point to.

The preamble names the vendored half explicitly, because the whole thesis here is that upstream is carried rather than reimplemented — those portions remain © David Heinemeier Hansson and the Omarchy contributors, under the same licence. `zicochaos/omarchy-nix` does the same thing and its wording was the model.

README's License section now links the file instead of restating it.

## How I proved the check fails

No check to break — this adds a file and retargets one README line. Nothing in `.github/scripts/` enumerates root files, and `readme-counts.sh` derives nothing from this section.

## Checks run locally

- Confirmed no script enumerates repository-root files
- `readme-counts.sh` untouched by this change (it reads skills, apps, commands, installer questions)

- [x] `nix fmt` / statix / deadnix are clean (no Nix changed)
- [x] New files are `git add`ed
- [x] If this adds an option: n/a
- [x] If this adds a `checks.*` entry: none

## Why now

It came up while reviewing `zicochaos/omarchy-nix`, an independent NixOS port of the same upstream. Their LICENSE is a clean MIT with an upstream-attribution preamble; ours was missing entirely. Worth fixing on its own merits, and necessary before borrowing anything from anyone.