### PR TITLE
Upstream's /etc overlay is an inventory with a reason per file, and a bump cannot add to it silently

### DIFF
--- a/data/etc-overlay.nix
+++ b/data/etc-overlay.nix
@@ -1,0 +1,252 @@
+# Every file in upstream's /etc overlay, and what answers it here.
+#
+# Omarchy's Arch package copies `etc/` straight into `/etc`. This port copies
+# the same tree into `$out/share/omarchy/etc` -- the `cp -r .` in
+# pkgs/omarchy/default.nix -- and NOTHING INSTALLS IT. Not one of these 40
+# files is read on a running nixarchy machine, and until this file existed
+# nothing in the repository said so, or said what took each one's place.
+#
+# So the risk is not that a file is ignored. It is that a file is ignored
+# WITHOUT A DECISION: upstream adds a sysctl, a modprobe quirk, a sudoers
+# rule, and the desktop quietly behaves differently from Omarchy's with
+# nothing to notice it.  A row here is that decision, written down.
+#
+# ## The rule that keeps this file honest
+#
+# tests/etc-overlay.nix diffs these keys against the shipped tree and fails in
+# BOTH directions: a file upstream ships with no row is unclassified, and a row
+# for a file upstream dropped is stale. So a source bump cannot be merged by
+# editing this file alone -- the same argument data/bin-ledger.nix makes about
+# classification, applied to an inventory.
+#
+# ## The classes
+#
+#   native      a NixOS option in modules/ declares the equivalent
+#   seed        modules/home.nix seeds it per user
+#   covered     another mechanism satisfies it -- the reason names which
+#   na          Arch-stack specific, nothing here to answer it
+#   divergent   meaningful on NixOS, deliberately NOT adopted
+#
+# `divergent` is not in #642's four classes, and is the reason this file is
+# worth reading. Seventeen of these are neither native, nor covered, nor
+# inapplicable: they would do something here and we do not do it. Calling those
+# `na` would have made the inventory the rubber stamp #642 warns about. Each
+# `divergent` row names the NixOS option that would carry it, so adopting one
+# later is a rebuild rather than an investigation.
+#
+# No row is `seed`: modules/home.nix seeds `config/` and `default/`, never
+# `etc/`, and that is itself a finding rather than an omission -- two files
+# here (fastfetch and kitty) are the system half of a pair whose user half IS
+# seeded, and both say so.
+#
+# ## What a reason is for
+#
+# One or two sentences a reader can check after an Omarchy release, naming the
+# option, the file, or the mechanism. "Not applicable to NixOS" is true of the
+# whole tree and therefore distinguishes nothing; the check enforces a floor on
+# reason length for that reason alone.
+#
+# The fail-closed manifest and the both-direction inventory diff are ideas from
+# zicochaos/omarchy-nix (MIT), an independent port that built the comparison
+# this repository had only written down. The code here is ours.
+{
+  "NetworkManager/conf.d/omarchy-wifi-powersave.conf" = {
+    class = "divergent";
+    reason = "wifi.powersave = 2 turns the driver's power saving off, which is what stops the multi-second stalls after an idle wifi link. networking.networkmanager.wifi.powersave is the option and nothing here sets it, so NetworkManager's own default stands.";
+  };
+
+  "cups/cups-browsed.conf" = {
+    class = "covered";
+    reason = "services.printing.browsed.enable = false in modules/nixos.nix, so cups-browsed never runs and has no configuration to read. Discovery is avahi's here, enabled in the same block with nssmdns4.";
+  };
+
+  "cups/cups-files.conf" = {
+    class = "native";
+    reason = "services.printing.enable generates /etc/cups/cups-files.conf from the module. The User/Group 209 in upstream's copy is Arch's cups uid, which is exactly the kind of number a NixOS machine must not be handed.";
+  };
+
+  "docker/daemon.json" = {
+    class = "divergent";
+    reason = "Sets json-file log rotation and pins bip/dns to 172.17.0.1 to pair with the resolved stub listener. modules/nixos.nix runs docker ROOTLESS by default, whose network is slirp4netns and not that bridge, so neither half transfers; the log limits would, through virtualisation.docker.rootless.daemon.settings, and are not set.";
+  };
+
+  "fastfetch/config.jsonc" = {
+    class = "divergent";
+    reason = "Upstream's About layout, installed to /etc/fastfetch/config.jsonc by the Arch package. Nothing writes that path here, so fastfetch and omarchy-launch-about fall back to fastfetch's stock layout -- and the one patch this repository applies to the etc tree (pkgs/omarchy/default.nix, the Nixarchy OS line) is applied to a file nothing reads.";
+  };
+
+  "gnupg/dirmngr.conf" = {
+    class = "na";
+    reason = "Keyserver fallbacks and a short connect timeout for the system dirmngr, which on Arch exists to keep `pacman-key --refresh-keys` working. There is no system keyring to refresh here; a user's own gpg reads ~/.gnupg/dirmngr.conf, which is theirs.";
+  };
+
+  "limine-entry-tool.d/omarchy-defaults.conf" = {
+    class = "covered";
+    reason = "limine-entry-tool is Arch-only and installer/host.nix boots systemd-boot. The half that is not about the bootloader -- a quiet splash -- is nixpkgs': boot.plymouth adds `splash` and NixOS already passes loglevel and udev.log_level. The snapshot entries are snapper's, which this port does not use.";
+  };
+
+  "limine-entry-tool.d/omarchy-uki.conf" = {
+    class = "na";
+    reason = "Turns on unified-kernel-image generation in limine-entry-tool. NixOS builds its boot entries from the system closure, so there is no equivalent switch to set.";
+  };
+
+  "mise/conf.d/omarchy.toml" = {
+    class = "divergent";
+    reason = "A mise tool_alias so `mise use -g cursor-agent` resolves, which is how upstream's omarchy-mise-install wrapper installs the Cursor CLI. mise reads /etc/mise/conf.d and nothing writes it here, so that one agent install fails while the others work.";
+  };
+
+  "mkinitcpio.conf.d/omarchy_hooks.conf" = {
+    class = "na";
+    reason = "HOOKS for mkinitcpio, including dropping kms on an NVIDIA-only machine. NixOS builds its initrd from boot.initrd.*; there is no hook list to order.";
+  };
+
+  "mkinitcpio.conf.d/thunderbolt_module.conf" = {
+    class = "covered";
+    reason = "MODULES+=(thunderbolt) for mkinitcpio. modules/nixos.nix feeds boot.initrd.availableKernelModules the whole nixpkgs all-hardware list, so an initrd here carries the Thunderbolt drivers without being told.";
+  };
+
+  "modprobe.d/omarchy-usb-autosuspend.conf" = {
+    class = "divergent";
+    reason = "`options usbcore autosuspend=-1` stops the kernel suspending USB devices, which is what keeps a keyboard or a dock from waking slowly or dropping. boot.extraModprobeConfig is the option and nothing here sets it.";
+  };
+
+  "nsswitch.conf" = {
+    class = "native";
+    reason = "NixOS generates /etc/nsswitch.conf from system.nssModules and system.nssDatabases. services.avahi.nssmdns4 in modules/nixos.nix adds the mdns entry this file's hosts line exists for.";
+  };
+
+  "plymouth/plymouthd.conf" = {
+    class = "native";
+    reason = "boot.plymouth.theme = \"omarchy\" in modules/nixos.nix, with themePackages naming the package that carries share/plymouth/themes/omarchy. programs.nixarchy.bootSplash chooses between mkDefault and mkForce for it.";
+  };
+
+  "profile.d/omarchy.sh" = {
+    class = "covered";
+    reason = "Sources /usr/share/omarchy/default/bash/env-bootstrap. programs.bash.interactiveShellInit sources the same default/bash/rc chain into /etc/bashrc, and modules/nixos.nix records that the two /usr paths that chain mentions are behind `[ -r ]` guards whose jobs this module and NixOS already do.";
+  };
+
+  "sddm.conf.d/10-theme.conf" = {
+    class = "native";
+    reason = "services.displayManager.sddm.theme = \"omarchy\" in modules/nixos.nix, which names the theme the package installs under share/sddm/themes.";
+  };
+
+  "sddm.conf.d/10-wayland.conf" = {
+    class = "native";
+    reason = "services.displayManager.sddm.wayland.enable = true in modules/nixos.nix. The CompositorCommand naming /usr/share/sddm/hyprland.lua is Arch's path; nixpkgs' sddm module supplies its own compositor command, so taking this file would break the greeter rather than configure it.";
+  };
+
+  "security/faillock.conf" = {
+    class = "covered";
+    reason = "Raises Arch's three failed passwords before a lockout to ten. NixOS' pam stack wires pam_faillock only as the logFailures audit module, never the preauth/authfail pair that locks an account, so there is no lockout limit to raise.";
+  };
+
+  "sudoers.d/omarchy-dns" = {
+    class = "divergent";
+    reason = "NOPASSWD for `omarchy-dns Cloudflare|Google|DHCP`, so the DNS panel switches without a prompt. The rule names /usr/bin/omarchy-dns, which does not exist here; a security.sudo.extraRules entry would have to name the store path or /run/current-system/sw/bin. Unadopted, so `omarchy dns` asks for a password.";
+  };
+
+  "sudoers.d/omarchy-passwd-tries" = {
+    class = "divergent";
+    reason = "`Defaults passwd_tries=10`, the sudo half of the lockout Omarchy loosens. security.sudo.extraConfig would carry it; nothing here does, so sudo's three attempts stand.";
+  };
+
+  "sudoers.d/omarchy-theme-browser" = {
+    class = "covered";
+    reason = "NOPASSWD for omarchy-theme-set-browser-policy, which writes an accent colour into each browser's policy directory. modules/nixos.nix creates those directories owned by programs.nixarchy.browserThemeUser through systemd.tmpfiles instead, so the script needs no root at all.";
+  };
+
+  "sudoers.d/omarchy-tzupdate" = {
+    class = "divergent";
+    reason = "NOPASSWD for `timedatectl set-timezone`, so the timezone picker applies without a prompt. Same shape as omarchy-dns: the rule names /usr/bin/timedatectl and no security.sudo.extraRules entry replaces it, so setting a timezone from the menu asks for a password.";
+  };
+
+  "sysctl.d/90-omarchy-file-watchers.conf" = {
+    class = "divergent";
+    reason = "fs.inotify.max_user_watches=524288, which is what stops a file watcher in a large checkout failing with ENOSPC. boot.kernel.sysctl is the option and nothing here sets it, so the kernel's 8192-per-user default stands.";
+  };
+
+  "sysctl.d/99-omarchy-sysctl.conf" = {
+    class = "divergent";
+    reason = "Desktop memory and writeback tuning. vm.swappiness=150 is the one that matters most here, because modules/nixos.nix turns zramSwap on for exactly the reason upstream raises it -- compressed swap in RAM is cheap to page to -- and then leaves swappiness at the kernel's 60. boot.kernel.sysctl would carry the whole file.";
+  };
+
+  "sysusers.d/omarchy-cups-browsed.conf" = {
+    class = "covered";
+    reason = "Allocates the cups-browsed system user. cups-browsed is off here (services.printing.browsed.enable = false), and NixOS declares users through users.users rather than sysusers.d in any case.";
+  };
+
+  "systemd/logind.conf.d/10-ignore-power-button.conf" = {
+    class = "native";
+    reason = "services.logind.settings.Login.HandlePowerKey = \"ignore\" in modules/nixos.nix, which is what lets Omarchy's own power menu answer the button instead of NixOS shutting the machine down.";
+  };
+
+  "systemd/logind.conf.d/20-inhibit-delay.conf" = {
+    class = "native";
+    reason = "services.logind.settings.Login.InhibitDelayMaxSec = 15 in modules/nixos.nix, giving omarchy-sleep-lock time to secure the screen before logind suspends anyway.";
+  };
+
+  "systemd/oomd.conf.d/10-omarchy.conf" = {
+    class = "divergent";
+    reason = "Tightens systemd-oomd to kill at 50% memory pressure held for 20s. nixpkgs' oomd module sets DefaultMemoryPressureLimit to 60% and leaves the duration at systemd's 30s; modules/nixos.nix adds the app.slice ManagedOOM drop-in but not these defaults, so a desktop here is killed later than on Omarchy.";
+  };
+
+  "systemd/resolved.conf.d/10-disable-multicast.conf" = {
+    class = "covered";
+    reason = "Turns LLMNR and resolved's MulticastDNS off so they do not race avahi. services.resolved is not enabled by this module at all -- avahi answers mDNS here -- so there is no second responder to silence.";
+  };
+
+  "systemd/resolved.conf.d/20-docker-dns.conf" = {
+    class = "covered";
+    reason = "A resolved stub listener on the docker bridge, the other half of etc/docker/daemon.json. Neither resolved nor the rooted docker daemon is enabled here, and rootless docker does not use that bridge.";
+  };
+
+  "systemd/system.conf.d/10-faster-shutdown.conf" = {
+    class = "divergent";
+    reason = "DefaultTimeoutStopSec=5s, the difference between a desktop that powers off at once and one that waits out systemd's 90 seconds on a hung unit. systemd.settings.Manager would carry it and nothing here does.";
+  };
+
+  "systemd/system.conf.d/20-omarchy-nofile.conf" = {
+    class = "divergent";
+    reason = "DefaultLimitNOFILE=65536:524288, raising the soft descriptor limit every system unit inherits from systemd's 1024. NixOS sets neither half, so a bundler, a watcher or a language server started by a system unit gets the low soft limit.";
+  };
+
+  "systemd/system/cups-browsed.service.d/10-omarchy.conf" = {
+    class = "covered";
+    reason = "Sandboxing for cups-browsed -- its own user, ProtectSystem=strict, NoNewPrivileges. The service is off here (services.printing.browsed.enable = false), so there is nothing to harden.";
+  };
+
+  "systemd/system/docker.service.d/no-block-boot.conf" = {
+    class = "covered";
+    reason = "DefaultDependencies=no so a rooted docker.service does not hold up boot. modules/nixos.nix leaves virtualisation.docker.enable at false and runs the rootless daemon as a user unit, which is not in the boot path at all.";
+  };
+
+  "systemd/system/plocate-updatedb.service.d/ac-only.conf" = {
+    class = "divergent";
+    reason = "ConditionACPower=true keeps the locate database rebuild off a laptop on battery. services.locate.enable is on in modules/nixos.nix and its timer runs the update unconditioned, so that rebuild can fire on battery here.";
+  };
+
+  "systemd/system/user@.service.d/10-faster-shutdown.conf" = {
+    class = "divergent";
+    reason = "TimeoutStopSec=5s on the user manager, the per-user half of system.conf.d/10-faster-shutdown.conf. A systemd.services.\"user@\" drop-in would carry it; unadopted, so logout and shutdown wait on a stuck user service.";
+  };
+
+  "systemd/user.conf.d/20-omarchy-nofile.conf" = {
+    class = "divergent";
+    reason = "DefaultLimitNOFILE=65536:524288 for the user manager -- the limit every graphical application actually inherits, since the session's units are started by it. systemd.user.extraConfig would carry it and nothing here does.";
+  };
+
+  "tmpfiles.d/omarchy-nopasswd-sudo.conf" = {
+    class = "covered";
+    reason = "Reaps /etc/sudoers.d/99-omarchy-nopasswd-* at boot so a temporary passwordless sudo cannot outlive it. pkgs/omarchy/nix-bin/omarchy-sudo-passwordless replaces the command that writes those files with a message pointing at security.sudo, so the file this cleans up is never written.";
+  };
+
+  "tmpfiles.d/omarchy-zswap.conf" = {
+    class = "covered";
+    reason = "Writes N to zswap's enabled parameter so it cannot compete with zram. nixpkgs' kernels leave CONFIG_ZSWAP_DEFAULT_ON off and nothing here turns zswap on, so zram -- enabled in modules/nixos.nix -- is already the only compressed swap.";
+  };
+
+  "xdg/kitty/kitty.conf" = {
+    class = "divergent";
+    reason = "Omarchy's kitty defaults -- font, padding, the CSI-u bindings for shift+enter, the remote-control socket -- installed to /etc/xdg/kitty/kitty.conf. modules/home.nix seeds upstream's config/kitty/kitty.conf into ~/.config, and that file is a five-line stub whose own comment points at this one for the real settings, so kitty here is themed but otherwise stock.";
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1898,6 +1898,10 @@
             inherit inputs;
             pkgs = pkgsFor.${system};
           };
+          # Upstream's /etc overlay, which nothing installs: data/etc-overlay.nix
+          # says what answers each file here, and this fails when upstream adds
+          # or drops one. See tests/etc-overlay.nix and #642.
+          etc-overlay = import ./tests/etc-overlay.nix { pkgs = pkgsFor.${system}; };
 
           # The reference initrd can mount a disk it was not built on, which is
           # a precondition for offline install stage 3. See

--- a/pkgs/AGENTS.md
+++ b/pkgs/AGENTS.md
@@ -75,6 +75,7 @@ purpose; a fenced block is what an agent copies.
 | `omarchy` | the tree builds, and the README's counts still match it |
 | `omarchy-runtime` | the replaced commands run |
 | `patched-files` | every `--replace-fail` patch still applies |
+| `etc-overlay` | the 40 files of upstream's `/etc` tree are each classified in `data/etc-overlay.nix` — nothing installs that tree, so every one of them is ignored, and the manifest is where "ignored on purpose" is written down |
 | `doctor-graphics` | the doctor's GPU rules, against fixture machines |
 | `doctor-ldd` | the doctor's dynamic-link check, against binaries built broken |
 | `dashboard-clock` | the install dashboard against a rewound clock |

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,6 +1,9 @@
 # tests/
 
-Every `checks.<name>` in `flake.nix` is a file here. 37 of them.
+Every `checks.<name>` in `flake.nix` is a file here.
+`nix eval .#checks.x86_64-linux --apply builtins.attrNames` lists them — this
+line used to carry the count, and the count was wrong by half, which is the
+§4 shape: a hand-written number nothing compares.
 
 ## Intent
 
@@ -172,6 +175,22 @@ Two mechanics that make this possible, and one that nearly stopped it:
   output — a fixture that quietly starts succeeding otherwise leaves the thing
   under test reading an empty string, and "recognised nothing" is
   indistinguishable from "there was nothing to recognise".
+
+## An inventory check cannot check its own reasons
+
+`bin-ledger` and `etc-overlay` are the same shape: a table in `data/` claiming
+something about upstream's tree, and a check that diffs the table's keys against
+that tree in both directions. What each proves is narrow and worth stating —
+**that every path is classified and no classification is stale.** Whether the
+row's *reason* is true is prose, and nothing here reads it.
+
+That is a documented hole rather than a fixable one: "`services.resolved` is not
+enabled, so there is no second mDNS responder to silence" is a claim about the
+whole module system, and a check strong enough to verify forty of those is the
+module system. What the check does instead is force the sentence to be written
+when upstream changes, and force it to be long enough to be checkable by a
+person — `etc-overlay` throws on a reason under 80 characters for that reason
+alone. Reasons go stale silently; the keys cannot.
 
 ## The cheap ones, which is where new checks usually belong
 

--- a/tests/etc-overlay.nix
+++ b/tests/etc-overlay.nix
@@ -1,0 +1,99 @@
+{ pkgs }:
+# Upstream's /etc overlay, held to data/etc-overlay.nix in both directions.
+#
+# The tree is carried into $out/share/omarchy/etc and nothing installs it, so
+# every file in it is ignored by definition. The manifest says which of those
+# are ignored because something else answers them and which are ignored because
+# nobody has decided yet; this makes upstream's next change force that decision
+# rather than arrive silently:
+#
+#   a file shipped with no row       unclassified -- decide, then add a row
+#   a row for a file no longer there stale -- the file went, the row must too
+#
+# Compared against the SHIPPED tree rather than inputs.omarchy, so the same
+# diff also proves the `cp -r .` in pkgs/omarchy/default.nix still carries
+# etc/ at all. It cannot be satisfied by editing the manifest alone, which is
+# the whole point -- data/bin-ledger.nix makes the same argument about
+# classification, and this one is about the inventory.
+#
+# The floor is the other half. `find` over a path that moved, or a tree that
+# stopped being copied, enumerates nothing -- and every assertion over an empty
+# list passes. A count below the floor is therefore a failure and not a clean
+# run; `find -L` for the same reason, since $shipped may be a result symlink.
+let
+  inherit (pkgs) lib;
+
+  manifest = import ../data/etc-overlay.nix;
+
+  classes = [
+    "covered"
+    "divergent"
+    "na"
+    "native"
+    "seed"
+  ];
+
+  # Checked at evaluation rather than in the script: a row with a class the
+  # manifest's own header does not define, or a one-line "not applicable"
+  # reason, is the rubber stamp this file exists to prevent.
+  malformed = lib.attrNames (
+    lib.filterAttrs (
+      _: row: !(builtins.elem row.class classes) || builtins.stringLength row.reason < 80
+    ) manifest
+  );
+in
+if malformed != [ ] then
+  throw ''
+    data/etc-overlay.nix: rows with an unknown class, or a reason under 80
+    characters, which is too short to be checkable after a release:
+
+      ${lib.concatStringsSep "\n      " malformed}
+
+    Classes: ${lib.concatStringsSep ", " classes}
+  ''
+else
+  pkgs.runCommand "nixarchy-etc-overlay"
+    {
+      shipped = pkgs.nixarchy-omarchy or pkgs.omarchy;
+      claimed = lib.concatStringsSep "\n" (lib.attrNames manifest);
+      passAsFile = [ "claimed" ];
+
+      # Upstream ships 40. A floor rather than the exact count, so adding a
+      # classified file is a manifest edit and not two.
+      floor = 30;
+    }
+    ''
+      set -o pipefail
+
+      # Named once, so the floor's message reports the directory that was
+      # actually walked rather than the one it was meant to be.
+      overlay="$shipped/share/omarchy/etc"
+
+      find -L "$overlay" -type f -printf '%P\n' | sort >shipped.list
+      sort <"$claimedPath" >claimed.list
+
+      found=$(wc -l <shipped.list)
+      if [ "$found" -lt "$floor" ]; then
+        echo "etc-overlay: found only $found files under" >&2
+        echo "  $overlay" >&2
+        echo "which is below the floor of $floor. Either upstream's overlay has" >&2
+        echo "shrunk that far -- reclassify it -- or the tree is no longer being" >&2
+        echo "copied and this check was about to pass by enumerating nothing." >&2
+        exit 1
+      fi
+
+      if ! diff -u claimed.list shipped.list; then
+        echo >&2
+        echo "etc-overlay: data/etc-overlay.nix does not match the shipped tree." >&2
+        echo "In that diff, reading against the manifest:" >&2
+        echo >&2
+        echo "  +path  upstream ships it and no row classifies it. Read the file," >&2
+        echo "         decide what answers it here, and add a row with a reason." >&2
+        echo "  -path  the row claims a file upstream no longer ships. Delete it;" >&2
+        echo "         a stale row is a claim about nothing." >&2
+        exit 1
+      fi
+
+      echo "etc-overlay: all $found files classified, none stale"
+      touch "$out"
+    ''


### PR DESCRIPTION
## What this changes, and why

Omarchy's Arch package copies `etc/` straight into `/etc`. This port copies the same 40 files into `$out/share/omarchy/etc` (the `cp -r .` in `pkgs/omarchy/default.nix`) and **installs none of them**, so every one of them is ignored — and until now nothing in the repository enumerated the tree, or said what took each file's place. `data/etc-overlay.nix` classifies all 40 with a reason each, and `checks.etc-overlay` diffs its keys against the shipped tree in both directions, so an Omarchy bump that adds or drops a file forces the decision at bump time instead of leaving a desktop that quietly behaves differently from upstream's.

To be precise about the risk, because the obvious justification is wrong and #642 says so: this would **not** have caught #202. That was `config/hypr/xdph.conf`, in `config/`, and `omarchy-config-delta.sh`'s `refs()` already greps `custom_picker_binary=`. The gap is the other one — a `sysctl.d` rule, a `modprobe.d` quirk, a `sudoers.d` entry arriving upstream and being ignored with nobody deciding to ignore it.

**Classes, 40 rows:** `native` 7 · `covered` 13 · `divergent` 17 · `na` 3 · `seed` 0.

`divergent` is a fifth class, not one of the four in the issue, and it is the reason the file is worth reading: 17 of these would do something on NixOS and we do not do it. Forcing those into `na` ("Arch-stack specific") would have made the manifest the rubber stamp #642 warns against. Every `divergent` row names the NixOS option that would carry it. No row is `seed` — `modules/home.nix` seeds `config/` and `default/`, never `etc/` — which is itself a finding, because two files here are the system half of a pair whose user half *is* seeded.

**Three divergences found while writing it, each user-visible:**

- `etc/fastfetch/config.jsonc` is the one file this repository patches (`default.nix:614`, the "Nixarchy (Omarchy 4.0.3)" OS line) and it is patched in a tree nothing reads. Nothing writes `/etc/fastfetch/config.jsonc`, so `fastfetch` and `omarchy-launch-about` render fastfetch's stock layout, not Omarchy's About screen.
- `etc/xdg/kitty/kitty.conf` holds Omarchy's kitty defaults — font, padding, the CSI-u bindings for shift+enter, the remote-control socket. The seeded `~/.config/kitty/kitty.conf` is a five-line stub whose own comment points at this file for the real settings, so kitty here is themed and otherwise stock.
- `etc/mise/conf.d/omarchy.toml` is the `tool_alias` that `mise use -g cursor-agent` resolves through, which is how `omarchy-mise-install` installs the Cursor CLI. `/etc/mise/conf.d` is unwritten here, so that one agent install fails while the others work.

None are fixed here — this PR is the inventory, and each is now a row that says what is missing rather than a surprise for a user.

## How I proved the check fails

Run as a bash script (not pasted into zsh), four directions. Restored from a `cp` of the good file rather than `git checkout`, because the file was already `git add`ed and the index is what a restore would have handed back.

**1. Upstream ships a file with no row** — deleted the `sysctl.d/99-omarchy-sysctl.conf` row:

```
> --- claimed.list       2026-09-12 12:43:00.578140650 +0000
> +++ shipped.list    2026-09-12 12:43:00.576140622 +0000
> @@ -21,6 +21,7 @@
>  sysctl.d/90-omarchy-file-watchers.conf
> +sysctl.d/99-omarchy-sysctl.conf
>  systemd/logind.conf.d/10-ignore-power-button.conf
>
> etc-overlay: data/etc-overlay.nix does not match the shipped tree.
> In that diff, reading against the manifest:
>
>   +path  upstream ships it and no row classifies it. Read the file,
>          decide what answers it here, and add a row with a reason.
>   -path  the row claims a file upstream no longer ships. Delete it;
>          a stale row is a claim about nothing.
[exit 1]
```

**2. A row for a file upstream does not ship** — added `sysctl.d/97-omarchy-imaginary.conf`:

```
> @@ -21,7 +21,6 @@
>  sysctl.d/90-omarchy-file-watchers.conf
> -sysctl.d/97-omarchy-imaginary.conf
>  sysctl.d/99-omarchy-sysctl.conf
> etc-overlay: data/etc-overlay.nix does not match the shipped tree.
[exit 1]
```

**3. The floor** — pointed the `find` at a subdirectory so the enumeration finds almost nothing, which is what a moved path or a tree that stopped being copied looks like:

```
> etc-overlay: found only 2 files under
>   /nix/store/n57b3rxn75a0481hphh0zlwbw06n750y-omarchy-4.0.3/share/omarchy/etc
> which is below the floor of 30. Either upstream's overlay has
> shrunk that far -- reclassify it -- or the tree is no longer being
> copied and this check was about to pass by enumerating nothing.
[exit 1]
```

**4. A rubber-stamp reason** — replaced one reason with `"Arch-specific."`:

```
error: data/etc-overlay.nix: rows with an unknown class, or a reason under 80
characters, which is too short to be checkable after a release:

  gnupg/dirmngr.conf

Classes: covered, divergent, na, native, seed
[exit 1]
```

**Restored, all four reverted:**

```
nixarchy-etc-overlay> etc-overlay: all 40 files classified, none stale
[exit 0]
```

## Checks run locally

- `nix build .#checks.x86_64-linux.etc-overlay` — green, and red in all four directions above.
- `nix fmt -- --ci`, `statix check .`, `deadnix --fail .` — clean.
- No VM check built locally, deliberately: install jobs were in flight and a local VM build on p620 starves them (AGENTS.md §6).

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (a flake cannot see untracked files)
- [ ] If this adds an option: `tests/options.nix` covers both states — adds none
- [x] If this adds a `checks.*` entry: a PR-triggered workflow builds it — `build.yml`'s claimed list is an opt-OUT, so the generated step builds `etc-overlay` with no workflow edit (and none is made here; §11)

## What this cost, and where it is written down

`tests/AGENTS.md` gains a section on the shape `bin-ledger` and `etc-overlay` share and the hole they both have: the **keys** are checked in both directions and the **reasons** are prose nothing reads. That is a documented hole rather than a fixable one — a check strong enough to verify forty reasons about the module system *is* the module system — so what the check does instead is force the sentence to be written when upstream changes, and force it to be long enough to be checkable by a person (it throws on a reason under 80 characters).

The same file also loses its "37 of them" check count. There are 75 `checks.<name>` entries today; the number was wrong by half and nothing compared it, which is §4's own shape in the file that teaches §4. Replaced with the `nix eval --apply builtins.attrNames` that answers it, rather than a fresh number that rots the same way.

- [x] A general lesson is recorded in `AGENTS.md`

Closes #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mkz9oJ9nPQacByrCndNLoY
