### PR TITLE
The bin ledger learns what a shipped script does, not just that it changed

### DIFF
--- a/.github/scripts/check-bin-ledger.py
+++ b/.github/scripts/check-bin-ledger.py
@@ -18,6 +18,13 @@ So the class is DERIVED here, and data/bin-ledger.nix carries only the rows
 where the port diverges -- the reason, which no comparison can derive. The check
 then asserts derived == declared, both directions.
 
+The class answers "did this file change" and cannot answer "what does this file
+do". So beside it there is a behaviour scan (PATTERNS below) that reads what a
+shipped script actually calls -- ufw, an enable, a usermod, a write under /etc --
+and holds each match against an `allow` field, on the same biconditional. That is
+the half that survives an Omarchy bump: a vendored script that GAINS one of those
+calls stays byte-identical to the new upstream, and the class alone would pass it.
+
 Modes:
 
   (default)  check.  Exits non-zero with every problem named.
@@ -43,6 +50,7 @@ MIN_UPSTREAM = 400
 MIN_SHIPPED = 400
 MIN_VENDOR = 300
 MIN_ROWS = 20
+MIN_MATCHES = 40
 
 # A class the ledger may declare. `vendor` is derived and normally unwritable --
 # a row for a file identical to upstream is a rubber stamp -- with one exception
@@ -52,6 +60,54 @@ CLASSES = ("patch", "replace", "new", "vendor")
 # Upstream's package manager, and the AUR helper it reaches for. Word-boundary
 # matched after comments are stripped, so prose about pacman does not count.
 PACMAN = re.compile(r"\b(pacman|yay)\b")
+
+# What a script DOES, as opposed to whether it changed.
+#
+# The derived class answers "does this file differ from upstream" very well and
+# says nothing about what the file is for. A vendored command that gains
+# `systemctl enable`, `usermod` or a write under /etc at the next Omarchy bump
+# is byte-identical to the new upstream, derives as `vendor`, and passes -- so
+# the classification cannot see the one change that matters most on NixOS,
+# where those paths are declarative and an imperative one does not survive a
+# rebuild.
+#
+# So: a script matching a group needs a row naming that group in `allow`, and a
+# row naming a group the script no longer matches is stale. Both directions,
+# same as everything else here.
+#
+# The fail-closed pattern-group scheme is zicochaos/omarchy-nix's idea (MIT);
+# the patterns, the groups and the code below are ours.
+#
+# These over-match on purpose. `cp /etc/skel/. ~/` reads /etc and counts as an
+# etc-write; heredoc prose naming usermod counts as account-tools, because
+# comment-stripping cannot see inside a heredoc. A false positive costs one row
+# saying so, which is an audit; a false negative costs the whole point.
+PATTERNS = {
+    "ufw": r"\bufw\b",
+    "systemctl-system": (
+        r"\bsystemctl\b(?![^\n]*--user)[^\n]*\b(?:enable|disable|mask|unmask)\b"
+    ),
+    "systemctl-user": r"\bsystemctl\s+--user\b",
+    "etc-write": (
+        r">>?\s*/etc/"
+        r"|\b(?:tee|cp|mv|ln|install|mkdir|rm|chmod|chown|touch)\b[^\n]*\s/etc/"
+        r"|\bsed\b[^\n]*\s-i\b[^\n]*\s/etc/"
+    ),
+    "boot-write": (
+        r"\b(?:bootctl|grub-install|grub-mkconfig"
+        r"|limine-update|limine-install|limine-deploy|limine-snapper-sync)\b"
+        r"|>>?\s*/boot/"
+        r"|\b(?:tee|cp|mv|ln|install|mkdir|rm|chmod|chown|touch)\b[^\n]*\s/boot/"
+    ),
+    "modprobe": r"\b(?:modprobe|rmmod|insmod)\b",
+    "account-tools": r"\b(?:usermod|useradd|userdel|groupadd|gpasswd|chsh|visudo)\b",
+    "kernel-ctl": r"\bsysctl\s+-w\b|>\s*/proc/sys/|>\s*/sys/",
+    "initrd-boot": r"\b(?:mkinitcpio|dracut|update-initramfs)\b",
+    "rfkill": r"\brfkill\b",
+    "nmcli-radio": r"\bnmcli\s+radio\b",
+    "ctl-set": r"\b(?:timedatectl|hostnamectl|localectl|loginctl)\s+set-",
+}
+PATTERNS = {group: re.compile(rx) for group, rx in PATTERNS.items()}
 
 
 def die(message):
@@ -84,6 +140,38 @@ def strip_comments(text):
     behaviour keeps the migration honest.
     """
     return "\n".join(re.sub(r"#.*", "", line) for line in text.splitlines())
+
+
+def scan(shipped_bin, shipped):
+    """{name: {group, ...}} for every shipped command that mutates the system.
+
+    Comment-stripped, like the pacman scan, and for the same reason: a bin that
+    only MENTIONS systemctl is not calling it.
+    """
+    matched = {}
+    for name in sorted(shipped):
+        try:
+            with open(
+                os.path.join(shipped_bin, name), encoding="utf-8", errors="replace"
+            ) as handle:
+                text = strip_comments(handle.read())
+        except OSError:
+            continue
+        groups = {g for g, rx in PATTERNS.items() if rx.search(text)}
+        if groups:
+            matched[name] = groups
+
+    total = sum(len(groups) for groups in matched.values())
+    if total < MIN_MATCHES:
+        die(
+            f"the behaviour scan matched {total} time(s) across "
+            f"{len(matched)} command(s), expected at least {MIN_MATCHES}.\n"
+            "  A scan that sees nothing reports that nothing needs a row, "
+            "which is the one failure this file exists to refuse. Either the "
+            "patterns stopped compiling against real scripts, or the tree "
+            "moved."
+        )
+    return matched
 
 
 def derive(upstream_bin, shipped_bin, nix_bin):
@@ -160,7 +248,7 @@ def derive(upstream_bin, shipped_bin, nix_bin):
     return derived, upstream, shipped
 
 
-def problems(ledger, derived, upstream, shipped, shipped_bin):
+def problems(ledger, derived, upstream, shipped, shipped_bin, matched):
     """Every way the ledger and the trees can disagree."""
     found = []
 
@@ -215,12 +303,17 @@ def problems(ledger, derived, upstream, shipped, shipped_bin):
 
         # 4. The rubber stamp. A row for a file identical to upstream restates
         #    `cmp`, unless it is carrying a pacman reason (see below).
-        if actual == "vendor" and not declared.get("pacman"):
+        if (
+            actual == "vendor"
+            and not declared.get("pacman")
+            and not declared.get("allow")
+        ):
             found.append(
                 f"{name}: a row for a file identical to upstream.\n"
                 "    Vendored commands do not get rows -- the comparison "
                 "already proves it. Delete this, unless it needs a `pacman` "
-                "field, which is the one thing a vendor row may carry."
+                "or an `allow` field -- the two things a vendor row may carry, "
+                "because neither restates the comparison."
             )
 
         reason = (declared.get("reason") or "").strip()
@@ -277,19 +370,47 @@ def problems(ledger, derived, upstream, shipped, shipped_bin):
                 "keeps meaning what it says."
             )
 
+    # 7. The behaviour scan, on the same biconditional as the pacman one. A
+    #    command that mutates the system needs a row naming the groups it
+    #    matches; a row naming a group the command no longer matches is stale,
+    #    which is how an upstream cleanup gets noticed instead of assumed.
+    for name in sorted(set(matched) | set(ledger)):
+        actual = matched.get(name, set())
+        declared = set((ledger.get(name, {}).get("allow") or "").split())
+
+        for group in sorted(actual - declared):
+            found.append(
+                f"{name}: matches `{group}` and its row does not allow it.\n"
+                f"    Add `allow = \"{' '.join(sorted(actual))}\";` and say in "
+                "the reason why that path is carried here, or patch it out. "
+                "The class only says the file changed; this says what it does."
+            )
+        for group in sorted(declared - actual):
+            found.append(
+                f"{name}: allows `{group}` and no longer matches it.\n"
+                "    Upstream cleaned it up, or a patch of ours removed the "
+                "call. Prune the group, so the allowance keeps meaning "
+                "something."
+            )
+
     return found
 
 
-def seed(ledger, derived):
+def seed(ledger, derived, matched):
     """Skeleton rows for everything unclassified, class filled, reason not."""
     rows = []
     for name in sorted(derived):
-        if name in ledger or derived[name] == "vendor":
+        if name in ledger:
             continue
+        groups = sorted(matched.get(name, ()))
+        if derived[name] == "vendor" and not groups:
+            continue
+        allow = f'    allow = "{" ".join(groups)}";\n' if groups else ""
         rows.append(
             f'  "{name}" = {{\n'
             f'    class = "{derived[name]}";\n'
             f'    reason = "FIXME";\n'
+            f"{allow}"
             f"  }};"
         )
     return rows
@@ -333,18 +454,28 @@ def main():
     for name, row in ledger.items():
         if row.get("class") not in CLASSES:
             die(f"{name}: class {row.get('class')!r} is not one of {CLASSES}")
+        # `allow` is a space-separated string, not a list, because the parser
+        # above reads quoted strings only -- a list-valued key would be
+        # invisible to it and the allowance would silently mean nothing.
+        for group in (row.get("allow") or "").split():
+            if group not in PATTERNS:
+                die(
+                    f"{name}: allow names {group!r}, which is not a pattern "
+                    f"group. Known groups: {', '.join(sorted(PATTERNS))}"
+                )
 
     upstream_bin = os.path.join(args.upstream, "bin")
     shipped_bin = os.path.join(args.shipped, "bin")
     derived, upstream, shipped = derive(upstream_bin, shipped_bin, args.nix_bin)
+    matched = scan(shipped_bin, shipped)
 
     if args.seed:
-        rows = seed(ledger, derived)
+        rows = seed(ledger, derived, matched)
         print(f"# {len(rows)} rows need writing. reason = FIXME will not pass.")
         print("\n".join(rows))
         return 0
 
-    found = problems(ledger, derived, upstream, shipped, shipped_bin)
+    found = problems(ledger, derived, upstream, shipped, shipped_bin, matched)
 
     if args.report:
         if not found:
@@ -352,7 +483,9 @@ def main():
                 f"Every one of the {len(shipped)} shipped commands is upstream's "
                 f"or has a row: {len(ledger)} rows, "
                 f"{sum(1 for c in derived.values() if c == 'vendor')} vendored "
-                "untouched."
+                f"untouched, "
+                f"{sum(len(g) for g in matched.values())} behaviour match(es) "
+                "allowed."
             )
         for problem in found:
             print("- " + problem.splitlines()[0])
@@ -380,7 +513,12 @@ def main():
     for cls in derived.values():
         counts[cls] = counts.get(cls, 0) + 1
     summary = ", ".join(f"{n} {cls}" for cls, n in sorted(counts.items()))
-    print(f"{len(shipped)} commands: {summary}. {len(ledger)} rows, all true.")
+    scanned = sum(len(groups) for groups in matched.values())
+    print(
+        f"{len(shipped)} commands: {summary}. {len(ledger)} rows, all true. "
+        f"{scanned} behaviour match(es) across {len(matched)} command(s), "
+        "all allowed."
+    )
     return 0
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,14 @@ Two mechanical traps that produced fake green results here, live:
   iterated once, over the whole string. Interactive shells on the machines
   this repo is developed on are zsh. Put `#!/usr/bin/env bash` on the script
   and run it as a script, not by pasting into your shell.
+- **A break that stays green may be a break that never applied.** Step 1 of the
+  contract is as fallible as the check. A `sed -i` written against
+  `^rfkill unblock bluetooth` matched nothing, because the line is indented
+  inside a function -- so the check passed, and for a minute that read as the
+  check being blind to the thing it was written for. Before concluding anything
+  about a check, prove the break landed: `git diff`, or `grep` the file for
+  what you meant to remove. A silent no-op break and a blind check are
+  indistinguishable from the exit status alone.
 
 And the same rule read backwards, for the day a check goes red on you: **ask
 whether it was testing the property or the arrangement.** #220 moved the menu

--- a/data/bin-ledger.nix
+++ b/data/bin-ledger.nix
@@ -2,12 +2,14 @@
 #
 # Omarchy is 444 commands. This port ships all of them and 10 of its own, and
 # 386 of the 444 are byte-identical below the shebang -- patchShebangs rewrites
-# line 1 and nothing else touches them. So the interesting surface is the 58
-# rows here, and CI derives the rest rather than trusting a hand list.
+# line 1 and nothing else touches them. So the interesting surface is the rows
+# here, and CI derives the rest rather than trusting a hand list.
 #
 # ## The rule that keeps this file honest
 #
-# A vendored command does NOT get a row. A row is a CLAIM that the shipped file
+# A vendored command does NOT get a row, unless it carries a `pacman` or an
+# `allow` field -- see below, and note that neither of those restates the
+# comparison. Otherwise a row is a CLAIM that the shipped file
 # differs from upstream, and .github/scripts/check-bin-ledger.py fails in BOTH
 # directions: a file that differs with no row is unclassified, and a row whose
 # derived class no longer matches is stale. Neither can be satisfied by editing
@@ -29,6 +31,35 @@
 # The diff-based derivation is strictly stronger than grepping for
 # substituteInPlace: it catches the sed sites that no grep can see.
 #
+# ## What the file DOES, beside what changed
+#
+# The classes above answer "did this file change". They cannot answer "what
+# does this file do", and on NixOS that is the question that bites: a vendored
+# command that gains `systemctl enable`, `usermod`, a write under /etc or an
+# initramfs regeneration at the next Omarchy bump is byte-identical to the new
+# upstream, derives as `vendor`, and passes.
+#
+# So a row may also carry `allow`, a space-separated list of the behaviour
+# groups .github/scripts/check-bin-ledger.py finds in the shipped script --
+# ufw, systemctl-system, systemctl-user, etc-write, boot-write, modprobe,
+# account-tools, kernel-ctl, initrd-boot, rfkill, nmcli-radio, ctl-set. Same
+# biconditional as everything else here: a script matching a group with no
+# allowance fails, and an allowance the script no longer matches fails too, so
+# an upstream cleanup is reported rather than assumed.
+#
+# `allow` is a STRING and not a list because the ledger is read by regex over
+# quoted strings; a list-valued key would be invisible to the parser and the
+# allowance would silently mean nothing.
+#
+# The patterns over-match on purpose -- `cp /etc/skel/. ~/` reads /etc and
+# still counts -- because a false positive costs one row saying so, and a false
+# negative costs the whole point. That is also why a vendor row may carry
+# `allow`: unlike a bare vendor row it restates nothing the comparison already
+# proves.
+#
+# The fail-closed pattern-group scheme is zicochaos/omarchy-nix's idea (MIT).
+# The patterns, the groups and the code are ours.
+#
 # ## What a reason is for
 #
 # One or two sentences saying WHY the file differs, specific enough that a
@@ -40,20 +71,18 @@
 # the row goes stale, CI says so, and the row is deleted. Being told is the
 # point.
 {
-  "nixarchy-ask" = {
-    class = "new";
-    reason = "Not in upstream. Wraps omarchy-agent-prompt with prompts that name the skill and insist on measure-then-propose, so routing is fixed here rather than re-guessed on every invocation.";
-  };
   "nixarchy-android" = {
     class = "new";
     reason = "Not in upstream. scrcpy over Wi-Fi needs adb pair and adb connect on two different ports, one of them regenerated every time the pairing dialog opens, with a code valid for seconds; and `adb mdns services` cannot find them because nixpkgs' android-tools is built without an mDNS backend. This discovers both through avahi, which nixarchy already runs.";
   };
-
+  "nixarchy-ask" = {
+    class = "new";
+    reason = "Not in upstream. Wraps omarchy-agent-prompt with prompts that name the skill and insist on measure-then-propose, so routing is fixed here rather than re-guessed on every invocation.";
+  };
   "nixarchy-channel" = {
     class = "new";
     reason = "Not in upstream. The generated flake documents following stable as prose telling you to hand-edit nixpkgs AND home-manager; this does both or neither, because moving one without the other is the pairing that breaks.";
   };
-
   "nixarchy-config-repo" = {
     class = "new";
     reason = "Not in upstream. The installer leaves /etc/nixos as a git repository with a staged tree and no commit; this commits it, adds a remote and CI, and is idempotent on a re-run.";
@@ -69,18 +98,19 @@
   "nixarchy-preview" = {
     class = "new";
     reason = "Not in upstream, where a config change is a pacman transaction with no dry run to look at. Builds nixosConfigurations.<host>.config.system.build.vm -- the same configuration re-evaluated under qemu-vm.nix -- and boots it in a window, on a managed disk that is refused when stale rather than silently reused.";
+    allow = "account-tools";
   };
   "nixarchy-reinstall-iso" = {
     class = "new";
     reason = "Not in upstream, whose recovery story is snapper snapshots on the same disk. Builds a bootable image from this machine's own configuration -- the system closure and /etc/nixos, never /home or secrets -- after refusing on low disk, an uncommitted tree, or a running system that drifted from the flake.";
   };
-  "nixarchy-try" = {
-    class = "new";
-    reason = "Not in upstream, where trying an app IS installing it (pacman, then remove). Runs a catalogue app or nixpkgs attribute once from the machine's own pinned nixpkgs -- nix shell -f with the catalogue's binary field, never nix run's mainProgram guess -- and prints the app-enable/pkg-add hand-off when it exits.";
-  };
   "nixarchy-rollback" = {
     class = "new";
     reason = "Not in upstream, whose undo is omarchy-snapshot via snapper and limine. Lists and switches NixOS system generations, which are the bootable snapshot every rebuild already leaves behind.";
+  };
+  "nixarchy-try" = {
+    class = "new";
+    reason = "Not in upstream, where trying an app IS installing it (pacman, then remove). Runs a catalogue app or nixpkgs attribute once from the machine's own pinned nixpkgs -- nix shell -f with the catalogue's binary field, never nix run's mainProgram guess -- and prints the app-enable/pkg-add hand-off when it exits.";
   };
   "nixarchy-unfreeze" = {
     class = "new";
@@ -101,10 +131,32 @@
   "omarchy-apply-lock" = {
     class = "patch";
     reason = "Its root PATH reset points at /usr/bin, which holds nothing here, so it lost tee and getent while writing lock-screen PAM files; and its `-x /usr/bin/fprintd-list` probe was never true.";
+    allow = "etc-write";
+  };
+  "omarchy-apply-system" = {
+    class = "vendor";
+    reason = "Vendored unchanged, and the account-tools match is prose: `usermod` appears only in the --defer-provisioning paragraph of the usage heredoc, which comment-stripping cannot see. The script is upstream's chroot entry point for an Arch install; the installer here is installer/, which never calls it.";
+    allow = "account-tools";
   };
   "omarchy-audio-tuning" = {
     class = "patch";
     reason = "It tests for the LSP limiter at a fixed path under /usr/lib/lv2. NixOS keeps LV2 plugins in the store and points hosts at them with LV2_PATH, so the search is over LV2_PATH and the system profile.";
+    allow = "systemctl-user";
+  };
+  "omarchy-bluetooth-power" = {
+    class = "vendor";
+    reason = "Vendored unchanged. `rfkill block/unblock bluetooth` sets the radio's soft block, which is runtime kernel state rather than configuration, so it behaves here as it does upstream and is meant not to survive a reboot.";
+    allow = "rfkill";
+  };
+  "omarchy-channel-current" = {
+    class = "vendor";
+    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
+    pacman = "Update, channel, keyring and mirror plumbing. Unreachable here because pkgs/omarchy/nix-bin replaces the entry points the UI calls -- omarchy-update and omarchy-update-available.";
+  };
+  "omarchy-channel-set" = {
+    class = "vendor";
+    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
+    pacman = "Update, channel, keyring and mirror plumbing. Unreachable here because pkgs/omarchy/nix-bin replaces the entry points the UI calls -- omarchy-update and omarchy-update-available.";
   };
   "omarchy-clipboard-open" = {
     class = "patch";
@@ -114,6 +166,16 @@
     class = "new";
     reason = "Not in upstream, which sets a cursor size but never a theme, because on Arch one arrives with the desktop packages. Picks Bibata Ice or Classic from the mode in the theme's colors.toml.";
   };
+  "omarchy-debug" = {
+    class = "vendor";
+    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
+    pacman = "Reads pacman state for display only; nothing is installed or removed.";
+  };
+  "omarchy-debug-idle" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Reads `systemctl --user status omarchy-sleep-lock.service` for a diagnostic dump; nothing is started, stopped or enabled.";
+    allow = "systemctl-user";
+  };
   "omarchy-default-agent" = {
     class = "replace";
     reason = "Upstream installs the agent with `mise use -g`: imperative, its shims only reach an interactive shell (the menu launches through `bash -c`), and its npm backend needs a node that is not in this closure.";
@@ -121,6 +183,31 @@
   "omarchy-default-browser" = {
     class = "patch";
     reason = "It names chromium.desktop, which nixpkgs calls chromium-browser.desktop, so setting the browser exited 1 having set nothing and the no-argument read printed the raw desktop id.";
+  };
+  "omarchy-dev-install-ydoo" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Upstream adds $USER to the input group with pkexec usermod, loads uinput with modprobe, and starts ydotool.service as a user unit. The first two are declarative here -- users.users.<name>.extraGroups and boot.kernelModules -- so a run does not survive the next rebuild.";
+    allow = "account-tools modprobe systemctl-user";
+  };
+  "omarchy-dev-link" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Points /etc/omarchy.conf at a development checkout with `sudo tee`, after validating a sudoers fragment with `visudo -cf`. OMARCHY_PATH is a store path here, so the file it writes contradicts the one the session reads.";
+    allow = "account-tools etc-write";
+  };
+  "omarchy-dev-pkg-test" = {
+    class = "vendor";
+    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
+    pacman = "Development tooling, not on any user path.";
+  };
+  "omarchy-dev-unlink" = {
+    class = "vendor";
+    reason = "Vendored unchanged. The other half of omarchy-dev-link: rewrites /etc/omarchy.conf back to the default target with `sudo tee`, and is wrong here for the same reason.";
+    allow = "etc-write";
+  };
+  "omarchy-dns" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Writes /etc/systemd/resolved.conf with `tee` to switch DNS providers. That file is generated from services.resolved on NixOS, so the write is reverted by the next rebuild.";
+    allow = "etc-write";
   };
   "omarchy-games-retro-cores" = {
     class = "replace";
@@ -130,9 +217,29 @@
     class = "patch";
     reason = "It hardcodes /usr/lib/libretro. nixpkgs puts the cores inside the retroarch wrapper's own store path, so the directory is resolved at runtime with `omarchy-retroarch-cores`.";
   };
+  "omarchy-hibernation-available" = {
+    class = "vendor";
+    reason = "Vendored unchanged, and read-only: it decides hibernation is set up by testing for /etc/mkinitcpio.conf.d/omarchy_resume.conf, which nothing on NixOS creates, so it reports unavailable -- which is right, because modules/nixos.nix ships zram and no hibernation swap.";
+    allow = "initrd-boot";
+  };
+  "omarchy-hibernation-remove" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Removes the swap file, edits /etc/fstab in place and reruns limine-mkinitcpio. /etc/fstab is generated from fileSystems here and there is no mkinitcpio, so it has nothing correct to undo.";
+    allow = "etc-write initrd-boot";
+  };
+  "omarchy-hibernation-setup" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Creates a swap file and writes /etc/mkinitcpio.conf.d and /etc/limine-entry-tool.d drop-ins before regenerating the initramfs. The initrd is built from the configuration here, so hibernation is a swapDevices plus boot.resumeDevice change rather than this.";
+    allow = "etc-write initrd-boot";
+  };
   "omarchy-hw-vulkan" = {
     class = "patch";
     reason = "It looks in /usr/share/vulkan/icd.d, which does not exist on NixOS -- hardware.graphics puts the ICD manifests under /run/opengl-driver -- so it answered no Vulkan on every machine.";
+  };
+  "omarchy-install-ai-hermes" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Stops omarchy-hermes-theme.service before reinstalling; stopping a user unit is session state and carries no configuration.";
+    allow = "systemctl-user";
   };
   "omarchy-install-font" = {
     class = "replace";
@@ -142,13 +249,43 @@
     class = "patch";
     reason = "Nine /usr/share/libretro paths it writes into retroarch.cfg: core info, shaders and joypad autoconfig now point at nixpkgs packages, and the rest, which have none, at ~/.local/share/retroarch.";
   };
+  "omarchy-install-gaming-xbox-controllers" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Blacklists xpad in /etc/modprobe.d, loads hid_xpadneo, and adds $USER to the input group. All three are declarative here -- boot.blacklistedKernelModules, boot.kernelModules and extraGroups -- so the imperative run does not survive a rebuild.";
+    allow = "account-tools etc-write modprobe";
+  };
   "omarchy-install-service-1password" = {
     class = "patch";
     reason = "It drops a JSON stub into /usr/share/chromium/extensions with sudo; that is a store path here, so the write fails. Replaced by a message naming programs.chromium.extensions.";
   };
+  "omarchy-install-service-nordvpn" = {
+    class = "vendor";
+    reason = "Vendored unchanged. `systemctl enable --now nordvpnd` plus `usermod -aG nordvpn`. data/apps.nix carries nordvpn as a package; the daemon and the group belong in the configuration, not in an enable call.";
+    allow = "account-tools systemctl-system";
+  };
+  "omarchy-install-service-once" = {
+    class = "vendor";
+    reason = "Vendored unchanged. `systemctl enable --now once-background.service`, for a unit no module here defines, so the enable fails rather than half-succeeding.";
+    allow = "systemctl-system";
+  };
+  "omarchy-install-service-sunshine" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Opens ports with `ufw allow` and enables sunshine as a user unit. There is no ufw on this system -- modules/nixos.nix uses networking.firewall -- and no sunshine module, so both halves are imperative paths with no declarative counterpart yet.";
+    allow = "systemctl-user ufw";
+  };
+  "omarchy-install-service-tailscale" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Enables tailscaled.service and a user receive unit. modules/services/tailscale.nix already declares the daemon, so the system half duplicates a service the configuration owns.";
+    allow = "systemctl-system systemctl-user";
+  };
   "omarchy-launch-browser" = {
     class = "patch";
     reason = "It reads the browser's .desktop from {~/.local,~/.nix-profile,/usr}/share/applications. On NixOS those live under /run/current-system/sw and /etc/profiles/per-user, so the lookup found nothing.";
+  };
+  "omarchy-launch-openclaw" = {
+    class = "vendor";
+    reason = "Vendored unchanged, and read-only: `systemctl --user is-enabled openclaw-gateway.service` decides whether to launch the gateway or the client.";
+    allow = "systemctl-user";
   };
   "omarchy-launch-signal" = {
     class = "patch";
@@ -162,10 +299,20 @@
     class = "patch";
     reason = "Four edits: the desktop-file search paths, the chromium-browser.desktop fallback name, `chromium*` added to the browser case, and `env -u BROWSER` around xdg-settings -- the last upstream's own bug.";
   };
+  "omarchy-menu-timezone" = {
+    class = "vendor";
+    reason = "Vendored unchanged. `sudo timedatectl set-timezone` rewrites /etc/localtime, which time.timeZone owns on NixOS, so the menu's choice is reverted by the next rebuild.";
+    allow = "ctl-set";
+  };
   "omarchy-migrate" = {
     class = "replace";
     reason = "Upstream's 86 migration scripts use sudo, write under /usr and call pacman, and with no state directory every one counts as pending. --pending reports nothing to do; a bare run is told why.";
     pacman = "Ours, in pkgs/omarchy/nix-bin. The pacman line is heredoc prose or upstream code left dead after an early exit -- neither of which comment-stripping can see.";
+  };
+  "omarchy-openclaw-onboard" = {
+    class = "vendor";
+    reason = "Vendored unchanged, and read-only: reads MainPID off openclaw-gateway.service with `systemctl --user show`.";
+    allow = "systemctl-user";
   };
   "omarchy-pkg-add" = {
     class = "replace";
@@ -179,6 +326,11 @@
     class = "replace";
     reason = "Upstream shows an fzf picker over `yay -Slqa` and installs the selection with yay. There is no AUR on NixOS, so this says so and points at the Install menu.";
   };
+  "omarchy-pkg-drop" = {
+    class = "vendor";
+    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
+    pacman = "A menu row modules/apps.nix overrides away, so nothing on this system reaches the pacman path inside it.";
+  };
   "omarchy-pkg-install" = {
     class = "replace";
     reason = "Upstream offers a fuzzy picker over `pacman -Slq` and installs with `pacman -S`. Points at ~/.config/nixarchy/apps.nix and nixarchy-apply, since an imperative install would not survive a rebuild.";
@@ -190,6 +342,11 @@
   "omarchy-pkg-present" = {
     class = "replace";
     reason = "Upstream asks `pacman -Q`. There is no package database here, so the closest honest answer is whether the command is runnable; menu rows needing exactness check the app selection themselves.";
+  };
+  "omarchy-pkg-remove" = {
+    class = "vendor";
+    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
+    pacman = "A menu row modules/apps.nix overrides away, so nothing on this system reaches the pacman path inside it.";
   };
   "omarchy-plugin-clone" = {
     class = "patch";
@@ -203,6 +360,12 @@
     class = "replace";
     reason = "Upstream stages a recoloured theme into /usr/share with sudo and rebuilds the initramfs with mkinitcpio. The initrd is built from the configuration here, so this names boot.plymouth and exits non-zero.";
   };
+  "omarchy-provision-owner" = {
+    class = "vendor";
+    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
+    pacman = "Reads pacman state for display only; nothing is installed or removed.";
+    allow = "account-tools boot-write ctl-set etc-write initrd-boot";
+  };
   "omarchy-provision-user" = {
     class = "patch";
     reason = "Two edits: `xdg-settings set default-web-browser chromium.desktop` exits 2 under `set -euo pipefail` and aborted provisioning, and the shipped HEY.desktop is installed prefixed as omarchy-HEY.desktop.";
@@ -210,6 +373,17 @@
   "omarchy-refresh-applications" = {
     class = "patch";
     reason = "Its two copies land 17 desktop files at the store's 444, so the next run cannot rewrite them; under `set -euo pipefail` that aborted omarchy-provision-user before it marked finalize-user.";
+  };
+  "omarchy-refresh-limine" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Replaces /boot/limine.conf from the package default and runs limine-update and limine-snapper-sync. The bootloader here is generated from boot.loader, so this writes over a file nothing reads.";
+    allow = "boot-write";
+  };
+  "omarchy-refresh-pacman" = {
+    class = "vendor";
+    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
+    pacman = "Update, channel, keyring and mirror plumbing. Unreachable here because pkgs/omarchy/nix-bin replaces the entry points the UI calls -- omarchy-update and omarchy-update-available.";
+    allow = "etc-write";
   };
   "omarchy-refresh-plymouth" = {
     class = "replace";
@@ -219,9 +393,45 @@
     class = "replace";
     reason = "Upstream removes and re-copies the theme into /usr/share/sddm/themes with sudo. It ships inside the package at share/sddm/themes/omarchy and services.displayManager.sddm.theme already names it.";
   };
+  "omarchy-reinstall-configs" = {
+    class = "vendor";
+    reason = "Vendored unchanged, and the etc-write match is a read -- `cp -af /etc/skel/. ~/` -- which is the acceptable over-match the pattern header names. /etc/skel is empty on NixOS, so it copies nothing.";
+    allow = "etc-write";
+  };
+  "omarchy-reinstall-pkgs" = {
+    class = "vendor";
+    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
+    pacman = "Update, channel, keyring and mirror plumbing. Unreachable here because pkgs/omarchy/nix-bin replaces the entry points the UI calls -- omarchy-update and omarchy-update-available.";
+  };
+  "omarchy-reminder" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Lists and stops the omarchy-reminder-*.timer user units it created itself, under ~/.config/systemd/user, which is the user's own tree rather than the system's.";
+    allow = "systemctl-user";
+  };
+  "omarchy-remove-ai-hermes" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Stops omarchy-hermes-theme.service on the way out; session state, no configuration.";
+    allow = "systemctl-user";
+  };
+  "omarchy-remove-ai-openclaw" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Disables the openclaw user units it installed under ~/.config/systemd/user, which is the user's own tree.";
+    allow = "systemctl-user";
+  };
   "omarchy-remove-browser" = {
     class = "patch";
     reason = "It writes chromium.desktop as the fallback default browser, a name nixpkgs does not use, and its `|| true` swallowed the failure -- so removing Chrome left a default resolving to nothing.";
+    allow = "etc-write";
+  };
+  "omarchy-remove-dev-env" = {
+    class = "vendor";
+    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
+    pacman = "A menu row modules/apps.nix overrides away, so nothing on this system reaches the pacman path inside it.";
+  };
+  "omarchy-remove-gaming-xbox-controllers" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Deletes the /etc/modprobe.d and /etc/modules-load.d files omarchy-install-gaming-xbox-controllers wrote. Neither exists here, because both settings are declarative.";
+    allow = "etc-write modprobe";
   };
   "omarchy-remove-launcher-entry" = {
     class = "patch";
@@ -235,6 +445,57 @@
   "omarchy-remove-security-fingerprint" = {
     class = "patch";
     reason = "Same PAM edit as omarchy-remove-security-fido2: `sed -i` over a symlink into /etc/static/pam.d detaches the stack. The function goes; dropping the packages and the omarchy-lock file stays.";
+    allow = "etc-write";
+  };
+  "omarchy-remove-security-sshd" = {
+    class = "vendor";
+    reason = "Vendored unchanged. `systemctl disable --now sshd.service` and a `ufw delete` of the rate limit. services.openssh owns sshd here and there is no ufw, so neither half is the way this is turned off.";
+    allow = "systemctl-system ufw";
+  };
+  "omarchy-remove-security-sudoless-docker" = {
+    class = "vendor";
+    reason = "Vendored unchanged. `gpasswd -d $USER docker` removes a group membership that users.users.<name>.extraGroups owns on NixOS, so a rebuild puts it back.";
+    allow = "account-tools";
+  };
+  "omarchy-remove-service-sunshine" = {
+    class = "vendor";
+    reason = "Vendored unchanged. The undo of omarchy-install-service-sunshine, imperative for the same two reasons: no ufw on this system, and no sunshine module to disable.";
+    allow = "systemctl-user ufw";
+  };
+  "omarchy-remove-service-tailscale" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Disables tailscaled.service, which modules/services/tailscale.nix declares, so the disable is undone by the next rebuild rather than by a mistake.";
+    allow = "systemctl-system systemctl-user";
+  };
+  "omarchy-restart-audio" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Restarts pipewire, pipewire-pulse and wireplumber as user units, which is session state and exactly what a restart command should do.";
+    allow = "systemctl-user";
+  };
+  "omarchy-restart-bluetooth" = {
+    class = "vendor";
+    reason = "Vendored unchanged. `rfkill unblock bluetooth` and a `rfkill list`: runtime radio state, same as omarchy-bluetooth-power.";
+    allow = "rfkill";
+  };
+  "omarchy-restart-shell" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Reads OMARCHY_PATH out of `systemctl --user show-environment` and try-restarts the invitation units; session state only.";
+    allow = "systemctl-user";
+  };
+  "omarchy-restart-trackpad" = {
+    class = "vendor";
+    reason = "Vendored unchanged. `modprobe -r intel_quicki2c && modprobe intel_quicki2c` reloads one driver at runtime. That is a reload rather than configuration, and works here as it does upstream.";
+    allow = "modprobe";
+  };
+  "omarchy-restart-wifi" = {
+    class = "vendor";
+    reason = "Vendored unchanged. `rfkill unblock wifi` and `nmcli radio wifi on`. NetworkManager is the network stack here too, so both calls do what they do upstream.";
+    allow = "nmcli-radio rfkill";
+  };
+  "omarchy-restart-xcompose" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Stops and starts omarchy-fcitx5.service, a user unit. modules/nixos.nix configures fcitx5, but the restart itself is session state.";
+    allow = "systemctl-user";
   };
   "omarchy-retroarch-cores" = {
     class = "new";
@@ -249,6 +510,16 @@
     reason = "Same as fido2: setup_pam_config and setup_lock_fingerprint_pam edit NixOS-managed PAM stacks. fprintd-enroll stays; the PAM step names services.fprintd and the fprintAuth options instead.";
     pacman = "A menu row modules/apps.nix overrides away, so nothing on this system reaches the pacman path inside it.";
   };
+  "omarchy-setup-security-sshd" = {
+    class = "vendor";
+    reason = "Vendored unchanged. `systemctl enable --now sshd.service` and `ufw limit 22/tcp`. services.openssh and networking.firewall are the declarative route, and there is no ufw here for the second half to reach.";
+    allow = "systemctl-system ufw";
+  };
+  "omarchy-setup-security-sudoless-docker" = {
+    class = "vendor";
+    reason = "Vendored unchanged. `usermod -aG docker $USER` adds a group membership that users.users.<name>.extraGroups owns on NixOS, so the change is lost at the next rebuild.";
+    allow = "account-tools";
+  };
   "omarchy-snapshot" = {
     class = "replace";
     reason = "Upstream drives snapper through limine, which is neither the bootloader here nor packaged, and `@` holds almost no system anyway. Snapshots /home and /var/lib, and restores from the running system.";
@@ -260,6 +531,11 @@
   "omarchy-system-factory-reset" = {
     class = "replace";
     reason = "Upstream clones the Quattro ISO's @factory snapshot and then re-keys LUKS. This uses the nixarchy installer's @factory/@factory-home baseline, restores /home and /var/lib only, and stops if it is absent.";
+  };
+  "omarchy-system-factory-reset-finish" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Runs as root from a sysinit unit and clears machine identity: userdel, the /etc/ssh host keys, NetworkManager connections, the sddm autologin drop-in and /etc/machine-id. Most of those paths are generated on NixOS, and the unit it removes itself from does not exist here.";
+    allow = "account-tools etc-write";
   };
   "omarchy-theme-set" = {
     class = "patch";
@@ -273,86 +549,33 @@
     class = "new";
     reason = "Not in upstream, which ships theme setters for vscode, obsidian and others but none for Zed, pointing at the AUR's omazed instead -- which cannot work on v4. Reads the palette from colors.toml.";
   };
+  "omarchy-toggle-crash-capture" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Starts and stops omarchy-crash-watch.service, a user unit; session state, no configuration.";
+    allow = "systemctl-user";
+  };
+  "omarchy-toggle-hybrid-gpu" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Writes /etc/supergfxd.conf, edits it with `sed -i`, drops a unit override under /etc/systemd/system and enables supergfxd. Nothing here packages supergfxd and /etc/systemd/system is generated, so the whole path is Arch-only.";
+    allow = "etc-write systemctl-system";
+  };
   "omarchy-update" = {
     class = "replace";
     reason = "Upstream's updater prunes pacman packages, takes a snapper snapshot and refreshes the keyring, demanding 10 GiB before it starts. This moves the flake inputs forward with `nh os switch --update`.";
-  };
-  "omarchy-update-available" = {
-    class = "replace";
-    reason = "Upstream asks pacman and counts commits behind a git checkout of $OMARCHY_PATH, which here is a store path with no history. Exits 1, because the bar widget lights up on exit 0 alone.";
-  };
-  "omarchy-update-restart" = {
-    class = "patch";
-    reason = "It infers a kernel change from /usr/lib/modules/*/vmlinuz and `pacman -Qo`; the glob matches nothing, so it prompted a reboot every time. Compares /run/booted-system with /run/current-system.";
-  };
-  "omarchy-version" = {
-    class = "patch";
-    reason = "It reads the version from `pacman -Q omarchy` and treats an OMARCHY_PATH outside /usr/share as a git checkout, so it printed a bare `dev`. The build splices the real version in instead.";
-    pacman = "Ours, in pkgs/omarchy/nix-bin. The pacman line is heredoc prose or upstream code left dead after an early exit -- neither of which comment-stripping can see.";
-  };
-  "omarchy-version-channel" = {
-    class = "patch";
-    reason = "It greps /etc/pacman.conf and the mirrorlist for Omarchy's mirrors to choose stable or edge; with no pacman both fell through to `unknown`. Prints `nixos-version` before the first grep.";
-    pacman = "Ours, in pkgs/omarchy/nix-bin. The pacman line is heredoc prose or upstream code left dead after an early exit -- neither of which comment-stripping can see.";
-  };
-  "omarchy-voxtype-config" = {
-    class = "replace";
-    reason = "Upstream runs `voxtype configure` in a floating terminal. voxtype is opt-in here, so the bar's Dictation click produced `voxtype: command not found`; this says how to enable it instead.";
-  };
-  "omarchy-channel-current" = {
-    class = "vendor";
-    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
-    pacman = "Update, channel, keyring and mirror plumbing. Unreachable here because pkgs/omarchy/nix-bin replaces the entry points the UI calls -- omarchy-update and omarchy-update-available.";
-  };
-  "omarchy-channel-set" = {
-    class = "vendor";
-    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
-    pacman = "Update, channel, keyring and mirror plumbing. Unreachable here because pkgs/omarchy/nix-bin replaces the entry points the UI calls -- omarchy-update and omarchy-update-available.";
-  };
-  "omarchy-debug" = {
-    class = "vendor";
-    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
-    pacman = "Reads pacman state for display only; nothing is installed or removed.";
-  };
-  "omarchy-dev-pkg-test" = {
-    class = "vendor";
-    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
-    pacman = "Development tooling, not on any user path.";
-  };
-  "omarchy-pkg-drop" = {
-    class = "vendor";
-    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
-    pacman = "A menu row modules/apps.nix overrides away, so nothing on this system reaches the pacman path inside it.";
-  };
-  "omarchy-pkg-remove" = {
-    class = "vendor";
-    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
-    pacman = "A menu row modules/apps.nix overrides away, so nothing on this system reaches the pacman path inside it.";
-  };
-  "omarchy-provision-owner" = {
-    class = "vendor";
-    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
-    pacman = "Reads pacman state for display only; nothing is installed or removed.";
-  };
-  "omarchy-refresh-pacman" = {
-    class = "vendor";
-    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
-    pacman = "Update, channel, keyring and mirror plumbing. Unreachable here because pkgs/omarchy/nix-bin replaces the entry points the UI calls -- omarchy-update and omarchy-update-available.";
-  };
-  "omarchy-reinstall-pkgs" = {
-    class = "vendor";
-    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
-    pacman = "Update, channel, keyring and mirror plumbing. Unreachable here because pkgs/omarchy/nix-bin replaces the entry points the UI calls -- omarchy-update and omarchy-update-available.";
-  };
-  "omarchy-remove-dev-env" = {
-    class = "vendor";
-    reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
-    pacman = "A menu row modules/apps.nix overrides away, so nothing on this system reaches the pacman path inside it.";
   };
   "omarchy-update-aur-pkgs" = {
     class = "vendor";
     reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
     pacman = "Update, channel, keyring and mirror plumbing. Unreachable here because pkgs/omarchy/nix-bin replaces the entry points the UI calls -- omarchy-update and omarchy-update-available.";
+  };
+  "omarchy-update-available" = {
+    class = "replace";
+    reason = "Upstream asks pacman and counts commits behind a git checkout of $OMARCHY_PATH, which here is a store path with no history. Exits 1, because the bar widget lights up on exit 0 alone.";
+  };
+  "omarchy-update-firmware" = {
+    class = "vendor";
+    reason = "Vendored unchanged. `install -D /usr/lib/fwupd/efi/fwupdx64.efi /boot/EFI/arch/fwupdx64.efi` stages the fwupd EFI binary from a path that does not exist on NixOS, where services.fwupd owns this.";
+    allow = "boot-write";
   };
   "omarchy-update-keyring" = {
     class = "vendor";
@@ -369,6 +592,10 @@
     reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
     pacman = "Update, channel, keyring and mirror plumbing. Unreachable here because pkgs/omarchy/nix-bin replaces the entry points the UI calls -- omarchy-update and omarchy-update-available. Its whole job is PRINTING advice about pacman, so the word is the output rather than a call.";
   };
+  "omarchy-update-restart" = {
+    class = "patch";
+    reason = "It infers a kernel change from /usr/lib/modules/*/vmlinuz and `pacman -Qo`; the glob matches nothing, so it prompted a reboot every time. Compares /run/booted-system with /run/current-system.";
+  };
   "omarchy-update-system-pkgs" = {
     class = "vendor";
     reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
@@ -383,15 +610,40 @@
     class = "vendor";
     reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
     pacman = "Update, channel, keyring and mirror plumbing. Unreachable here because pkgs/omarchy/nix-bin replaces the entry points the UI calls -- omarchy-update and omarchy-update-available.";
+    allow = "etc-write initrd-boot modprobe systemctl-system systemctl-user ufw";
   };
   "omarchy-upload-log" = {
     class = "vendor";
     reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
     pacman = "Reads pacman state for display only; nothing is installed or removed.";
   };
+  "omarchy-version" = {
+    class = "patch";
+    reason = "It reads the version from `pacman -Q omarchy` and treats an OMARCHY_PATH outside /usr/share as a git checkout, so it printed a bare `dev`. The build splices the real version in instead.";
+    pacman = "Ours, in pkgs/omarchy/nix-bin. The pacman line is heredoc prose or upstream code left dead after an early exit -- neither of which comment-stripping can see.";
+  };
+  "omarchy-version-channel" = {
+    class = "patch";
+    reason = "It greps /etc/pacman.conf and the mirrorlist for Omarchy's mirrors to choose stable or edge; with no pacman both fell through to `unknown`. Prints `nixos-version` before the first grep.";
+    pacman = "Ours, in pkgs/omarchy/nix-bin. The pacman line is heredoc prose or upstream code left dead after an early exit -- neither of which comment-stripping can see.";
+  };
   "omarchy-version-pkgs" = {
     class = "vendor";
     reason = "Vendored unchanged. This row exists only to record why an Arch-only package path is carried and unreachable -- see `pacman` below.";
     pacman = "Reads pacman state for display only; nothing is installed or removed.";
+  };
+  "omarchy-voxtype-config" = {
+    class = "replace";
+    reason = "Upstream runs `voxtype configure` in a floating terminal. voxtype is opt-in here, so the bar's Dictation click produced `voxtype: command not found`; this says how to enable it instead.";
+  };
+  "omarchy-voxtype-remove" = {
+    class = "vendor";
+    reason = "Vendored unchanged. Disables voxtype.service, a user unit installed under the user's own tree.";
+    allow = "systemctl-user";
+  };
+  "omarchy-windows-vm" = {
+    class = "vendor";
+    reason = "Vendored unchanged, and the modprobe match is prose: the two `sudo modprobe kvm-*` lines are inside the help text printed when KVM is unavailable, which comment-stripping cannot see. modules/nixos.nix loads the KVM modules declaratively.";
+    allow = "modprobe";
   };
 }


### PR DESCRIPTION
## What this changes, and why

`.github/scripts/check-bin-ledger.py` derives a command's class by comparing the
shipped tree with upstream. That answers *"did this file change"* very well and
says nothing about *"what does this file do"* — and on NixOS the second question
is the one that bites. A vendored command that gains `systemctl enable`,
`usermod`, a write under `/etc` or an initramfs regeneration at the next Omarchy
bump is byte-identical to the **new** upstream, derives as `vendor`, and passes
in silence. `PACMAN = re.compile(r"\b(pacman|yay)\b")` was the only behavioural
pattern in the repository.

So twelve pattern groups sit beside it — `ufw`, `systemctl-system`,
`systemctl-user`, `etc-write`, `boot-write`, `modprobe`, `account-tools`,
`kernel-ctl`, `initrd-boot`, `rfkill`, `nmcli-radio`, `ctl-set` — scanned over
the same comment-stripped text the pacman scan already uses, and held against a
new `allow` field on the same biconditional as everything else here: **a script
matching a group with no allowance fails, and an allowance that no longer fires
fails too.** The second direction is what turns an upstream cleanup into a
report rather than an assumption.

Three decisions worth naming for review:

- **`allow` is a space-separated STRING, not a list.** The ledger parser is
  `re.findall(r'(\w+)\s*=\s*"([^"]*)"', body)` — strings only. A list-valued key
  would be invisible to it and the allowance would silently mean nothing. No
  parser change was needed.
- **A vendor row may carry `allow`**, for exactly the reason it may carry
  `pacman`: neither restates what `cmp` already proves, so neither is the rubber
  stamp the header refuses.
- **`MIN_MATCHES = 40` is the floor**, beside `MIN_UPSTREAM`/`MIN_SHIPPED`/
  `MIN_VENDOR`/`MIN_ROWS`. 78 matches across 51 commands today; a scan that falls
  under 40 refuses rather than reporting that nothing needs a row. This file's
  own rule — *"the dangerous failure is a check that stopped seeing its
  subject."*

The patterns over-match on purpose and the header says so: `cp -af /etc/skel/. ~/`
is a read and still counts as `etc-write`. A false positive costs one row saying
so, which is an audit; a false negative costs the whole point. Three of the new
rows are exactly that — `usermod` inside a usage heredoc, `modprobe` inside help
text — which comment-stripping cannot see, the same shape as the existing
`pacman` rows' wording.

43 new rows and 8 amended ones cover the current tree. Most record an Arch-only
path carried and imperative here: `ufw` where `networking.firewall` is the route,
`usermod -aG` where `users.users.<name>.extraGroups` is,
`/etc/systemd/resolved.conf` where `services.resolved` is.

**No workflow edit.** `checks.bin-ledger` already exists and `build.yml:747`
already builds it on pull requests, and `omarchy.yml` already runs `--report`
into the bump PR body — so the advisory/fatal split absorbs this as-is. Flagging
it rather than touching a CI gate (§11); nothing looks to me like it needs one.

Credit: the fail-closed pattern-group scheme is `zicochaos/omarchy-nix`'s idea
(MIT). The patterns, the groups and the code are ours, and the ledger header
says so.

Closes #641

## How I proved the check fails

Three directions, in `bash` with `pipefail`, against a writable copy of the real
shipped tree so that case 1 is a faithful simulation of an Omarchy bump rather
than an argument.

```
######## 0. baseline, unmodified tree ########
459 commands: 15 new, 28 patch, 20 replace, 396 vendor. 125 rows, all true. 78 behaviour match(es) across 51 command(s), all allowed.
exit=0

######## 1. an Omarchy bump gives a vendored command a systemctl enable ########
# appended `sudo systemctl enable --now bluetooth.service` to omarchy-restart-bluetooth
#   (vendored, has a row, allows rfkill only)
# appended `sudo usermod -aG video "$USER"`               to omarchy-font-set
#   (vendored, has no row at all)
data/bin-ledger.nix and the built package disagree, 4 time(s):

  omarchy-font-set: shipped as `patch` and has no row.
    Add one to data/bin-ledger.nix saying why this port diverges. `--seed` prints a skeleton.
  omarchy-restart-bluetooth: the row says `vendor` and the build produces `patch`.
    A patch row gone vendor usually means upstream adopted the change -- delete the row. The other direction means something started diverging without anyone saying why.
  omarchy-font-set: matches `account-tools` and its row does not allow it.
    Add `allow = "account-tools";` and say in the reason why that path is carried here, or patch it out. The class only says the file changed; this says what it does.
  omarchy-restart-bluetooth: matches `systemctl-system` and its row does not allow it.
    Add `allow = "rfkill systemctl-system";` and say in the reason why that path is carried here, or patch it out. The class only says the file changed; this says what it does.
exit=1

######## 2. an allowance that no longer fires (upstream cleaned the call up) ########
# commented out the two `rfkill (un)block bluetooth` lines in omarchy-bluetooth-power
data/bin-ledger.nix and the built package disagree, 2 time(s):

  omarchy-bluetooth-power: the row says `vendor` and the build produces `patch`.
    A patch row gone vendor usually means upstream adopted the change -- delete the row. The other direction means something started diverging without anyone saying why.
  omarchy-bluetooth-power: allows `rfkill` and no longer matches it.
    Upstream cleaned it up, or a patch of ours removed the call. Prune the group, so the allowance keeps meaning something.
exit=1

######## 3. the floor: a scan that has stopped seeing its subject ########
# every pattern still compiles; each one had `zzznomatch` appended
bin-ledger: the behaviour scan matched 18 time(s) across 17 command(s), expected at least 40.
  A scan that sees nothing reports that nothing needs a row, which is the one failure this file exists to refuse. Either the patterns stopped compiling against real scripts, or the tree moved.
exit=1

######## 4. restored ########
459 commands: 15 new, 28 patch, 20 replace, 396 vendor. 125 rows, all true. 78 behaviour match(es) across 51 command(s), all allowed.
exit=0
```

Case 3 is a partial blinding rather than a total one — appending to an
alternation only kills its last branch, so 18 of 78 matches survived — which is
the more interesting shape anyway: the floor catches a scan that has *mostly*
stopped seeing its subject, not only one that sees nothing.

## Checks run locally

- `nix build .#checks.x86_64-linux.bin-ledger --print-build-logs` — green, and
  it is the check this PR changes.
- `nix build .#checks.x86_64-linux.options --no-link` — green (nothing in
  `modules/` changed; run as a sanity pass).
- No VM check built locally: CI install jobs share this machine, and starving
  one is somebody else's guest-side timeout (§6).

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (a flake cannot see untracked files) — no new
      files; both changed files were already tracked
- [x] If this adds an option: `tests/options.nix` covers both states — n/a
- [x] If this adds a `checks.*` entry: a PR-triggered workflow builds it — n/a,
      no new entry; `bin-ledger` is already built by `build.yml:747`

## What this cost, and where it is written down

One general lesson, recorded in `AGENTS.md` §1 as a third bullet beside the
pipefail and zsh traps, because it is a trap in §1 itself:

> **A break that stays green may be a break that never applied.** Step 1 of the
> contract is as fallible as the check. My case-2 `sed -i` was written against
> `^rfkill unblock bluetooth` and matched nothing, because the line is indented
> inside a function — so the check passed, and for a minute that read as the
> check being blind to the thing it was written for. Prove the break landed
> before concluding anything about the check: a silent no-op break and a blind
> check are indistinguishable from the exit status alone.

- [x] A general lesson is recorded in `AGENTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQCpvhg8cysYMZBfkVyDLT
