### PR TITLE
Rootless Docker stops trying to start for the display manager

### DIFF
--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -1152,6 +1152,29 @@ in
 
       # Why: modules/AGENTS.md#omarchy-path-default-systemd-user-which-upstream-i
       user.services = {
+        # nixpkgs guards the rootless Docker user unit with
+        # `ConditionUser = "!root"`, and root is not the problem. The unit is
+        # `wantedBy = default.target`, so systemd starts it for EVERY user
+        # session that has one -- including the display manager's. `sddm` is
+        # uid 175, is not root, has no subuid range, and rootlesskit cannot
+        # build a uid map without one:
+        #
+        #   dockerd-rootless: failed to setup UID/GID map: failed to compute
+        #   uid/gid map: No subuid ranges found for user 175 ("sddm")
+        #
+        # So every machine with a display manager gained a failing unit the
+        # moment rootless became the default (#619). Nothing a user runs
+        # depends on sddm having a Docker daemon, which is exactly why it would
+        # have sat there red forever.
+        #
+        # `!@system` is the condition that was meant: not root, and not any
+        # other account that exists to run a service rather than to be sat in
+        # front of. mkForce because nixpkgs sets the narrower value at ordinary
+        # priority -- this corrects upstream's literal, not a user's choice.
+        docker.unitConfig.ConditionUser = lib.mkIf config.virtualisation.docker.rootless.enable (
+          lib.mkForce "!@system"
+        );
+
         bt-agent = {
           description = "Bluetooth pairing agent (auto-accept)";
           documentation = [ "man:bt-agent(1)" ];

--- a/tests/options.nix
+++ b/tests/options.nix
@@ -1209,6 +1209,16 @@ let
   dockerRootlessDefault = dockerDefault.virtualisation.docker.rootless.enable;
   dockerRootlessRooted = dockerRooted.virtualisation.docker.rootless.enable;
 
+  # The rootless daemon is a systemd USER unit, `wantedBy = default.target`,
+  # so systemd starts it for every user session that has one -- the display
+  # manager's included. nixpkgs guards it with `ConditionUser = "!root"`, and
+  # root was never the problem: `sddm` is uid 175, is not root, and has no
+  # subuid range, so rootlesskit fails to build a uid map and the unit dies at
+  # every boot. Nothing a user runs depends on sddm having a Docker daemon,
+  # which is why it would have stayed red and unnoticed.
+  dockerRootlessCondition =
+    dockerDefault.systemd.user.services.docker.unitConfig.ConditionUser or "unset";
+
   # ---- "nixarchy wrote this machine", both ways -------------------------
   #
   # The armed commands -- nixarchy-config-repo, and the post-boot hook that
@@ -1449,6 +1459,7 @@ pkgs.runCommand "nixarchy-options"
     dockerGroups = pkgs.lib.concatStringsSep " " dockerGroups;
     dockerRootedGroups = pkgs.lib.concatStringsSep " " dockerRootedGroups;
     dockerRootlessDefault = pkgs.lib.boolToString dockerRootlessDefault;
+    inherit dockerRootlessCondition;
     dockerRootlessRooted = pkgs.lib.boolToString dockerRootlessRooted;
     managedModeA = pkgs.lib.boolToString managedModeA;
     factoryUnitModeA = pkgs.lib.boolToString factoryUnitModeA;
@@ -1762,6 +1773,18 @@ pkgs.runCommand "nixarchy-options"
                exit 1 ;;
             *) echo "no docker group by default" ;;
           esac
+          # Not merely "is it set" -- the value nixpkgs ships passes that and
+          # still starts the unit for sddm. This asserts system accounts are
+          # excluded, which is the property, and it fails on upstream's own
+          # default rather than only on an empty one.
+          case "$dockerRootlessCondition" in
+            *"@system"*) echo "the rootless daemon skips system accounts" ;;
+            *) echo "rootless docker starts for system users too:" >&2
+               echo "  ConditionUser is '$dockerRootlessCondition', which does not exclude @system." >&2
+               echo "  sddm is uid 175 with no subuid range -- the unit dies at every boot." >&2
+               exit 1 ;;
+          esac
+
           [ "$dockerRootlessDefault" = "true" ] || {
             echo "no docker group AND no rootless daemon: docker is simply gone" >&2
             exit 1


### PR DESCRIPTION
## What this changes, and why

**#619 is mine and it shipped a regression.** Making rootless Docker the default gave every machine with a display manager a unit that fails at every boot:

```
dockerd-rootless[1588]: [rootlesskit:parent] error: failed to setup UID/GID map:
  failed to compute uid/gid map: No subuid ranges found for user 175 ("sddm")
systemd[1427]: docker.service: Failed with result 'exit-code'.
systemd[1427]: Failed to start Docker Application Container Engine (Rootless).
```

The rootless daemon is a systemd **user** service with `wantedBy = default.target`, so systemd starts it for *every* user session that has one — the greeter's included. nixpkgs guards it with `ConditionUser = "!root"`, and **root was never the problem**: `sddm` is uid 175, is not root, and has no subuid range, so rootlesskit cannot build a uid map.

`!@system` is the condition that was meant: not root, and not any other account that exists to run a service rather than to be sat in front of. `mkForce` because nixpkgs sets the narrower value at ordinary priority — this corrects upstream's literal, not a user's choice.

Not Arch-specific and not upstream's bug. It is this port's own default, introduced three hours ago.

## How I proved the check fails

The existing assertions checked `rootless.enable` was `true` — the **arrangement**, not the property. The property is that the daemon does not chase accounts that cannot run it, so the new assertion reads the `ConditionUser` and requires `@system` to be excluded. That matters: it fails against **nixpkgs' own default**, not merely against an empty value.

Restoring upstream's `!root`:

```
error: Cannot build '/nix/store/rv4sqs3kjfkmnzhf4abgz5ww0zcr2qpx-nixarchy-options.drv'.
       > rootless docker starts for system users too:
       >   ConditionUser is '!root', which does not exclude @system.
```

Green with `!@system` — verification run in flight as I open this; I will confirm in a comment rather than assert it here.

## Checks run locally

- `nix build .#checks.x86_64-linux.options` — red on `!root` (above), green run confirming
- `nix eval` on `nixosConfigurations.vm`: `{"cond":"!@system","rootless":true}`

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (none)
- [x] If this adds an option: covered in both states
- [x] If this adds a `checks.*` entry: none

## What this cost, and where it is written down

Two general lessons, both already covered by existing sections rather than needing new ones:

**§1, read backwards.** #619's assertions were green throughout and asserted the wrong thing. "Is rootless enabled" is the arrangement; "does the daemon avoid accounts that cannot run it" is the property. This is the same shape as the §1 note about checks that encode the shape of a file rather than the property they protect.

**§5 has a sibling worth knowing.** While diagnosing this I evaluated `nixosConfigurations.vm` from the main checkout and got `rootless: false`, which would have led me to conclude there was nothing wrong. The checkout was 8 commits behind `main`; `git fetch` is not `git pull`, and a flake evaluated against a stale working tree gives a confidently wrong answer with no warning. I re-checked from a worktree of `origin/main` and got `rootless: true, cond: "!root"`.

**And the failure class.** Nothing a user runs depends on sddm having a Docker daemon, so this was red and harmless — which is exactly why it would have stayed there. It was found by a real install check on an unrelated PR (#638), not by reading the code.

## Blocking

#638's install check fails on this, since it is `main`'s state rather than that branch's change. This should land first.

Refs #619
