### PR TITLE
Upstream's own SKILL.md is classified section by section, so a bump cannot rewrite it under us

### DIFF
--- a/.github/scripts/check-skill-parity.py
+++ b/.github/scripts/check-skill-parity.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Upstream's own SKILL.md, classified section by section, and held to it.
+
+pkgs/omarchy/default.nix renames upstream's `omarchy` skill to `nixarchy` and
+copies ours over the top. That replacement is correct and stays -- docs/manual/
+ai.md says why, under "The skills are rewritten, because upstream's would lie".
+Replacing it WITHOUT NOTICING WHAT CHANGED is the problem: upstream's file is
+13 KB of 19 headings and 14 command groups, and every one of them can move at a
+bump with nothing in this repository able to say so.
+
+The existing guards are all about names and counts -- readme-counts.sh asserts
+the skill count and per-skill rows, build.yml asserts exact skill-set equality
+and frontmatter. A section added INSIDE upstream's SKILL.md trips none of them.
+
+So data/skill-parity.nix carries one row per upstream section and per command
+group, and this holds it to that claim in BOTH directions:
+
+  an upstream section with no row        unclassified
+  a row for a section upstream dropped   stale
+  a `preserved` heading missing here     the claim is false
+  an `anchor` that greps nothing here    the claim is unproven
+  a section whose upstream text moved    re-audit, then update the digest
+
+The digest is what makes this more than a heading census. A row pins a short
+sha256 of upstream's section body, so upstream can neither add a section nor
+rewrite one it already has without a person looking at it. A key-set diff alone
+would let upstream replace the whole body of an adapted section in silence --
+which is the exact bug this exists to catch.
+
+The idea, and the anchor-proof shape, come from zicochaos/omarchy-nix's
+skills/omarchy/skill-parity.json (MIT). The code is ours.
+
+Stdlib only, and it refuses to run on a tree it extracted nothing from -- same
+floor discipline as check-bin-ledger.py and omarchy-patched-files.sh, because
+the dangerous failure is not a wrong answer, it is a check that stopped seeing
+its subject and reported success.
+"""
+
+import argparse
+import hashlib
+import os
+import re
+import sys
+
+# Floors. Measured at omarchy 0534987: 19 headings, 14 groups.
+MIN_HEADINGS = 15
+MIN_GROUPS = 10
+
+CLASSES = ("preserved", "adapted", "omitted")
+
+HEADING = re.compile(r"^(#{2,4})\s+(\S.*?)\s*$")
+GROUP_ROW = re.compile(r"^\|\s*`(omarchy\s+[a-z-]+)`\s*\|")
+
+
+def die(message):
+    print(f"skill-parity: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def normalise(lines):
+    """Body text with the whitespace noise taken out.
+
+    Trailing spaces and blank-line runs are formatting, not content, and a
+    digest that moves when a blank line does is a digest nobody will trust.
+    """
+    text = "\n".join(line.rstrip() for line in lines)
+    return re.sub(r"\n{2,}", "\n\n", text).strip()
+
+
+def digest(text):
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:12]
+
+
+def sections(path):
+    """Every heading and command-group row upstream's SKILL.md carries.
+
+    Keyed the way a reader would grep for it: the heading line verbatim, and
+    `group: omarchy pkg` for a row of the Command Groups table. A heading's
+    body runs to the next heading of any level.
+    """
+    with open(path, encoding="utf-8") as handle:
+        lines = handle.read().splitlines()
+
+    found = {}
+    key = None
+    body = []
+    headings = groups = 0
+    for line in lines:
+        match = HEADING.match(line)
+        if match:
+            if key:
+                found[key] = normalise(body)
+            key = line.strip()
+            body = []
+            headings += 1
+            continue
+        body.append(line)
+        row = GROUP_ROW.match(line)
+        if row:
+            found[f"group: {row.group(1)}"] = normalise([line])
+            groups += 1
+    if key:
+        found[key] = normalise(body)
+
+    if headings < MIN_HEADINGS:
+        die(
+            f"{headings} headings extracted from {path}, expected at least "
+            f"{MIN_HEADINGS}. A parse that sees nothing agrees with everything, "
+            "so it is refused."
+        )
+    if groups < MIN_GROUPS:
+        die(
+            f"{groups} command groups extracted from {path}, expected at least "
+            f"{MIN_GROUPS}. Same reason."
+        )
+    return found
+
+
+def ours(directory):
+    """Everything this port's own skill says, as one blob.
+
+    Anchors and `preserved` headings are looked for here rather than in the
+    built package: the claim is about what we wrote, and reading the source
+    tree keeps this check an evaluation rather than a package build.
+    """
+    text = []
+    for name in sorted(os.listdir(directory)):
+        if name.endswith(".md"):
+            with open(os.path.join(directory, name), encoding="utf-8") as handle:
+                text.append(handle.read())
+    if not text:
+        die(f"no .md files under {directory}")
+    return "\n".join(text)
+
+
+def problems(manifest, upstream, mine):
+    found = []
+
+    for key in sorted(set(upstream) - set(manifest)):
+        found.append(
+            f"unclassified: upstream's SKILL.md has {key!r} and "
+            f"data/skill-parity.nix does not.\n"
+            f"    Upstream changed. Decide what this port does with it and add "
+            f'a row: class, upstream = "{digest(upstream[key])}", and an anchor '
+            f"or a reason."
+        )
+
+    for key in sorted(set(manifest) - set(upstream)):
+        found.append(
+            f"stale: data/skill-parity.nix classifies {key!r} and upstream's "
+            f"SKILL.md no longer has it.\n"
+            f"    Upstream removed or renamed it. Delete the row, or retarget "
+            f"it at the new name."
+        )
+
+    for key in sorted(set(manifest) & set(upstream)):
+        row = manifest[key]
+        klass = row.get("class")
+        anchor = row.get("anchor")
+        reason = row.get("reason")
+
+        pinned = row.get("upstream")
+        current = digest(upstream[key])
+        if pinned != current:
+            found.append(
+                f"moved: upstream rewrote {key!r}.\n"
+                f"    Pinned {pinned}, upstream is now {current}. Read the new "
+                f"text, decide whether the classification still holds, then "
+                f'set upstream = "{current}".'
+            )
+
+        if klass == "omitted":
+            if not reason:
+                found.append(
+                    f"{key!r} is omitted with no reason. An omission with no "
+                    f"reason is indistinguishable from an oversight."
+                )
+            if anchor:
+                found.append(
+                    f"{key!r} is omitted and carries an anchor. An omitted "
+                    f"section has nothing here to point at."
+                )
+            continue
+
+        if not anchor:
+            found.append(
+                f"{key!r} is {klass} and has no anchor. The claim that it "
+                f"survived here is unproven without one."
+            )
+        elif anchor not in mine:
+            found.append(
+                f"{key!r} is {klass} and its anchor is not in this port's "
+                f"skill: {anchor!r}.\n"
+                f"    Either the content went and the row should say omitted, "
+                f"or the anchor text was edited and needs updating."
+            )
+
+        if klass == "preserved" and not key.startswith("group: ") and key not in mine:
+            found.append(
+                f"{key!r} is preserved and this port's skill has no such "
+                f"heading. Preserved means the section is still here under the "
+                f"same heading -- if it moved or was renamed, it is adapted."
+            )
+
+    return found
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--upstream", required=True, help="omarchy source tree")
+    parser.add_argument("--skill", required=True, help="our skills/nixarchy dir")
+    parser.add_argument("--manifest", required=True, help="data/skill-parity.nix")
+    parser.add_argument("--report", action="store_true", help="digests, for a bump")
+    args = parser.parse_args()
+
+    # Nix, read by regex, and not JSON -- the same call check-bin-ledger.py
+    # makes and for the same reason: the load-bearing part of the file is the
+    # prose, and a per-row reason does not survive JSON.
+    if not os.path.exists(args.manifest):
+        die(f"no manifest at {args.manifest}")
+    text = open(args.manifest, encoding="utf-8").read()
+    manifest = {}
+    for key, body in re.findall(r'"([^"]+)"\s*=\s*\{(.*?)\};', text, re.S):
+        row = dict(re.findall(r'(\w+)\s*=\s*"((?:[^"\\]|\\.)*)"', body))
+        if row:
+            manifest[key] = {k: v.replace('\\"', '"') for k, v in row.items()}
+    if not manifest:
+        die(f"no rows parsed from {args.manifest}. An empty manifest agrees "
+            "with everything, so it is refused.")
+
+    for key, row in manifest.items():
+        if row.get("class") not in CLASSES:
+            die(f"{key}: class {row.get('class')!r} is not one of {CLASSES}")
+
+    skill_md = os.path.join(
+        args.upstream, "default", "agents", "skills", "omarchy", "SKILL.md"
+    )
+    if not os.path.exists(skill_md):
+        die(f"upstream SKILL.md not found at {skill_md}")
+
+    upstream = sections(skill_md)
+    mine = ours(args.skill)
+
+    if args.report:
+        for key in sorted(upstream):
+            print(f'"{key}" -- upstream = "{digest(upstream[key])}"')
+        return
+
+    found = problems(manifest, upstream, mine)
+    if found:
+        print(
+            f"data/skill-parity.nix and upstream's SKILL.md disagree, "
+            f"{len(found)} problem(s):\n",
+            file=sys.stderr,
+        )
+        for problem in found:
+            print(f"  {problem}\n", file=sys.stderr)
+        print(
+            "  Upstream's SKILL.md is replaced wholesale by this port, on "
+            "purpose. This manifest is the record of what that replacement "
+            "decided, so a bump cannot change upstream's file without somebody "
+            "deciding again. See docs/manual/ai.md and #643.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    classes = {}
+    for row in manifest.values():
+        classes[row["class"]] = classes.get(row["class"], 0) + 1
+    summary = ", ".join(f"{n} {c}" for c, n in sorted(classes.items()))
+    print(
+        f"{len(upstream)} upstream sections and command groups, all "
+        f"classified: {summary}."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/data/skill-parity.nix
+++ b/data/skill-parity.nix
@@ -1,0 +1,259 @@
+# Every section of upstream's own SKILL.md, and what this port did with it.
+#
+# pkgs/omarchy/default.nix renames upstream's `omarchy` skill to `nixarchy` and
+# copies ours over the top, so upstream's SKILL.md -- 13 KB, 19 headings, 14
+# command groups -- is replaced wholesale. That replacement is deliberate and
+# stays: docs/manual/ai.md says why, under "The skills are rewritten, because
+# upstream's would lie". An Arch-shaped instruction handed to an agent on NixOS
+# is worse than no instruction.
+#
+# What was missing is the record of WHAT was replaced. Every other guard we
+# have on the skills is about names and counts -- readme-counts.sh asserts the
+# skill count and a row per skill, build.yml asserts skill-set equality and
+# frontmatter. A section appearing inside upstream's SKILL.md, or the body of
+# one being rewritten, trips none of them.
+#
+# ## The rule that keeps this file honest
+#
+# .github/scripts/check-skill-parity.py fails in BOTH directions -- an upstream
+# section with no row is unclassified, a row upstream no longer has is stale --
+# and it pins a digest of upstream's text per row, so a bump cannot rewrite a
+# section under us either. None of that can be satisfied by editing this file:
+# the upstream side is read from inputs.omarchy, the same source pkgs/omarchy
+# vendors.
+#
+# ## The classes
+#
+#   preserved  the section is here under the same heading, saying the same
+#              thing. `anchor` proves it.
+#   adapted    the section is here and was rewritten for NixOS. `anchor` is a
+#              string from OUR version, so the claim is checked rather than
+#              asserted, and `reason` says what moved.
+#   omitted    the section is not here at all. `reason` is required, and an
+#              anchor is refused -- there is nothing to point at.
+#
+# ## When upstream bumps
+#
+# The check names each section whose digest moved. Read the new text, decide
+# again, then update `upstream` -- `check-skill-parity.py --report` prints the
+# current digests. Updating a digest is the act of having decided; that is why
+# it is a hand edit and not a derived file.
+#
+# The idea, and the anchor-proof shape, come from zicochaos/omarchy-nix's
+# skills/omarchy/skill-parity.json (MIT). The code here is ours.
+{
+  "## When This Skill MUST Be Used" = {
+    class = "adapted";
+    upstream = "c4b249c56563";
+    anchor = "- Installing packages or changing system configuration — use the `nixos` skill";
+    reason = "Upstream's exclusion is Omarchy source development. Here the routing decision that matters first is packages-and-system versus desktop, because on NixOS those are different files with different lifetimes, so the exclusion names the `nixos` skill before it names source development.";
+  };
+
+  "## Topic Guides" = {
+    class = "adapted";
+    upstream = "85358cfcd451";
+    anchor = "reporting Nixarchy and Omarchy bugs";
+    reason = "Same six guides, one line changed: contributing.md here routes a bug between this port and upstream first, rather than assuming every bug is Omarchy's.";
+  };
+
+  "## Critical Safety Rules" = {
+    class = "adapted";
+    upstream = "a99ca335d725";
+    anchor = "read-only `/nix/store` path";
+    reason = "Upstream's rule is that /usr/share/omarchy is overwritten on update. Here the path is a store path mounted read-only, so the rule is stronger and stated as such: a write does not lose later, it fails now.";
+  };
+
+  "## Privilege Escalation" = {
+    class = "adapted";
+    upstream = "d4ded906a1a4";
+    anchor = "Use `pkexec` only when the caller cannot interact with a terminal";
+    reason = "The sudo/pkexec split is upstream's and kept. The sentence about Omarchy granting passwordless sudo to particular commands is dropped: that is an Arch packaging arrangement this port does not make.";
+  };
+
+  "## System Architecture" = {
+    class = "adapted";
+    upstream = "087c2f1646b5";
+    anchor = "Two config systems coexist and the boundary matters";
+    reason = "The component table gains the flake as the base OS row and the generated menu, and the section states the boundary that has no upstream equivalent: ~/.config is yours and imperative, the flake half is declarative and needs a rebuild.";
+  };
+
+  "## Command Discovery" = {
+    class = "adapted";
+    upstream = "d45ca4a1fa32";
+    anchor = "omarchy commands --json";
+    reason = "The discovery commands are upstream's. What changes is where a command's source is read from -- $OMARCHY_PATH rather than /usr/share/omarchy -- because the store path is the only correct spelling here.";
+  };
+
+  "### Command Groups" = {
+    class = "adapted";
+    upstream = "ac64c63b62d2";
+    anchor = "Run `omarchy --help` for the full list. The most common groups:";
+    reason = "The table is upstream's with three purpose cells rewritten; each of those is its own row below, so this row covers the table's frame rather than its contents.";
+  };
+
+  "group: omarchy refresh" = {
+    class = "preserved";
+    upstream = "059222c5d912";
+    anchor = "| `omarchy refresh` | Reset config to defaults (backs up first) |";
+  };
+
+  "group: omarchy restart" = {
+    class = "preserved";
+    upstream = "84629bb0b1f4";
+    anchor = "| `omarchy restart` | Restart a service/app |";
+  };
+
+  "group: omarchy toggle" = {
+    class = "preserved";
+    upstream = "ce587d348b8d";
+    anchor = "| `omarchy toggle` | Toggle feature on/off |";
+  };
+
+  "group: omarchy theme" = {
+    class = "preserved";
+    upstream = "5192b6f42133";
+    anchor = "| `omarchy theme` | Theme management |";
+  };
+
+  "group: omarchy bar" = {
+    class = "preserved";
+    upstream = "3ca199b05468";
+    anchor = "| `omarchy bar` | Bar layout and widgets |";
+  };
+
+  "group: omarchy plugin" = {
+    class = "preserved";
+    upstream = "586c77079ba7";
+    anchor = "| `omarchy plugin` | Manage/clone shell plugins |";
+  };
+
+  "group: omarchy hook" = {
+    class = "preserved";
+    upstream = "e848ce440eac";
+    anchor = "| `omarchy hook` | Install automation hooks |";
+  };
+
+  "group: omarchy install" = {
+    class = "adapted";
+    upstream = "20c177d0ea7c";
+    anchor = "Queue an app into the Nix selection";
+    reason = "Upstream installs optional software with pacman. Here the verb queues the app into the declarative selection instead, so the purpose cell says what it does rather than what it is called.";
+  };
+
+  "group: omarchy launch" = {
+    class = "preserved";
+    upstream = "0548e5830525";
+    anchor = "| `omarchy launch` | Launch apps |";
+  };
+
+  "group: omarchy capture" = {
+    class = "preserved";
+    upstream = "25b0b6e33af6";
+    anchor = "| `omarchy capture` | Screenshots and recordings |";
+  };
+
+  "group: omarchy reminder" = {
+    class = "preserved";
+    upstream = "bf2d6226790f";
+    anchor = "| `omarchy reminder` | Desktop notification reminders |";
+  };
+
+  "group: omarchy pkg" = {
+    class = "adapted";
+    upstream = "4c54b363d4be";
+    anchor = "**Explains the declarative route; installs nothing**";
+    reason = "`omarchy pkg add` is a pacman transaction upstream. The command still exists here and deliberately installs nothing, so the cell has to say so -- an agent reading upstream's wording would run it and report an install that never happened.";
+  };
+
+  "group: omarchy setup" = {
+    class = "preserved";
+    upstream = "18fd0a0973a9";
+    anchor = "| `omarchy setup` | Interactive setup wizards |";
+  };
+
+  "group: omarchy update" = {
+    class = "adapted";
+    upstream = "12f7f777e610";
+    anchor = "| `omarchy update` | `nix flake update` + `nixos-rebuild switch` |";
+    reason = "\"System updates\" is true of both and useful in neither. Naming the two commands tells the reader that the update moves the flake lock and rebuilds, which is what decides whether it is safe to run now.";
+  };
+
+  "## Configuration Locations" = {
+    class = "preserved";
+    upstream = "dddbfc7f586a";
+    anchor = "The Omarchy shell (bar, notifications, plugins, idle) is configured in";
+  };
+
+  "### Terminals" = {
+    class = "preserved";
+    upstream = "7255894c8ce9";
+    anchor = "~/.config/ghostty/config";
+  };
+
+  "### Other Configs" = {
+    class = "adapted";
+    upstream = "ad42e6e43311";
+    anchor = "Note that `/etc` on NixOS is generated from the system configuration.";
+    reason = "The table is upstream's. The paragraph after it is new: one of its rows points into /etc, which on NixOS may be a store symlink, and editing it is the mistake that looks like it worked.";
+  };
+
+  "## Safe Customization Patterns" = {
+    class = "preserved";
+    upstream = "e3b0c44298fc";
+    anchor = "## Safe Customization Patterns";
+  };
+
+  "### Edit User Config Directly" = {
+    class = "adapted";
+    upstream = "98d4f7d16e60";
+    anchor = "None of this needs a rebuild. That is the point of the boundary";
+    reason = "The edit-backup-apply loop is upstream's. The menu line is replaced because the jsonc is generated here, and the closing paragraph says the desktop half needs no rebuild -- the question a reader arriving from the nixos skill will have.";
+  };
+
+  "### Reset to Defaults -- ALWAYS SEEK USER CONFIRMATION BEFORE RUNNING" = {
+    class = "preserved";
+    upstream = "897cd8e0fb74";
+    anchor = "omarchy refresh hyprland";
+  };
+
+  "## System Commands" = {
+    class = "adapted";
+    upstream = "0e08895d8c64";
+    anchor = "omarchy update                  # nix flake update + nixos-rebuild switch";
+    reason = "The command list is upstream's; the comment on `omarchy update` names what it runs here, for the same reason the command-group row does.";
+  };
+
+  "## Troubleshooting" = {
+    class = "adapted";
+    upstream = "f1b9b329a7d8";
+    anchor = "**`omarchy reinstall` exists but cannot finish here.**";
+    reason = "Upstream's debug and refresh commands are kept. What is added is the one command that is present and cannot complete: `omarchy reinstall` starts with a pacman transaction the shim refuses, and an agent needs to know that before it recommends it.";
+  };
+
+  "## Decision Framework" = {
+    class = "adapted";
+    upstream = "4cbd9cd66fc8";
+    anchor = "Use the `nixos` skill.** Do not run `omarchy pkg add` expecting an install";
+    reason = "Upstream's numbered ladder gains the question this port exists to answer: a package install, or anything outside ~/.config, leaves this skill entirely.";
+  };
+
+  "### Reminder Requests" = {
+    class = "preserved";
+    upstream = "7da70548cd70";
+    anchor = "omarchy reminder 15 \"Pickup Jack\"";
+  };
+
+  "## Out of Scope" = {
+    class = "adapted";
+    upstream = "6cb63bb9d8ed";
+    anchor = "which is read-only anyway";
+    reason = "Same exclusions, re-pathed: /usr/share/omarchy becomes $OMARCHY_PATH, `omarchy dev` is dropped because it is not shipped, and package installation is added as the exclusion that sends the reader to the nixos skill.";
+  };
+
+  "## Example Requests" = {
+    class = "adapted";
+    upstream = "b7553b92485c";
+    anchor = "\"My change disappeared after a reboot\"";
+    reason = "Upstream's examples are kept where the answer is the same command. Three are replaced by the two mistakes that only happen here -- asking this skill to install something, and an imperative change that does not survive a reboot -- because an example is how an agent learns the boundary.";
+  };
+}

--- a/docs/manual/ai.md
+++ b/docs/manual/ai.md
@@ -82,6 +82,18 @@ install`, which "work" and then vanish at the next rebuild. That is the one
 failure mode that looks like success, so the skill is renamed `nixarchy` and its
 front page rewritten rather than patched.
 
+Rewriting it wholesale leaves a second problem, which `data/skill-parity.nix`
+answers: upstream's own `SKILL.md` can gain a section, lose one, or have one
+rewritten at any bump, and a replacement performed without reading it would
+never notice. The manifest carries one row per upstream heading and per command
+group — `preserved`, `adapted` or `omitted`, with a reason where the content is
+gone and an `anchor` string that has to be findable in this port's skill where
+it is not — and `checks.skill-parity` fails in both directions plus on a pinned
+digest, so the decision is forced at bump time rather than found by a user. The
+idea and the anchor-proof shape come from [zicochaos/omarchy-nix][zon] (MIT).
+
+[zon]: https://github.com/zicochaos/omarchy-nix
+
 `nixos` is new and owns the install question outright. Its first rule is that
 a request that would normally end in an install command ends in a file edit and
 a rebuild instead, and it ranks the routes: `nixarchy-app-enable <id>` then

--- a/flake.nix
+++ b/flake.nix
@@ -1841,6 +1841,13 @@
             pkgs = pkgsFor.${system};
           };
 
+          # data/skill-parity.nix, held to upstream's own SKILL.md. See
+          # tests/skill-parity.nix and #643.
+          skill-parity = import ./tests/skill-parity.nix {
+            inherit inputs;
+            pkgs = pkgsFor.${system};
+          };
+
           # The reference initrd can mount a disk it was not built on, which is
           # a precondition for offline install stage 3. See
           # tests/reference-initrd.nix and #436.

--- a/tests/skill-parity.nix
+++ b/tests/skill-parity.nix
@@ -1,0 +1,34 @@
+{ inputs, pkgs }:
+# Upstream's own SKILL.md, section by section, against what this port decided.
+#
+# pkgs/omarchy/default.nix replaces upstream's skill wholesale -- correctly, and
+# docs/manual/ai.md says why. data/skill-parity.nix is the record of what that
+# replacement decided, and this holds it to the claim in both directions:
+#
+#   an upstream section with no row       unclassified
+#   a row upstream no longer has          stale
+#   a `preserved` heading missing here    the claim is false
+#   an anchor that greps nothing here     the claim is unproven
+#   a section whose upstream text moved   re-audit, then re-pin
+#
+# The upstream side is inputs.omarchy -- the same source pkgs/omarchy vendors,
+# so the comparison is against exactly what was replaced -- and our side is the
+# skill source tree rather than the built package, which keeps this an
+# evaluation plus a grep rather than a package build.
+#
+# Why: #643, and the wider argument in #640.
+pkgs.runCommand "nixarchy-skill-parity"
+  {
+    nativeBuildInputs = [ pkgs.python3 ];
+    upstream = inputs.omarchy;
+    skill = ../pkgs/omarchy/skills/nixarchy;
+    manifest = ../data/skill-parity.nix;
+    script = ../.github/scripts/check-skill-parity.py;
+  }
+  ''
+    python3 $script \
+      --upstream "$upstream" \
+      --skill "$skill" \
+      --manifest "$manifest"
+    touch $out
+  ''


### PR DESCRIPTION
## What this changes, and why

`pkgs/omarchy/default.nix` renames upstream's `omarchy` skill to `nixarchy` and
copies ours over the top, so upstream's own `SKILL.md` — 13 KB, 19 headings, 14
command groups — is replaced wholesale. That replacement is correct and stays;
`docs/manual/ai.md` says why, under *"The skills are rewritten, because
upstream's would lie"*. Replacing it **without noticing what changed** is the
problem: upstream can add a section, drop one, or rewrite the body of one at any
bump, and nothing in this repository could say so. The existing guards are all
names and counts — `readme-counts.sh` asserts the skill count and a row per
skill name, `build.yml` asserts skill-set equality and frontmatter — and a
section added *inside* upstream's `SKILL.md` trips none of them.

`data/skill-parity.nix` now carries one row per upstream heading and per command
group: `preserved`, `adapted` or `omitted`, with a **reason** required where the
content is gone, and an **anchor** string that must be findable in this port's
own skill where it is not. `checks.skill-parity` holds the manifest to that
claim in both directions — an upstream section with no row is *unclassified*, a
row upstream no longer has is *stale* — plus a pinned short digest of each
upstream section, so a rewritten body trips too. A key-set diff alone would let
upstream replace the whole body of an adapted section in silence, which is the
exact bug this exists to catch.

The upstream side is read from `inputs.omarchy`, the same source `pkgs/omarchy`
vendors, so the manifest cannot be satisfied by editing the manifest — the same
argument `data/bin-ledger.nix` + `tests/bin-ledger.nix` already make about
commands, applied to the skill's prose.

Today: **33 rows — 17 adapted, 16 preserved, 0 omitted.**

The idea, and the `anchor`-proof shape, come from
[`zicochaos/omarchy-nix`](https://github.com/zicochaos/omarchy-nix)'s
`skills/omarchy/skill-parity.json` (MIT). The code is ours; the manifest header
and the script say so.

Closes #643

## How I proved the check fails

Copied upstream's tree out of the store, broke `SKILL.md` four ways, ran the
checker against the copy each time, restored between each. Run as a **bash**
script, not pasted into a shell.

```
### 0. baseline, unmodified upstream
33 upstream sections and command groups, all classified: 17 adapted, 16 preserved.
EXIT=0

### 1. upstream GAINS a section (unclassified)
data/skill-parity.nix and upstream's SKILL.md disagree, 1 problem(s):

  unclassified: upstream's SKILL.md has '## Pacman Cache Maintenance' and data/skill-parity.nix does not.
    Upstream changed. Decide what this port does with it and add a row: class, upstream = "da7a7514180a", and an anchor or a reason.
EXIT=1

### 2. upstream LOSES a section the manifest names (stale)
data/skill-parity.nix and upstream's SKILL.md disagree, 1 problem(s):

  stale: data/skill-parity.nix classifies '## Privilege Escalation' and upstream's SKILL.md no longer has it.
    Upstream removed or renamed it. Delete the row, or retarget it at the new name.
EXIT=1

### 3. upstream REWRITES a section body (moved)
data/skill-parity.nix and upstream's SKILL.md disagree, 1 problem(s):

  moved: upstream rewrote '### Command Groups'.
    Pinned ac64c63b62d2, upstream is now c6128baa367e. Read the new text, decide whether the classification still holds, then set upstream = "c6128baa367e".
EXIT=1

### 4. the floor: a SKILL.md the parser sees nothing in
skill-parity: 0 headings extracted from .../omarchy/SKILL.md, expected at least 15. A parse that sees nothing agrees with everything, so it is refused.
EXIT=1

### 5. restored, green again
33 upstream sections and command groups, all classified: 17 adapted, 16 preserved.
EXIT=0
```

And the anchor half failed for real while writing the manifest — I pinned
`### Terminals` to a table row upstream has and this port writes as a code
block, and the check refused the claim rather than accepting it:

```
  '### Terminals' is preserved and its anchor is not in this port's skill: '| alacritty | `~/.config/alacritty/alacritty.toml` |'.
    Either the content went and the row should say omitted, or the anchor text was edited and needs updating.
EXIT=1
```

Floors are `MIN_HEADINGS = 15` and `MIN_GROUPS = 10` against a measured 19 and
14, and the manifest is refused if it parses to zero rows — §1's "a check that
extracts nothing agrees with everything".

## Checks run locally

- `nix build .#checks.x86_64-linux.skill-parity` — green (the new check; it is
  an evaluation plus a grep, seconds)
- `nix fmt -- --ci`, `statix check .`, `deadnix --fail .` — all clean
- No VM checks built locally, deliberately: install jobs share this machine.

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [ ] If this adds an option: `tests/options.nix` covers both states — n/a, no option
- [x] If this adds a `checks.*` entry: a PR-triggered workflow builds it —
      `build.yml`'s claimed list is an **opt-OUT**, so the generated step picks
      `skill-parity` up with no workflow edit. No CI gate touched.

## What this cost, and where it is written down

Nothing general. Every trap I could have hit here was already written down and
avoided because of it — `git add` before evaluating (§5), verifying under bash
(§1), `git checkout HEAD --` rather than `--` alone, and not building a VM check
while install jobs are in flight (§6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFrWEdMGGrgnPtDo1vMrun
