### PR TITLE
The doctor-graphics check records whether the doctor finished, and says what it read when a case fails

### DIFF
--- a/pkgs/doctor.sh
+++ b/pkgs/doctor.sh
@@ -326,8 +326,13 @@ if [ -n "${OMARCHY_PATH:-}" ] && [ -e "$sw/bin/omarchy" ]; then
   # not the package's, while bin/ inside it still symlinks straight back. Left
   # as a literal comparison, this told every machine it was running an older
   # build.
+  # `|| true`, because this is the one section whose whole subject is a path
+  # that may no longer exist: a session started before a GC still names the
+  # collected build. readlink -f fails on it, pipefail carries that, and
+  # errexit killed the doctor here -- at the exact finding it was written to
+  # print -- taking the Graphics snippet and everything after it with it.
   session=$(readlink -f "$OMARCHY_PATH/bin/omarchy" 2>/dev/null |
-    sed 's|/bin/omarchy$||')
+    sed 's|/bin/omarchy$||') || true
   if [ "${session:-$OMARCHY_PATH}" != "$installed" ]; then
     finding "This session is running an older build" "$warn" ""
     say "     ${dim}session:   $OMARCHY_PATH${off}"

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -214,6 +214,19 @@ Two branches only these can reach, as illustration:
 - A forbid-pattern matches prose too. Forbidding a bare package name failed
   against correctly-gated code because the surrounding comment mentioned it —
   match the call, not the string.
+- **A tool that prints its verdict last fails every assertion at once when
+  it dies, and says nothing about dying.** `doctor-graphics` asserts on the
+  doctor's snippet, which the doctor prints after every other section, and the
+  doctor runs under `errexit`. So any host read between the Graphics section
+  and the end that fails -- and the fixture pins none of them -- kills the
+  doctor, the snippet is never printed, and the check reports five `no
+  /intelBusId/ in the output` lines that read exactly like five wrong GPU
+  rules. The harness had `|| true` on the doctor, so the one number that
+  would have said "it died" was thrown away (#645). Capture the exit status
+  as part of the output and assert on it first; and when a case fails, print
+  the full transcript plus the host state the fixture does not control, because
+  a check that disagrees with itself across two runners and cannot say what
+  differed is one people learn to re-run until green.
 - **Never name a shell variable `out` in a `runCommand` script.** `$out` is the
   derivation's output path, and assigning to it means every assertion passes
   and the build then fails with *"builder failed to produce output path"* —

--- a/tests/doctor-graphics.nix
+++ b/tests/doctor-graphics.nix
@@ -63,10 +63,40 @@ pkgs.runCommand "nixarchy-doctor-graphics" { nativeBuildInputs = [ pkgs.gnugrep 
       # is a non-zero last status and kills the subshell before the doctor runs.
       # The case with no third argument produced no output at all because of it.
       if [ -n "''${3-}" ]; then export LIBVA_DRIVER_NAME="$3"; fi
-      ${doctor}/bin/nixarchy-doctor 2>&1 ) || true
+      # The exit status is part of the output, on purpose. The doctor runs
+      # under errexit and prints the snippet LAST, so a host read that dies
+      # anywhere after the Graphics section -- #645 -- fails every snippet
+      # assertion at once while saying nothing about why. The status line is
+      # what says it, and the transcript is what the failure dump prints.
+      rc=0; ${doctor}/bin/nixarchy-doctor 2>&1 || rc=$?
+      echo "doctor exit status: $rc"
+    ) | tee -a transcript
+  }
+
+  # What the fixture does NOT control and the doctor still reads. Printed
+  # when a case fails, because a check that disagrees with itself across two
+  # runners and cannot say what differed between them is one people learn to
+  # re-run until green (#645).
+  dump() {
+    echo "== the doctor's full output, every case"; cat transcript
+    echo "== host state the fixture does not control"
+    echo "uname -r: $(uname -r)"; echo "id: $(id)"
+    echo "SHELL=''${SHELL-unset} TMPDIR=''${TMPDIR-unset} XDG_RUNTIME_DIR=''${XDG_RUNTIME_DIR-unset}"
+    echo "MemTotal: $(awk '/^MemTotal:/ { print $2 }' /proc/meminfo) kB"
+    echo "cpu: $(grep -m1 '^vendor_id' /proc/cpuinfo)"
+    echo "mounts:"; grep -E ' (/|/build|/tmp|/proc|/sys) ' /proc/self/mountinfo || true
+    for c in "is-enabled docker.service" "--user is-enabled docker.service" "is-active display-manager.service"; do
+      # shellcheck disable=SC2086
+      echo "systemctl $c -> $(${pkgs.systemd}/bin/systemctl $c 2>&1 || true)"
+    done
   }
 
   fails=0
+  # Every case starts here: a doctor that did not finish has not answered.
+  ran() { # ran <name> <output>
+    if printf '%s' "$2" | grep -q 'doctor exit status: 0'; then echo "  ok      $1: the doctor ran to completion"
+    else echo "  FAILED  $1: the doctor died -- the last lines say where"; printf '%s\n' "$2" | tail -5; fails=$((fails + 1)); fi
+  }
   want() { # want <name> <output> <pattern>
     if printf '%s' "$2" | grep -q "$3"; then echo "  ok      $1"
     else echo "  FAILED  $1: no /$3/ in the output"; fails=$((fails + 1)); fi
@@ -81,7 +111,8 @@ pkgs.runCommand "nixarchy-doctor-graphics" { nativeBuildInputs = [ pkgs.gnugrep 
   # Every `want` below fails identically when the doctor produced nothing, which
   # is indistinguishable from every rule being wrong. Say which it is.
   printf '%s' "$h" | grep -q 'Graphics' || {
-    echo "the doctor printed no Graphics section at all:"; printf '%s\n' "$h"; exit 1; }
+    echo "the doctor printed no Graphics section at all:"; dump; exit 1; }
+  ran  "hybrid"                      "$h"
   want "hybrid is detected"          "$h" 'Hybrid graphics'
   want "decode-only driver is named" "$h" 'cannot encode'
   want "the libva pin is named"      "$h" 'pinning libva'
@@ -95,6 +126,7 @@ pkgs.runCommand "nixarchy-doctor-graphics" { nativeBuildInputs = [ pkgs.gnugrep 
   want "sync is offered as a choice" "$h" 'prime.sync.enable'
 
   a=$(run amd vainfo-enc)
+  ran     "amd"                      "$a"
   want    "encode is recognised"     "$a" 'Video encoding available'
   wantnot "single GPU is not hybrid" "$a" 'Hybrid graphics'
   # e3 is the case that makes the conversion undeniable: read as decimal it is
@@ -107,6 +139,7 @@ pkgs.runCommand "nixarchy-doctor-graphics" { nativeBuildInputs = [ pkgs.gnugrep 
 
   # No driver answered -- the branch that could not fire.
   n=$(run amd vainfo-none)
+  ran     "no driver"                "$n"
   want    "no driver is said so"     "$n" 'No VAAPI driver answered'
   # And is NOT mistaken for a driver that merely cannot encode, which is what
   # this machine was told before: a wrong diagnosis, plus advice about
@@ -121,15 +154,18 @@ pkgs.runCommand "nixarchy-doctor-graphics" { nativeBuildInputs = [ pkgs.gnugrep 
   # bare string and failed against correctly-gated code, which would have sent
   # someone deleting the explanation instead of the snippet.
   nv=$(run nvidia vainfo-none)
+  ran     "nvidia"                   "$nv"
   wantnot "no intel snippet on nvidia" "$nv" 'extraPackages.*intel-media-driver'
   nvd=$(run nvidia vainfo)
+  ran     "decode-only nvidia"       "$nvd"
   wantnot "none on decode-only nvidia" "$nvd" 'extraPackages.*intel-media-driver'
   # ...and it is still offered where it helps, so the gate did not simply
   # delete the advice.
   i=$(run hybrid vainfo-none)
+  ran     "intel, no driver"         "$i"
   want    "intel snippet on intel"    "$i" 'extraPackages.*intel-media-driver'
 
-  [ "$fails" = 0 ] || { echo "$fails case(s) failed"; exit 1; }
+  [ "$fails" = 0 ] || { echo "$fails case(s) failed"; dump; exit 1; }
   echo "the doctor reads a GPU correctly"
   touch $out
 ''


### PR DESCRIPTION
## What this changes, and why

`checks.doctor-graphics` asserts on the doctor's snippet, which the doctor prints **last**, and the doctor runs under `writeShellApplication`'s `errexit`. So any host read after the Graphics section that fails kills the doctor before the snippet exists, and the check reports five `no /intelBusId = "PCI:0:2:0"/ in the output` lines that read exactly like five wrong GPU rules. The harness had `|| true` on the doctor, so the one number that would have said "it died" was discarded. That is the shape of #645: a check whose answer can depend on the host, and that cannot say what it read.

This PR does three things:

1. **The harness records the exit status as part of each case's output** (`doctor exit status: N`), asserts on it first (`ran`), and on any failure prints the full transcript of every case plus the host state the fixture does not control — kernel, uid/groups, `SHELL`/`TMPDIR`/`XDG_RUNTIME_DIR`, MemTotal, CPU vendor, the mounts the doctor reads out of `/proc/self/mountinfo`, and what `systemctl` answers.
2. **One real death fixed in `pkgs/doctor.sh`.** With `OMARCHY_PATH` naming a store path that has since been garbage-collected — the stale-session case that section exists to diagnose — `readlink -f | sed` fails, pipefail carries it, errexit kills the doctor at the exact finding it was about to print. `|| true` on that line. It cannot fire inside the sandbox (no `/run/current-system`), so it is not the CI flake, but it is the mechanism in its real-machine form, and it was live.
3. **The audit, and its honest result.** Probed what a build sandbox on this runner host lets the doctor see: `/proc` (meminfo, cpuinfo, mountinfo), `uname -r`, `id`, and `systemctl` (answers `not-found` / "Host is down"). No `/sys`, no `/run`, `/etc` has three files. Every one of those reads is inside a conditional or `|| true`-guarded, so none can reach the Graphics assertions except by a death — which the harness now names. A 13-way perturbation matrix outside the sandbox (tmpfs vs disk `TMPDIR`, `SHELL` fish/unset, bogus and real `XDG_RUNTIME_DIR`, `BROWSER`, `NIXARCHY_KERNEL_RELEASE`, `NIXARCHY_FLAKE` missing/real, `NIXARCHY_LDD_SCAN` missing) gives byte-identical Graphics output; only `OMARCHY_PATH` broke it, and that is item 2.

**What I could not establish:** which assertion went red in run 34658788247. Both run ids in #645 return 404 from the API (as runs and as jobs), and `gh run list --commit 84944bd…` is empty, so the log is gone. The `systemctl --user` gate in `1eda596` landed *after* both runs, so both ran the ungated version — and in the sandbox that call returns `not-found` rc=4 inside an `if`, which cannot fail a case. It was not the cause. The next disagreement will say what it read; this one cannot be reconstructed.

Also: `doctor-graphics` is built by the `omarchy` job on **`ubuntu-latest`**, not a self-hosted runner, so the runner-to-runner variable is a GitHub-hosted host, not p510 vs p620.

## How I proved the check fails

Break: a host read that dies after the Graphics section — `false` inserted before the Wireless section of `pkgs/doctor.sh`, edit count asserted (`break present: 1`), committed so the flake sees it, then both checks built against it.

**The check on `origin/main`, against the broken doctor** — five greps fail, eleven pass, nothing says the doctor died:

```
  ok      hybrid is detected
  ok      decode-only driver is named
  ok      the libva pin is named
  FAILED  intel bus id, hex->decimal: no /intelBusId = "PCI:0:2:0"/ in the output
  FAILED  nvidia bus id, hex->decimal: no /nvidiaBusId = "PCI:1:0:0"/ in the output
  FAILED  offload is written: no /offload.enable = true/ in the output
  FAILED  sync is offered as a choice: no /prime.sync.enable/ in the output
  ok      encode is recognised
  ...
  FAILED  intel snippet on intel: no /extraPackages.*intel-media-driver/ in the output
5 case(s) failed
```

**This PR's check, same broken doctor:**

```
  FAILED  hybrid: the doctor died -- the last lines say where
Graphics
  This driver cannot encode VA-API NVDEC driver, decode only
  LIBVA_DRIVER_NAME is pinning libva to 'nvidia', which cannot encode
  Hybrid graphics Intel + NVIDIA, no PRIME configuration read
doctor exit status: 1
  FAILED  intel bus id, hex->decimal: no /intelBusId = "PCI:0:2:0"/ in the output
  ...
11 case(s) failed
== the doctor's full output, every case
(transcript of all six runs)
== host state the fixture does not control
uname -r: 7.2.4
id: uid=1000(nixbld) gid=100(nixbld) groups=100(nixbld)
SHELL=/nix/store/...-bash-5.3p15/bin/bash TMPDIR=/build XDG_RUNTIME_DIR=unset
MemTotal: 263701156 kB
cpu: vendor_id        : AuthenticAMD
mounts:
7411 7283 8:17 /nix-build/nix-2309170-156563412/build /build rw,nosuid,nodev,relatime - ext4 /dev/sdb1 rw
7419 7283 0:130 / /proc rw,relatime - proc none rw
...
systemctl is-enabled docker.service -> not-found
systemctl --user is-enabled docker.service -> not-found
systemctl is-active display-manager.service -> System has not been booted with systemd as init system (PID 1). Can't operate.
```

Break removed (`break present: 0`), check green: 22 `ok` lines, `the doctor reads a GPU correctly`.

**The doctor fix, outside the sandbox** (built package, hybrid fixture, `OMARCHY_PATH=/nix/store/nope` on a machine where `/run/current-system/sw/bin/omarchy` exists):

```
before:  omarchy-path   rc=1 asserted-lines=0/7 bytes=655     (dies after printing "Session")
after:   omarchy-path   rc=0 asserted-lines=7/7 bytes=6297    (reports "running an older build")
```

Run under bash as a script, not pasted into a shell.

## Checks run locally

- `nix build .#checks.x86_64-linux.doctor-graphics` — green, and red under the break above
- the `origin/main` version of the same check via `--impure --expr`, red under the break with the output shown
- no VM checks built; install jobs were in flight on this host

- [x] `nix fmt` / statix / deadnix are clean
- [x] New files are `git add`ed (none added)
- [x] If this adds an option: n/a
- [x] If this adds a `checks.*` entry: n/a — existing check, already built by the `omarchy` job

## What this cost, and where it is written down

- [x] `tests/AGENTS.md`, under *Working here*: a tool that prints its verdict last fails every assertion at once when it dies and says nothing about dying — capture the exit status as output, assert on it first, dump the transcript and the uncontrolled host state on failure.

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFUw1YVdZ731GifokobLob
